### PR TITLE
Added Compositor.CreateCompositionVisualSnapshot API

### DIFF
--- a/api/Avalonia.Skia.nupkg.xml
+++ b/api/Avalonia.Skia.nupkg.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Avalonia.Skia.ISkiaGpuWithPlatformGraphicsContext.TryGetGrContext</Target>
+    <Left>baseline/netstandard2.0/Avalonia.Skia.dll</Left>
+    <Right>target/netstandard2.0/Avalonia.Skia.dll</Right>
+  </Suppression>
+</Suppressions>

--- a/samples/ControlCatalog/Pages/OpenGlPage.xaml
+++ b/samples/ControlCatalog/Pages/OpenGlPage.xaml
@@ -3,8 +3,11 @@
              x:Class="ControlCatalog.Pages.OpenGlPage"
              xmlns:pages="using:ControlCatalog.Pages"
              xmlns:openGl="clr-namespace:ControlCatalog.Pages.OpenGl">
-  <Grid>
+  <Grid x:Name="MainGrid">
     <pages:OpenGlPageControl x:Name="GL"/>
     <openGl:GlPageKnobs x:Name="Knobs" />
+    <Button x:Name="Snapshot"
+            IsVisible="False"
+            VerticalAlignment="Bottom" HorizontalAlignment="Right"  Click="SnapshotClick">Snapshot</Button>
   </Grid>
 </UserControl>

--- a/samples/ControlCatalog/Pages/OpenGlPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/OpenGlPage.xaml.cs
@@ -1,8 +1,12 @@
+using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.OpenGL;
 using Avalonia.OpenGL.Controls;
+using Avalonia.Rendering.Composition;
 using ControlCatalog.Pages.OpenGl;
 
 // ReSharper disable StringLiteralTypo
@@ -16,6 +20,30 @@ namespace ControlCatalog.Pages
             AvaloniaXamlLoader.Load(this);
             this.FindControl<OpenGlPageControl>("GL")
                 !.Init(this.FindControl<GlPageKnobs>("Knobs")!);
+            
+            AttachedToVisualTree += delegate
+            {
+                if (TopLevel.GetTopLevel(this) is Window)
+                    this.FindControl<Button>("Snapshot")!.IsVisible = true;
+            };
+        }
+        
+        private async void SnapshotClick(object sender, RoutedEventArgs e)
+        {
+            var v = ElementComposition.GetElementVisual(this)!;
+            var snap = await v.Compositor.CreateCompositionVisualSnapshot(v, 1.5);
+            await new Window()
+            {
+                Content = new ScrollViewer()
+                {
+                    HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    Content = new Image()
+                    {
+                        Source = snap
+                    }
+                }
+            }.ShowDialog((Window)TopLevel.GetTopLevel(this));
         }
     }
 

--- a/src/Avalonia.Base/Platform/IDrawingContextImpl.cs
+++ b/src/Avalonia.Base/Platform/IDrawingContextImpl.cs
@@ -229,4 +229,10 @@ namespace Avalonia.Platform
         /// </summary>
         bool CanBlit { get; }
     }
+
+    public interface IDrawingContextLayerWithRenderContextAffinityImpl : IDrawingContextLayerImpl
+    {
+        bool HasRenderContextAffinity { get; }
+        IBitmapImpl CreateNonAffinedSnapshot();
+    }
 }

--- a/src/Avalonia.Base/Platform/IPlatformRenderInterface.cs
+++ b/src/Avalonia.Base/Platform/IPlatformRenderInterface.cs
@@ -215,6 +215,14 @@ namespace Avalonia.Platform
         /// </param>
         /// <returns>An <see cref="IRenderTarget"/>.</returns>
         IRenderTarget CreateRenderTarget(IEnumerable<object> surfaces);
+
+        /// <summary>
+        /// Creates an offscreen render target 
+        /// </summary>
+        /// <param name="pixelSize">The size, in pixels, of the render target</param>
+        /// <param name="scaling">The scaling which will be reported by IBitmap.Dpi</param>
+        /// <returns></returns>
+        IDrawingContextLayerImpl CreateOffscreenRenderTarget(PixelSize pixelSize, double scaling);
         
         /// <summary>
         /// Indicates that the context is no longer usable. This method should be thread-safe

