### PR TITLE
Validate visual parent on attaching to the tree

### DIFF
--- a/src/Avalonia.Base/Visual.cs
+++ b/src/Avalonia.Base/Visual.cs
@@ -495,7 +495,7 @@ namespace Avalonia
             _visualRoot = e.Root;
             if (_visualParent is null)
             {
-                throw new InvalidOperationException("Visual was attached to the root without being added to the visual parent first.")
+                throw new InvalidOperationException("Visual was attached to the root without being added to the visual parent first.");
             }
 
             if (RenderTransform is IMutableTransform mutableTransform)

--- a/src/Avalonia.Base/Visual.cs
+++ b/src/Avalonia.Base/Visual.cs
@@ -493,6 +493,10 @@ namespace Avalonia
             Logger.TryGet(LogEventLevel.Verbose, LogArea.Visual)?.Log(this, "Attached to visual tree");
 
             _visualRoot = e.Root;
+            if (_visualParent is null)
+            {
+                throw new InvalidOperationException("Visual was attached to the root without being added to the visual parent first.")
+            }
 
             if (RenderTransform is IMutableTransform mutableTransform)
             {
@@ -505,14 +509,14 @@ namespace Avalonia
                 AttachToCompositor(compositingRenderer.Compositor);
             }
             InvalidateMirrorTransform();
-            UpdateIsEffectivelyVisible(_visualParent!.IsEffectivelyVisible);
+            UpdateIsEffectivelyVisible(_visualParent.IsEffectivelyVisible);
             OnAttachedToVisualTree(e);
             AttachedToVisualTree?.Invoke(this, e);
             InvalidateVisual();
             
-            _visualRoot.Renderer.RecalculateChildren(_visualParent!);
+            _visualRoot.Renderer.RecalculateChildren(_visualParent);
             
-            if (ZIndex != 0 && _visualParent is { })
+            if (ZIndex != 0)
                 _visualParent.HasNonUniformZIndexChildren = true;
             
             var visualChildren = VisualChildren;


### PR DESCRIPTION
As reported, it is possible to bypass "protected" method rules and manually raise AttachedToVisualTree event, without control being attached to the parent. It results in NRE.
While we shouldn't allow manual raise of AttachedToVisualTree event, we also should output more clear validation errors instead of NRE.

cc @jmacato and @MrJul