### PR TITLE
Adjust diagnostic apis

### DIFF
--- a/src/Avalonia.Base/Avalonia.Base.csproj
+++ b/src/Avalonia.Base/Avalonia.Base.csproj
@@ -59,6 +59,7 @@
     <InternalsVisibleTo Include="Avalonia.Tizen, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Dialogs, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Diagnostics, PublicKey=$(AvaloniaPublicKey)" />
+    <InternalsVisibleTo Include="AvaloniaUI.DiagnosticsSupport.Avalonia, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.LinuxFramebuffer, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
   </ItemGroup>

--- a/src/Avalonia.Base/Data/Core/MultiBindingExpression.cs
+++ b/src/Avalonia.Base/Data/Core/MultiBindingExpression.cs
@@ -49,6 +49,12 @@ internal class MultiBindingExpression : UntypedBindingExpressionBase, IBindingEx
     }
 
     public override string Description => "MultiBinding";
+    internal UntypedBindingExpressionBase?[] Expressions => _expressions;
+    internal IMultiValueConverter? Converter => _converter;
+    internal CultureInfo? ConverterCulture => _converterCulture;
+    internal object? ConverterParameter => _converterParameter;
+    internal object? FallbackValue => _fallbackValue;
+    internal object? TargetNullValue => _targetNullValue;
 
     protected override void StartCore()
     {

--- a/src/Avalonia.Base/Diagnostics/AvaloniaObjectExtensions.cs
+++ b/src/Avalonia.Base/Diagnostics/AvaloniaObjectExtensions.cs
@@ -18,5 +18,14 @@ namespace Avalonia.Diagnostics
         {
             return o.GetDiagnosticInternal(property);
         }
+
+        /// <summary>
+        /// Gets a value store diagnostics for a <see cref="AvaloniaObject"/>.
+        /// </summary>
+        /// <param name="avaloniaObject">The avalonia object.</param>
+        public static ValueStoreDiagnostic GetValueStoreDiagnostic(this AvaloniaObject avaloniaObject)
+        {
+            return avaloniaObject.GetValueStore().GetStoreDiagnostic();
+        }
     }
 }

--- a/src/Avalonia.Base/Diagnostics/IValueFrameDiagnostic.cs
+++ b/src/Avalonia.Base/Diagnostics/IValueFrameDiagnostic.cs
@@ -19,8 +19,8 @@ public interface IValueFrameDiagnostic
         Style,
         Template
     }
-    
-    string? Description { get; }
+
+    object? Source { get; } 
     FrameType Type { get; }
     bool IsActive { get; }
     BindingPriority Priority { get; }

--- a/src/Avalonia.Base/Diagnostics/LocalValueFrameDiagnostic.cs
+++ b/src/Avalonia.Base/Diagnostics/LocalValueFrameDiagnostic.cs
@@ -9,8 +9,8 @@ internal class LocalValueFrameDiagnostic : IValueFrameDiagnostic
     {
         Values = values;
     }
-    
-    public string? Description => null;
+
+    public object? Source => null;
     public IValueFrameDiagnostic.FrameType Type => IValueFrameDiagnostic.FrameType.Local;
     public bool IsActive => true;
     public BindingPriority Priority => BindingPriority.LocalValue;

--- a/src/Avalonia.Base/Diagnostics/StyleValueFrameDiagnostic.cs
+++ b/src/Avalonia.Base/Diagnostics/StyleValueFrameDiagnostic.cs
@@ -15,12 +15,7 @@ internal class StyleValueFrameDiagnostic : IValueFrameDiagnostic
         _styleInstance = styleInstance;
     }
 
-    public string? Description => _styleInstance.Source switch
-    {
-        Style s => GetFullSelector(s),
-        ControlTheme t => t.TargetType?.Name,
-        _ => null
-    };
+    public object? Source => _styleInstance.Source;
 
     public IValueFrameDiagnostic.FrameType Type => _styleInstance.Source switch
     {
@@ -43,23 +38,6 @@ internal class StyleValueFrameDiagnostic : IValueFrameDiagnostic
                 }
             }
         }
-    }
-
-    private string GetFullSelector(Style? style)
-    {
-        var selectors = new Stack<string>();
-
-        while (style is not null)
-        {
-            if (style.Selector is not null)
-            {
-                selectors.Push(style.Selector.ToString());
-            }
-            
-            style = style.Parent as Style;
-        }
-
-        return string.Concat(selectors);
     }
 
     [Unstable("Compatibility with 11.x")]

--- a/src/Avalonia.Base/Diagnostics/StyledElementExtensions.cs
+++ b/src/Avalonia.Base/Diagnostics/StyledElementExtensions.cs
@@ -11,16 +11,7 @@ namespace Avalonia.Diagnostics;
 [PrivateApi]
 public static class StyledElementExtensions
 {
-    /// <summary>
-    /// Gets a style diagnostics for a <see cref="StyledElement"/>.
-    /// </summary>
-    /// <param name="styledElement">The element.</param>
-    public static ValueStoreDiagnostic GetValueStoreDiagnostic(this StyledElement styledElement)
-    {
-        return styledElement.GetValueStore().GetStoreDiagnostic();
-    }
-
-    [Obsolete("Use StyledElementExtensions.GetValueStoreDiagnostic instead", true)]
+    [Obsolete("Use AvaloniaObjectExtensions.GetValueStoreDiagnostic instead", true)]
     public static StyleDiagnostics GetStyleDiagnostics(this StyledElement styledElement)
     {
         var diagnostics = styledElement.GetValueStore().GetStoreDiagnostic();

--- a/src/Avalonia.Base/Diagnostics/ValueFrameDiagnostic.cs
+++ b/src/Avalonia.Base/Diagnostics/ValueFrameDiagnostic.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Avalonia.Data;
 using Avalonia.PropertyStore;
 using Avalonia.Styling;
@@ -14,7 +15,7 @@ internal sealed class ValueFrameDiagnostic : IValueFrameDiagnostic
         _valueFrame = valueFrame;
     }
 
-    public string? Description => (_valueFrame.Owner?.Owner as StyledElement)?.StyleKey.Name;
+    public object? Source => _valueFrame.Owner?.Owner;
 
     public IValueFrameDiagnostic.FrameType Type => IValueFrameDiagnostic.FrameType.Template;
 

--- a/src/Avalonia.Controls/Avalonia.Controls.csproj
+++ b/src/Avalonia.Controls/Avalonia.Controls.csproj
@@ -20,6 +20,7 @@
     <InternalsVisibleTo Include="Avalonia.Markup.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.DesignerSupport, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Diagnostics, PublicKey=$(AvaloniaPublicKey)"/>
+    <InternalsVisibleTo Include="AvaloniaUI.DiagnosticsSupport.Avalonia, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.LeakTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Headless, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Native, PublicKey=$(AvaloniaPublicKey)" />


### PR DESCRIPTION
Changes GetValueStoreDiagnostic API to work with any AvaloniaObject type, makes it return original Source (Style or ControlTheme) instead of compositing string. Move selector concatenation to dev-tools instead.