### PR TITLE
Fix INotifyCollectionChanged Move and Replace handling

### DIFF
--- a/src/Avalonia.Base/Collections/AvaloniaDictionaryExtensions.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaDictionaryExtensions.cs
@@ -70,11 +70,6 @@ namespace Avalonia.Collections
                     case NotifyCollectionChangedAction.Move:
                     case NotifyCollectionChangedAction.Replace:
                         Remove(e.OldItems!);
-                        int newIndex = e.NewStartingIndex;
-                        if(newIndex > e.OldStartingIndex)
-                        {
-                            newIndex -= e.OldItems!.Count;
-                        }
                         Add(e.NewItems!);
                         break;
 

--- a/src/Avalonia.Base/Collections/AvaloniaList.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaList.cs
@@ -466,7 +466,7 @@ namespace Avalonia.Collections
 
             if (newIndex > oldIndex)
             {
-                modifiedNewIndex -= count;
+                modifiedNewIndex -= count - 1;
             }
 
             _inner.InsertRange(modifiedNewIndex, items);

--- a/src/Avalonia.Base/Collections/AvaloniaListExtensions.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaListExtensions.cs
@@ -99,14 +99,29 @@ namespace Avalonia.Collections
                         break;
 
                     case NotifyCollectionChangedAction.Move:
-                    case NotifyCollectionChangedAction.Replace:
+                        if (e.OldStartingIndex < 0)
+                        {
+                            goto case NotifyCollectionChangedAction.Reset;
+                        }
+
                         Remove(e.OldStartingIndex, e.OldItems!);
-                        int newIndex = e.NewStartingIndex;
+                        var newIndex = e.NewStartingIndex;
+
                         if(newIndex > e.OldStartingIndex)
                         {
-                            newIndex -= e.OldItems!.Count;
+                            newIndex -= e.OldItems!.Count - 1;
                         }
+
                         Add(newIndex, e.NewItems!);
+                        break;
+                    case NotifyCollectionChangedAction.Replace:
+                        if (e.OldStartingIndex < 0)
+                        {
+                            goto case NotifyCollectionChangedAction.Reset;
+                        }
+
+                        Remove(e.OldStartingIndex, e.OldItems!);
+                        Add(e.NewStartingIndex, e.NewItems!);
                         break;
 
                     case NotifyCollectionChangedAction.Remove:

--- a/src/Avalonia.Controls/Presenters/PanelContainerGenerator.cs
+++ b/src/Avalonia.Controls/Presenters/PanelContainerGenerator.cs
@@ -93,9 +93,29 @@ namespace Avalonia.Controls.Presenters
                     Remove(e.OldStartingIndex, e.OldItems!.Count);
                     break;
                 case NotifyCollectionChangedAction.Replace:
-                case NotifyCollectionChangedAction.Move:
+                    if (e.OldStartingIndex < 0)
+                    {
+                        goto case NotifyCollectionChangedAction.Reset;
+                    }
+
                     Remove(e.OldStartingIndex, e.OldItems!.Count);
                     Add(e.NewStartingIndex, e.NewItems!);
+                    break;
+                case NotifyCollectionChangedAction.Move:
+                    if (e.OldStartingIndex < 0)
+                    {
+                        goto case NotifyCollectionChangedAction.Reset;
+                    }
+
+                    Remove(e.OldStartingIndex, e.OldItems!.Count);
+                    var insertIndex = e.NewStartingIndex;
+
+                    if (e.NewStartingIndex > e.OldStartingIndex)
+                    {
+                        insertIndex -= e.OldItems.Count - 1;
+                    }
+
+                    Add(insertIndex, e.NewItems!);
                     break;
                 case NotifyCollectionChangedAction.Reset:
                     ClearItemsControlLogicalChildren();

--- a/src/Avalonia.Controls/Selection/SelectionNodeBase.cs
+++ b/src/Avalonia.Controls/Selection/SelectionNodeBase.cs
@@ -139,10 +139,35 @@ namespace Avalonia.Controls.Selection
                         break;
                     }
                 case NotifyCollectionChangedAction.Replace:
