### PR TITLE
Use the himetric location instead of the pixel location.

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -112,7 +112,7 @@ namespace Avalonia.Win32.Interop
             /// </summary>
             Hide = 0,
             /// <summary>
-            /// Activates and displays a window. If the window is minimized, maximized, or arranged, the system restores it to its original 
+            /// Activates and displays a window. If the window is minimized, maximized, or arranged, the system restores it to its original
             /// size and position. An application should specify this flag when displaying the window for the first time.
             /// </summary>
             Normal = 1,
@@ -147,12 +147,12 @@ namespace Avalonia.Win32.Interop
             /// </summary>
             ShowNA = 8,
             /// <summary>
-            /// Activates and displays the window. If the window is minimized, maximized, or arranged, the system restores it to its original size and position. 
+            /// Activates and displays the window. If the window is minimized, maximized, or arranged, the system restores it to its original size and position.
             /// An application should specify this flag when restoring a minimized window.
             /// </summary>
             Restore = 9,
             /// <summary>
-            /// Sets the show state based on the <see cref="ShowWindowCommand"/> value specified in the STARTUPINFO structure passed to the CreateProcess function 
+            /// Sets the show state based on the <see cref="ShowWindowCommand"/> value specified in the STARTUPINFO structure passed to the CreateProcess function
             /// by the program that started the application.
             /// </summary>
             ShowDefault = 10,
@@ -1174,6 +1174,9 @@ namespace Avalonia.Win32.Interop
         public static extern bool GetPointerTouchInfo(uint pointerId, out POINTER_TOUCH_INFO touchInfo);
 
         [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool GetPointerDeviceRects(IntPtr device, out RECT pointerDeviceRect, out RECT displayRect);
+
+        [DllImport("user32.dll", SetLastError = true)]
         public static extern bool GetPointerTouchInfoHistory(uint pointerId, ref int entriesCount, [MarshalAs(UnmanagedType.LPArray), In, Out] POINTER_TOUCH_INFO[] touchInfos);
 
         [DllImport("user32.dll", SetLastError = true)]
@@ -1221,12 +1224,12 @@ namespace Avalonia.Win32.Interop
 
         [DllImport("user32.dll", EntryPoint = "DefWindowProcW")]
         public static extern IntPtr DefWindowProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
-        
+
         public const int SC_MOUSEMOVE = 0xf012;
- 
+
         [DllImport("user32.dll", CharSet = CharSet.Unicode, EntryPoint = "SendMessageW")]
         public static extern IntPtr SendMessage(IntPtr hWnd, int Msg, IntPtr wParam, IntPtr lParam);
-        
+
         [DllImport("user32.dll", EntryPoint = "DispatchMessageW")]
         public static extern IntPtr DispatchMessage(ref MSG lpmsg);
 
@@ -1534,7 +1537,7 @@ namespace Avalonia.Win32.Interop
 
         [DllImport("user32.dll", EntryPoint = "SetCursor")]
         internal static extern IntPtr SetCursor(IntPtr hCursor);
-        
+
         [DllImport("ole32.dll", PreserveSig = true)]
         internal static extern int CoCreateInstance(in Guid clsid,
             IntPtr ignore1, int ignore2, in Guid iid, [Out] out IntPtr pUnkOuter);
@@ -2176,7 +2179,7 @@ namespace Avalonia.Win32.Interop
             /// </summary>
             CF_UNICODETEXT = 13,
             /// <summary>
-            /// A handle to type HDROP that identifies a list of files. 
+            /// A handle to type HDROP that identifies a list of files.
             /// </summary>
             CF_HDROP = 15,
         }

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -1207,8 +1207,8 @@ namespace Avalonia.Win32
         {
             GetPointerDeviceRects(info.sourceDevice, out var pointerDeviceRect, out var displayRect);
             var himetricLocation = new Point(
-                info.ptHimetricLocationX * displayRect.Width / (double)pointerDeviceRect.Width,
-                info.ptHimetricLocationY * displayRect.Height / (double)pointerDeviceRect.Height);
+                info.ptHimetricLocationRawX * displayRect.Width / (double)pointerDeviceRect.Width,
+                info.ptHimetricLocationRawY * displayRect.Height / (double)pointerDeviceRect.Height);
             return himetricLocation;
         }
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -176,7 +176,7 @@ namespace Avalonia.Win32
                     {
                         requestDpi = _dpi;
                     }
