### PR TITLE
Added `Binding.Delay` feature

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindingExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindingExtension.cs
@@ -26,6 +26,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
             return new CompiledBindingExtension
             {
                 Path = Path,
+                Delay = Delay,
                 Converter = Converter,
                 ConverterCulture = ConverterCulture,
                 ConverterParameter = ConverterParameter,
@@ -92,6 +93,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
                 source,
                 nodes,
                 FallbackValue,
+                delay: TimeSpan.FromMilliseconds(Delay),
                 converter: Converter,
                 converterParameter: ConverterParameter,
                 targetNullValue: TargetNullValue);
@@ -125,6 +127,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
                 source,
                 nodes,
                 FallbackValue,
+                delay: TimeSpan.FromMilliseconds(Delay),
                 converter: Converter,
                 converterCulture: ConverterCulture,
                 converterParameter: ConverterParameter,

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ReflectionBindingExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ReflectionBindingExtension.cs
@@ -33,6 +33,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
                 Mode = Mode,
                 Path = Path,
                 Priority = Priority,
+                Delay = Delay,
                 Source = Source,
                 StringFormat = StringFormat,
                 RelativeSource = RelativeSource,
@@ -42,6 +43,9 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
                 UpdateSourceTrigger = UpdateSourceTrigger,
             };
         }
+
+        /// <inheritdoc cref="BindingBase.Delay"/>
+        public int Delay { get; set; }
 
         public IValueConverter? Converter { get; set; }
 

--- a/src/Markup/Avalonia.Markup/Data/Binding.cs
+++ b/src/Markup/Avalonia.Markup/Data/Binding.cs
@@ -120,6 +120,7 @@ namespace Avalonia.Data
                 source,
                 nodes,
                 FallbackValue,
+                delay: TimeSpan.FromMilliseconds(Delay),
                 converter: Converter,
                 converterParameter: ConverterParameter,
                 targetNullValue: TargetNullValue);
@@ -168,6 +169,7 @@ namespace Avalonia.Data
                 source,
                 nodes,
                 FallbackValue,
+                delay: TimeSpan.FromMilliseconds(Delay),
                 converter: Converter,
                 converterCulture: ConverterCulture,
                 converterParameter: ConverterParameter,

--- a/src/Markup/Avalonia.Markup/Data/BindingBase.cs
+++ b/src/Markup/Avalonia.Markup/Data/BindingBase.cs
@@ -31,6 +31,17 @@ namespace Avalonia.Data
         }
 
         /// <summary>
