### PR TITLE
Disable runtime marshalling for getprocaddress

### DIFF
--- a/src/Android/Avalonia.Android/Avalonia.Android.csproj
+++ b/src/Android/Avalonia.Android/Avalonia.Android.csproj
@@ -4,7 +4,6 @@
     <SupportedOSPlatformVersion>$(AvsMinSupportedAndroidVersion)</SupportedOSPlatformVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AndroidResgenNamespace>Avalonia.Android.Internal</AndroidResgenNamespace>
-    <EnableRuntimeMarshalling>true</EnableRuntimeMarshalling>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />

--- a/src/Avalonia.OpenGL/Avalonia.OpenGL.csproj
+++ b/src/Avalonia.OpenGL/Avalonia.OpenGL.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks);netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <EnableRuntimeMarshalling>true</EnableRuntimeMarshalling>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Avalonia.Vulkan/Avalonia.Vulkan.csproj
+++ b/src/Avalonia.Vulkan/Avalonia.Vulkan.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks);netstandard2.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <EnableRuntimeMarshalling>true</EnableRuntimeMarshalling>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Contributes towards https://github.com/AvaloniaUI/Avalonia/issues/16273

## What does the pull request do?

Adjust GetProcAddressInitializationGenerator to not rely on runtime marshalling.
And disables runtime marshalling for OpenGL, Vulkan and Android projects.

Tested with AngleGL and Vulkan on Windows, running control catalog and opengl demo. Also GpuIntetop.

## What is the current behavior?

Old generated code:
```csharp
delegate* unmanaged[Stdcall]<global::Avalonia.Vulkan.UnmanagedInterop.VkDevice,ref global::Avalonia.Vulkan.UnmanagedInterop.VkFenceCreateInfo,global::System.IntPtr,out global::Avalonia.Vulkan.UnmanagedInterop.VkFence,global::Avalonia.Vulkan.UnmanagedInterop.VkResult>_addr_CreateFence;
[global::System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute(global::System.Runtime.InteropServices.CallingConvention.Cdecl)]
internal delegate global::Avalonia.Vulkan.UnmanagedInterop.VkResult __wasmDummyCreateFence(global::Avalonia.Vulkan.UnmanagedInterop.VkDevice a0,ref global::Avalonia.Vulkan.UnmanagedInterop.VkFenceCreateInfo a1,global::System.IntPtr a2,out global::Avalonia.Vulkan.UnmanagedInterop.VkFence a3);
public  partial global::Avalonia.Vulkan.UnmanagedInterop.VkResult CreateFence(global::Avalonia.Vulkan.UnmanagedInterop.VkDevice @device, ref global::Avalonia.Vulkan.UnmanagedInterop.VkFenceCreateInfo @pCreateInfo, global::System.IntPtr @pAllocator, out global::Avalonia.Vulkan.UnmanagedInterop.VkFence @pFence)
    {
        return _addr_CreateFence(@device, ref @pCreateInfo, @pAllocator, out @pFence);
    }
```


## What is the updated/expected behavior with this PR?

New generated code:
```csharp
delegate* unmanaged[Stdcall]<global::Avalonia.Vulkan.UnmanagedInterop.VkDevice,global::Avalonia.Vulkan.UnmanagedInterop.VkFenceCreateInfo*,nint,global::Avalonia.Vulkan.UnmanagedInterop.VkFence*,global::Avalonia.Vulkan.UnmanagedInterop.VkResult>_addr_CreateFence;  
[global::System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute(global::System.Runtime.InteropServices.CallingConvention.Cdecl)]
internal delegate global::Avalonia.Vulkan.UnmanagedInterop.VkResult __wasmDummyCreateFence(global::Avalonia.Vulkan.UnmanagedInterop.VkDevice a0,global::Avalonia.Vulkan.UnmanagedInterop.VkFenceCreateInfo* a1,nint a2,global::Avalonia.Vulkan.UnmanagedInterop.VkFence* a3);
public  partial global::Avalonia.Vulkan.UnmanagedInterop.VkResult CreateFence(global::Avalonia.Vulkan.UnmanagedInterop.VkDevice @device, ref global::Avalonia.Vulkan.UnmanagedInterop.VkFenceCreateInfo @pCreateInfo, nint @pAllocator, out global::Avalonia.Vulkan.UnmanagedInterop.VkFence @pFence)
    {
        fixed(global::Avalonia.Vulkan.UnmanagedInterop.VkFenceCreateInfo* @__p_pCreateInfo = &pCreateInfo)
        fixed(global::Avalonia.Vulkan.UnmanagedInterop.VkFence* @__p_pFence = &pFence)
        return _addr_CreateFence(@device, @__p_pCreateInfo, @pAllocator, @__p_pFence);
    }
```

Note: ref/out parameters are kept in the user facing API, while unmanaged delegates now use pointers instead. With fixed statements in between.

