### PR TITLE
Win32 - Fix Window Frame Size and Position issues.

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -1,17 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
-using Avalonia.Platform;
 using Avalonia.Threading;
 using Avalonia.Win32.Automation;
 using Avalonia.Win32.Input;
-using Avalonia.Win32.Interop;
 using Avalonia.Win32.Interop.Automation;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
 
@@ -648,6 +645,8 @@ namespace Avalonia.Win32
                             Resized(clientSize / RenderScaling, _resizeReason);
                         }
 
+                        if (IsWindowVisible(_hwnd) && !_shown)
+                            _shown = true;
 
                         if (stateChanged)
                         {
@@ -666,10 +665,16 @@ namespace Avalonia.Win32
 
                             if (_isClientAreaExtended)
                             {
-                                UpdateExtendMargins();
+                                ExtendClientArea();
 
                                 ExtendClientAreaToDecorationsChanged?.Invoke(true);
                             }
+                        }
+                        else if (windowState == WindowState.Maximized && _isClientAreaExtended)
+                        {
+                            ExtendClientArea();
+
+                            ExtendClientAreaToDecorationsChanged?.Invoke(true);
                         }
 
                         return IntPtr.Zero;
@@ -681,8 +686,7 @@ namespace Avalonia.Win32
 
                 case WindowsMessage.WM_MOVE:
                     {
-                        PositionChanged?.Invoke(new PixelPoint((short)(ToInt32(lParam) & 0xffff),
-                            (short)(ToInt32(lParam) >> 16)));
+                        PositionChanged?.Invoke(Position);
                         return IntPtr.Zero;
                     }
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1451,8 +1451,6 @@ namespace Avalonia.Win32
 
             if (!_isFullScreenActive && ((oldProperties.Decorations != newProperties.Decorations) || forceChanges))
             {
-                var style = GetStyle();
-
                 var margin = newProperties.Decorations == SystemDecorations.BorderOnly ? 1 : 0;
 
                 var margins = new MARGINS
@@ -1467,10 +1465,9 @@ namespace Avalonia.Win32
 
                 if (_shown || forceChanges)
                 {
-                    GetWindowRect(_hwnd, out var rcWindow);
-
-                    SetWindowPos(_hwnd, IntPtr.Zero, rcWindow.left, rcWindow.top, 0 ,0,
-                        SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOACTIVATE | SetWindowPosFlags.SWP_NOSIZE |
+                    SetWindowPos(_hwnd, IntPtr.Zero, 0, 0, 0 ,0,
+                        SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOACTIVATE |
+                        SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOMOVE |
                         SetWindowPosFlags.SWP_FRAMECHANGED);
                 }
             }

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -263,14 +263,8 @@ namespace Avalonia.Win32
         {
             get
             {
-                if (DwmIsCompositionEnabled(out var compositionEnabled) != 0 || !compositionEnabled)
-                {
-                    GetWindowRect(_hwnd, out var rcWindow);
-                    return new Size(rcWindow.Width, rcWindow.Height) / RenderScaling;
-                }
-
-                DwmGetWindowAttribute(_hwnd, (int)DwmWindowAttribute.DWMWA_EXTENDED_FRAME_BOUNDS, out var rect, Marshal.SizeOf<RECT>());
-                return new Size(rect.Width, rect.Height) / RenderScaling;
+                GetWindowRect(_hwnd, out var rcWindow);
+                return new Size(rcWindow.Width, rcWindow.Height) / RenderScaling;
             }
         }
 
@@ -510,6 +504,7 @@ namespace Avalonia.Win32
             var result = DwmSetWindowAttribute(_hwnd, (int)DwmWindowAttribute.DWMWA_USE_HOSTBACKDROPBRUSH, &pvUseBackdropBrush, sizeof(int));
             return result == 0;
         }
+
         public IEnumerable<object> Surfaces
             => _glSurface is null ?
                 new object[] { Handle, _framebuffer } :
