### PR TITLE
Disable opengl for simulator

### DIFF
--- a/src/iOS/Avalonia.iOS/Platform.cs
+++ b/src/iOS/Avalonia.iOS/Platform.cs
@@ -115,6 +115,7 @@ namespace Avalonia.iOS
             {
 #if !MACCATALYST
                 if (renderingMode == iOSRenderingMode.OpenGl
+                    && ObjCRuntime.Runtime.Arch != Arch.SIMULATOR
                     && !OperatingSystem.IsMacCatalyst()
 #pragma warning disable CA1422
                     && Eagl.EaglPlatformGraphics.TryCreate() is { } eaglGraphics)


### PR DESCRIPTION
OpenGL crashes newest simulators somewhere at first render (too late to intercept it during initialization).
11.2 builds already use Metal by default.
But for backporting, it should be a lower impact to simply disable opengl only for simulators, while keeping old behavior for devices.

## Fixed issues

Closes https://github.com/AvaloniaUI/Avalonia/pull/15994
Fixes https://github.com/AvaloniaUI/Avalonia/issues/14933