### PR TITLE
Fix ClickOnce entry assembly not having Avalonia XAML compilation output

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -174,6 +174,12 @@
       <_AvaloniaXamlCompiledSymbols Include="@(_DebugSymbolsIntermediatePath->Metadata('AvaloniaCompileOutput'))"/>
       <_DebugSymbolsIntermediatePath Remove="@(_DebugSymbolsIntermediatePath)"/>
       <_DebugSymbolsIntermediatePath Include="@(_AvaloniaXamlCompiledSymbols)"/>
+      
+      <!-- ClickOnce takes a copy of @(IntermediateAssembly) during the evaluation phase -->
+      <_DeploymentManifestEntryPoint Remove="@(_DeploymentManifestEntryPoint)" />
+      <_DeploymentManifestEntryPoint Include="@(_AvaloniaXamlCompiledAssembly)">
+        <TargetPath>$(TargetFileName)</TargetPath>
+      </_DeploymentManifestEntryPoint>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
ClickOnce records the "entry point assembly" [at evaluation time](https://github.com/dotnet/msbuild/blob/1205246b0fe49f0d00316c103cf0c381d96063d4/src/Tasks/Microsoft.Common.CurrentVersion.targets#L437). This means that even though our `InjectAvaloniaXamlOutput` target executes at the correct time, there is a copy of the original file path that it doesn't know about and so can't update. As a result, the assembly being published doesn't have XAML compile output (all referenced assemblies are OK though).

## What is the updated/expected behavior with this PR?
We now update the ClickOnce item.

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #16732 