### PR TITLE
Prevent .NET from randomly calling WndProc in RequestCompositionBatchCommitAsync

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Compositor.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Compositor.cs
@@ -108,6 +108,7 @@ namespace Avalonia.Rendering.Composition
             Dispatcher.VerifyAccess();
             if (_nextCommit == null)
             {
+                using var _ = NonPumpingLockHelper.Use();
                 _nextCommit = new ();
                 var pending = _pendingBatch;
                 if (pending != null)


### PR DESCRIPTION
This method isn't reentrancy-friendly and that less-than-stellar way of dealing with COM objects in .NET is causing [this to happen](https://github.com/AvaloniaUI/Avalonia/issues/15226#issuecomment-2282825475)

This happens only on windows and only due to .NET locks being defective on STA threads, which is why it was hard to catch.

Should fix https://github.com/AvaloniaUI/Avalonia/issues/15226

Thanks [arnirichard](https://github.com/arnirichard) for the stack trace which made it obvious