### PR TITLE
Execute Dispatcher.RunJobs after each headless NUnit test

### DIFF
--- a/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
+++ b/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
@@ -109,6 +109,7 @@ internal class AvaloniaTestMethodCommand : TestCommand
         if (context.ExecutionStatus != TestExecutionStatus.AbortRequested)
         {
             _afterTest.ForEach(a => a());
+            Dispatcher.UIThread.RunJobs();
         }
         
         return context.CurrentResult;


### PR DESCRIPTION
This PR ensures that `Dispatcher.RunJobs()` runs after each headless NUnit test, preventing pending jobs from being executed in the next test.

Note that the XUnit headless infrastructure was already doing this:
https://github.com/AvaloniaUI/Avalonia/blob/432fbe8a9eb2e3c807bf71bed43968efbd5a3dec/src/Headless/Avalonia.Headless.XUnit/AvaloniaTestCaseRunner.cs#L33

This PR should make tests from #17103 pass.