### PR TITLE
11.2.x Private/PublicAPI adjustments

### DIFF
--- a/api/Avalonia.Skia.nupkg.xml
+++ b/api/Avalonia.Skia.nupkg.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>

--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -2,20 +2,38 @@
 <!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:Avalonia.Diagnostics.AppliedStyle</Target>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Diagnostics.AppliedStyle.get_HasActivator</Target>
     <Left>baseline/netstandard2.0/Avalonia.Base.dll</Left>
     <Right>target/netstandard2.0/Avalonia.Base.dll</Right>
   </Suppression>
   <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:Avalonia.Diagnostics.StyleDiagnostics</Target>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Diagnostics.AppliedStyle.get_IsActive</Target>
+    <Left>baseline/netstandard2.0/Avalonia.Base.dll</Left>
+    <Right>target/netstandard2.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Diagnostics.AppliedStyle.get_Style</Target>
     <Left>baseline/netstandard2.0/Avalonia.Base.dll</Left>
     <Right>target/netstandard2.0/Avalonia.Base.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Diagnostics.StyledElementExtensions.GetStyleDiagnostics(Avalonia.StyledElement)</Target>
+    <Left>baseline/netstandard2.0/Avalonia.Base.dll</Left>
+    <Right>target/netstandard2.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Diagnostics.StyleDiagnostics.#ctor(System.Collections.Generic.IReadOnlyList{Avalonia.Diagnostics.AppliedStyle})</Target>
+    <Left>baseline/netstandard2.0/Avalonia.Base.dll</Left>
+    <Right>target/netstandard2.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Diagnostics.StyleDiagnostics.get_AppliedStyles</Target>
     <Left>baseline/netstandard2.0/Avalonia.Base.dll</Left>
     <Right>target/netstandard2.0/Avalonia.Base.dll</Right>
   </Suppression>
@@ -54,6 +72,12 @@
     <Target>M:Avalonia.Controls.Primitives.IPopupHost.ConfigurePosition(Avalonia.Controls.Primitives.PopupPositioning.PopupPositionRequest)</Target>
     <Left>baseline/netstandard2.0/Avalonia.Controls.dll</Left>
     <Right>target/netstandard2.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0009</DiagnosticId>
+    <Target>T:Avalonia.Diagnostics.StyleDiagnostics</Target>
+    <Left>baseline/netstandard2.0/Avalonia.Base.dll</Left>
+    <Right>target/netstandard2.0/Avalonia.Base.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0009</DiagnosticId>

--- a/src/Avalonia.Base/Diagnostics/IValueFrameDiagnostic.cs
+++ b/src/Avalonia.Base/Diagnostics/IValueFrameDiagnostic.cs
@@ -4,9 +4,10 @@ using Avalonia.Metadata;
 
 namespace Avalonia.Diagnostics;
 
+[PrivateApi]
 public record ValueEntryDiagnostic(AvaloniaProperty Property, object? Value);
 
-[Unstable]
+[PrivateApi]
 [NotClientImplementable]
 public interface IValueFrameDiagnostic
 {

--- a/src/Avalonia.Base/Diagnostics/StyleDiagnostics.cs
+++ b/src/Avalonia.Base/Diagnostics/StyleDiagnostics.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Metadata;
+using Avalonia.Styling;
+
+namespace Avalonia.Diagnostics;
+
+[PrivateApi]
+[Unstable("Use StyledElementExtensions.GetValueStoreDiagnostic() instead")]
+public class StyleDiagnostics
+{
+    /// <summary>
+    /// Currently applied styles.
+    /// </summary>
+    public IReadOnlyList<AppliedStyle> AppliedStyles { get; }
+
+    public StyleDiagnostics(IReadOnlyList<AppliedStyle> appliedStyles)
+    {
+        AppliedStyles = appliedStyles;
+    }
+}
+
+[PrivateApi]
+[Unstable("Use StyledElementExtensions.GetValueStoreDiagnostic() instead")]
+public sealed class AppliedStyle
+{
+    private readonly StyleInstance _instance;
+
+    internal AppliedStyle(StyleInstance instance)
+    {
+        _instance = instance;
+    }
+
+    public bool HasActivator => _instance.HasActivator;
+    public bool IsActive => _instance.IsActive();
+    public StyleBase Style => (StyleBase)_instance.Source;
+}

--- a/src/Avalonia.Base/Diagnostics/StyleValueFrameDiagnostic.cs
+++ b/src/Avalonia.Base/Diagnostics/StyleValueFrameDiagnostic.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Avalonia.Data;
+using Avalonia.Metadata;
 using Avalonia.PropertyStore;
 using Avalonia.Styling;
 
@@ -60,4 +61,7 @@ internal class StyleValueFrameDiagnostic : IValueFrameDiagnostic
 
         return string.Concat(selectors);
     }