+        /// Gets or sets the amount of time, in milliseconds, to wait before updating the binding 
+        /// source after the value on the target changes.
+        /// </summary>
+        /// <remarks>
+        /// There is no delay when the source is updated via <see cref="UpdateSourceTrigger.LostFocus"/> 
+        /// or <see cref="BindingExpressionBase.UpdateSource"/>. Nor is there a delay when 
+        /// <see cref="BindingMode.OneWayToSource"/> is active and a new source object is provided.
+        /// </remarks>
+        public int Delay { get; set; }
+
+        /// <summary>
         /// Gets or sets the <see cref="IValueConverter"/> to use.
         /// </summary>
         public IValueConverter? Converter { get; set; }

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Delay.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Delay.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.UnitTests;
+using Xunit;
+
+#nullable enable
+
+namespace Avalonia.Markup.UnitTests.Data;
+
+public class BindingTests_Delay : IDisposable
+{
+    private const int DelayMilliseconds = 10;
+    private const string InitialFooValue = "foo";
+
+    private readonly ManualTimerDispatcher _dispatcher;
+    private readonly IDisposable _app;
+    private readonly BindingTests.Source _source;
+    private readonly TextBox _target;
+    private readonly Binding _binding;
+    private readonly BindingExpressionBase _bindingExpr;
+    
+    public BindingTests_Delay()
+    {
+        _dispatcher = new ManualTimerDispatcher();
+        _app = UnitTestApplication.Start(new(dispatcherImpl: _dispatcher, focusManager: new FocusManager(), keyboardDevice: () => new KeyboardDevice()));
+
+        _source = new BindingTests.Source { Foo = InitialFooValue };
+        _target = new TextBox { DataContext = _source };
+        _binding = new Binding(nameof(_source.Foo), BindingMode.TwoWay) { Delay = DelayMilliseconds };
+
+        _bindingExpr = _target.Bind(TextBox.TextProperty, _binding);
+
+        Assert.Equal(_source.Foo, _target.Text);
+    }
+
+    public void Dispose()
+    {
+        _app.Dispose();
+    }
+
+    [Fact]
+    public void Delayed_Binding_Should_Set_Value_Only_After_Delay_Elapsed()
+    {
+        _target.Text = "bar";
+        Assert.Equal(InitialFooValue, _source.Foo);
+
+        SetTimeAndExecuteTimers(DelayMilliseconds / 2);
+        Assert.Equal(InitialFooValue, _source.Foo);
+
+        SetTimeAndExecuteTimers(DelayMilliseconds + 1);
+
+        Assert.Equal("bar", _source.Foo);
+    }
+
+    [Fact]
+    public void Delayed_Binding_Should_Not_Set_Value_After_Being_Disposed()
+    {
+        _target.Text = "bar";
+        Assert.Equal(InitialFooValue, _source.Foo);
+
+        _bindingExpr.Dispose();
+
+        SetTimeAndExecuteTimers(DelayMilliseconds + 1);
+
+        Assert.Equal(InitialFooValue, _source.Foo);
+    }
+
+    [Fact]
+    public void Delayed_Binding_Should_Restart_If_Value_Changes_During_Delay()
+    {
+        _target.Text = "bar";
+        Assert.Equal(InitialFooValue, _source.Foo);
+
+        SetTimeAndExecuteTimers(DelayMilliseconds / 2);
+
+        _target.Text = "baz";
+
+        SetTimeAndExecuteTimers(DelayMilliseconds + 1); // we set a new value half-way through the delay, so the delay is still in effect at this timestamp
+
+        Assert.Equal(InitialFooValue, _source.Foo);
+
+        SetTimeAndExecuteTimers(DelayMilliseconds * 2);
+
+        Assert.Equal("baz", _source.Foo);
+    }
+
+    [Fact]
+    public void Delayed_Binding_Should_Not_Execute_If_Value_Returns_To_Original()
+    {
+        _target.Text = "bar";
+        Assert.Equal(InitialFooValue, _source.Foo);
+
+        SetTimeAndExecuteTimers(DelayMilliseconds / 2);
+
+        _target.Text = InitialFooValue;
+
+        SetTimeAndExecuteTimers(DelayMilliseconds * 2);
+
+        Assert.Equal(InitialFooValue, _source.Foo);
+        Assert.Equal(1, _source.FooSetCount);
+    }
+
+    [Fact]
+    public void Delayed_Binding_UpdateSource_Call_Should_Update_Source_Immediately()
+    {
+        _target.Text = "bar";
+        _bindingExpr.UpdateSource();
+
+        Assert.Equal("bar", _source.Foo);
+    }
+
+    [Fact]
+    public void Delayed_Binding_UpdateTrigger_LostFocus_Should_Update_Source_Immediately()
+    {
+        var secondBox = new TextBox();
+
+        new TestRoot() { Child = new Panel() { Children = { _target, secondBox } } };
+
+        _target.Bind(TextBox.TextProperty, new Binding(nameof(_source.Foo), BindingMode.TwoWay) { Delay = DelayMilliseconds, UpdateSourceTrigger = UpdateSourceTrigger.LostFocus });
+
+        Assert.True(_target.Focus());
+        _target.Text = "bar";
+
+        Assert.Equal(InitialFooValue, _source.Foo);
+
+        Assert.True(secondBox.Focus());
+        Assert.Equal("bar", _source.Foo);
+    }
+
+    [Fact]
+    public void Delayed_Binding_OneWayToSource_DataContext_Change_Should_Update_Source_Immediately()
+    {
+        _target.Bind(TextBlock.TextProperty, new Binding(nameof(_source.Foo), BindingMode.OneWayToSource) { Delay = DelayMilliseconds });
+
+        _target.Text = "bar";
+
+        var newSource = new BindingTests.Source();
+
+        _target.DataContext = newSource;
+
+        Assert.Equal("bar", newSource.Foo);
+    }
+
+    [Fact]
+    public void Delayed_Binding_Should_Update_Target_Immediately()
+    {
+        _source.Foo = "bar";
+        Assert.Equal("bar", _target.Text);
+    }
+
+    private void SetTimeAndExecuteTimers(long time)
+    {
+        _dispatcher.Now = time;
+        _dispatcher.RaiseTimerEvent();
+    }
+
+    private class ManualTimerDispatcher : IDispatcherImpl
+    {
+        public bool CurrentThreadIsLoopThread => true;
+        public long Now { get; set; }
+
+        public event Action? Signaled;
+        public event Action? Timer;
+
+        public void Signal() { Signaled?.Invoke(); }
+
+        public void UpdateTimer(long? dueTimeInMs) { }
+
+        public void RaiseTimerEvent() => Timer?.Invoke();
+    }
+}


### PR DESCRIPTION
Updates to binding sources can now be delayed by configuring each binding.

## What is the updated/expected behavior with this PR?
The delay feature works in the same way as WPF's. When the target property is changed, a `DispatcherTimer` is started (or restarted) and the source is only updated when the timer elapses.

As with WPF, there is no delay when the source is updated via `UpdateSourceTrigger.LostFocus` or `BindingExpressionBase.UpdateSource()`. Nor is there a delay when `BindingMode.OneWayToSource` is active and a new source object is provided.

### Other binding types
`MultiBinding` does not support writing back to the source, so does not have a `Delay` property.

`TemplateBinding` could support `Delay` but I didn't implement it there. WPF's equivalent type doesn't have it, and I also don't see a use case within the context of a `ControlTemplate`.

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #7380