### PR TITLE
TitleBar.Height setter crashes integrational tests app

### DIFF
--- a/src/Avalonia.Controls/Chrome/TitleBar.cs
+++ b/src/Avalonia.Controls/Chrome/TitleBar.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Controls.Chrome
 
             if (window.WindowState != WindowState.FullScreen)
             {
-                Height = window.WindowDecorationMargin.Top;
+                Height = Math.Max(0, window.WindowDecorationMargin.Top);
 
                 if (_captionButtons != null)
                 {


### PR DESCRIPTION
## What does the pull request do?

Integrational tests regression after https://github.com/AvaloniaUI/Avalonia/pull/15753
Margins can be negative, but Height cannot be anymore - this PR fixes TitleBar Height setter call.
It didn't crash before because TitleBar was changing this value once more later before layout pass. 