### PR TITLE
Extract non-generic members from frequently used generic types

### DIFF
--- a/src/Avalonia.Base/AvaloniaPropertyRegistry.cs
+++ b/src/Avalonia.Base/AvaloniaPropertyRegistry.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace Avalonia
 {
@@ -259,7 +257,12 @@ namespace Avalonia
             AvaloniaObject o,
             DirectPropertyBase<T> property)
         {
-            return FindRegisteredDirect(o, property) ??
+            return (DirectPropertyBase<T>)GetRegisteredDirectUntyped(o, property);
+        }
+
+        internal AvaloniaProperty GetRegisteredDirectUntyped(AvaloniaObject o, AvaloniaProperty property)
+        {
+            return FindRegisteredDirectUntyped(o, property) ??
                    throw new ArgumentException($"Property '{property.Name} not registered on '{o.GetType()}");
         }
 
@@ -331,7 +334,14 @@ namespace Avalonia
             AvaloniaObject o,
             DirectPropertyBase<T> property)
         {
-            if (property.Owner == o.GetType())
+            return (DirectPropertyBase<T>?)FindRegisteredDirectUntyped(o, property);
+        }
+
+        private AvaloniaProperty? FindRegisteredDirectUntyped(AvaloniaObject o, AvaloniaProperty property)
+        {
+            Debug.Assert(property.IsDirect);
+
+            if (property.OwnerType == o.GetType())
             {
                 return property;
             }
@@ -345,7 +355,7 @@ namespace Avalonia
 
                 if (p == property)
                 {
-                    return (DirectPropertyBase<T>)p;
+                    return p;
                 }
             }
 

--- a/src/Avalonia.Base/PropertyStore/BindingEntryBase.cs
+++ b/src/Avalonia.Base/PropertyStore/BindingEntryBase.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using Avalonia.Reactive;
 using Avalonia.Data;
 using Avalonia.Threading;
+using static Avalonia.PropertyStore.BindingEntryBaseNonGenericHelper;
 
 namespace Avalonia.PropertyStore
 {
@@ -11,8 +11,6 @@ namespace Avalonia.PropertyStore
         IObserver<BindingValue<TSource>>,
         IDisposable
     {
-        private static readonly IDisposable s_creating = Disposable.Empty;
-        private static readonly IDisposable s_creatingQuiet = Disposable.Create(() => { });
         private IDisposable? _subscription;
         private bool _hasValue;
         private TValue? _value;
@@ -119,7 +117,7 @@ namespace Avalonia.PropertyStore
             if (_subscription is not null)
                 return;
 
-            _subscription = produceValue ? s_creating : s_creatingQuiet;
+            _subscription = produceValue ? Creating : CreatingQuiet;
             _subscription = Source switch
             {
                 IObservable<BindingValue<TSource>> bv => bv.Subscribe(this),
@@ -153,7 +151,7 @@ namespace Avalonia.PropertyStore
                 {
                     instance._value = value.Value;
                     instance._hasValue = true;
-                    if (instance._subscription is not null && instance._subscription != s_creatingQuiet)
+                    if (instance._subscription is not null && instance._subscription != CreatingQuiet)
                         instance.Frame.Owner?.OnBindingValueChanged(instance, instance.Frame.Priority);
                 }
             }

--- a/src/Avalonia.Base/PropertyStore/BindingEntryBaseNonGenericHelper.cs
+++ b/src/Avalonia.Base/PropertyStore/BindingEntryBaseNonGenericHelper.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Avalonia.Reactive;
+
+namespace Avalonia.PropertyStore;
+
+/// <summary>
+/// Contains fields for <see cref="BindingEntryBase{TValue,TSource}"/> that aren't using generic arguments.
+/// Separated to avoid unnecessary generic instantiations.
+/// </summary>
+internal static class BindingEntryBaseNonGenericHelper
+{
+    public static readonly IDisposable Creating = Disposable.Empty;
+    public static readonly IDisposable CreatingQuiet = Disposable.Create(() => { });
+}

--- a/src/Avalonia.Base/PropertyStore/EffectiveValue`1.cs
+++ b/src/Avalonia.Base/PropertyStore/EffectiveValue`1.cs
@@ -192,7 +192,7 @@ namespace Avalonia.PropertyStore
         }
 
         protected override object? GetBoxedValue() => Value;
-        
+
         private static T GetValue(IValueEntry entry)
         {
             if (entry is IValueEntry<T> typed)
@@ -240,14 +240,11 @@ namespace Avalonia.PropertyStore
 
             if (valueChanged)
             {
-                using var notifying = PropertyNotifying.Start(owner.Owner, property);
-                owner.Owner.RaisePropertyChanged(property, oldValue, Value, Priority, true);
-                if (property.Inherits)
-                    owner.OnInheritedEffectiveValueChanged(property, oldValue, this);
+                NotifyValueChanged(owner, property, oldValue);
             }
             else if (baseValueChanged)
             {
-                owner.Owner.RaisePropertyChanged(property, default, _baseValue!, BasePriority, false);
+                NotifyBaseValueChanged(owner, property);
             }
         }
 
@@ -296,19 +293,27 @@ namespace Avalonia.PropertyStore
 
             if (valueChanged)
             {
-                using var notifying = PropertyNotifying.Start(owner.Owner, property);
-                owner.Owner.RaisePropertyChanged(property, oldValue, Value, Priority, true);
-                if (property.Inherits)
-                    owner.OnInheritedEffectiveValueChanged(property, oldValue, this);
+                NotifyValueChanged(owner, property, oldValue);
             }
             
             if (baseValueChanged)
             {
-                owner.Owner.RaisePropertyChanged(property, default, _baseValue!, BasePriority, false);
+                NotifyBaseValueChanged(owner, property);
             }
         }
 