--- a/src/Avalonia.Base/Platform/IScopedResource.cs
+++ b/src/Avalonia.Base/Platform/IScopedResource.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading;
+
+namespace Avalonia.Platform;
+
+public interface IScopedResource<T> : IDisposable
+{
+    public T Value { get; }
+}
+
+public class ScopedResource<T> : IScopedResource<T>
+{
+    private int _disposed = 0;
+    private T _value;
+    private Action? _dispose;
+    private ScopedResource(T value, Action dispose)
+    {
+        _value = value;
+        _dispose = dispose;
+    }
+    
+    public static IScopedResource<T> Create(T value, Action dispose) => new ScopedResource<T>(value, dispose);
+
+    public void Dispose()
+    {
+        if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
+        {
+            var disp = _dispose!;
+            _value = default!;
+            _dispose = null;
+            disp();
+        }
+    }
+
+    public T Value
+    {
+        get
+        {
+            if (_disposed == 1)
+                throw new ObjectDisposedException(this.GetType().FullName);
+            return _value;
+        }
+    }
+}

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionContainerVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionContainerVisual.cs
@@ -16,14 +16,13 @@ namespace Avalonia.Rendering.Composition.Server
         private LtrbRect? _transformedContentBounds;
         private IImmutableEffect? _oldEffect;
         
-        protected override void RenderCore(CompositorDrawingContextProxy canvas, LtrbRect currentTransformedClip,
-            IDirtyRectTracker dirtyRects)
+        protected override void RenderCore(ServerVisualRenderContext context, LtrbRect currentTransformedClip)
         {
-            base.RenderCore(canvas, currentTransformedClip, dirtyRects);
+            base.RenderCore(context, currentTransformedClip);
 
             foreach (var ch in Children)
             {
-                ch.Render(canvas, currentTransformedClip, dirtyRects);
+                ch.Render(context, currentTransformedClip);
             }
         }
 

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionDrawListVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionDrawListVisual.cs
@@ -40,17 +40,15 @@ internal class ServerCompositionDrawListVisual : ServerCompositionContainerVisua
         base.DeserializeChangesCore(reader, committedAt);
     }
 
-    protected override void RenderCore(CompositorDrawingContextProxy canvas, LtrbRect currentTransformedClip,
-        IDirtyRectTracker dirtyRects)
+    protected override void RenderCore(ServerVisualRenderContext context, LtrbRect currentTransformedClip)
     {
         if (_renderCommands != null 
-            && currentTransformedClip.Intersects(TransformedOwnContentBounds)
-            && dirtyRects.Intersects(TransformedOwnContentBounds))
+            && context.ShouldRenderOwnContent(this, currentTransformedClip))
         {
-            _renderCommands.Render(canvas);
+            _renderCommands.Render(context.Canvas);
         }
 
