### PR TITLE
Do not shape and render null terminator

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
@@ -9,6 +9,8 @@ namespace Avalonia.Media.TextFormatting
     /// </summary>
     public class TextCharacters : TextRun
     {
+        private static char[] ZeroWidthSpace = ['\u200b'];
+
         /// <summary>
         /// Constructs a run for text content from a string.
         /// </summary>
@@ -81,6 +83,15 @@ namespace Avalonia.Media.TextFormatting
             var previousTypeface = previousProperties?.Typeface;
             var previousGlyphTypeface = previousProperties?.CachedGlyphTypeface;
             var textSpan = text.Span;
+
+            //Read first codepoint
+            var firstCodepoint = Codepoint.ReadAt(textSpan, 0, out _);
+
+            //Detect null terminator
+            if (firstCodepoint.Value == 0)
+            {
+                return new UnshapedTextRun(ZeroWidthSpace.AsMemory(), defaultProperties, biDiLevel);
+            }
 
             if (TryGetShapeableLength(textSpan, defaultGlyphTypeface, null, out var count))
             {

--- a/src/Skia/Avalonia.Skia/TextShaperImpl.cs
+++ b/src/Skia/Avalonia.Skia/TextShaperImpl.cs
@@ -14,8 +14,6 @@ namespace Avalonia.Skia
 {
     internal class TextShaperImpl : ITextShaperImpl
     {
-        private const uint ZeroWidthSpace = '\u200b';
-
         private static readonly ConcurrentDictionary<int, Language> s_cachedLanguage = new();
 
         public ShapedBuffer ShapeText(ReadOnlyMemory<char> text, TextShaperOptions options)
@@ -69,17 +67,7 @@ namespace Avalonia.Skia
 
                     var glyphIndex = (ushort)sourceInfo.Codepoint;
 
-                    var glyphCluster = (int)(sourceInfo.Cluster);
-
-                    if (glyphIndex == 0)
-                    {
-                        var codepoint = Codepoint.ReadAt(textSpan, glyphCluster, out _);
-
-                        if (codepoint.GeneralCategory == GeneralCategory.Control)
-                        {
-                            glyphIndex = options.Typeface.GetGlyph(ZeroWidthSpace);
-                        }
-                    }
+                    var glyphCluster = (int)sourceInfo.Cluster;
 
                     var glyphAdvance = GetGlyphAdvance(glyphPositions, i, textScale) + options.LetterSpacing;
 

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
@@ -1374,6 +1374,29 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
             }
         }
 
+        [Fact]
+        public void Should_Ignore_Null_Terminator()
+        {
+            var text = "\x0";
+
+            using (Start())
+            {
+                var defaultProperties = new GenericTextRunProperties(Typeface.Default);
+                var textSource = new SingleBufferTextSource(text, defaultProperties, true);
+
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, double.PositiveInfinity,
+                        new GenericTextParagraphProperties(FlowDirection.LeftToRight, TextAlignment.Left,
+                        true, true, defaultProperties, TextWrapping.NoWrap, 0, 0, 0));
+
+                Assert.NotNull(textLine);
+
+                Assert.Equal(0, textLine.Width);
+            }
+        }
+
         private class FixedRunsTextSource : ITextSource
         {
             private readonly IReadOnlyList<TextRun> _textRuns;

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
@@ -1374,11 +1374,13 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
             }
         }
 
-        [Fact]
-        public void Should_Ignore_Null_Terminator()
+        [Theory]
+        [InlineData("\0", 0.0)]
+        [InlineData("\0\0\0", 0.0)]
+        [InlineData("\0A\0\0", 7.201171875)]
+        [InlineData("\0AA\0AA\0", 28.8046875)]
+        public void Should_Ignore_Null_Terminator(string text, double width)
         {
-            var text = "\x0";
-
             using (Start())
             {
                 var defaultProperties = new GenericTextRunProperties(Typeface.Default);
@@ -1393,7 +1395,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 Assert.NotNull(textLine);
 
-                Assert.Equal(0, textLine.Width);
+                Assert.Equal(width, textLine.Width);
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR ensures we do not try to shape and render null terminators. This matches what WPF is doing.

This PR reverts changes from here #17004

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
