### PR TITLE
Fix an issue that DirtyRects are full region every frame.

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -80,7 +80,6 @@ namespace Avalonia.Rendering.Composition.Server
         partial void DeserializeChangesExtra(BatchStreamReader c)
         {
             _redrawRequested = true;
-            _fullRedrawRequested = true;
         }
 
         public void Render()


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

This PR #14924 add a field `_fullRedrawRequested` to force the dirty rects to be ignored and redraw the whole window. After that, the rendering performance becomes poor. By the test on my machine, the fps drops from 45 to 30.

I can't figure out why this field is introduced. There is no description about this field in the PR !14924 nor in the comments. So I'm trying to remove the assignment and fix the dirty rects.

The previous PR:

- https://github.com/AvaloniaUI/Avalonia/pull/14924

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

See this video below to view the dirty rect changes before and after this PR.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

[!The Comparing Video](https://github.com/user-attachments/assets/c4e1c962-dcb0-493e-8c30-6f62e58e9070)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Remove the assignment of the `_fullRedrawRequested` field.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

To be discussed.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
