### PR TITLE
feat(XamlX): Trim text before invoke Color.Parse

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
@@ -172,6 +172,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
 
             if (type.Equals(types.Color))
             {
+                text = text.Trim();
                 if (!Color.TryParse(text, out Color color))
                 {
                     return ReturnOnParseError($"Unable to parse \"{text}\" as a color", out result);

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/AvaloniaIntrinsicsTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/AvaloniaIntrinsicsTests.cs
@@ -108,6 +108,24 @@ public class AvaloniaIntrinsicsTests : XamlTestBase
             Assert.Contains(contains, runtimeXamlDiagnostic.Title, StringComparison.OrdinalIgnoreCase);
         }
     }
+
+    /// <summary>
+    /// GitHub Issue <see href="https://github.com/AvaloniaUI/Avalonia/issues/15320">#15320</see>
+    /// </summary>
+    [Fact]
+    public void Should_Parse_Formatted_Color_Tag()
+    {
+        var target = AvaloniaRuntimeXamlLoader
+                .Parse<ResourceDictionary>($"""
+                                            <ResourceDictionary xmlns="https://github.com/avaloniaui"
+                                                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                                                <Color x:Key="ColorKey">
+                                                    White
+                                                </Color>
+                                            </ResourceDictionary>
+                                            """);
+        Assert.NotNull(target);
+    }
 }
 
 public class TestIntrinsicsControl : Control


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Trim text before invoke Color.Parse

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
If Color Tag contains one o more space the compiler throw `Error AVLN:0004 Avalonia: Unable to parse`

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #15320