-        private class UncommonFields
+        private void NotifyValueChanged(ValueStore owner, StyledProperty<T> property, T oldValue)
+        {
+            using var notifying = PropertyNotifying.Start(owner.Owner, property);
+            owner.Owner.RaisePropertyChanged(property, oldValue, Value, Priority, true);
+            if (property.Inherits)
+                owner.OnInheritedEffectiveValueChanged(property, oldValue, this);
+        }
+
+        private void NotifyBaseValueChanged(ValueStore owner, StyledProperty<T> property)
+            => owner.Owner.RaisePropertyChanged(property, default, _baseValue!, BasePriority, false);
+
+        private sealed class UncommonFields
         {
             public Func<AvaloniaObject, T, T>? _coerce;
             public T? _uncoercedValue;

--- a/src/Avalonia.Base/Reactive/AnonymousObserver.cs
+++ b/src/Avalonia.Base/Reactive/AnonymousObserver.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using static Avalonia.Reactive.AnonymousObserverNonGenericHelper;
 
 namespace Avalonia.Reactive;
 
@@ -10,8 +10,6 @@ namespace Avalonia.Reactive;
 /// <typeparam name="T">The type of the elements in the sequence.</typeparam>
 public class AnonymousObserver<T> : IObserver<T>
 {
-    private static readonly Action<Exception> ThrowsOnError = ex => throw ex;
-    private static readonly Action NoOpCompleted = () => { };  
     private readonly Action<T> _onNext;
     private readonly Action<Exception> _onError;
     private readonly Action _onCompleted;

--- a/src/Avalonia.Base/Reactive/AnonymousObserverNonGenericHelper.cs
+++ b/src/Avalonia.Base/Reactive/AnonymousObserverNonGenericHelper.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Avalonia.Reactive;
+
+/// <summary>
+/// Contains fields for <see cref="AnonymousObserver{T}"/> that aren't using generic arguments.
+/// Separated to avoid unnecessary generic instantiations.
+/// </summary>
+internal static class AnonymousObserverNonGenericHelper
+{
+    public static readonly Action<Exception> ThrowsOnError = ex => throw ex;
+    public static readonly Action NoOpCompleted = () => { };
+}

--- a/src/Avalonia.Base/StyledPropertyNonGenericHelper.cs
+++ b/src/Avalonia.Base/StyledPropertyNonGenericHelper.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Avalonia;
+
+/// <summary>
+/// Contains methods for <see cref="StyledProperty{TValue}"/> that aren't using generic arguments.
+/// Separated to avoid unnecessary generic instantiations.
+/// </summary>
+internal static class StyledPropertyNonGenericHelper
+{
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ThrowInvalidValue(string propertyName, object? value, string paramName)
+    {
+        var type = value?.GetType().FullName ?? "(null)";
+
+        throw new ArgumentException(
+            $"Invalid value for Property '{propertyName}': '{value}' ({type})",
+            paramName);
+    }
+
+    public static void ThrowInvalidDefaultValue(string propertyName, object? defaultValue, string paramName)
+    {
+        throw new ArgumentException(
+            $"'{defaultValue}' is not a valid default value for '{propertyName}'.",
+            paramName);
+    }
+}

--- a/src/Avalonia.Base/Threading/Dispatcher.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.cs
@@ -64,7 +64,7 @@ public partial class Dispatcher : IDispatcher
     /// <summary>
     /// Checks that the current thread is the UI thread.
     /// </summary>
-    public bool CheckAccess() => _impl?.CurrentThreadIsLoopThread ?? true;
+    public bool CheckAccess() => _impl.CurrentThreadIsLoopThread;
 
     /// <summary>
     /// Checks that the current thread is the UI thread and throws if not.


### PR DESCRIPTION
## What does the pull request do?
This PR:
 - Extracts some non-generic code paths from generic types or methods that have a lot of instantiations, such as `StyledProperty<T>` or `AvaloniaObject.Bind<T>`.
 - Extracts common generic code in `EffectiveValue<T>` into separate methods (the extra call is completely negligible in this case).
 - Moves some common static non-generic fields outside of the generic types.
 - Slightly change the flow of `StyledProperty<T>.ShouldSetValue()` and `PropertyNotifying` (without any behavioral change), for better codegen.

On a NativeAOT hello world built for win-x64, this removes 324 KB of native code.
This will also help standard JIT builds with less work to do, and fewer allocations of duplicate fields.