### PR TITLE
Allow selection of multiple consecutive blocks in SelectingItemsControl.

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -817,6 +817,10 @@ namespace Avalonia.Controls.Primitives
             else if (range)
             {
                 using var operation = Selection.BatchUpdate();
+                if (!toggleModifier)
+                {
+                    Selection.Clear();
+                }
                 Selection.SelectRange(Selection.AnchorIndex, index);
             }
             else if (!fromFocus && toggle)

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -817,7 +817,6 @@ namespace Avalonia.Controls.Primitives
             else if (range)
             {
                 using var operation = Selection.BatchUpdate();
-                Selection.Clear();
                 Selection.SelectRange(Selection.AnchorIndex, index);
             }
             else if (!fromFocus && toggle)

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests_Multiple.cs
@@ -168,6 +168,36 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void ToggleModifier_And_Range_Should_Select_Second_Range()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var target = new ListBox
+                {
+                    Template = new FuncControlTemplate(CreateListBoxTemplate),
+                    ItemsSource = new[] { "Foo", "Bar", "Baz", "Gap", "Boo", "Far", "Faz" },
+                    SelectionMode = SelectionMode.Multiple,
+                    Width = 100,
+                    Height = 100,
+                };
+
+                var root = new TestRoot(target);
+                root.LayoutManager.ExecuteInitialLayoutPass();
+
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
+                // Select first range
+                _helper.Click(target.Presenter.Panel.Children[0]);
+                _helper.Click(target.Presenter.Panel.Children[2], modifiers: KeyModifiers.Shift);
+
+                // Select second range
+                _helper.Click(target.Presenter.Panel.Children[4], modifiers: KeyModifiers.Control);
+                _helper.Click(target.Presenter.Panel.Children[6], modifiers: KeyModifiers.Control | KeyModifiers.Shift);
+
+                Assert.Equal(new[] { "Foo", "Bar", "Baz", "Boo", "Far", "Faz" }, target.SelectedItems);
+            }
+        }
+
+        [Fact]
         public void Should_Ctrl_Select_Correct_Item_When_Duplicate_Items_Are_Present()
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))


### PR DESCRIPTION
## What does the pull request do?

This PR fixes issue #16905 by retaining the current selection when range and toggleModifier are true in SelectingItemsControl.UpdateSelection(...).

## What is the current behavior?

Currently non-consecutive blocks can not be selected because the current selection is cleared when a range is being selected regardless of the value of toggleModifier.

## What is the updated/expected behavior with this PR?

You can select a second range in any SelectingItemsControl by holding Ctrl to start a new selection and Ctrl + Shift to select the new range. This should not (and now doesn't) clear the original selection.

## How was the solution implemented (if it's not obvious)?

Made the call to Selection.Clear() conditional on !toggleModifier when range is true.

## Checklist

- [X] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

N/A - All existing tests still pass.

## Obsoletions / Deprecations

N/A

## Fixed issues
Fixes #16905 
