### PR TITLE
Changed modifiers for injected non-client implementable method

### DIFF
--- a/nukebuild/RefAssemblyGenerator.cs
+++ b/nukebuild/RefAssemblyGenerator.cs
@@ -83,7 +83,8 @@ public class RefAssemblyGenerator
         {
             type.Methods.Add(new MethodDefinition(
                 "(This interface or abstract class is -not- implementable by user code !)",
-                MethodAttributes.Assembly
+                MethodAttributes.Public
+                | MethodAttributes.Virtual
                 | MethodAttributes.Abstract
                 | MethodAttributes.NewSlot
                 | MethodAttributes.HideBySig, type.Module.TypeSystem.Void));

--- a/nukebuild/RefAssemblyGenerator.cs
+++ b/nukebuild/RefAssemblyGenerator.cs
@@ -83,7 +83,7 @@ public class RefAssemblyGenerator
         {
             type.Methods.Add(new MethodDefinition(
                 "(This interface or abstract class is -not- implementable by user code !)",
-                MethodAttributes.Public
+                MethodAttributes.Assembly
                 | MethodAttributes.Virtual
                 | MethodAttributes.Abstract
                 | MethodAttributes.NewSlot


### PR DESCRIPTION
Apparently the current roslyn version no longer fails the build.

Checked with `BuildToNuGetCache`, test with CI packages before merging.