+
+    [Unstable("Compatibility with 11.x")]
+    public AppliedStyle AsAppliedStyle() => new AppliedStyle(_styleInstance);
 }

--- a/src/Avalonia.Base/Diagnostics/StyledElementExtensions.cs
+++ b/src/Avalonia.Base/Diagnostics/StyledElementExtensions.cs
@@ -1,8 +1,11 @@
-﻿namespace Avalonia.Diagnostics;
+using Avalonia.Metadata;
+
+namespace Avalonia.Diagnostics;
 
 /// <summary>
 /// Defines diagnostic extensions on <see cref="StyledElement"/>s.
 /// </summary>
+[PrivateApi]
 public static class StyledElementExtensions
 {
     /// <summary>

--- a/src/Avalonia.Base/Diagnostics/StyledElementExtensions.cs
+++ b/src/Avalonia.Base/Diagnostics/StyledElementExtensions.cs
@@ -1,4 +1,7 @@
+﻿using System;
+using System.Linq;
 using Avalonia.Metadata;
+using Avalonia.Styling;
 
 namespace Avalonia.Diagnostics;
 
@@ -16,4 +19,15 @@ public static class StyledElementExtensions
     {
         return styledElement.GetValueStore().GetStoreDiagnostic();
     }
+
+    [Obsolete("Use StyledElementExtensions.GetValueStoreDiagnostic instead", true)]
+    public static StyleDiagnostics GetStyleDiagnostics(this StyledElement styledElement)
+    {
+        var diagnostics = styledElement.GetValueStore().GetStoreDiagnostic();
+        return new StyleDiagnostics(diagnostics.AppliedFrames
+            .OfType<StyleValueFrameDiagnostic>()
+            .Select(f => f.AsAppliedStyle())
+            .ToArray());
+    }
 }
+

--- a/src/Avalonia.Base/Diagnostics/ValueStoreDiagnostic.cs
+++ b/src/Avalonia.Base/Diagnostics/ValueStoreDiagnostic.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
+using Avalonia.Metadata;
 using Avalonia.Styling;
 
 namespace Avalonia.Diagnostics;
 
+[PrivateApi]
 public class ValueStoreDiagnostic
 {
     /// <summary>

--- a/src/Avalonia.Base/Media/Fonts/Tables/InvalidFontTableException.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/InvalidFontTableException.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Media.Fonts.Tables
     /// Exception font loading can throw if it encounters invalid data during font loading.
     /// </summary>
     /// <seealso cref="Exception" />
-    public class InvalidFontTableException : Exception
+    internal class InvalidFontTableException : Exception
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="InvalidFontTableException"/> class.

--- a/src/Avalonia.Base/Media/Fonts/Tables/KnownNameIds.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/KnownNameIds.cs
@@ -8,7 +8,7 @@ namespace Avalonia.Media.Fonts.Tables
     /// Provides enumeration of common name ids
     /// <see href="https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-ids"/>
     /// </summary>
-    public enum KnownNameIds : ushort
+    internal enum KnownNameIds : ushort
     {
         /// <summary>
         /// The copyright notice

--- a/src/Avalonia.Base/Media/Fonts/Tables/MissingFontTableException.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/MissingFontTableException.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Media.Fonts.Tables
     /// Exception font loading can throw if it finds a required table is missing during font loading.
     /// </summary>
     /// <seealso cref="Exception" />
-    public class MissingFontTableException : Exception
+    internal class MissingFontTableException : Exception
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MissingFontTableException"/> class.

--- a/src/Browser/Avalonia.Browser/Rendering/RenderWorker.cs
+++ b/src/Browser/Avalonia.Browser/Rendering/RenderWorker.cs
@@ -10,7 +10,7 @@ using Avalonia.Browser.Interop;
 
 namespace Avalonia.Browser.Rendering;
 
-public partial class RenderWorker
+internal partial class RenderWorker
 {
     [DllImport("*")]
     private static extern int pthread_self();


### PR DESCRIPTION
See #16635

This PR removes couple of APIs that were added to the public surface by accident.
And avoids breaking change made in https://github.com/AvaloniaUI/Avalonia/pull/13802, as it might break third party dev tools. Old diagnostic API was still marked as a PrivateAPI, so no new app can use it, but old apps will still work.