### PR TITLE
Switch to a HashSet<T> as backing for SafeEnumerableList

### DIFF
--- a/src/Avalonia.Base/Controls/Classes.cs
+++ b/src/Avalonia.Base/Controls/Classes.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Controls
     /// </remarks>
     public class Classes : AvaloniaList<string>, IPseudoClasses
     {
-        private SafeEnumerableList<IClassesChangedListener>? _listeners;
+        private SafeEnumerableHashSet<IClassesChangedListener>? _listeners;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Classes"/> class.

--- a/src/Avalonia.Base/Utilities/SafeEnumerableHashSet.cs
+++ b/src/Avalonia.Base/Utilities/SafeEnumerableHashSet.cs
@@ -5,12 +5,12 @@ using System.Collections.Generic;
 namespace Avalonia.Utilities
 {
     /// <summary>
-    /// Implements a simple list which is safe to modify during enumeration.
+    /// Implements a simple set which is safe to modify during enumeration.
     /// </summary>
     /// <typeparam name="T">The item type.</typeparam>
     /// <remarks>
-    /// Implements a list which, when written to while enumerating, performs a copy of the list
-    /// items. Note this this class doesn't actually implement <see cref="IList{T}"/> as it's not
+    /// Implements a set which, when written to while enumerating, performs a copy of the set
+    /// items. Note this class doesn't actually implement <see cref="ISet{T}"/> as it's not
     /// currently needed - feel free to add missing methods etc.
     /// </remarks>
     internal class SafeEnumerableHashSet<T> : IEnumerable<T>

--- a/tests/Avalonia.Controls.UnitTests/Utils/SafeEnumerableHashSetTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Utils/SafeEnumerableHashSetTests.cs
@@ -4,12 +4,12 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Utils
 {
-    public class SafeEnumerableListTests
+    public class SafeEnumerableHashSetTests
     {
         [Fact]
-        public void List_Is_Not_Copied_Outside_Enumeration()
+        public void Set_Is_Not_Copied_Outside_Enumeration()
         {
-            var target = new SafeEnumerableList<string>();
+            var target = new SafeEnumerableHashSet<string>();
             var inner = target.Inner;
 
             target.Add("foo");
@@ -20,9 +20,9 @@ namespace Avalonia.Controls.UnitTests.Utils
         }
 
         [Fact]
-        public void List_Is_Copied_Outside_Enumeration()
+        public void Set_Is_Copied_Outside_Enumeration()
         {
-            var target = new SafeEnumerableList<string>();
+            var target = new SafeEnumerableHashSet<string>();
             var inner = target.Inner;
 
             target.Add("foo");
@@ -43,13 +43,13 @@ namespace Avalonia.Controls.UnitTests.Utils
                 Assert.NotSame(inner, target.Inner);
             }
 
-            Assert.Equal(new[] { "foo", "bar", "baz", "baz" }, target);
+            Assert.Equal(new HashSet<string> { "foo", "bar", "baz", "baz" }, target);
         }
 
         [Fact]
-        public void List_Is_Not_Copied_After_Enumeration()
+        public void Set_Is_Not_Copied_After_Enumeration()
         {
-            var target = new SafeEnumerableList<string>();
+            var target = new SafeEnumerableHashSet<string>();
             var inner = target.Inner;
 
             target.Add("foo");
@@ -67,9 +67,9 @@ namespace Avalonia.Controls.UnitTests.Utils
         }
 
         [Fact]
-        public void List_Is_Copied_Only_Once_During_Enumeration()
+        public void Set_Is_Copied_Only_Once_During_Enumeration()
         {
-            var target = new SafeEnumerableList<string>();
+            var target = new SafeEnumerableHashSet<string>();
             var inner = target.Inner;
 
             target.Add("foo");
@@ -87,14 +87,14 @@ namespace Avalonia.Controls.UnitTests.Utils
         }
 
         [Fact]
-        public void List_Is_Copied_During_Nested_Enumerations()
+        public void Set_Is_Copied_During_Nested_Enumerations()
         {
-            var target = new SafeEnumerableList<string>();
+            var target = new SafeEnumerableHashSet<string>();
             var initialInner = target.Inner;
-            var firstItems = new List<string>();
-            var secondItems = new List<string>();
-            List<string> firstInner;
-            List<string> secondInner;
+            var firstItems = new HashSet<string>();
+            var secondItems = new HashSet<string>();
+            HashSet<string> firstInner;
+            HashSet<string> secondInner;
 
             target.Add("foo");
 
@@ -118,9 +118,9 @@ namespace Avalonia.Controls.UnitTests.Utils
                 firstItems.Add(i);
             }
 
-            Assert.Equal(new[] { "foo" }, firstItems);
-            Assert.Equal(new[] { "foo", "bar" }, secondItems);
-            Assert.Equal(new[] { "foo", "bar", "baz", "baz" }, target);
+            Assert.Equal(new HashSet<string> { "foo" }, firstItems);
+            Assert.Equal(new HashSet<string> { "foo", "bar" }, secondItems);
+            Assert.Equal(new HashSet<string> { "foo", "bar", "baz", "baz" }, target);
 
             var finalInner = target.Inner;
             target.Add("final");


### PR DESCRIPTION
## What does the pull request do?
Switches `SafeEnumerableList` to `SafeEnumerableSet`, in order to offer better performance on the `.Add` and `.Remove` methods

## What is the current behavior?
As the `Classes` class adds and removes listeners it stores them in a `SafeEnumerableList`. When listeners are removed they are removed from this list. However, since the backing store for this collection is a `List<T>` the `.Remove` method becomes a O(n) scan on the items. In our application we were seeing significant pauses in the application when the number of listeners grew rather large. In our case one of the lists had about 700 listeners, so the pauses became quite large.

In addition, if it is assumed that listeners that are added recently (like those deep in a tree) will be removed first, we can see another problem: the items we remove will most likely be at the end of the collection.

## What is the updated/expected behavior with this PR?
The backing store is now a HashSet. None of the public APIs have changed in behavior, although there may be slight differences in performance, similar to those expected from switching from a list to a hashset. 

## How was the solution implemented (if it's not obvious)?
Pretty much the same as the previous solution except for the following changes: 

* We can't do a `_list[idx]` inside the `Enumerable` class as HashSets don't support offset indexing. Instead when we create the enumerable we wrap the specialized .NET HashSet enumerator, and add our functionality to this method. This also means that we no longer need a few of the fields on `Enumerable`
* We have to clone the `HashSet` if it is modified during enumeration. This is supported via `new HashSet(_set)` which has an optimized fastpath in the .NET Constructor. It is true that cloning a hashset is slower than cloning an array, but it is assumed that the "modified while enumerating" usecases are rare. 

## Checklist

- [x] Added unit tests (if possible)?
  - Existing tests were updated
- [x] Added XML documentation to any related classes?
  - No classes added
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
  - Internal class, not required
