### PR TITLE
Improve rendering performance by reducing at least one frame rendering delay.

### DIFF
--- a/src/Avalonia.Base/Media/MediaContext.Compositor.cs
+++ b/src/Avalonia.Base/Media/MediaContext.Compositor.cs
@@ -21,9 +21,16 @@ partial class MediaContext
         var commit = compositor.Commit();
         _requestedCommits.Remove(compositor);
         _pendingCompositionBatches[compositor] = commit;
-        commit.Processed.ContinueWith(_ =>
-            _dispatcher.Post(() => CompositionBatchFinished(compositor, commit), DispatcherPriority.Send),
-            TaskContinuationOptions.ExecuteSynchronously);
+        if (_dispatcherOptions.InstantRendering)
+        {
+            CompositionBatchFinished(compositor, commit);
+        }
+        else
+        {
+            commit.Processed.ContinueWith(_ =>
+                    _dispatcher.Post(() => CompositionBatchFinished(compositor, commit), DispatcherPriority.Send),
+                TaskContinuationOptions.ExecuteSynchronously);
+        }
         return commit;
     }
     

--- a/src/Avalonia.Base/Media/MediaContext.cs
+++ b/src/Avalonia.Base/Media/MediaContext.cs
@@ -26,6 +26,7 @@ internal partial class MediaContext : ICompositorScheduler
 
     private List<Action>? _invokeOnRenderCallbacks;
     private readonly Stack<List<Action>> _invokeOnRenderCallbackListPool = new();
+    private readonly DispatcherOptions _dispatcherOptions;
 
     private readonly DispatcherTimer _animationsTimer = new(DispatcherPriority.Render)
     {
@@ -37,13 +38,14 @@ internal partial class MediaContext : ICompositorScheduler
 
     private readonly Dictionary<object, TopLevelInfo> _topLevels = new();
 
-    private MediaContext(Dispatcher dispatcher, TimeSpan inputStarvationTimeout)
+    private MediaContext(Dispatcher dispatcher, DispatcherOptions dispatcherOptions)
     {
         _render = Render;
         _inputMarkerHandler = InputMarkerHandler;
         _clock = new(this);
         _dispatcher = dispatcher;
-        MaxSecondsWithoutInput = inputStarvationTimeout.TotalSeconds;
+        _dispatcherOptions = dispatcherOptions;
+        MaxSecondsWithoutInput = dispatcherOptions.InputStarvationTimeout.TotalSeconds;
         _animationsTimer.Tick += (_, _) =>
         {
             _animationsTimer.Stop();
@@ -62,7 +64,7 @@ internal partial class MediaContext : ICompositorScheduler
             if (context == null)
             {
                 var opts = AvaloniaLocator.Current.GetService<DispatcherOptions>() ?? new();
-                context = new MediaContext(Dispatcher.UIThread, opts.InputStarvationTimeout);
+                context = new MediaContext(Dispatcher.UIThread, opts);
                 AvaloniaLocator.CurrentMutable.Bind<MediaContext>().ToConstant(context);
             }
 

--- a/src/Avalonia.Base/Threading/DispatcherOptions.cs
+++ b/src/Avalonia.Base/Threading/DispatcherOptions.cs
@@ -18,4 +18,10 @@ public class DispatcherOptions
     /// the same thread as rendering.
     /// </remarks>
     public TimeSpan InputStarvationTimeout { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether rendering should be performed synchronously.<br/>
+    /// Otherwise, rendering will be invoked from UI thread to the render thread, back to the UI thread and then back to the render thread.
+    /// </summary>
+    public bool InstantRendering { get; set; } = false;
 }


### PR DESCRIPTION

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

After several hours testing, we found that the Avalonia app renders with a delay after the input event. Comparing to all the same code in WPF, the delay is very noticeable.

![image](https://github.com/user-attachments/assets/73b4d259-62cb-4996-a4cc-6303447007b3)

Please see the picture above:

1. We draw a polyline point by point in the `PointerMove` event.
1. Move the finger left to right with a constant speed. Record a video or capture the screen to view the rendering delay.

The first one is the Avalonia app before this PR. The sencond one is the Avalonia app after this PR. The third one is the WPF app. We can see that:

1. The WPF renders very fast and it tracks the finger very well. (We see the line moves ahead of the finger circle because the finger circle needs some time to render.)
1. The Avalonia app before this PR renders with a long delay. (We see the line is almost outside of the finger circle.)
1. The Avalonia app after this PR renders with a short delay. (We see the line is a little bit following the finger circle center.)

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Before this PR, when a pointer event is triggered:

1. The Pointer message is dispatched on the UI thread.
1. An rendering request is sent to the render thread (a frame of the `DwmRenderTimerLoop`).
1. A callback is called on the UI thread and it commits the final rendering.
1. The next rendering (a frame of the `DwmRenderTimerLoop`) is ticked and all the rendering is done here.

As a result, after a pointer event, the rendering is done at the second frame. This is the reason why we see the rendering delay.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

After this PR, when a pointer event is triggered:

1. The Pointer message is dispatched on the UI thread.
1. We commit the final rendering without sending and waiting for the callback.
1. When a rendering come, all the rendering is done.

After a pointer event, the rendering is done at the first frame. As a result, the rendering delay is reduced at least one frame. (16ms on a 60fps screen)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

I can't figure out the best solution to fix this issue. So I want to discuss it with you.

Solution 1 (this PR):

1. Add an option for developers to choose whether to render immediately or wait for the callback.
1. If the option is enabled, we skip the callback and render immediately.

Solution 2:

1. Always skip the callback and render immediately.

Solution 3:

1. Your better advice is appreciated.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

If someone create the `MediaContext` with reflection, it will fail because the constructor is changed.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