-        base.RenderCore(canvas, currentTransformedClip, dirtyRects);
+        base.RenderCore(context, currentTransformedClip);
     }
     
     public void DependencyQueuedInvalidate(IServerRenderResource sender) => ValuesInvalidated();

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionExperimentalAcrylicVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionExperimentalAcrylicVisual.cs
@@ -5,18 +5,17 @@ namespace Avalonia.Rendering.Composition.Server;
 
 internal partial class ServerCompositionExperimentalAcrylicVisual
 {
-    protected override void RenderCore(CompositorDrawingContextProxy canvas, LtrbRect currentTransformedClip,
-        IDirtyRectTracker dirtyRects)
+    protected override void RenderCore(ServerVisualRenderContext context, LtrbRect currentTransformedClip)
     {
         var cornerRadius = CornerRadius;
-        canvas.DrawRectangle(
+        context.Canvas.DrawRectangle(
             Material,
             new RoundedRect(
                 new Rect(0, 0, Size.X, Size.Y),
                 cornerRadius.TopLeft, cornerRadius.TopRight,
                 cornerRadius.BottomRight, cornerRadius.BottomLeft));
 
-        base.RenderCore(canvas, currentTransformedClip, dirtyRects);
+        base.RenderCore(context, currentTransformedClip);
     }
 
     public override LtrbRect OwnContentBounds => new(0, 0, Size.X, Size.Y);

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionSolidColorVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionSolidColorVisual.cs
@@ -5,9 +5,8 @@ namespace Avalonia.Rendering.Composition.Server;
 
 internal partial class ServerCompositionSolidColorVisual
 {
-    protected override void RenderCore(CompositorDrawingContextProxy canvas, LtrbRect currentTransformedClip,
-        IDirtyRectTracker dirtyRects)
+    protected override void RenderCore(ServerVisualRenderContext context, LtrbRect currentTransformedClip)
     {
-        canvas.DrawRectangle(new ImmutableSolidColorBrush(Color), null, new Rect(0, 0, Size.X, Size.Y));
+        context.Canvas.DrawRectangle(new ImmutableSolidColorBrush(Color), null, new Rect(0, 0, Size.X, Size.Y));
     }
 }

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionSurfaceVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionSurfaceVisual.cs
@@ -5,8 +5,7 @@ namespace Avalonia.Rendering.Composition.Server;
 
 internal partial class ServerCompositionSurfaceVisual
 {
-    protected override void RenderCore(CompositorDrawingContextProxy canvas, LtrbRect currentTransformedClip,
-        IDirtyRectTracker dirtyRects)
+    protected override void RenderCore(ServerVisualRenderContext context, LtrbRect currentTransformedClip)
     {
         if (Surface == null)
             return;
@@ -15,7 +14,7 @@ internal partial class ServerCompositionSurfaceVisual
         var bmp = Surface.Bitmap.Item;
 
         //TODO: add a way to always render the whole bitmap instead of just assuming 96 DPI
-        canvas.DrawBitmap(Surface.Bitmap.Item, 1, new Rect(bmp.PixelSize.ToSize(1)), new Rect(
+        context.Canvas.DrawBitmap(Surface.Bitmap.Item, 1, new Rect(bmp.PixelSize.ToSize(1)), new Rect(
             new Size(Size.X, Size.Y)));
     }
 

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.DirtyRects.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.DirtyRects.cs
@@ -35,7 +35,7 @@ internal partial class ServerCompositionTarget
     public Rect SnapToDevicePixels(Rect rect) => SnapToDevicePixels(new(rect), Scaling).ToRect();
     public LtrbRect SnapToDevicePixels(LtrbRect rect) => SnapToDevicePixels(rect, Scaling);
         
-    private static LtrbRect SnapToDevicePixels(LtrbRect rect, double scale)
+    public static LtrbRect SnapToDevicePixels(LtrbRect rect, double scale)
     {
         return new LtrbRect(
             Math.Floor(rect.Left * scale) / scale,

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -214,7 +214,10 @@ namespace Avalonia.Rendering.Composition.Server
                     context.PushLayer(DirtyRects.CombinedRect.ToRectUnscaled());
 
                 using (var proxy = new CompositorDrawingContextProxy(context))
-                    root.Render(proxy, null, DirtyRects);
+                {
+                    var ctx = new ServerVisualRenderContext(proxy, DirtyRects, false);
+                    root.Render(ctx, null);
+                }
 
                 if (useLayerClip)
                     context.PopLayer();

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositor.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositor.cs
@@ -23,6 +23,7 @@ namespace Avalonia.Rendering.Composition.Server
 
         private readonly Queue<CompositionBatch> _batches = new Queue<CompositionBatch>();
         private readonly Queue<Action> _receivedJobQueue = new();
+        private readonly Queue<Action> _receivedPostTargetJobQueue = new();
         public long LastBatchId { get; private set; }
         public Stopwatch Clock { get; } = Stopwatch.StartNew();
         public TimeSpan ServerNow { get; private set; }
@@ -36,6 +37,8 @@ namespace Avalonia.Rendering.Composition.Server
         internal static readonly object RenderThreadDisposeStartMarker = new();
         internal static readonly object RenderThreadJobsStartMarker = new();
         internal static readonly object RenderThreadJobsEndMarker = new();
+        internal static readonly object RenderThreadPostTargetJobsStartMarker = new();
+        internal static readonly object RenderThreadPostTargetJobsEndMarker = new();
         public CompositionOptions Options { get; }
         public ServerCompositorAnimations Animations { get; }
 
@@ -83,7 +86,12 @@ namespace Avalonia.Rendering.Composition.Server
                         var readObject = stream.ReadObject();
                         if (readObject == RenderThreadJobsStartMarker)
                         {
-                            ReadServerJobs(stream);
+                            ReadServerJobs(stream, _receivedJobQueue, RenderThreadJobsEndMarker);
+                            continue;
+                        }
+                        if (readObject == RenderThreadPostTargetJobsStartMarker)
+                        {
+                            ReadServerJobs(stream, _receivedPostTargetJobQueue, RenderThreadPostTargetJobsEndMarker);
                             continue;
                         }
 
@@ -111,11 +119,11 @@ namespace Avalonia.Rendering.Composition.Server
             }
         }
 
-        void ReadServerJobs(BatchStreamReader reader)
+        void ReadServerJobs(BatchStreamReader reader, Queue<Action> queue, object endMarker)
         {
             object? readObject;
-            while ((readObject = reader.ReadObject()) != RenderThreadJobsEndMarker)
-                _receivedJobQueue.Enqueue((Action)readObject!);
+            while ((readObject = reader.ReadObject()) != endMarker)
+                queue.Enqueue((Action)readObject!);
         }
 
         void ReadDisposeJobs(BatchStreamReader reader)
@@ -128,12 +136,12 @@ namespace Avalonia.Rendering.Composition.Server
             }
         }
 
-        void ExecuteServerJobs()
+        void ExecuteServerJobs(Queue<Action> queue)
         {
-            while(_receivedJobQueue.Count > 0)
+            while(queue.Count > 0)
                 try
                 {
-                    _receivedJobQueue.Dequeue()();
+                    queue.Dequeue()();
                 }
                 catch
                 {
@@ -221,9 +229,10 @@ namespace Avalonia.Rendering.Composition.Server
                 if(!RenderInterface.IsReady)
                     return;
                 RenderInterface.EnsureValidBackendContext();
-                ExecuteServerJobs();
+                ExecuteServerJobs(_receivedJobQueue);
                 foreach (var t in _activeTargets)
                     t.Render();
+                ExecuteServerJobs(_receivedPostTargetJobQueue);
             }
             catch (Exception e) when(RT_OnContextLostExceptionFilterObserver(e) && catchExceptions)
             {

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCustomCompositionVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCustomCompositionVisual.cs
@@ -71,11 +71,10 @@ internal sealed class ServerCompositionCustomVisual : ServerCompositionContainer
             Compositor.Animations.AddToClock(this);
     }
 
-    protected override void RenderCore(CompositorDrawingContextProxy canvas, LtrbRect currentTransformedClip,
-        IDirtyRectTracker dirtyRects)
+    protected override void RenderCore(ServerVisualRenderContext ctx, LtrbRect currentTransformedClip)
     {
-        canvas.AutoFlush = true;
-        using var context = new ImmediateDrawingContext(canvas, GlobalTransformMatrix, false);
+        ctx.Canvas.AutoFlush = true;
+        using var context = new ImmediateDrawingContext(ctx.Canvas, GlobalTransformMatrix, false);
         try
         {
             _handler.Render(context, currentTransformedClip.ToRect());
@@ -86,6 +85,6 @@ internal sealed class ServerCompositionCustomVisual : ServerCompositionContainer
                 ?.Log(_handler, $"Exception in {_handler.GetType().Name}.{nameof(CompositionCustomVisualHandler.OnRender)} {{0}}", e);
         }
 
-        canvas.AutoFlush = false;
+        ctx.Canvas.AutoFlush = false;
     }
 }

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerVisualRenderContext.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerVisualRenderContext.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Platform;
+
+namespace Avalonia.Rendering.Composition.Server;
+
+internal class ServerVisualRenderContext
+{
+    public IDirtyRectTracker? DirtyRects { get; }
+    public bool DetachedRendering { get; }
+    public CompositorDrawingContextProxy Canvas { get; }
+    private readonly Stack<Matrix>? _transformStack;
+
+    public ServerVisualRenderContext(CompositorDrawingContextProxy canvas, IDirtyRectTracker? dirtyRects,
+        bool detachedRendering)
+    {
+        Canvas = canvas;
+        DirtyRects = dirtyRects;
+        DetachedRendering = detachedRendering;
+        if (detachedRendering)
+        {
+            _transformStack = new();
+            _transformStack.Push(canvas.Transform);
+        }
+    }
+
+
+    public bool ShouldRender(ServerCompositionVisual visual, LtrbRect currentTransformedClip)
+    {
+        if (DetachedRendering)
+            return true;
+        if (currentTransformedClip.IsZeroSize)
+            return false;
+        if (DirtyRects?.Intersects(currentTransformedClip) == false)
+            return false;
+        return true;
+    }
+
+    public bool ShouldRenderOwnContent(ServerCompositionVisual visual, LtrbRect currentTransformedClip)
+    {
+        if (DetachedRendering)
+            return true;
+        return currentTransformedClip.Intersects(visual.TransformedOwnContentBounds)
+               && DirtyRects?.Intersects(visual.TransformedOwnContentBounds) != false;
+    }
+
+    public RestoreTransform SetOrPushTransform(ServerCompositionVisual visual)
+    {
+        if (!DetachedRendering)
+        {
+            Canvas.Transform = visual.GlobalTransformMatrix;
+            return default;
+        }
+        else
+        {
+            var transform = visual.CombinedTransformMatrix * _transformStack!.Peek();
+            Canvas.Transform = transform;
+            _transformStack.Push(transform);
+            return new RestoreTransform(this);
+        }
+    }
+
+    public struct RestoreTransform(ServerVisualRenderContext? parent) : IDisposable
+    {
+        public void Dispose()
+        {
+            if (parent != null)
+            {
+                parent._transformStack!.Pop();
+                parent.Canvas.Transform = parent._transformStack.Peek();
+            }
+        }
+    }
+    
+}

--- a/src/Avalonia.Controls/BorderVisual.cs
+++ b/src/Avalonia.Controls/BorderVisual.cs
@@ -46,9 +46,9 @@ class CompositionBorderVisual : CompositionDrawListVisual
         {
         }
 
-        protected override void RenderCore(CompositorDrawingContextProxy canvas, LtrbRect currentTransformedClip,
-            IDirtyRectTracker dirtyRects)
+        protected override void RenderCore(ServerVisualRenderContext ctx, LtrbRect currentTransformedClip)
         {
+            var canvas = ctx.Canvas;
             if (ClipToBounds)
             {
                 var clipRect = Root!.SnapToDevicePixels(new Rect(new Size(Size.X, Size.Y)));
@@ -58,7 +58,7 @@ class CompositionBorderVisual : CompositionDrawListVisual
                     canvas.PushClip(new RoundedRect(clipRect, _cornerRadius));
             }
 
-            base.RenderCore(canvas, currentTransformedClip, dirtyRects);
+            base.RenderCore(ctx, currentTransformedClip);
             
             if(ClipToBounds)
                 canvas.PopClip();

--- a/src/Headless/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
@@ -61,6 +61,9 @@ namespace Avalonia.Headless
             => new HeadlessGeometryStub(g1.Bounds.Union(g2.Bounds));
 
         public IRenderTarget CreateRenderTarget(IEnumerable<object> surfaces) => new HeadlessRenderTarget();
+        public IDrawingContextLayerImpl CreateOffscreenRenderTarget(PixelSize pixelSize, double scaling) => 
+            new HeadlessBitmapStub(pixelSize, new Vector(96 * scaling, 96 * scaling));
+
         public bool IsLost => false;
         public IReadOnlyDictionary<Type, object> PublicFeatures { get; } = new Dictionary<Type, object>();
         public object? TryGetFeature(Type featureType) => null;

--- a/src/Skia/Avalonia.Skia/Gpu/ISkiaGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/ISkiaGpu.cs
@@ -31,6 +31,7 @@ namespace Avalonia.Skia
     public interface ISkiaGpuWithPlatformGraphicsContext : ISkiaGpu
     {
         IPlatformGraphicsContext? PlatformGraphicsContext { get; }
+        IScopedResource<GRContext>? TryGetGrContext();
     }
     
     public interface ISkiaSurface : IDisposable

--- a/src/Skia/Avalonia.Skia/Gpu/Metal/SkiaMetalGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/Metal/SkiaMetalGpu.cs
@@ -34,6 +34,10 @@ internal class SkiaMetalGpu : ISkiaGpu, ISkiaGpuWithPlatformGraphicsContext
     public IDisposable EnsureCurrent() => _device.EnsureCurrent();
     public IPlatformGraphicsContext? PlatformGraphicsContext => _device;
 
+    public IScopedResource<GRContext> TryGetGrContext() =>
+        ScopedResource<GRContext>.Create(_context ?? throw new ObjectDisposedException(nameof(SkiaMetalApi)),
+            EnsureCurrent().Dispose);
+
     public ISkiaGpuRenderTarget? TryCreateRenderTarget(IEnumerable<object> surfaces)
     {
         foreach (var surface in surfaces)

--- a/src/Skia/Avalonia.Skia/Gpu/OpenGl/GlSkiaGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/OpenGl/GlSkiaGpu.cs
@@ -164,6 +164,8 @@ namespace Avalonia.Skia
         public bool IsLost => _glContext.IsLost;
         public IDisposable EnsureCurrent() => _glContext.EnsureCurrent();
         public IPlatformGraphicsContext? PlatformGraphicsContext => _glContext;
+        public IScopedResource<GRContext> TryGetGrContext() =>
+            ScopedResource<GRContext>.Create(GrContext, EnsureCurrent().Dispose);
 
         public object? TryGetFeature(Type featureType)
         {

--- a/src/Skia/Avalonia.Skia/SkiaBackendContext.cs
+++ b/src/Skia/Avalonia.Skia/SkiaBackendContext.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Avalonia.Controls.Platform.Surfaces;
 using Avalonia.OpenGL;
 using Avalonia.Platform;
+using SkiaSharp;
 
 namespace Avalonia.Skia;
 
@@ -58,6 +59,27 @@ internal class SkiaContext : IPlatformRenderInterfaceContext
 
         throw new NotSupportedException(
             "Don't know how to create a Skia render target from any of provided surfaces");
+    }
+
+    public IDrawingContextLayerImpl CreateOffscreenRenderTarget(PixelSize pixelSize, double scaling)
+    {
+        using (var gr = (_gpu as ISkiaGpuWithPlatformGraphicsContext)?.TryGetGrContext())
+        {
+            var createInfo = new SurfaceRenderTarget.CreateInfo
+            {
+                Width = pixelSize.Width,
+                Height = pixelSize.Height,
+                Dpi = new Vector(96 * scaling, 96 * scaling),
+                Format = null,
+                DisableTextLcdRendering = false,
+                GrContext = gr?.Value,
+                Gpu = _gpu,
+                DisableManualFbo = true,
+                Session = null
+            };
+
+            return new SurfaceRenderTarget(createInfo);
+        }
     }
 
     public bool IsLost => _gpu?.IsLost ?? false;

--- a/src/Skia/Avalonia.Skia/SurfaceRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/SurfaceRenderTarget.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Skia
     /// <summary>
     /// Skia render target that writes to a surface.
     /// </summary>
-    internal class SurfaceRenderTarget : IDrawingContextLayerImpl, IDrawableBitmapImpl
+    internal class SurfaceRenderTarget : IDrawingContextLayerImpl, IDrawableBitmapImpl, IDrawingContextLayerWithRenderContextAffinityImpl
     {
         private readonly ISkiaSurface _surface;
         private readonly SKCanvas _canvas;
@@ -233,6 +233,15 @@ namespace Avalonia.Skia
             public ISkiaGpuRenderSession? Session;
 
             public bool DisableManualFbo;
+        }
+
+        public bool HasRenderContextAffinity => _grContext != null;
+        public IBitmapImpl CreateNonAffinedSnapshot()
+        {
+            if (!HasRenderContextAffinity)
+                throw new InvalidOperationException();
+            using var image = SnapshotImage();
+            return new ImmutableBitmap(image.ToRasterImage(true));
         }
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
+++ b/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
@@ -179,6 +179,10 @@ namespace Avalonia.Direct2D1
             }
 
             public IRenderTarget CreateRenderTarget(IEnumerable<object> surfaces) => _platform.CreateRenderTarget(surfaces);
+
+            public IDrawingContextLayerImpl CreateOffscreenRenderTarget(PixelSize pixelSize, double scaling) =>
+                new WicRenderTargetBitmapImpl(pixelSize, new Vector(96 * scaling, 96 * scaling));
+
             public bool IsLost => false;
             public IReadOnlyDictionary<Type, object> PublicFeatures { get; } = new Dictionary<Type, object>();
         }


### PR DESCRIPTION
The API allows to take a snapshot of a visual attached to a window including GPU interop objects.

The changes will be later used for new RTB and for compositor-side visual brushes.