### PR TITLE
[macOS]: Call layer.setNeedsDisplay on show.

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -106,6 +106,13 @@ HRESULT WindowBaseImpl::Show(bool activate, bool isDialog) {
 
         _shown = true;
         [Window setCollectionBehavior:collectionBehavior];
+        
+        // Ensure that we call needsDisplay = YES so that AvnView.updateLayer is called after the
+        // window is shown: if the client is pumping messages during the window creation/show
+        // process, it's possible that updateLayer gets called after the window is created but
+        // before it's is shown.
+        [View.layer setNeedsDisplay];
+        
         return S_OK;
     }
 }


### PR DESCRIPTION
## What does the pull request do?

The `AvaloniaNative.GlPlatformSurface.CreateGlRenderTarget` method can only be called on the UI thread. In normal circumstances this method is called in response to a call to `TopLevel.HandlePaint` from the native `AvnView.updateLayer` method. The flow of operations goes like this:

1. Window is created
2. Window is shown
3. Window is registered with the compositor
4. `AvnView.updateLayer` is called
5. Which calls `TopLevel.HandlePaint`
6. Which calls `MediaContext.ImmediateRenderRequested` to render on the UI thread
7. This render operation calls `GlPlatformSurface.CreateGlRenderTarget` on the UI thread and a GL render target is created
8. Subsequent render operations on the render thread use this render target

However, a customer was experiencing a problem where `AvnView.updateLayer` and by extension `TopLevel.HandlePaint` were being called before the window is shown. This broke the creation of the GL render target:

1. Window is created
2.  `AvnView.updateLayer` is called
3. Which calls `TopLevel.HandlePaint`
4. Which calls `MediaContext.ImmediateRenderRequested`
5. But the window hasn't been registered with the compositor so nothing happens
6. Subsequent render operations are run on the render thread and try to create a render target
7. But this fails because the render target can only be created on the UI thread

This was happening because the customer is creating/showing the window by pushing jobs to the dispatcher, causing the `HandlePaint` request to come in earlier than expected.

## What is the current behavior?

The window is blank until a resize happens (which causes `HandlePaint` to be called).

## How was the solution implemented (if it's not obvious)?

The layer is invalidated at the end of a show operation, so `AvnView.updateLayer`/`HandlePaint` is called, creating the render target