-                                        
+
                     return LoadIcon(requestIcon, requestDpi)?.Handle ?? default;
 
                 case WindowsMessage.WM_KEYDOWN:
@@ -778,7 +778,7 @@ namespace Avalonia.Win32
                     {
                         LostFocus?.Invoke();
                     }
-                   
+
                     break;
 
                 case WindowsMessage.WM_INPUTLANGCHANGE:
@@ -1095,8 +1095,11 @@ namespace Avalonia.Win32
         }
         private RawPointerPoint CreateRawPointerPoint(POINTER_TOUCH_INFO info)
         {
-            var pointerInfo = info.pointerInfo;
-            var point = PointToClient(new PixelPoint(pointerInfo.ptPixelLocationX, pointerInfo.ptPixelLocationY));
+            GetPointerDeviceRects(info.pointerInfo.sourceDevice, out var pointerDeviceRect, out var displayRect);
+            var himetricLocation = new Point(
+                info.pointerInfo.ptHimetricLocationX * displayRect.Width / (double)pointerDeviceRect.Width,
+                info.pointerInfo.ptHimetricLocationY * displayRect.Height / (double)pointerDeviceRect.Height);
+            var point = PointToClient(himetricLocation);
 
             var pointerPoint = new RawPointerPoint
             {

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -1096,9 +1096,10 @@ namespace Avalonia.Win32
         private RawPointerPoint CreateRawPointerPoint(POINTER_TOUCH_INFO info)
         {
             GetPointerDeviceRects(info.pointerInfo.sourceDevice, out var pointerDeviceRect, out var displayRect);
+            var pointerInfo = info.pointerInfo;
             var himetricLocation = new Point(
-                info.pointerInfo.ptHimetricLocationX * displayRect.Width / (double)pointerDeviceRect.Width,
-                info.pointerInfo.ptHimetricLocationY * displayRect.Height / (double)pointerDeviceRect.Height);
+                pointerInfo.ptHimetricLocationX * displayRect.Width / (double)pointerDeviceRect.Width,
+                pointerInfo.ptHimetricLocationY * displayRect.Height / (double)pointerDeviceRect.Height);
             var point = PointToClient(himetricLocation);
 
             var pointerPoint = new RawPointerPoint
@@ -1132,8 +1133,12 @@ namespace Avalonia.Win32
         }
         private RawPointerPoint CreateRawPointerPoint(POINTER_PEN_INFO info)
         {
+            GetPointerDeviceRects(info.pointerInfo.sourceDevice, out var pointerDeviceRect, out var displayRect);
             var pointerInfo = info.pointerInfo;
-            var point = PointToClient(new PixelPoint(pointerInfo.ptPixelLocationX, pointerInfo.ptPixelLocationY));
+            var himetricLocation = new Point(
+                pointerInfo.ptHimetricLocationX * displayRect.Width / (double)pointerDeviceRect.Width,
+                pointerInfo.ptHimetricLocationY * displayRect.Height / (double)pointerDeviceRect.Height);
+            var point = PointToClient(himetricLocation);
             return new RawPointerPoint
             {
                 Position = point,

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -1207,8 +1207,8 @@ namespace Avalonia.Win32
         {
             GetPointerDeviceRects(info.sourceDevice, out var pointerDeviceRect, out var displayRect);
             var himetricLocation = new Point(
-                info.ptHimetricLocationRawX * displayRect.Width / (double)pointerDeviceRect.Width,
-                info.ptHimetricLocationRawY * displayRect.Height / (double)pointerDeviceRect.Height);
+                info.ptHimetricLocationRawX * displayRect.Width / (double)pointerDeviceRect.Width + displayRect.left,
+                info.ptHimetricLocationRawY * displayRect.Height / (double)pointerDeviceRect.Height + displayRect.top);
             return himetricLocation;
         }
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -1095,11 +1095,7 @@ namespace Avalonia.Win32
         }
         private RawPointerPoint CreateRawPointerPoint(POINTER_TOUCH_INFO info)
         {
-            GetPointerDeviceRects(info.pointerInfo.sourceDevice, out var pointerDeviceRect, out var displayRect);
-            var pointerInfo = info.pointerInfo;
-            var himetricLocation = new Point(
-                pointerInfo.ptHimetricLocationX * displayRect.Width / (double)pointerDeviceRect.Width,
-                pointerInfo.ptHimetricLocationY * displayRect.Height / (double)pointerDeviceRect.Height);
+            var himetricLocation = GetHimetricLocation(info.pointerInfo);
             var point = PointToClient(himetricLocation);
 
             var pointerPoint = new RawPointerPoint
@@ -1133,11 +1129,7 @@ namespace Avalonia.Win32
         }
         private RawPointerPoint CreateRawPointerPoint(POINTER_PEN_INFO info)
         {
-            GetPointerDeviceRects(info.pointerInfo.sourceDevice, out var pointerDeviceRect, out var displayRect);
-            var pointerInfo = info.pointerInfo;
-            var himetricLocation = new Point(
-                pointerInfo.ptHimetricLocationX * displayRect.Width / (double)pointerDeviceRect.Width,
-                pointerInfo.ptHimetricLocationY * displayRect.Height / (double)pointerDeviceRect.Height);
+            var himetricLocation = GetHimetricLocation(info.pointerInfo);
             var point = PointToClient(himetricLocation);
             return new RawPointerPoint
             {
@@ -1204,6 +1196,20 @@ namespace Avalonia.Win32
             _langid = langid;
 
             Imm32InputMethod.Current.SetLanguageAndWindow(this, Hwnd, hkl);
+        }
+
+        /// <summary>
+        /// Get the location of the pointer in himetric units.
+        /// </summary>
+        /// <param name="info">The pointer info.</param>
+        /// <returns>The location of the pointer in himetric units.</returns>
+        private Point GetHimetricLocation(POINTER_INFO info)
+        {
+            GetPointerDeviceRects(info.sourceDevice, out var pointerDeviceRect, out var displayRect);
+            var himetricLocation = new Point(
+                info.ptHimetricLocationX * displayRect.Width / (double)pointerDeviceRect.Width,
+                info.ptHimetricLocationY * displayRect.Height / (double)pointerDeviceRect.Height);
+            return himetricLocation;
         }
 
         private static int ToInt32(IntPtr ptr)

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -454,7 +454,7 @@ namespace Avalonia.Win32
         {
             SetUseHostBackdropBrush(false);
             SetLegacyTransparency(false);
-            
+
             CompositionEffectsSurface!.SetBlur(_currentThemeVariant switch
             {
                 PlatformThemeVariant.Light => BlurEffect.MicaLight,
@@ -468,7 +468,7 @@ namespace Avalonia.Win32
         {
             if (Win32Platform.WindowsVersion < PlatformConstants.Windows8 || !UseRedirectionBitmap)
                 return false;
-            
+
             // On pre-Win8 this method was blurring a window, which is a different from desired behavior.
             // On win8+ we use this method as a fallback, when WinUI/DComp composition with true transparency isn't available.
             // Note: there is no guarantee that this behavior won't be changed back to true blur in Win12.
@@ -496,7 +496,7 @@ namespace Avalonia.Win32
 
             // AcrylicBlur requires window to set DWMWA_USE_HOSTBACKDROPBRUSH flag on Win11+.
             // It's not necessary on older versions and it's not necessary with Mica brush.
-            
+
             var pvUseBackdropBrush = useHostBackdropBrush ? 1 : 0;
             var result = DwmSetWindowAttribute(_hwnd, (int)DwmWindowAttribute.DWMWA_USE_HOSTBACKDROPBRUSH, &pvUseBackdropBrush, sizeof(int));
             return result == 0;
@@ -657,11 +657,30 @@ namespace Avalonia.Win32
             InvalidateRect(_hwnd, ref r, false);
         }
 
+        /// <summary>
+        /// Transform a screen pixel point to the point in the client area.<br/>
+        /// To transform a point with precise value, use the <see cref="PointToClient(Point)"/> overload instead.
+        /// </summary>
+        /// <param name="point">The screen pixel point to be transformed.</param>
+        /// <returns>The point in the client area.</returns>
         public Point PointToClient(PixelPoint point)
         {
             var p = new POINT { X = point.X, Y = point.Y };
             ScreenToClient(_hwnd, ref p);
             return new Point(p.X, p.Y) / RenderScaling;
+        }
+
+        /// <summary>
+        /// Transform a screen point to the point in the client area.<br/>
+        /// Comparing to the <see cref="PixelPoint"/> overload, this method receives double values and can be more precise.
+        /// </summary>
+        /// <param name="point">The screen point to be transformed.</param>
+        /// <returns>The point in the client area.</returns>
+        public Point PointToClient(Point point)
+        {
+            var p = new POINT { X = 0, Y = 0 };
+            ClientToScreen(_hwnd, ref p);
+            return new Point(point.X - p.X, point.Y - p.Y) / RenderScaling;
         }
 
         public PixelPoint PointToScreen(Point point)
@@ -960,7 +979,7 @@ namespace Avalonia.Win32
 
             Handle = new WindowImplPlatformHandle(this);
 
-            RegisterTouchWindow(_hwnd, 0);
+                RegisterTouchWindow(_hwnd, 0);
 
             if (ShCoreAvailable && Win32Platform.WindowsVersion >= PlatformConstants.Windows8_1)
             {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

This PR uses the `ptHimetricLocation` in the `POINTER_INFO` struct instead of the `ptPixelLocation` which makes the touch pointer more accurate.

As a result, if we draw all the touch points line-by-line, the path will be more smooth and accurate. See the following image for the comparison:

![The Comparison of the drawn path](https://github.com/user-attachments/assets/bd3a0d5f-57bf-41ca-853c-96d4f6c8e5de)

The following is a sample output of the touch points with the `ptPixelLocation` and `ptHimetricLocation`:

```
Pixel=2770, 1189 Himetric=2770.320129847705, 1189.298228010676
Pixel=2768, 1185 Himetric=2767.756328348931, 1185.3536954907588
Pixel=2765, 1181 Himetric=2765.1483233760405, 1181.23577692601
Pixel=2762, 1178 Himetric=2762.4519114549157, 1177.507976962132
Pixel=2760, 1174 Himetric=2759.5344821632075, 1173.780176998254
Pixel=2757, 1170 Himetric=2756.6170528714993, 1170.2257630792078
Pixel=2754, 1167 Himetric=2753.655420105674, 1166.6713491601613
Pixel=2751, 1163 Himetric=2750.605380391615, 1163.2036282635308
Pixel=2747, 1160 Himetric=2747.4669337293226, 1159.9092934117316
Pixel=2744, 1157 Himetric=2744.416894015264, 1156.6583050711404
```

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

1. The touch point use the `ptPixelLocation` which is an integer value.
1. The `PointToClient` method only receives `PixelPoint` parameter which loses the decimal part of the touch point.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

1. The touch point uses the `ptHimetricLocation` which is a float value.
1. The `PointToClient` method receives `Point` parameter which keeps the decimal part of the touch point. I've written a new overload for the existed one.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

I think there is no breaking changes.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

