### PR TITLE
Fixed TabItem.ContentTemplate being reused for the next tab item

### DIFF
--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -207,10 +207,21 @@ namespace Avalonia.Controls
                 container ??= ContainerFromIndex(SelectedIndex);
                 if (container != null)
                 {
+                    if (SelectedContentTemplate != SelectContentTemplate(container.GetValue(ContentTemplateProperty)))
+                    {
+                        // If the value of SelectedContentTemplate is about to change, clear it first. This ensures
+                        // that the template is not reused as soon as SelectedContent changes in the statement below
+                        // this block, and also that controls generated from it are unloaded before SelectedContent
+                        // (which is typically their DataContext) changes.
+                        SelectedContentTemplate = null;
+                    }
+
                     _selectedItemSubscriptions = new CompositeDisposable(
                         container.GetObservable(ContentControl.ContentProperty).Subscribe(v => SelectedContent = v),
-                        // Note how we fall back to our own ContentTemplate if the container doesn't specify one
-                        container.GetObservable(ContentControl.ContentTemplateProperty).Subscribe(v => SelectedContentTemplate = v ?? ContentTemplate));
+                        container.GetObservable(ContentControl.ContentTemplateProperty).Subscribe(v => SelectedContentTemplate = SelectContentTemplate(v)));
+
+                    // Note how we fall back to our own ContentTemplate if the container doesn't specify one
+                    IDataTemplate? SelectContentTemplate(IDataTemplate? containerTemplate) => containerTemplate ?? ContentTemplate;
                 }
             }
         }

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -406,6 +406,41 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Previous_ContentTemplate_Is_Not_Reused_When_TabItem_Changes()
+        {
+            int templatesBuilt = 0;
+
+            var target = new TabControl
+            {
+                Template = TabControlTemplate(),
+                Items =
+                {
+                    TabItemFactory("First tab content"),
+                    TabItemFactory("Second tab content"),
+                },
+            };
+
+            var root = new TestRoot(target);
+            ApplyTemplate(target);
+
+            target.SelectedIndex = 0;
+            target.SelectedIndex = 1;
+
+            Assert.Equal(2, templatesBuilt);
+
+            TabItem TabItemFactory(object content) => new()
+            {
+                Content = content,
+                ContentTemplate = new FuncDataTemplate<object>((actual, ns) =>
+                {
+                    Assert.Equal(content, actual);
+                    templatesBuilt++;
+                    return new Border();
+                })
+            };
+        }
+
+        [Fact]
         public void Should_Not_Propagate_DataContext_To_TabItem_Content()
         {
             var dataContext = "DataContext";


### PR DESCRIPTION
When `TabControl` switches between items, it first changes `SelectedContent`, and then changes `SelectedContentTemplate`. This means that there is a gap within which the content and content template can be out of sync.

## What does the pull request do?
This PR determines whether `SelectedContentTemplate` is about to change when switching `TabItem`. If it is, the value is now cleared before changing either `SelectedContent` or `SelectedContentTemplate`. This avoids an unnecessary template build call and prevents the old template and any controls generated from it from ever seeing the new content object. They may not expect or support the new content object.

## Breaking changes
None, unless you count the template being built with the wrong content immediately before being built again with the right content a supported feature.

## Obsoletions / Deprecations
None.