### PR TITLE
Add character casing to TextBox control

### DIFF
--- a/samples/ControlCatalog/Pages/TextBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/TextBoxPage.xaml
@@ -88,6 +88,12 @@
         <TextBox Width="200" Text="Custom font italic" FontWeight="Normal" FontStyle="Italic" FontFamily="/Assets/Fonts/SourceSansPro-Italic.ttf#Source Sans Pro"/>
         <TextBox Width="200" Text="Custom font italic bold" FontWeight="Bold" FontStyle="Italic" FontFamily="/Assets/Fonts/SourceSansPro-*.ttf#Source Sans Pro"/>
       </StackPanel>
+
+      <StackPanel Orientation="Vertical" Spacing="8" Margin="8">
+        <TextBox Width="200" Text="Default casing" />
+        <TextBox Width="200" Text="Upper casing" CharacterCasing="Upper" />
+        <TextBox Width="200" Text="Lower casing" CharacterCasing="Lower" />
+      </StackPanel>
     </WrapPanel>
     <TextBox AcceptsReturn="True" TextWrapping="Wrap" Height="200" MaxWidth="400"
              FontFamily="avares://ControlCatalog/Assets/Fonts#WenQuanYi Micro Hei"

--- a/src/Avalonia.Base/Media/CharacterCasing.cs
+++ b/src/Avalonia.Base/Media/CharacterCasing.cs
@@ -1,0 +1,23 @@
+﻿namespace Avalonia.Media
+{
+    /// <summary>
+    /// Defines how text is cased.
+    /// </summary>
+    public enum CharacterCasing
+    {
+        /// <summary>
+        /// The text casing is normal.
+        /// </summary>
+        Normal,
+
+        /// <summary>
+        /// The text casing is upper.
+        /// </summary>
+        Upper,
+
+        /// <summary>
+        /// The text casing is lower.
+        /// </summary>
+        Lower
+    }
+}

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -403,6 +403,14 @@ namespace Avalonia.Controls
             set => SetValue(CaretIndexProperty, value);
         }
 
+        private void OnCharacterCasingChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            var tb = (TextBox)e.Sender;
+            var newValue = AdjustCasing(tb.Text);
+
+            SetCurrentValue(TextProperty, newValue);
+        }
+
         private void OnCaretIndexChanged(AvaloniaPropertyChangedEventArgs e)
         {
             UndoRedoState state;
@@ -926,7 +934,7 @@ namespace Avalonia.Controls
             }
             else if (change.Property == CharacterCasingProperty)
             {
-                Text = AdjustCasing(Text);
+                OnCharacterCasingChanged(change);
             }
             else if (change.Property == CaretIndexProperty)
             {

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -146,6 +146,9 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<TextAlignment> TextAlignmentProperty =
             TextBlock.TextAlignmentProperty.AddOwner<TextBox>();
 
+        public static readonly StyledProperty<CharacterCasing> CharacterCasingProperty =
+            AvaloniaProperty.Register<TextBox, CharacterCasing>(nameof(CharacterCasing), defaultValue: CharacterCasing.Normal);
+
         /// <summary>
         /// Defines the <see cref="HorizontalAlignment"/> property.
         /// </summary>
@@ -632,6 +635,12 @@ namespace Avalonia.Controls
             set => SetValue(TextAlignmentProperty, value);
         }
 
+        public CharacterCasing CharacterCasing
+        {
+            get => GetValue(CharacterCasingProperty);
+            set => SetValue(CharacterCasingProperty, value);
+        }
+
         /// <summary>
         /// Gets or sets the placeholder or descriptive text that is displayed even if the <see cref="Text"/>
         /// property is not yet set.
@@ -915,6 +924,10 @@ namespace Avalonia.Controls
                 UpdatePseudoclasses();
                 UpdateCommandStates();
             }
+            else if (change.Property == CharacterCasingProperty)
+            {
+                Text = AdjustCasing(Text);
+            }
             else if (change.Property == CaretIndexProperty)
             {
                 OnCaretIndexChanged(change);
@@ -1017,6 +1030,7 @@ namespace Avalonia.Controls
             }
 
             input = SanitizeInputText(input);
+            input = AdjustCasing(input);
 
             if (string.IsNullOrEmpty(input))
             {
@@ -2111,6 +2125,14 @@ namespace Avalonia.Controls
 
             return text.Substring(start, end - start);
         }
