### PR TITLE
Reduced memory alloc for combined binding subjects

### DIFF
--- a/src/Avalonia.Base/Data/InstancedBinding.cs
+++ b/src/Avalonia.Base/Data/InstancedBinding.cs
@@ -155,7 +155,7 @@ namespace Avalonia.Data
             _ = observable ?? throw new ArgumentNullException(nameof(observable));
             _ = observer ?? throw new ArgumentNullException(nameof(observer));
 
-            var subject = new CombinedSubject<object?>(observer, observable);
+            var subject = observable == observer ? observable : new CombinedSubject<object?>(observer, observable);
             return new InstancedBinding(subject, BindingMode.TwoWay, priority);
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Removes one allocation and additional virtual calls caused by needles creation of `CombinedSubject<T>` when both the observer and the observable are the same object.


## What is the current behavior?

Always create a wrapper.


## What is the updated/expected behavior with this PR?

No behavior change at all.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
