### PR TITLE
Add missing Screen.Equals/GetHashCode overrides

### DIFF
--- a/src/Avalonia.Controls/Platform/IScreenImpl.cs
+++ b/src/Avalonia.Controls/Platform/IScreenImpl.cs
@@ -27,7 +27,8 @@ namespace Avalonia.Platform
         public override IPlatformHandle? TryGetPlatformHandle() => platformHandle;
 
         public override int GetHashCode() => platformHandle.GetHashCode();
-        public override bool Equals(object? obj)
+
+        public override bool Equals(Screen? obj)
         {
             return obj is PlatformScreen other && platformHandle.Equals(other.TryGetPlatformHandle()!);
         }

--- a/src/Avalonia.Controls/Platform/Screen.cs
+++ b/src/Avalonia.Controls/Platform/Screen.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using Avalonia.Diagnostics;
 using Avalonia.Metadata;
 using Avalonia.Utilities;
@@ -122,13 +123,19 @@ namespace Avalonia.Platform
         /// </returns>
         public virtual IPlatformHandle? TryGetPlatformHandle() => null;
 
+        // TODO12: make abstract
+        /// <inheritdoc />
+        public override int GetHashCode()
+            => RuntimeHelpers.GetHashCode(this);
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+            => obj is Screen other && Equals(other);
+
+        // TODO12: make abstract
         /// <inheritdoc/>
-        public bool Equals(Screen? other)
-        {
-            if (other is null) return false;
-            if (ReferenceEquals(this, other)) return true;
-            return base.Equals(other);
-        }
+        public virtual bool Equals(Screen? other)
+            => ReferenceEquals(this, other);
 
         public static bool operator ==(Screen? left, Screen? right)
         {


### PR DESCRIPTION
This PR adds missing overrides for `Equals(object)` and `GetHashCode()` on `Screen`.
This has two purposes: first to fix some build warnings, and second to correct the screen equality behavior.

Before this PR, `Screen.Equals(Screen)` was delegating to `base.Equals(object)`. I think it was meant to call the `Equals(object)` overridden in the derived `PlatformScreen`, but the `base` call make it _non_-virtual. 

Basically, `Equals(Screen)` was always equivalent to `ReferenceEquals()` and thus different from `Equals(object)`.

`Equals(object)` now calls `Equals(Screen)`, which is overridden.
Ideally, we should make `Screen`, `Screen.Equals(Screen)` and `Screen.GetHashCode()` abstract in v12.
