### PR TITLE
Fix --no-build publishing when axaml compiler is used

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -160,7 +160,7 @@
       AnalyzerConfigFiles="@(EditorConfigFiles)"/>
   </Target>
   
-  <Target Name="InjectAvaloniaXamlOutput" DependsOnTargets="PrepareToCompileAvaloniaXaml" AfterTargets="CompileAvaloniaXaml" BeforeTargets="CopyFilesToOutputDirectory;BuiltProjectOutputGroup"
+  <Target Name="InjectAvaloniaXamlOutput" DependsOnTargets="PrepareToCompileAvaloniaXaml" AfterTargets="CompileAvaloniaXaml" BeforeTargets="CopyFilesToOutputDirectory;BuiltProjectOutputGroup;ComputeResolvedFilesToPublishList"
           Condition="'@(AvaloniaResource)@(AvaloniaXaml)' != '' AND $(EnableAvaloniaXamlCompilation) != false">
     <ItemGroup>
       <_AvaloniaXamlCompiledAssembly Include="@(IntermediateAssembly->Metadata('AvaloniaCompileOutput'))"/>


### PR DESCRIPTION
## What does the pull request do?
Fixes `dotnet publish --no-build` when axaml compiler is used.

## What is the current behavior?
The original assembly before axaml compilation is copied resulting in the following crash:
`Unhandled exception. Avalonia.Markup.Xaml.XamlLoadException: No precompiled XAML found for AvaloniaApplication1.App, make sure to specify x:Class and include your XAML file as AvaloniaResource`

## What is the updated/expected behavior with this PR?
The proper assembly is copied over, and the application starts correctly.

## How was the solution implemented (if it's not obvious)?
I've used `ComputeResolvedFilesToPublishList`  because that's where `IntermediateAssembly` and `_DebugSymbolsIntermediatePath` are processed.
~~An alternative solution is prepending `InjectAvaloniaXamlOutput` to `PublishItemsOutputGroupDependsOn`~~ Turns out even that won't work because `ComputeAndCopyFilesToPublishDirectory` would end up calling `ComputeResolvedFilesToPublishList` before `PublishItemsOutputGroup`.
Adding `PublishItemsOutputGroup` to `InjectAvaloniaXamlOutput`'s `BeforeTargets` won't work because it will run after `ComputeResolvedFilesToPublishList`.

### Repro
`rm -rf bin obj && dotnet build -c Release && dotnet publish --no-build && ./bin/Release/net8.0/publish/AvaloniaApplication1`