+
+        private string? AdjustCasing(string? text) => CharacterCasing switch
+        {
+            CharacterCasing.Lower => text?.ToLower(System.Globalization.CultureInfo.CurrentCulture),
+            CharacterCasing.Upper => text?.ToUpper(System.Globalization.CultureInfo.CurrentCulture),
+            CharacterCasing.Normal => text,
+            _ => text
+        };
 
         /// <summary>
         /// Returns the sum of any vertical whitespace added between the <see cref="ScrollViewer"/> and <see cref="TextPresenter"/> in the control template.

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -406,7 +406,7 @@ namespace Avalonia.Controls
         private void OnCharacterCasingChanged(AvaloniaPropertyChangedEventArgs e)
         {
             var tb = (TextBox)e.Sender;
-            var newValue = AdjustCasing(tb.Text);
+            var newValue = AdjustCasing(tb.Text, e.GetNewValue<CharacterCasing>());
 
             SetCurrentValue(TextProperty, newValue);
         }
@@ -591,8 +591,8 @@ namespace Avalonia.Controls
             {
                 textBox.SnapshotUndoRedo();
             }
-
-            return value;
+            
+            return AdjustCasing(value, textBox.CharacterCasing);
         }
 
         /// <summary>
@@ -643,6 +643,9 @@ namespace Avalonia.Controls
             set => SetValue(TextAlignmentProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets the <see cref="CharacterCasing"/> of the TextBox.
+        /// </summary>
         public CharacterCasing CharacterCasing
         {
             get => GetValue(CharacterCasingProperty);
@@ -926,7 +929,7 @@ namespace Avalonia.Controls
                 CoerceValue(CaretIndexProperty);
                 CoerceValue(SelectionStartProperty);
                 CoerceValue(SelectionEndProperty);
-
+                
                 RaiseTextChangeEvents();
 
                 UpdatePseudoclasses();
@@ -1038,7 +1041,7 @@ namespace Avalonia.Controls
             }
 
             input = SanitizeInputText(input);
-            input = AdjustCasing(input);
+            input = AdjustCasing(input, CharacterCasing);
 
             if (string.IsNullOrEmpty(input))
             {
@@ -2134,7 +2137,13 @@ namespace Avalonia.Controls
             return text.Substring(start, end - start);
         }
 
-        private string? AdjustCasing(string? text) => CharacterCasing switch
+        /// <summary>
+        /// Adjust the text casing.
+        /// </summary>
+        /// <param name="text">The text to adjust.</param>
+        /// <param name="characterCasing">The character casing we want.</param>
+        /// <returns></returns>
+        private static string? AdjustCasing(string? text, CharacterCasing characterCasing) => characterCasing switch
         {
             CharacterCasing.Lower => text?.ToLower(System.Globalization.CultureInfo.CurrentCulture),
             CharacterCasing.Upper => text?.ToUpper(System.Globalization.CultureInfo.CurrentCulture),

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -929,7 +929,6 @@ namespace Avalonia.Controls
                 CoerceValue(CaretIndexProperty);
                 CoerceValue(SelectionStartProperty);
                 CoerceValue(SelectionEndProperty);
-                
                 RaiseTextChangeEvents();
 
                 UpdatePseudoclasses();

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -1402,6 +1402,21 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Should_Update_Casing_After_First_Render()
+        {
+            var tb = new TextBox
+            {
+                Template = CreateTemplate(),
+                Text = "abc"
+            };
+
+            tb.Measure(Size.Infinity);
+            tb.CharacterCasing = CharacterCasing.Upper;
+            
+            Assert.Equal("ABC", tb.Text);
+        }
+
+        [Fact]
         public void Should_Move_Caret_To_EndOfLine()
         {
             using (UnitTestApplication.Start(Services))

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -1385,6 +1385,22 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        [Theory]
+        [InlineData(CharacterCasing.Lower, "LoWer", "lower")]
+        [InlineData(CharacterCasing.Upper, "uppEr", "UPPER")]
+        [InlineData(CharacterCasing.Normal, "NorMal", "NorMal")]
+        public void Should_Respect_Casing(CharacterCasing casing, string value, string expected)
+        {
+            var target = new TextBox
+            {
+                Template = CreateTemplate(),
+                CharacterCasing = casing,
+                Text = value
+            };
+
+            Assert.Equal(target.Text, expected);
+        }
+
         [Fact]
         public void Should_Move_Caret_To_EndOfLine()
         {


### PR DESCRIPTION
## What does the pull request do?
Add character casing to TextBox 


## What is the current behavior?
Currently, we cannot add a specific casing to the text from the TextBox


## What is the updated/expected behavior with this PR?
We can add the property CharacterCasing to `Upper`, `Lower` or `Normal` to manage casing (by default, Normal).


## How was the solution implemented (if it's not obvious)?
Add a property and try to follow conventions.


## Checklist

- [x] Added tests
- [x] Update sample project
- [ ] Submit a PR to https://github.com/AvaloniaUI/avalonia-docs to add new property

## Breaking changes
N/A

## Obsoletions / Deprecations
N/A

## Fixed issues
Fixes #11931
