### PR TITLE
[macOS] Fixes stuck mouse buttons after drag

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.h
+++ b/native/Avalonia.Native/src/OSX/AvnView.h
@@ -19,6 +19,7 @@
 -(AvnPoint) translateLocalPoint:(AvnPoint)pt;
 -(void) onClosed;
 -(void) setModifiers:(NSEventModifierFlags)modifierFlags;
+-(void) resetPressedMouseButtons;
 
 -(AvnPlatformResizeReason) getResizeReason;
 -(void) setResizeReason:(AvnPlatformResizeReason)reason;

--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -485,6 +485,15 @@
     _modifierState = [self getModifiers:modifierFlags];
 }
 
+- (void)resetPressedMouseButtons
+{
+    _isLeftPressed = false;
+    _isRightPressed = false;
+    _isMiddlePressed = false;
+    _isXButton1Pressed = false;
+    _isXButton2Pressed = false;
+}
+
 - (void)flagsChanged:(NSEvent *)event
 {
     auto newModifierState = [self getModifiers:[event modifierFlags]];

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -430,6 +430,7 @@ HRESULT WindowBaseImpl::BeginDragAndDropOperation(AvnDragDropEffects effects, Av
         op |= NSDragOperationLink;
     if ((ieffects & (int) AvnDragDropEffects::Move) != 0)
         op |= NSDragOperationMove;
+    [View resetPressedMouseButtons];
     [View beginDraggingSessionWithItems:@[dragItem] event:nsevent
                                  source:CreateDraggingSource((NSDragOperation) op, cb, sourceHandle)];
     return S_OK;

--- a/samples/ControlCatalog/Pages/DragAndDropPage.xaml
+++ b/samples/ControlCatalog/Pages/DragAndDropPage.xaml
@@ -1,6 +1,16 @@
 <UserControl x:Class="ControlCatalog.Pages.DragAndDropPage"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <UserControl.Styles>
+    <Style Selector="Border.draggable">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="{DynamicResource SystemAccentColor}" />
+      <Setter Property="BorderThickness" Value="2" />
+      <Setter Property="Padding" Value="16" />
+    </Style>
+  </UserControl.Styles>
+
   <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h2">Example of Drag+Drop capabilities</TextBlock>
 
@@ -8,21 +18,15 @@
       <StackPanel Margin="8"
                   MaxWidth="160">
         <Border Name="DragMeText"
-                Padding="16"
-                BorderBrush="{DynamicResource SystemAccentColor}"
-                BorderThickness="2">
+                Classes="draggable">
           <TextBlock Name="DragStateText" TextWrapping="Wrap">Drag Me (text)</TextBlock>
         </Border>
         <Border Name="DragMeFiles"
-                Padding="16"
-                BorderBrush="{DynamicResource SystemAccentColor}"
-                BorderThickness="2">
+                Classes="draggable">
           <TextBlock Name="DragStateFiles" TextWrapping="Wrap">Drag Me (files)</TextBlock>
         </Border>
         <Border Name="DragMeCustom"
-                Padding="16"
-                BorderBrush="{DynamicResource SystemAccentColor}"
-                BorderThickness="2">
+                Classes="draggable">
           <TextBlock Name="DragStateCustom" TextWrapping="Wrap">Drag Me (custom)</TextBlock>
         </Border>
       </StackPanel>


### PR DESCRIPTION
## What does the pull request do?
This PR resets the internal mouse button states when a drag operation is started on macOS, as we don't get `mouseUp` events anymore when a dragging session is in progress.

Note that all states are reset on drag since we don't really know what other buttons might be pressed/released during dragging.
Also, it matches the observed behavior on macOS: all pressed buttons must be released for the drop events to be triggered, and not only the one that initiated the drag.

## What is the current behavior?
After dragging, the initial mouse button is stuck.

## What is the updated/expected behavior with this PR?
The mouse button isn't stuck anymore.

## Fixed issues
 - Fixes the macOS part of #16936