-                case NotifyCollectionChangedAction.Move:
                     {
+                        if (e.OldStartingIndex < 0)
+                        {
+                            goto case NotifyCollectionChangedAction.Reset;
+                        }
+
                         var removeChange = OnItemsRemoved(e.OldStartingIndex, e.OldItems!);
                         var addChange = OnItemsAdded(e.NewStartingIndex, e.NewItems!);
+                        shiftIndex = removeChange.ShiftIndex;
+                        shiftDelta = removeChange.ShiftDelta + addChange.ShiftDelta;
+                        removed = removeChange.RemovedItems;
+                        break;
+                    }
+                case NotifyCollectionChangedAction.Move:
+                    {
+                        if (e.OldStartingIndex < 0)
+                        {
+                            goto case NotifyCollectionChangedAction.Reset;
+                        }
+
+                        var removeChange = OnItemsRemoved(e.OldStartingIndex, e.OldItems!);
+                        var insertIndex = e.NewStartingIndex;
+
+                        if (e.NewStartingIndex > e.OldStartingIndex)
+                        {
+                            insertIndex -= e.OldItems!.Count - 1;
+                        }
+
+                        var addChange = OnItemsAdded(insertIndex, e.NewItems!);
                         shiftIndex = removeChange.ShiftIndex;
                         shiftDelta = removeChange.ShiftDelta + addChange.ShiftDelta;
                         removed = removeChange.RemovedItems;

--- a/src/Avalonia.Controls/VirtualizingCarouselPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingCarouselPanel.cs
@@ -236,9 +236,29 @@ namespace Avalonia.Controls
                     Remove(e.OldStartingIndex, e.OldItems!.Count);
                     break;
                 case NotifyCollectionChangedAction.Replace:
-                case NotifyCollectionChangedAction.Move:
+                    if (e.OldStartingIndex < 0)
+                    {
+                        goto case NotifyCollectionChangedAction.Reset;
+                    }
+
                     Remove(e.OldStartingIndex, e.OldItems!.Count);
                     Add(e.NewStartingIndex, e.NewItems!.Count);
+                    break;
+                case NotifyCollectionChangedAction.Move:
+                    if (e.OldStartingIndex < 0)
+                    {
+                        goto case NotifyCollectionChangedAction.Reset;
+                    }
+
+                    Remove(e.OldStartingIndex, e.OldItems!.Count);
+                    var insertIndex = e.NewStartingIndex;
+
+                    if (e.NewStartingIndex > e.OldStartingIndex)
+                    {
+                        insertIndex -= e.OldItems.Count - 1;
+                    }
+
+                    Add(insertIndex, e.NewItems!.Count);
                     break;
                 case NotifyCollectionChangedAction.Reset:
                     if (_realized is not null)

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -272,8 +272,20 @@ namespace Avalonia.Controls
                     _realizedElements.ItemsReplaced(e.OldStartingIndex, e.OldItems!.Count, _recycleElementOnItemRemoved);
                     break;
                 case NotifyCollectionChangedAction.Move:
+                    if (e.OldStartingIndex < 0)
+                    {
+                        goto case NotifyCollectionChangedAction.Reset;
+                    }
+
                     _realizedElements.ItemsRemoved(e.OldStartingIndex, e.OldItems!.Count, _updateElementIndex, _recycleElementOnItemRemoved);
-                    _realizedElements.ItemsInserted(e.NewStartingIndex, e.NewItems!.Count, _updateElementIndex);
+                    var insertIndex = e.NewStartingIndex;
+
+                    if (e.NewStartingIndex > e.OldStartingIndex)
+                    {
+                        insertIndex -= e.OldItems.Count - 1;
+                    }
+
+                    _realizedElements.ItemsInserted(insertIndex, e.NewItems!.Count, _updateElementIndex);
                     break;
                 case NotifyCollectionChangedAction.Reset:
                     _realizedElements.ItemsReset(_recycleElementOnItemRemoved);

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Avalonia.Collections;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
 using Avalonia.UnitTests;
@@ -86,6 +87,20 @@ namespace Avalonia.Controls.UnitTests.Presenters
                 var panel = Assert.IsType<StackPanel>(target.Panel);
 
                 items.Move(0, 2);
+                root.LayoutManager.ExecuteLayoutPass();
+
+                AssertContainers(panel, items);
+            }
+
+            [Fact]
+            public void Updates_Container_For_Moved_Range_Of_Items()
+            {
+                using var app = Start();
+                AvaloniaList<string> items = ["foo", "bar", "baz"];
+                var (target, _, root) = CreateTarget(items);
+                var panel = Assert.IsType<StackPanel>(target.Panel);
+
+                items.MoveRange(0, 2, 2);
                 root.LayoutManager.ExecuteLayoutPass();
 
                 AssertContainers(panel, items);

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingCarouselPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingCarouselPanelTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Animation;
+using Avalonia.Collections;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
@@ -108,6 +110,28 @@ namespace Avalonia.Controls.UnitTests
             Assert.Single(target.Children);
             Assert.Same(container, target.Children[0]);
             Assert.Equal("bar", container.Content);
+        }
+
+        [Fact]
+        public void Handles_Moved_Item_Range()
+        {
+            using var app = Start();
+            AvaloniaList<string> items = ["foo", "bar", "baz", "qux", "quux"];
+            var (target, carousel) = CreateTarget(items);
+            var container = Assert.IsType<ContentPresenter>(target.Children[0]);
+
+            carousel.SelectedIndex = 3;
+            Layout(target);
+            items.MoveRange(0, 2, 4);
+            Layout(target);
+
+            Assert.Multiple(() =>
+            {
+                Assert.Single(target.Children);
+                Assert.Same(container, target.Children[0]);
+                Assert.Equal("qux", container.Content);
+                Assert.Equal(1, carousel.SelectedIndex);
+            });
         }
 
         public class Transitions

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -198,6 +198,68 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Updates_Elements_On_Item_Moved()
+        {
+            // Arrange
+
+            using var app = App();
+
+            var actualItems = new AvaloniaList<string>(Enumerable
+                .Range(0, 100)
+                .Select(x => $"Item {x}"));
+
+            var (target, _, itemsControl) = CreateTarget(items: actualItems);
+
+            var expectedRealizedElementContents = new[] { 1, 2, 0, 3, 4, 5, 6, 7, 8, 9 }
+                .Select(x => $"Item {x}");
+
+            // Act
+
+            actualItems.Move(0, 2);
+            Layout(target);
+
+            // Assert
+
+            var actualRealizedElementContents = target
+                .GetRealizedElements()
+                .Cast<ContentPresenter>()
+                .Select(x => x.Content);
+
+            Assert.Equivalent(expectedRealizedElementContents, actualRealizedElementContents);
+        }
+
+        [Fact]
+        public void Updates_Elements_On_Item_Range_Moved()
+        {
+            // Arrange
+
+            using var app = App();
+
+            var actualItems = new AvaloniaList<string>(Enumerable
+                .Range(0, 100)
+                .Select(x => $"Item {x}"));
+
+            var (target, _, itemsControl) = CreateTarget(items: actualItems);
+
+            var expectedRealizedElementContents = new[] { 2, 0, 1, 3, 4, 5, 6, 7, 8, 9 }
+                .Select(x => $"Item {x}");
+
+            // Act
+
+            actualItems.MoveRange(0, 2, 3);
+            Layout(target);
+
+            // Assert
+
+            var actualRealizedElementContents = target
+                .GetRealizedElements()
+                .Cast<ContentPresenter>()
+                .Select(x => x.Content);
+
+            Assert.Equivalent(expectedRealizedElementContents, actualRealizedElementContents);
+        }
+
+        [Fact]
         public void Updates_Elements_On_Item_Remove()
         {
             using var app = App();


### PR DESCRIPTION
## What does the pull request do?

This PR changes multi-item `Move` and `Replace` event handlers in Avalonia to conform with the [MAUI implementation](https://github.com/dotnet/maui/blob/cc683f0e99547c2ed4875296d7451332ef64ca73/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs#L25-L88).

This PR also corrects the meaning of `AvaloniaList.MoveRange` (i.e., `Move(X, Y)` should match `MoveRange(X, 1, Y)`).

## What is the current behavior?

- `MoveRange` emits incorrect `INotifyCollectionChanged` events (it is off by one).
- Multi-item `Move` and `Replace` operations incorrectly affect
  - Users of `AvaloniaListExtensions`.
  - `ItemsControl`.
  - `VirtualizingStackPanel`.

## What is the updated/expected behavior with this PR?

- `MoveRange` emits correct `INotifyCollectionChanged` events.
- Multi-item `Move` and `Replace` handlers are correctly implemented.


## How was the solution implemented (if it's not obvious)?

Implemented by following the [MAUI implementation](https://github.com/dotnet/maui/blob/cc683f0e99547c2ed4875296d7451332ef64ca73/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs#L25-L88).

## Checklist

- [X] Added unit tests (if possible)?
- [X] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

- Changes the behavior of `Avalonia.MoveRange`.
- Changes the interpretation of `Move` and `Replace` events (e.g., if users previously depended on the incorrect behavior).

## Fixed issues

Fixes #17157
