### PR TITLE
Fixed publishing multi-architecture Android builds

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -133,7 +133,7 @@
     DependsOnTargets="$(CompileAvaloniaXamlDependsOn)"
     Inputs="@(CompileAvaloniaXamlInputs)"
     Outputs="@(CompileAvaloniaXamlOutputs)"
-    Condition="'@(AvaloniaResource)@(AvaloniaXaml)' != '' AND $(DesignTimeBuild) != true AND $(EnableAvaloniaXamlCompilation) != false">
+    Condition="'@(AvaloniaResource)@(AvaloniaXaml)' != '' AND $(EnableAvaloniaXamlCompilation) != false AND '$(SkipCompilerExecution)' != 'true'">
 
     <!--
       $(IntermediateOutputPath)/Avalonia/references is using from AvaloniaVS for retrieve library references.
@@ -161,7 +161,7 @@
   </Target>
   
   <Target Name="InjectAvaloniaXamlOutput" DependsOnTargets="PrepareToCompileAvaloniaXaml" AfterTargets="CompileAvaloniaXaml" BeforeTargets="CopyFilesToOutputDirectory;BuiltProjectOutputGroup;ComputeResolvedFilesToPublishList"
-          Condition="'@(AvaloniaResource)@(AvaloniaXaml)' != '' AND $(EnableAvaloniaXamlCompilation) != false">
+          Condition="'@(AvaloniaResource)@(AvaloniaXaml)' != '' AND $(EnableAvaloniaXamlCompilation) != false AND '$(SkipCompilerExecution)' != 'true'">
     <ItemGroup>
       <_AvaloniaXamlCompiledAssembly Include="@(IntermediateAssembly->Metadata('AvaloniaCompileOutput'))"/>
       <IntermediateAssembly Remove="@(IntermediateAssembly)"/>
@@ -192,7 +192,7 @@
           DependsOnTargets="InjectAvaloniaXamlOutput"
           AfterTargets="ComputeIlcCompileInputs"
           BeforeTargets="PrepareForILLink"
-          Condition="$([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '9.0')) AND '@(AvaloniaResource)@(AvaloniaXaml)' != '' AND $(EnableAvaloniaXamlCompilation) != false">
+          Condition="$([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '9.0')) AND '@(AvaloniaResource)@(AvaloniaXaml)' != '' AND $(EnableAvaloniaXamlCompilation) != false AND '$(SkipCompilerExecution)' != 'true'">
     <ItemGroup>
       <ManagedBinary Remove="$(IntermediateOutputPath)$(TargetName)$(TargetExt)" />
       <ManagedBinary Include="@(_AvaloniaXamlCompiledAssembly)" />


### PR DESCRIPTION
Avalonia now respects the `SkipCompilerExecution` property. This fixes multi-architecture Android builds, in which the path to the intermediate assembly, which has already been transformed once, is passed to each inner build and then transformed again.

If compiler execution is being skipped then the presence of compiled output cannot be relied on, so not transforming the assembly paths seems harmless to me. This property check can replace `DesignTimeBuild` [as both are passed at the same time](https://github.com/dotnet/msbuild/wiki/MSBuild-Tips-&-Tricks/ce81baf1075c5826d385bff8d5e91895cf4fe641#visual-studio-design-time-intellisense-builds).

The Android SDK passes the assembly path like this:

![image](https://github.com/user-attachments/assets/8c162051-5eb4-47e2-8cd3-8449f8888f79)

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #17099