### PR TITLE
fix #12190, the name of FontFamily is null will cause crash

### DIFF
--- a/src/Avalonia.Base/Media/Typeface.cs
+++ b/src/Avalonia.Base/Media/Typeface.cs
@@ -48,7 +48,7 @@ namespace Avalonia.Media
             FontStyle style = FontStyle.Normal,
             FontWeight weight = FontWeight.Normal,
             FontStretch stretch = FontStretch.Normal)
-            : this(new FontFamily(fontFamilyName), style, weight, stretch)
+            : this(fontFamilyName == null ? FontFamily.Default : new FontFamily(fontFamilyName), style, weight, stretch)
         {
         }
 


### PR DESCRIPTION
## What does the pull request do?
This PR fix if the name of FontFamily is null when calling the constructor of FontFamily from Typeface, will cause the application crash.

## What is the current behavior?
When the name of FontFamily is null, use `FontFamily.Default` instead.

## What is the updated/expected behavior with this PR?
When the name of FontFamily is null, it can fallback to default family.


## How was the solution implemented (if it's not obvious)?
Add a null check ternary conditional operator



## Fixed issues
Fixes #12190
