### PR TITLE
Vulkan - Fix display surface lost error

### DIFF
--- a/src/Avalonia.Vulkan/VulkanKhrSurfaceRenderTarget.cs
+++ b/src/Avalonia.Vulkan/VulkanKhrSurfaceRenderTarget.cs
@@ -7,7 +7,6 @@ namespace Avalonia.Vulkan;
 
 internal class VulkanKhrRenderTarget : IVulkanRenderTarget
 {
-    private VulkanKhrSurface _khrSurface;
     private readonly IVulkanPlatformGraphicsContext _context;
     private VulkanDisplay _display;
     private VulkanImage? _image;
@@ -18,8 +17,7 @@ internal class VulkanKhrRenderTarget : IVulkanRenderTarget
     public VulkanKhrRenderTarget(IVulkanKhrSurfacePlatformSurface surface, IVulkanPlatformGraphicsContext context)
     {
         _platformSurface = surface;
-        _khrSurface = new(context, surface);
-        _display = VulkanDisplay.CreateDisplay(context, _khrSurface);
+        _display = VulkanDisplay.CreateDisplay(context, surface);
         _context = context;
         IsRgba = _display.SurfaceFormat.format >= VkFormat.VK_FORMAT_R8G8B8A8_UNORM &&
                  _display.SurfaceFormat.format <= VkFormat.VK_FORMAT_R8G8B8A8_SRGB;
@@ -46,8 +44,6 @@ internal class VulkanKhrRenderTarget : IVulkanRenderTarget
         DestroyImage();
         _display?.Dispose();
         _display = null!;
-        _khrSurface?.Dispose();
-        _khrSurface = null!;
     }
 
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fix vulkan rendering issue when a vulkan surface is destroyed while the application is still running. This is done by disposing the old surface and recreating it and the swapchain.


## What is the current behavior?
When a window is no longer valid for a vulkan surface, vulkan throws a VK_ERROR_SURFACE_LOST_KHR error and the surface can no longer be rendered on to. This is very common on Android where any android surface, which acts as a native window, is destroyed when the app suspends.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #16718