### PR TITLE
Fix parsing of XAML setters when the child isn't a text node

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlSetterTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlSetterTransformer.cs
@@ -80,9 +80,25 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
 
             var valueProperty = on.Children
                 .OfType<XamlAstXamlPropertyValueNode>()
-                .FirstOrDefault(p => p.Property.GetClrProperty().Name == "Value" && p.Values.Count == 1 && p.Values[0] is XamlAstTextNode);
-            var textValue = valueProperty?.Values.FirstOrDefault() as XamlAstTextNode
-                            ?? on.Children.OfType<XamlAstTextNode>().FirstOrDefault();
+                .FirstOrDefault(p => p.Property.GetClrProperty().Name == "Value");
+
+            XamlAstTextNode? textValue = null;
+
+            if (valueProperty is not null)
+            {
+                if (valueProperty.Values.Count == 1)
+                    textValue = valueProperty.Values[0] as XamlAstTextNode;
+            }
+            else
+            {
+                var nonPropertyChildren = on.Children
+                    .Where(child => child is not XamlAstXamlPropertyValueNode)
+                    .ToArray();
+
+                if (nonPropertyChildren.Length == 1)
+                    textValue = nonPropertyChildren[0] as XamlAstTextNode;
+            }
+
             if (textValue is not null
                 && XamlTransformHelpers.TryGetCorrectlyTypedValue(context, textValue,
                     propType, out _))

--- a/tests/Avalonia.Markup.Xaml.UnitTests/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/StyleTests.cs
@@ -1,8 +1,7 @@
 using System.Linq;
-using System.Reactive.Linq;
 using Avalonia.Controls;
 using Avalonia.Data;
-using Avalonia.PropertyStore;
+using Avalonia.Layout;
 using Avalonia.Styling;
 using Avalonia.UnitTests;
 using Xunit;
@@ -12,13 +11,34 @@ namespace Avalonia.Markup.Xaml.UnitTests
     public class StyleTests : XamlTestBase
     {
         [Fact]
-        public void Binding_Should_Be_Assigned_To_Setter_Value_Instead_Of_Bound()
+        public void Binding_As_Attribute_Should_Be_Assigned_To_Setter_Value_Instead_Of_Bound()
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformWrapper))
             {
                 var xaml = "<Style Selector='Button' xmlns='https://github.com/avaloniaui'><Setter Property='Content' Value='{Binding}'/></Style>";
                 var style = (Style)AvaloniaRuntimeXamlLoader.Load(xaml);
                 var setter = (Setter)(style.Setters.First());
+
+                Assert.IsType<Binding>(setter.Value);
+            }
+        }
+
+        [Theory]
+        [InlineData(nameof(ContentControl.Content))] // standard property
+        [InlineData(nameof(Layoutable.Margin))] // primitive property which can be directly parsed
+        public void Binding_As_Element_Should_Be_Assigned_To_Setter_Value(string propertyName)
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformWrapper))
+            {
+                var style = (Style)AvaloniaRuntimeXamlLoader.Load(
+                    $"""
+                     <Style Selector="Button" xmlns="https://github.com/avaloniaui">
+                         <Setter Property="{propertyName}">
+                             <Binding />
+                         </Setter>
+                     </Style>
+                     """);
+                var setter = (Setter)style.Setters.First();
 
                 Assert.IsType<Binding>(setter.Value);
             }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a problem introduced by #16153 that was preventing nested elements from being correctly assigned to property setters of primitive types.

The implementation now checks that there is a *single* parseable text node, instead of taking only the very first one into account.

A unit test has been added.

## Fixed issues
 - Fixes #16754
