### PR TITLE
Fixed an issue with X11 window state judgment caused by the order of Atoms.

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -721,37 +721,11 @@ namespace Avalonia.X11
                 WindowState state = WindowState.Normal;
                 if(hasValue)
                 {
-
                     XGetWindowProperty(_x11.Display, _handle, _x11.Atoms._NET_WM_STATE, IntPtr.Zero, new IntPtr(256),
                         false, (IntPtr)Atom.XA_ATOM, out _, out _, out var nitems, out _,
                         out var prop);
-                    int maximized = 0;
                     var pitems = (IntPtr*)prop.ToPointer();
-                    for (var c = 0; c < nitems.ToInt32(); c++)
-                    {
-                        if (pitems[c] == _x11.Atoms._NET_WM_STATE_HIDDEN)
-                        {
-                            state = WindowState.Minimized;
-                            break;
-                        }
-
-                        if(pitems[c] == _x11.Atoms._NET_WM_STATE_FULLSCREEN)
-                        {
-                            state = WindowState.FullScreen;
-                            break;
-                        }
-
-                        if (pitems[c] == _x11.Atoms._NET_WM_STATE_MAXIMIZED_HORZ ||
-                            pitems[c] == _x11.Atoms._NET_WM_STATE_MAXIMIZED_VERT)
-                        {
-                            maximized++;
-                            if (maximized == 2)
-                            {
-                                state = WindowState.Maximized;
-                                break;
-                            }
-                        }
-                    }
+                    state = AtomsToWindowState(nitems, pitems);
                     XFree(prop);
                 }
                 if (_lastWindowState != state)
@@ -761,6 +735,38 @@ namespace Avalonia.X11
                 }
             }
 
+        }
+
+        private WindowState AtomsToWindowState(IntPtr nitems, IntPtr* pitems)
+        {
+            for (var c = 0; c < nitems.ToInt32(); c++)
+            {
+                if (pitems[c] == _x11.Atoms._NET_WM_STATE_HIDDEN)
+                {
+                    return WindowState.Minimized;
+                }
+            }
+            for (var c = 0; c < nitems.ToInt32(); c++)
+            {
+                if(pitems[c] == _x11.Atoms._NET_WM_STATE_FULLSCREEN)
+                {
+                    return WindowState.FullScreen;
+                }
+            }
+            int maximized = 0;
+            for (var c = 0; c < nitems.ToInt32(); c++)
+            {
+                if (pitems[c] == _x11.Atoms._NET_WM_STATE_MAXIMIZED_HORZ ||
+                    pitems[c] == _x11.Atoms._NET_WM_STATE_MAXIMIZED_VERT)
+                {
+                    maximized++;
+                    if (maximized == 2)
+                    {
+                        return WindowState.Maximized;
+                    }
+                }
+            }
+            return WindowState.Normal;
         }
 
         private static RawInputModifiers TranslateModifiers(XModifierMask state)


### PR DESCRIPTION

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Let's see a atom list of a sample Avalonia window:

```
_NET_WM_STATE_MAXIMIZED_VERT, _NET_WM_STATE_MAXIMIZED_HORZ, _NET_WM_STATE_HIDDEN, _NET_WM_STATE_FULLSCREEN
```

Before this PR, the `WindowState.Maximized` condition will be `true` first and return. So the window `WindowState` property will be set to `Maximized` but the window is actually `Hidden`.

After this PR, the `WindowState.Hidden` condition will be checked first and return. So the window `WindowState` property will be set to `Minimized` and the window is actually `Hidden`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

There is only one loop to check the atom list. The order of atoms will affect the result of the window state judgment.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

The window state judgment is more accurate.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

I changed the loop from a single one to per-atom specific.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

Nothing.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
