### PR TITLE
Fix SimpleTheme for TimePicker

### DIFF
--- a/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
@@ -24,9 +24,9 @@ namespace Avalonia.Controls
     [TemplatePart("PART_Popup",                   typeof(Popup))]
     [TemplatePart("PART_SecondColumnDivider",     typeof(Rectangle))]
     [TemplatePart("PART_SecondPickerHost",        typeof(Border))]
-    [TemplatePart("PART_ThirdColumnDivider",     typeof(Rectangle))]
-    [TemplatePart("PART_ThirdPickerHost",        typeof(Border))]
-    [TemplatePart("PART_FourthPickerHost",         typeof(Border))]
+    [TemplatePart("PART_ThirdColumnDivider",      typeof(Rectangle))]
+    [TemplatePart("PART_ThirdPickerHost",         typeof(Border))]
+    [TemplatePart("PART_FourthPickerHost",        typeof(Border))]
     [PseudoClasses(":hasnotime")]
     public class TimePicker : TemplatedControl
     {

--- a/src/Avalonia.Themes.Simple/Controls/TimePicker.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/TimePicker.xaml
@@ -173,12 +173,6 @@
                              FontSize="{TemplateBinding FontSize}"
                              FontWeight="{TemplateBinding FontWeight}" />
                 </Border>
-                
-                <Rectangle Name="PART_ThirdColumnDivider"
-                           Grid.Column="5"
-                           Width="{DynamicResource TimePickerSpacerThemeWidth}"
-                           HorizontalAlignment="Center"
-                           Fill="{DynamicResource TimePickerSpacerFill}" />
               </Grid>
             </Button>
 


### PR DESCRIPTION
## What does the pull request do?
Fixes #16743

## What is the current behaviour?
`TimePicker` crashes under the SimpleTheme

## What is the updated/expected behaviour with this PR?
`TimePicker` no longer crashes

## How was the solution implemented (if it's not obvious)?
Removes a duplicate part definition in `TimePicker`'s SimpleTheme control template

## Checklist

- [ ] Added unit tests (if possible)?
  - No added tests, but I'm happy to add additional tests with guidance
- [ ] Added XML documentation to any related classes?
  - No changes warranting documentation
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
_No breaking changes_

## Obsoletions / Deprecations
_No Obsoletions or Deprecations_

## Fixed issues
Fixes #16743
