### PR TITLE
Only add the text selection canvas when the textbox is focused

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -462,6 +462,7 @@ namespace Avalonia.Controls.Presenters
         public void ShowCaret()
         {
             EnsureCaretTimer();
+            EnsureTextSelectionLayer();
             _caretBlink = true;
             _caretTimer?.Start();
             InvalidateVisual();
@@ -470,10 +471,7 @@ namespace Avalonia.Controls.Presenters
         public void HideCaret()
         {
             _caretBlink = false;
-            if (TextSelectionHandleCanvas != null)
-            {
-                TextSelectionHandleCanvas.ShowHandles = false;
-            }
+            RemoveTextSelectionCanvas();
             _caretTimer?.Stop();
             InvalidateVisual();
         }
@@ -908,8 +906,6 @@ namespace Avalonia.Controls.Presenters
             base.OnAttachedToVisualTree(e);
 
             ResetCaretTimer();
-
-            EnsureTextSelectionLayer();
         }
 
         private void EnsureTextSelectionLayer()
@@ -929,6 +925,17 @@ namespace Avalonia.Controls.Presenters
             }
             if (_layer != null && TextSelectionHandleCanvas.VisualParent != _layer)
                 _layer?.Add(TextSelectionHandleCanvas);
+        }
+
+        private void RemoveTextSelectionCanvas()
+        {
+            if(_layer != null && TextSelectionHandleCanvas is { } canvas)
+            {
+                canvas.SetPresenter(null);
+                _layer.Remove(canvas);
+            }
+
+            TextSelectionHandleCanvas = null;
         }
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)

--- a/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
+++ b/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
@@ -273,7 +273,6 @@ namespace Avalonia.Controls.Primitives
                 {
                     _textBox.AddHandler(TextBox.TextChangingEvent, TextChanged, handledEventsToo: true);
                     _textBox.AddHandler(KeyDownEvent, TextBoxKeyDown, handledEventsToo: true);
-                    _textBox.AddHandler(LostFocusEvent, TextBoxLostFocus, handledEventsToo: true);
                     _textBox.AddHandler(PointerReleasedEvent, TextBoxPointerReleased, handledEventsToo: true);
                     _textBox.AddHandler(Gestures.HoldingEvent, TextBoxHolding, handledEventsToo: true);
 
@@ -289,7 +288,6 @@ namespace Avalonia.Controls.Primitives
                     _textBox.RemoveHandler(TextBox.TextChangingEvent, TextChanged);
                     _textBox.RemoveHandler(KeyDownEvent, TextBoxKeyDown);
                     _textBox.RemoveHandler(PointerReleasedEvent, TextBoxPointerReleased);
-                    _textBox.RemoveHandler(LostFocusEvent, TextBoxLostFocus);
                     _textBox.RemoveHandler(Gestures.HoldingEvent, TextBoxHolding);
 
                     _textBox.PropertyChanged -= TextBoxPropertyChanged;
@@ -388,11 +386,6 @@ namespace Avalonia.Controls.Primitives
                 MoveHandlesToSelection();
                 EnsureVisible();
             }
-        }
-
-        private void TextBoxLostFocus(object? sender, RoutedEventArgs e)
-        {
-            ShowHandles = false;
         }
 
         private void TextBoxKeyDown(object? sender, KeyEventArgs e)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
TextSelectionCanvas will now only be created and added to the visual tree when its TextBox is focused, and be removed when unfocused.


## What is the current behavior?
TextSelectionCanvas is currently created when a textbox is shows, even when not active. This occurs for every textbox in the visual tree. Even if not visible, it add some layout overhead.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
