### PR TITLE
Fix stuck internal macOS modifier keys

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.h
+++ b/native/Avalonia.Native/src/OSX/AvnView.h
@@ -18,6 +18,7 @@
 -(NSEvent* _Nonnull) lastMouseDownEvent;
 -(AvnPoint) translateLocalPoint:(AvnPoint)pt;
 -(void) onClosed;
+-(void) setModifiers:(NSEventModifierFlags)modifierFlags;
 
 -(AvnPlatformResizeReason) getResizeReason;
 -(void) setResizeReason:(AvnPlatformResizeReason)reason;

--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -480,6 +480,11 @@
     _parent->TopLevelEvents->RawKeyEvent(type, timestamp, modifiers, key, physicalKey, keySymbolUtf8);
 }
 
+- (void)setModifiers:(NSEventModifierFlags)modifierFlags
+{
+    _modifierState = [self getModifiers:modifierFlags];
+}
+
 - (void)flagsChanged:(NSEvent *)event
 {
     auto newModifierState = [self getModifiers:[event modifierFlags]];

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -298,7 +298,10 @@
 {
     if (_parent == nullptr)
         return;
-    
+
+    if (_parent->View != nullptr)
+        [_parent->View setModifiers:NSEvent.modifierFlags];
+
     _parent->BringToFront();
     
     dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the internal state of modifier keys that were getting stuck on macOS if the window lost the focus while a key was pressed. (Consequently, pressing the same modifier key again was ignored the first time.)

## How was the solution implemented (if it's not obvious)?
Internal modifiers are synchronized back when the window gets the focus.
