### PR TITLE
Prevent stack overflow in two-way bindings.

### DIFF
--- a/src/Avalonia.Base/Data/Core/BindingExpression.cs
+++ b/src/Avalonia.Base/Data/Core/BindingExpression.cs
@@ -512,8 +512,10 @@ internal partial class BindingExpression : UntypedBindingExpressionBase, IDescri
         Debug.Assert(_mode is BindingMode.TwoWay or BindingMode.OneWayToSource);
         Debug.Assert(UpdateSourceTrigger is UpdateSourceTrigger.PropertyChanged);
 
-        if (e.Property == TargetProperty)
-            WriteValueToSource(e.NewValue);
+        // The value must be read from the target object instead of using the value from the event
+        // because the value may have changed again between the time the event was raised and now.
+        if (e.Property == TargetProperty && TryGetTarget(out var target))
+            WriteValueToSource(target.GetValue(TargetProperty));
     }
 
     private object? ConvertFallback(object? fallback, string fallbackName)


### PR DESCRIPTION
## What does the pull request do?

Fixes a stack overflow when the target of a two-way binding alters the value of the binding during the change notification.

This is an alternative (simpler) fix than #16819

## How was the solution implemented (if it's not obvious)?

When a change is detected on the target object during the target -> source part of syncing the binding, the value must be read from the target object instead of using the value in the event because the value may have changed again between the time the event was raised and when we get the notification.

Fixes #16746