### PR TITLE
Prevent AutoCompleteBox getting stuck in a state where it can't drop down.

### DIFF
--- a/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
@@ -495,6 +495,31 @@ namespace Avalonia.Controls.UnitTests
             });
         }
 
+        [Fact]
+        public void Attempting_To_Open_Without_Items_Does_Not_Prevent_Future_Opening_With_Items()
+        {
+            RunTest((control, textbox) =>
+            {
+                // Allow the drop down to open without anything entered.
+                control.MinimumPrefixLength = 0;
+
+                // Clear the items.
+                var source = control.ItemsSource;
+                control.ItemsSource = null;
+                control.IsDropDownOpen = true;
+
+                // DropDown was not actually opened because there are no items.
+                Assert.False(control.IsDropDownOpen);
+
+                // Set the items and try to open the drop down again.
+                control.ItemsSource = source;
+                control.IsDropDownOpen = true;
+
+                // DropDown can now be opened.
+                Assert.True(control.IsDropDownOpen);
+            });
+        }
+
         /// <summary>
         /// Retrieves a defined predicate filter through a new AutoCompleteBox 
         /// control instance.


### PR DESCRIPTION
## What does the pull request do?

`AutoCompleteBox` sometimes can get stuck in a state where it can't get dropped down. A customer reported this, giving the use case where they set `IsDropDownOpen` (via a binding) before they set `ItemsSource` (also via a binding).

This happens because `AutoCompleteBox.RefeshView` has two state flags: `_filterInAction` and `_cancelRequested`. Usually these are reset when the method exits but in the case where there are no items, the method exits early leaving `_filterInAction` set to true.

Wrap the whole thing in a `try`...`finally` block to make sure the flags are always reset when the method exits, even if there are exceptions etc.

Note: the diff is best viewed using the `Hide whitespace` option on GitHub as the whole block has changed indentation.