### PR TITLE
fix(ToggleSwitch): only remove knob transitions when dragging

### DIFF
--- a/src/Avalonia.Controls/ToggleSwitch.cs
+++ b/src/Avalonia.Controls/ToggleSwitch.cs
@@ -255,14 +255,14 @@ namespace Avalonia.Controls
         {
             if (_knobsPanelPressed)
             {
-                if(_knobsPanel != null)
-                {
-                    _knobsPanel.Transitions = null;
-                }
                 var difference = e.GetPosition(_switchKnob) - _switchStartPoint;
 
                 if ((!_isDragging) && (System.Math.Abs(difference.X) > 3))
                 {
+                    if (_knobsPanel != null)
+                    {
+                        _knobsPanel.Transitions = null;
+                    }
                     _isDragging = true;
                     PseudoClasses.Set(":dragging", true);
                 }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a bug in `ToggleSwitch` that causes the knob transitions to be removed during certain user interactions.


## What is the current behavior?
When dragging the knob of a `ToggleSwitch`, the knob transitions are removed if the pointer is released without moving the cursor left or right more than 3 pixels. See below:
![ExistingBehavior](https://github.com/user-attachments/assets/e8fa6192-7a0b-419c-aec5-0ba86df74f4a)


## What is the updated/expected behavior with this PR?
The updated behavior keeps the transitions when the pointer is released before the cursors moves more than 3 pixels left or right.
![DesiredBehavior](https://github.com/user-attachments/assets/93510f59-38a1-495a-9941-88eca32a7b84)


## How was the solution implemented (if it's not obvious)?
The statement removing the transitions was moved inside the conditional checking if `_isDragging` is true.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #16335 