@@ -520,15 +515,10 @@ namespace Avalonia.Win32
             get
             {
                 GetWindowRect(_hwnd, out var rc);
-
-                var border = HiddenBorderSize;
-                return new PixelPoint(rc.left + border.Width, rc.top + border.Height);
+                return new PixelPoint(rc.left, rc.top);
             }
             set
             {
-                var border = HiddenBorderSize;
-                value = new PixelPoint(value.X - border.Width, value.Y - border.Height);
-
                 SetWindowPos(
                     Handle.Handle,
                     IntPtr.Zero,
@@ -542,23 +532,6 @@ namespace Avalonia.Win32
 
         private bool HasFullDecorations => _windowProperties.Decorations == SystemDecorations.Full;
 
-        private PixelSize HiddenBorderSize
-        {
-            get
-            {
-                // Windows 10 and 11 add a 7 pixel invisible border on the left/right/bottom of windows for resizing
-                if (Win32Platform.WindowsVersion.Major < 10 || !HasFullDecorations || GetStyle().HasFlag(WindowStyles.WS_POPUP))
-                {
-                    return PixelSize.Empty;
-                }
-
-                DwmGetWindowAttribute(_hwnd, (int)DwmWindowAttribute.DWMWA_EXTENDED_FRAME_BOUNDS, out var clientRect, Marshal.SizeOf<RECT>());
-                GetWindowRect(_hwnd, out var frameRect);
-                var borderWidth = GetSystemMetrics(SystemMetric.SM_CXBORDER);
-
-                return new PixelSize(clientRect.left - frameRect.left - borderWidth, 0);
-            }
-        }
 
         public void Move(PixelPoint point) => Position = point;
 
@@ -594,24 +567,28 @@ namespace Avalonia.Win32
 
             GetWindowPlacement(_hwnd, out var windowPlacement);
 
-            var clientScreenOrigin = new POINT();
-            ClientToScreen(_hwnd, ref clientScreenOrigin);
-
             var requestedClientRect = new RECT
             {
-                left = clientScreenOrigin.X,
-                right = clientScreenOrigin.X + requestedClientWidth,
-
-                top = clientScreenOrigin.Y,
-                bottom = clientScreenOrigin.Y + requestedClientHeight,
+                left = 0,
+                top = 0,
+                right = requestedClientWidth,
+                bottom = requestedClientHeight
             };
 
             var requestedWindowRect = _isClientAreaExtended ? requestedClientRect : ClientRectToWindowRect(requestedClientRect);
+            var windowWidth = requestedWindowRect.Width;
+            var windowHeight = requestedWindowRect.Height;
 
-            if (requestedWindowRect.Width == windowPlacement.NormalPosition.Width && requestedWindowRect.Height == windowPlacement.NormalPosition.Height)
+            if (windowWidth == windowPlacement.NormalPosition.Width && windowHeight == windowPlacement.NormalPosition.Height)
             {
                 return;
             }
+
+            var position = Position;
+            requestedWindowRect.left = position.X;
+            requestedWindowRect.top = position.Y;
+            requestedWindowRect.right = position.X + windowWidth;
+            requestedWindowRect.bottom = position.Y + windowHeight;
 
             windowPlacement.NormalPosition = requestedWindowRect;
 
@@ -1025,14 +1002,8 @@ namespace Avalonia.Win32
             if (fullscreen)
             {
                 GetWindowRect(_hwnd, out var windowRect);
-                GetClientRect(_hwnd, out var clientRect);
 
-                clientRect.left += windowRect.left;
-                clientRect.right += windowRect.left;
-                clientRect.top += windowRect.top;
-                clientRect.bottom += windowRect.top;
-
-                _savedWindowInfo.WindowRect = clientRect;
+                _savedWindowInfo.WindowRect = windowRect;
 
                 var current = GetStyle();
                 var currentEx = GetExtendedStyle();
@@ -1141,15 +1112,7 @@ namespace Avalonia.Win32
                 _isClientAreaExtended = false;
                 return;
             }
-            GetClientRect(_hwnd, out var rcClient);
             GetWindowRect(_hwnd, out var rcWindow);
-
-            // Inform the application of the frame change.
-            SetWindowPos(_hwnd,
-                IntPtr.Zero,
-                rcWindow.left, rcWindow.top,
-                rcClient.Width, rcClient.Height,
-                SetWindowPosFlags.SWP_FRAMECHANGED | SetWindowPosFlags.SWP_NOACTIVATE);
 
             if (_isClientAreaExtended && WindowState != WindowState.FullScreen)
             {
@@ -1170,8 +1133,6 @@ namespace Avalonia.Win32
                 _offScreenMargin = new Thickness();
                 _extendedMargins = new Thickness();
 
-                Resize(new Size(rcWindow.Width / RenderScaling, rcWindow.Height / RenderScaling), WindowResizeReason.Layout);
-
                 unsafe
                 {
                     int cornerPreference = (int)DwmWindowCornerPreference.DWMWCP_DEFAULT;
@@ -1188,6 +1149,13 @@ namespace Avalonia.Win32
             {
                 DisableCloseButton(_hwnd);
             }
+
+            // Inform the application of the frame change.
+            SetWindowPos(_hwnd,
+                IntPtr.Zero,
+                rcWindow.left, rcWindow.top,
+                0, 0,
+                SetWindowPosFlags.SWP_FRAMECHANGED | SetWindowPosFlags.SWP_NOACTIVATE | SetWindowPosFlags.SWP_NOSIZE);
 
             ExtendClientAreaToDecorationsChanged?.Invoke(_isClientAreaExtended);
         }
@@ -1454,7 +1422,7 @@ namespace Avalonia.Win32
                 {
                     style &= ~(fullDecorationFlags | WindowStyles.WS_THICKFRAME);
 
-                    if (newProperties.Decorations == SystemDecorations.BorderOnly && newProperties.WindowState != WindowState.Maximized)
+                    if (newProperties.Decorations == SystemDecorations.BorderOnly && newProperties.WindowState != WindowState.Maximized && newProperties.IsResizable)
                     {
                         style |= WindowStyles.WS_THICKFRAME | WindowStyles.WS_BORDER;
                     }
@@ -1497,23 +1465,12 @@ namespace Avalonia.Win32
 
                 DwmExtendFrameIntoClientArea(_hwnd, ref margins);
 
-
                 if (_shown || forceChanges)
                 {
-                    GetClientRect(_hwnd, out var oldClientRect);
-                    var oldClientRectOrigin = new POINT();
-                    ClientToScreen(_hwnd, ref oldClientRectOrigin);
-                    oldClientRect.Offset(oldClientRectOrigin);
+                    GetWindowRect(_hwnd, out var rcWindow);
 
-                    var newRect = oldClientRect;
-
-                    if (newProperties.Decorations == SystemDecorations.Full)
-                    {
-                        AdjustWindowRectEx(ref newRect, (uint)style, false, (uint)GetExtendedStyle());
-                    }
-
-                    SetWindowPos(_hwnd, IntPtr.Zero, newRect.left, newRect.top, newRect.Width, newRect.Height,
-                        SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOACTIVATE |
+                    SetWindowPos(_hwnd, IntPtr.Zero, rcWindow.left, rcWindow.top, 0 ,0,
+                        SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOACTIVATE | SetWindowPosFlags.SWP_NOSIZE |
                         SetWindowPosFlags.SWP_FRAMECHANGED);
                 }
             }

--- a/tests/Avalonia.IntegrationTests.Appium/WindowDecorationsTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowDecorationsTests.cs
@@ -12,7 +12,7 @@ public class WindowDecorationsTests : TestBase, IDisposable
     {
     }
 
-    [PlatformFact(TestPlatforms.MacOS)] // TODO fix me on Windows
+    [Fact]
     public void Window_Size_Should_Be_Consistent_Between_Toggles()
     {
         var window = Session.FindElementByAccessibilityId("MainWindow");

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -311,6 +311,44 @@ namespace Avalonia.IntegrationTests.Appium
             }
         }
 
+        [Fact]
+        public void Changing_SystemDecorations_Should_Not_Change_Frame_Size_And_Position()
+        {
+            using (OpenWindow(null, ShowWindowMode.NonOwned, WindowStartupLocation.Manual))
+            {
+                var info = GetWindowInfo();
+
+                Session.FindElementByAccessibilityId("CurrentSystemDecorations").Click();
+                Session.FindElementByAccessibilityId("SystemDecorationsNone").SendClick();
+                var updatedInfo = GetWindowInfo();
+                Assert.Equal(info.FrameSize, updatedInfo.FrameSize);
+                Assert.Equal(info.Position, updatedInfo.Position);
+
+                Session.FindElementByAccessibilityId("CurrentSystemDecorations").Click();
+                Session.FindElementByAccessibilityId("SystemDecorationsFull").SendClick();
+                updatedInfo = GetWindowInfo();
+                Assert.Equal(info.FrameSize, updatedInfo.FrameSize);
+                Assert.Equal(info.Position, updatedInfo.Position);
+            }
+        }
+
+        [Fact]
+        public void Changing_WindowState_Should_Not_Change_Frame_Size_And_Position()
+        {
+            using (OpenWindow())
+            {
+                var info = GetWindowInfo();
+
+                Session.FindElementByAccessibilityId("CurrentWindowState").SendClick();
+                Session.FindElementByAccessibilityId("WindowStateMaximized").SendClick();
+                Session.FindElementByAccessibilityId("CurrentWindowState").SendClick();
+                Session.FindElementByAccessibilityId("WindowStateNormal").SendClick();
+                var updatedInfo = GetWindowInfo();
+                Assert.Equal(info.FrameSize, updatedInfo.FrameSize);
+                Assert.Equal(info.Position, updatedInfo.Position);
+            }
+        }
+
         public static TheoryData<Size?, ShowWindowMode, WindowStartupLocation, bool> StartupLocationData()
         {
             var sizes = new Size?[] { null, new Size(400, 300) };
@@ -391,8 +429,8 @@ namespace Avalonia.IntegrationTests.Appium
         }
 
         private IDisposable OpenWindow(
-            Size? size,
-            ShowWindowMode mode,
+            Size? size = null,
+            ShowWindowMode mode = ShowWindowMode.NonOwned,
             WindowStartupLocation location = WindowStartupLocation.Manual,
             WindowState state = Controls.WindowState.Normal,
             bool canResize = true,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Our Window properties that rely on the window border/frame have inconsistent behavior on windows, esp. when compared to WPF. This pr ensures that the FrameSize and window Position doesn't change when decorations are changed, and client area is affected. Window Position and FrameSize now considers the whole window border, including the transparent border Windows apply to resizable windows. The following rules are enforced;
1. Updates to Position should not cause Frame Size to change
2. Updates to Width/Height should not cause Position to change
3. Updates to WindowState should ensure Frame properties of other states do not change
4. Updates to Decorations should not cause Frame properties of the current window state to change
    https://github.com/AvaloniaUI/Avalonia/issues/16529
    https://github.com/AvaloniaUI/Avalonia/issues/16454
5. PositionChanged event should report the Frame position
6. ExtendClient margins are calculated on updates to Window State
   https://github.com/AvaloniaUI/Avalonia/issues/16503

## What is the current behavior?
Window Position doesn't consider the transparent part of the border, only the visible part, which is usually just 1 pixel wide. This causes the window Position to change when client is extended to window frame, even though the window hasn't moved. This behavior also affects reported FrameSize, even though the window hasn't been resized. 
For normal windows with system decorations, setting system decorations to BorderOnly or None forces Frame to shrink to client area, instead of growing the client area like it is in WPF.


## What is the updated/expected behavior with this PR?
Window FrameSize and Position are only updated when there's a change in WindowState, when user updates Window.Position or when use resizes the window. They are kept unchanged when there's an update to ExtendedClient properties and SystemDecorations. FrameSize and Position will consider all parts of the window that the OS considers as part of the window decorations.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/16529
Fixes https://github.com/AvaloniaUI/Avalonia/issues/16454
Fixes https://github.com/AvaloniaUI/Avalonia/issues/16503
Fixes https://github.com/AvaloniaUI/Avalonia/issues/14604
Fixes https://github.com/AvaloniaUI/Avalonia/issues/11411