### PR TITLE
Apply NumericUpDown.FormatString changes immediately.

### DIFF
--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -479,7 +479,7 @@ namespace Avalonia.Controls
         {
             if (IsInitialized)
             {
-                SyncTextAndValueProperties(false, null);
+                SyncTextAndValueProperties(false, null, true);
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
@@ -62,6 +62,24 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(control.Value, expected);
         }
 
+        [Fact]
+        public void FormatString_Is_Applied_Immediately()
+        {
+            RunTest((control, textbox) =>
+            {
+                const decimal value = 10.11m;
+
+                // Establish and verify initial conditions.
+                control.FormatString = "F0";
+                control.Value = value;
+                Assert.Equal(value.ToString("F0"), control.Text);
+
+                // Check that FormatString is applied.
+                control.FormatString = "F2";
+                Assert.Equal(value.ToString("F2"), control.Text);
+            });
+        }
+
         public static IEnumerable<object[]> Increment_Decrement_TestData()
         {
             // if min and max are not defined and value was null, 0 should be ne new value after spin


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When FormatString value is changed, the new format is applied immediately.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When FormatString value is changed, the new format is applied only after focusing or interacting with the control or changing the value.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
When FormatString value is changed, the new format is applied immediately.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #16556