### PR TITLE
Extend the client area when a Win32 window is opened in maximised state

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -614,12 +614,7 @@ namespace Avalonia.Win32
                     break;
 
                 case WindowsMessage.WM_SHOWWINDOW:
-                    _shown = wParam != default;
-
-                    if (_isClientAreaExtended)
-                    {
-                        ExtendClientArea();
-                    }
+                    OnShowHideMessage(wParam != default);
                     break;
 
                 case WindowsMessage.WM_SIZE:
@@ -801,11 +796,11 @@ namespace Avalonia.Win32
                     var winPos = Marshal.PtrToStructure<WINDOWPOS>(lParam);
                     if((winPos.flags & (uint)SetWindowPosFlags.SWP_SHOWWINDOW) != 0)
                     {
-                        _shown = true;
+                        OnShowHideMessage(true);
                     }
                     else if ((winPos.flags & (uint)SetWindowPosFlags.SWP_HIDEWINDOW) != 0)
                     {
-                        _shown = false;
+                        OnShowHideMessage(false);
                     }
                     break;
             }
@@ -852,6 +847,16 @@ namespace Avalonia.Win32
             }
 
             return DefWindowProc(hWnd, msg, wParam, lParam);
+        }
+
+        private void OnShowHideMessage(bool shown)
+        {
+            _shown = shown;
+
+            if (_isClientAreaExtended)
+            {
+                ExtendClientArea();
+            }
         }
 
         private Lazy<IReadOnlyList<RawPointerPoint>?>? CreateLazyIntermediatePoints(POINTER_INFO info)


### PR DESCRIPTION
#16029 fixed the internal show/hide state not being updated when a window opens in a maximised state, but it didn't extend the client area in the same circumstances. This PR adds the required calls.

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #16503