### PR TITLE
Begin with DisableRuntimeMarshalling support + fix macOS Metal AOT

### DIFF
--- a/build/TrimmingEnable.props
+++ b/build/TrimmingEnable.props
@@ -19,4 +19,10 @@
     <WarningsAsErrors Condition="'$(IsAotCompatible)' == 'true'">$(WarningsAsErrors);IL3050;IL3051;IL3052;IL3053;IL3054;IL3055;IL3056</WarningsAsErrors>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) AND '$(EnableRuntimeMarshalling)' != 'true'">
+    <WarningsAsErrors>$(WarningsAsErrors);CA1420;CA1421</WarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) AND '$(EnableRuntimeMarshalling)' != 'true'">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute" />
+  </ItemGroup>
 </Project>

--- a/src/Android/Avalonia.Android/Avalonia.Android.csproj
+++ b/src/Android/Avalonia.Android/Avalonia.Android.csproj
@@ -4,6 +4,7 @@
     <SupportedOSPlatformVersion>$(AvsMinSupportedAndroidVersion)</SupportedOSPlatformVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AndroidResgenNamespace>Avalonia.Android.Internal</AndroidResgenNamespace>
+    <EnableRuntimeMarshalling>true</EnableRuntimeMarshalling>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/AndroidFramebuffer.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/AndroidFramebuffer.cs
@@ -6,7 +6,7 @@ using Avalonia.Platform;
 
 namespace Avalonia.Android.Platform.SkiaPlatform
 {
-    class AndroidFramebuffer : ILockedFramebuffer
+    unsafe class AndroidFramebuffer : ILockedFramebuffer
     {
         private IntPtr _window;
 
@@ -24,7 +24,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
                 bottom = ANativeWindow_getHeight(_window)
             };
             Size = new PixelSize(rc.right, rc.bottom);
-            ANativeWindow_lock(_window, out buffer, ref rc);
+            ANativeWindow_lock(_window, &buffer, &rc);
 
             Format = buffer.format == AndroidPixelFormat.WINDOW_FORMAT_RGB_565
                 ? PixelFormat.Rgb565 : PixelFormat.Rgba8888;
@@ -61,7 +61,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         internal static extern void ANativeWindow_unlockAndPost(IntPtr window);
 
         [DllImport("android")]
-        internal static extern int ANativeWindow_lock(IntPtr window, out ANativeWindow_Buffer outBuffer, ref ARect inOutDirtyBounds);
+        internal static extern int ANativeWindow_lock(IntPtr window, ANativeWindow_Buffer* outBuffer, ARect* inOutDirtyBounds);
         public enum AndroidPixelFormat
         {
             WINDOW_FORMAT_RGBA_8888 = 1,

--- a/src/Android/Avalonia.Android/Platform/Vulkan/VulkanSupport.cs
+++ b/src/Android/Avalonia.Android/Platform/Vulkan/VulkanSupport.cs
@@ -6,10 +6,10 @@ using Avalonia.Vulkan;
 
 namespace Avalonia.Android.Platform.Vulkan
 {
-    internal class VulkanSupport
+    internal partial class VulkanSupport
     {
-        [DllImport("libvulkan.so")]
-        private static extern IntPtr vkGetInstanceProcAddr(IntPtr instance, string name);
+        [LibraryImport("libvulkan.so", StringMarshalling = StringMarshalling.Utf8)]
+        private static partial IntPtr vkGetInstanceProcAddr(IntPtr instance, string name);
 
         public static VulkanPlatformGraphics? TryInitialize(VulkanOptions options) =>
             VulkanPlatformGraphics.TryCreate(options ?? new(), new VulkanPlatformSpecificOptions

--- a/src/Avalonia.Base/Avalonia.Base.csproj
+++ b/src/Avalonia.Base/Avalonia.Base.csproj
@@ -5,7 +5,6 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
-    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Assets\*.trie" />

--- a/src/Avalonia.Base/Media/Imaging/PixelFormatTranscoder.cs
+++ b/src/Avalonia.Base/Media/Imaging/PixelFormatTranscoder.cs
@@ -18,7 +18,7 @@ internal static unsafe class PixelFormatTranscoder
         AlphaFormat destAlphaFormat)
     {
         var pixelCount = srcSize.Width * srcSize.Height;
-        var bufferSize = pixelCount * Marshal.SizeOf<Rgba8888Pixel>();
+        var bufferSize = pixelCount * sizeof(Rgba8888Pixel);
         using var blob = new UnmanagedBlob(bufferSize);
       
         var pixels = new Span<Rgba8888Pixel>((void*)blob.Address, pixelCount);

--- a/src/Avalonia.FreeDesktop/Avalonia.FreeDesktop.csproj
+++ b/src/Avalonia.FreeDesktop/Avalonia.FreeDesktop.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks);netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <EnableRuntimeMarshalling>true</EnableRuntimeMarshalling>
   </PropertyGroup>
 
   <Import Project="../../build/TrimmingEnable.props" />

--- a/src/Avalonia.OpenGL/Avalonia.OpenGL.csproj
+++ b/src/Avalonia.OpenGL/Avalonia.OpenGL.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks);netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableRuntimeMarshalling>true</EnableRuntimeMarshalling>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Avalonia.Vulkan/Avalonia.Vulkan.csproj
+++ b/src/Avalonia.Vulkan/Avalonia.Vulkan.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks);netstandard2.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <EnableRuntimeMarshalling>true</EnableRuntimeMarshalling>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Avalonia.X11/Avalonia.X11.csproj
+++ b/src/Avalonia.X11/Avalonia.X11.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks);netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableRuntimeMarshalling>true</EnableRuntimeMarshalling>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Browser/Avalonia.Browser/Rendering/BrowserWebGlRenderTarget.cs
+++ b/src/Browser/Avalonia.Browser/Rendering/BrowserWebGlRenderTarget.cs
@@ -96,8 +96,8 @@ partial class WebGlContext : IGlContext, Avalonia.Skia.IGlSkiaSpecificOptionsFea
     [JSImport("WebGlRenderTarget.makeContextCurrent", AvaloniaModule.MainModuleName)]
     private static partial bool MakeContextCurrent(int context);
 
-    [DllImport("libSkiaSharp", EntryPoint = "eglGetProcAddress")]
-    private static extern IntPtr eglGetProcAddress(string name);
+    [LibraryImport("libSkiaSharp", EntryPoint = "eglGetProcAddress", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial IntPtr eglGetProcAddress(string name);
 
     private int _contextId;
     private readonly Thread _thread;

--- a/src/Linux/Avalonia.LinuxFramebuffer/Avalonia.LinuxFramebuffer.csproj
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Avalonia.LinuxFramebuffer.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks);netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableRuntimeMarshalling>true</EnableRuntimeMarshalling>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />

--- a/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
+++ b/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks);netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableRuntimeMarshalling>true</EnableRuntimeMarshalling>
     <!-- We still keep BinaryFormatter for WinForms compatibility. -->
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>


### PR DESCRIPTION
## What does the pull request do?

1. Sets DisableRuntimeMarshalling on every trimmable project, unless this project specified otherwise explicitly.
2. Sets EnableRuntimeMarshalling (custom prop) on every project, where runtime marshalling is still necessary (no need to do everything in one sit)
3. Makes Avalonia.Base and Avalonia.Skia compatible with DisableRuntimeMarshalling
4. As part of №3, fixes #17090 

## Fixed issues

Part #16273
Fixes #17090