### PR TITLE
Fix SplitView :closed pseudoclass not being added on control initialization #17176

### DIFF
--- a/src/Avalonia.Controls/SplitView/SplitView.cs
+++ b/src/Avalonia.Controls/SplitView/SplitView.cs
@@ -297,6 +297,7 @@ namespace Avalonia.Controls
             _pane = e.NameScope.Find<Panel>("PART_PaneRoot");
 
             UpdateVisualStateForDisplayMode(DisplayMode);
+            UpdatePaneStatePseudoClass(IsPaneOpen);
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -331,19 +332,13 @@ namespace Avalonia.Controls
             else if (change.Property == IsPaneOpenProperty)
             {
                 bool isPaneOpen = change.GetNewValue<bool>();
-
+                UpdatePaneStatePseudoClass(isPaneOpen);
                 if (isPaneOpen)
                 {
-                    PseudoClasses.Add(pcOpen);
-                    PseudoClasses.Remove(pcClosed);
-
                     OnPaneOpened(new RoutedEventArgs(PaneOpenedEvent, this));
                 }
                 else
                 {
-                    PseudoClasses.Add(pcClosed);
-                    PseudoClasses.Remove(pcOpen);
-
                     OnPaneClosed(new RoutedEventArgs(PaneClosedEvent, this));
                 }
             }
@@ -577,6 +572,20 @@ namespace Avalonia.Controls
 
             SetCurrentValue(IsPaneOpenProperty, false);
             e.Handled = true;
+        }
+
+        private void UpdatePaneStatePseudoClass(bool isPaneOpen)
+        {
+            if (isPaneOpen)
+            {
+                PseudoClasses.Add(pcOpen);
+                PseudoClasses.Remove(pcClosed);
+            }
+            else
+            {
+                PseudoClasses.Add(pcClosed);
+                PseudoClasses.Remove(pcOpen);
+            }
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/SplitViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SplitViewTests.cs
@@ -1,5 +1,7 @@
-﻿using Avalonia.Input;
+﻿using Avalonia.Animation;
+using Avalonia.Input;
 using Avalonia.UnitTests;
+using Moq;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
@@ -65,7 +67,8 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void SplitView_TemplateSettings_Are_Correct_For_Display_Modes()
         {
-            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow
+                .With(globalClock: new MockGlobalClock()));
             var wnd = new Window
             {
                 Width = 1280,

--- a/tests/Avalonia.Controls.UnitTests/SplitViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SplitViewTests.cs
@@ -280,5 +280,25 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.True(splitView.IsPaneOpen);
         }
+
+        [Fact]
+        public void With_Default_IsPaneOpen_Value_Should_Have_Closed_Pseudo_Class_Set()
+        {
+            // Testing this control Pseudo Classes requires placing the SplitView on a window
+            // prior to asserting them, because some of the pseudo classes are set either when
+            // the template is applied or the control is attached to the visual tree
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow
+                .With(globalClock: new MockGlobalClock()));
+            var wnd = new Window
+            {
+                Width = 1280,
+                Height = 720
+            };
+            var splitView = new SplitView();
+            wnd.Content = splitView;
+            wnd.Show();
+
+            Assert.Contains(splitView.Classes, ":closed".Equals);
+        }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR resolves the issue where the `:closed` pseudoclass was not set on control initialization if the `IsPaneOpen` property of the `SplitView` control had its default value (`false`) (issue #17176)

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Currently, if value of IsPaneOpen before control first renders is `false`, the `:closed` pseudoclass will not be added, which may cause issues with styling.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
`:closed` pseudoclass would be present right after control with `IsPaneOpen = false` rendered


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
In the original code, the addition or removal of the `:closed` / `:open` pseudoclass occurred only in the `OnPropertyChanged` method.
Since IsPaneOpen is of type `bool`, and the default value of `bool` is `false`, if a `SplitView` instance is created with `IsPaneOpen = false`, the `OnPropertyChanged` method will not be called.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #17176
