### PR TITLE
Make UiThreadRenderTimer to calculate the next tick time based on expected FPS

### DIFF
--- a/src/Avalonia.Base/Rendering/UiThreadRenderTimer.cs
+++ b/src/Avalonia.Base/Rendering/UiThreadRenderTimer.cs
@@ -3,39 +3,73 @@ using System.Diagnostics;
 using Avalonia.Metadata;
 using Avalonia.Reactive;
 using Avalonia.Threading;
+using System;
+using System.Diagnostics;
+using Avalonia.Metadata;
+using Avalonia.Threading;
 
-namespace Avalonia.Rendering
+namespace Avalonia.Rendering;
+
+/// <summary>
+/// Render timer that ticks on UI thread. Useful for debugging or bootstrapping on new platforms 
+/// </summary>
+public class UiThreadRenderTimer : DefaultRenderTimer
 {
+    private readonly Stopwatch _clock = Stopwatch.StartNew();
     /// <summary>
-    /// Render timer that ticks on UI thread. Useful for debugging or bootstrapping on new platforms 
+    /// Initializes a new instance of the <see cref="UiThreadRenderTimer"/> class.
     /// </summary>
-    [PrivateApi]
-    public class UiThreadRenderTimer : DefaultRenderTimer
+    /// <param name="framesPerSecond">The number of frames per second at which the loop should run.</param>
+    public UiThreadRenderTimer(int framesPerSecond) : base(framesPerSecond)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UiThreadRenderTimer"/> class.
-        /// </summary>
-        /// <param name="framesPerSecond">The number of frames per second at which the loop should run.</param>
-        public UiThreadRenderTimer(int framesPerSecond) : base(framesPerSecond)
+    }
+
+    /// <inheritdoc />
+    public override bool RunsInBackground => false;
+    
+    class TimerInstance : IDisposable
+    {
+        private UiThreadRenderTimer _parent;
+        private readonly Action<TimeSpan> _tick;
+        private DispatcherTimer _timer = new DispatcherTimer(DispatcherPriority.Render);
+
+        public TimerInstance(UiThreadRenderTimer parent, Action<TimeSpan> tick)
         {
+            _parent = parent;
+            _tick = tick;
+            _timer.Tick += OnTick;
+            _timer.Interval = Interval;
+            _timer.Start();
         }
 
-        /// <inheritdoc />
-        public override bool RunsInBackground => false;
-
-        /// <inheritdoc />
-        protected override IDisposable StartCore(Action<TimeSpan> tick)
+        private void OnTick(object? sender, EventArgs e)
         {
-            bool cancelled = false;
-            var st = Stopwatch.StartNew();
-            DispatcherTimer.Run(() =>
+            var tickedAt = _parent._clock.Elapsed;
+            var nextTickAt = tickedAt + Interval;
+            try
             {
-                if (cancelled)
-                    return false;
-                tick(st.Elapsed);
-                return !cancelled;
-            }, TimeSpan.FromSeconds(1.0 / FramesPerSecond), DispatcherPriority.UiThreadRender);
-            return Disposable.Create(() => cancelled = true);
+                _tick?.Invoke(tickedAt);
+            }
+            finally
+            {
+                var afterTick = _parent._clock.Elapsed;
+                var interval = nextTickAt - afterTick;
+                if (interval < s_minInterval)
+                    // We are way overdue, but shouldn't cause starvation in other areas
+                    interval = s_minInterval;
+                _timer.Interval = interval;
+            }
         }
+
+        private static readonly TimeSpan s_minInterval = TimeSpan.FromMilliseconds(1);
+        private TimeSpan Interval => TimeSpan.FromSeconds(1.0 / _parent.FramesPerSecond);
+
+        public void Dispose() => _timer.Stop();
+    }
+    
+    /// <inheritdoc />
+    protected override IDisposable StartCore(Action<TimeSpan> tick)
+    {
+        return new TimerInstance(this, tick);
     }
 }

--- a/src/Avalonia.Base/Rendering/UiThreadRenderTimer.cs
+++ b/src/Avalonia.Base/Rendering/UiThreadRenderTimer.cs
@@ -13,6 +13,7 @@ namespace Avalonia.Rendering;
 /// <summary>
 /// Render timer that ticks on UI thread. Useful for debugging or bootstrapping on new platforms 
 /// </summary>
+[PrivateApi]
 public class UiThreadRenderTimer : DefaultRenderTimer
 {
     private readonly Stopwatch _clock = Stopwatch.StartNew();
@@ -39,6 +40,7 @@ public class UiThreadRenderTimer : DefaultRenderTimer
             _tick = tick;
             _timer.Tick += OnTick;
             _timer.Interval = Interval;
+            Interval = TimeSpan.FromSeconds(1.0 / _parent.FramesPerSecond);
             _timer.Start();
         }
 
@@ -48,7 +50,7 @@ public class UiThreadRenderTimer : DefaultRenderTimer
             var nextTickAt = tickedAt + Interval;
             try
             {
-                _tick?.Invoke(tickedAt);
+                _tick(tickedAt);
             }
             finally
             {
@@ -62,7 +64,7 @@ public class UiThreadRenderTimer : DefaultRenderTimer
         }
 
         private static readonly TimeSpan s_minInterval = TimeSpan.FromMilliseconds(1);
-        private TimeSpan Interval => TimeSpan.FromSeconds(1.0 / _parent.FramesPerSecond);
+        private TimeSpan Interval { get; }
 
         public void Dispose() => _timer.Stop();
     }


### PR DESCRIPTION
DispatcherTimer.Interval indicates the interval between the previous tick _completion_ and the next one. Render timer, on the other hand, needs to have its interval to indicate time between tick starts.

