### PR TITLE
Android - Defer rendering till surface is created

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaActivity.cs
+++ b/src/Android/Avalonia.Android/AvaloniaActivity.cs
@@ -155,7 +155,7 @@ public class AvaloniaActivity : AppCompatActivity, IAvaloniaActivity
 
         base.OnDestroy();
     }
-        
+
     protected override void OnActivityResult(int requestCode, [GeneratedEnum] Result resultCode, Intent? data)
     {
         base.OnActivityResult(requestCode, resultCode, data);

--- a/src/Android/Avalonia.Android/AvaloniaMainActivity.cs
+++ b/src/Android/Avalonia.Android/AvaloniaMainActivity.cs
@@ -21,8 +21,8 @@ public class AvaloniaMainActivity : AvaloniaActivity
         {
             initialContent ??= Lifetime.MainView; 
 
-            Lifetime.Activity = this;
             _view = new AvaloniaView(this) { Content = initialContent };
+            Lifetime.Activity = this;
         }
         else
         {

--- a/src/Android/Avalonia.Android/AvaloniaView.cs
+++ b/src/Android/Avalonia.Android/AvaloniaView.cs
@@ -21,6 +21,7 @@ namespace Avalonia.Android
         private readonly ViewImpl _view;
 
         private IDisposable? _timerSubscription;
+        private bool _surfaceCreated;
 
         public AvaloniaView(Context context) : base(context)
         {
@@ -32,6 +33,18 @@ namespace Avalonia.Android
 
             this.SetBackgroundColor(global::Android.Graphics.Color.Transparent);
             OnConfigurationChanged();
+
+            _view.InternalView.SurfaceWindowCreated += InternalView_SurfaceWindowCreated;
+        }
+
+        private void InternalView_SurfaceWindowCreated(object? sender, EventArgs e)
+        {
+            _surfaceCreated = true;
+
+            if (Visibility == ViewStates.Visible)
+            {
+                OnVisibilityChanged(true);
+            }
         }
 
         internal TopLevelImpl TopLevelImpl => _view;
@@ -43,9 +56,10 @@ namespace Avalonia.Android
             set { _root.Content = value; }
         }
 
-        protected override void Dispose(bool disposing)
+        internal new void Dispose()
         {
-            base.Dispose(disposing);
+            OnVisibilityChanged(false);
+            _surfaceCreated = false;
             _root?.Dispose();
             _root = null!;
         }
@@ -70,6 +84,8 @@ namespace Avalonia.Android
 
         internal void OnVisibilityChanged(bool isVisible)
         {
+            if (_root == null || !_surfaceCreated)
+                return;
             if (isVisible && _timerSubscription == null)
             {
                 if (AvaloniaLocator.Current.GetService<IRenderTimer>() is ChoreographerTimer timer)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes https://github.com/AvaloniaUI/Avalonia/issues/16588 . For some reason, the Orientation and ScreenSize config change flags aren't being applied, even when set. This pr makes recreation of the activity safer, by deferring the start of the rendering session till after the view surface is created. This fixes issues where the app is started while the device is in a state where activities aren't visible, like in sleep/stand by, and when a config change forces the activity to be recreated, like in the linked pr.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/16588