### PR TITLE
Warning fixes: fall wave

### DIFF
--- a/samples/ControlCatalog/Pages/OpenGlPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/OpenGlPage.xaml.cs
@@ -43,7 +43,7 @@ namespace ControlCatalog.Pages
                         Source = snap
                     }
                 }
-            }.ShowDialog((Window)TopLevel.GetTopLevel(this));
+            }.ShowDialog((Window)TopLevel.GetTopLevel(this)!);
         }
     }
 

--- a/samples/IntegrationTestApp/IntegrationTestApp.csproj
+++ b/samples/IntegrationTestApp/IntegrationTestApp.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>$(AvsCurrentTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);AVP1012</NoWarn>
+    <NoWarn>$(NoWarn);AVP1012;AVLN3001</NoWarn>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <IncludeAvaloniaGenerators>true</IncludeAvaloniaGenerators>
   </PropertyGroup>

--- a/samples/IntegrationTestApp/MacOSIntegration.cs
+++ b/samples/IntegrationTestApp/MacOSIntegration.cs
@@ -21,7 +21,7 @@ namespace IntegrationTestApp
         
         public static long GetOrderedIndex(Window window)
         {
-            return Int64_objc_msgSend(window.PlatformImpl!.Handle.Handle, s_orderedIndexSelector);
+            return Int64_objc_msgSend(window.PlatformImpl!.Handle!.Handle, s_orderedIndexSelector);
         }
     }
 }

--- a/src/Avalonia.Base/Rendering/UiThreadRenderTimer.cs
+++ b/src/Avalonia.Base/Rendering/UiThreadRenderTimer.cs
@@ -1,11 +1,6 @@
 using System;
 using System.Diagnostics;
 using Avalonia.Metadata;
-using Avalonia.Reactive;
-using Avalonia.Threading;
-using System;
-using System.Diagnostics;
-using Avalonia.Metadata;
 using Avalonia.Threading;
 
 namespace Avalonia.Rendering;

--- a/src/Avalonia.Controls/Embedding/Offscreen/OffscreenTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Embedding/Offscreen/OffscreenTopLevelImpl.cs
@@ -29,7 +29,8 @@ namespace Avalonia.Controls.Embedding.Offscreen
 
         public abstract IEnumerable<object> Surfaces { get; }
 
-        public double DesktopScaling => _scaling;
+        public virtual double DesktopScaling => _scaling;
+
         public IPlatformHandle? Handle { get; }
 
         public Size ClientSize

--- a/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
+++ b/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
@@ -22,7 +22,7 @@ namespace Avalonia.Controls.Primitives
         private Point _lastRequestedPosition;
         private PopupPositionRequest? _popupPositionRequest;
         private Size _popupSize;
-        private bool _shown, _needsUpdate;
+        private bool _needsUpdate;
 
         public OverlayPopupHost(OverlayLayer overlayLayer)
         {
@@ -63,14 +63,12 @@ namespace Avalonia.Controls.Primitives
         public void Show()
         {
             _overlayLayer.Children.Add(this);
-            _shown = true;
         }
 
         /// <inheritdoc />
         public void Hide()
         {
             _overlayLayer.Children.Remove(this);
-            _shown = false;
         }
 
         public void TakeFocus()
@@ -78,7 +76,6 @@ namespace Avalonia.Controls.Primitives
             // Nothing to do here: overlay popups are implemented inside the window.
         }
 
-        /// <inheritdoc />
         [Unstable(ObsoletionMessages.MayBeRemovedInAvalonia12)]
         public void ConfigurePosition(Visual target, PlacementMode placement, Point offset,
             PopupAnchor anchor = PopupAnchor.None, PopupGravity gravity = PopupGravity.None,

--- a/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
+++ b/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
@@ -37,13 +37,12 @@ namespace Avalonia.DesignerSupport.Remote
         {
         }
 
-        public double DesktopScaling => 1.0;
+        public override double DesktopScaling => 1.0;
         public PixelPoint Position { get; set; }
         public Action<PixelPoint> PositionChanged { get; set; }
         public Action Deactivated { get; set; }
         public Action Activated { get; set; }
         public Func<WindowCloseReason, bool> Closing { get; set; }
-        public IPlatformHandle Handle { get; }
         public WindowState WindowState { get; set; }
         public Action<WindowState> WindowStateChanged { get; set; }
         public Size MaxAutoSizeHint { get; } = new Size(4096, 4096);

--- a/src/Avalonia.Native/StorageProviderApi.cs
+++ b/src/Avalonia.Native/StorageProviderApi.cs
@@ -128,7 +128,7 @@ internal class StorageProviderApi(IAvnStorageProvider native, bool sandboxEnable
         {
             fixed (byte* ptr = bytes)
             {
-                using var uriString = _native.ReadBookmarkFromBytes(ptr, bytes.Length);
+                using var uriString = _native.ReadBookmarkFromBytes(ptr, bytes!.Length);
                 return uriString is not null && Uri.TryCreate(uriString.String, UriKind.Absolute, out var uri) ?
                     uri :
                     null;

--- a/src/Avalonia.Native/TopLevelImpl.cs
+++ b/src/Avalonia.Native/TopLevelImpl.cs
@@ -494,7 +494,7 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
                 var args = new RawDragEvent(device, (RawDragEventType)type,
                     _parent._inputRoot, position.ToAvaloniaPoint(), dataObject, (DragDropEffects)effects,
                     (RawInputModifiers)modifiers);
-                _parent.Input(args);
+                _parent.Input?.Invoke(args);
                 return (AvnDragDropEffects)args.Effects;
             }
         }

--- a/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
+++ b/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
@@ -228,7 +228,10 @@ namespace Avalonia.X11.NativeDialogs
 
         private static void UpdateParent(IntPtr chooser, IWindowImpl parentWindow)
         {
-            var xid = parentWindow.Handle.Handle;
+            if (parentWindow.Handle is not { } handle)
+                return;
+
+            var xid = handle.Handle;
             gtk_widget_realize(chooser);
             var window = gtk_widget_get_window(chooser);
             var parent = GetForeignWindow(xid);

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -1497,8 +1497,8 @@ namespace Avalonia.X11
 
             var indexInWindowsSpan = new Dictionary<IntPtr, int>();
             for (var i = 0; i < windows.Length; i++)
-                if (windows[i].PlatformImpl is { } platformImpl)
-                    indexInWindowsSpan[platformImpl.Handle.Handle] = i;
+                if (windows[i].PlatformImpl is { Handle: { } handle })
+                    indexInWindowsSpan[handle.Handle] = i;
 
             foreach (var window in windows)
             {

--- a/src/Linux/Avalonia.LinuxFramebuffer/EpollDispatcherImpl.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/EpollDispatcherImpl.cs
@@ -54,6 +54,7 @@ internal unsafe class EpollDispatcherImpl : IControlledDispatcherImpl
     [DllImport("libc")]
     private extern static IntPtr read(int fd, void* buf, IntPtr count);
 
+#pragma warning disable CS8981 // The type name only contains lower-cased ascii characters. Such names may become reserved for the language.
     struct timespec
     {
         public IntPtr tv_sec;
@@ -65,6 +66,7 @@ internal unsafe class EpollDispatcherImpl : IControlledDispatcherImpl
         public timespec it_interval; // Interval for periodic timer
         public timespec it_value; // Initial expiration
     };
+#pragma warning restore CS8981 // The type name only contains lower-cased ascii characters. Such names may become reserved for the language.
 
     [DllImport("libc")]
     private extern static int timerfd_create(int clockid, int flags);

--- a/src/Windows/Avalonia.Win32/ScreenImpl.cs
+++ b/src/Windows/Avalonia.Win32/ScreenImpl.cs
@@ -6,7 +6,7 @@ using Avalonia.Platform;
 using Avalonia.Win32.Interop;
 using Windows.Win32;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
-using winmdroot = global::Windows.Win32;
+using Win32Interop = Windows.Win32;
 
 namespace Avalonia.Win32;
 
@@ -20,7 +20,7 @@ internal unsafe class ScreenImpl : ScreensBase<nint, WinScreen>
         var gcHandle = GCHandle.Alloc(screens);
         try
         {
-            PInvoke.EnumDisplayMonitors(default, default(winmdroot.Foundation.RECT*), EnumDisplayMonitorsCallback, (IntPtr)gcHandle);
+            PInvoke.EnumDisplayMonitors(default, default(Win32Interop.Foundation.RECT*), EnumDisplayMonitorsCallback, (IntPtr)gcHandle);
         }
         finally
         {
@@ -29,11 +29,11 @@ internal unsafe class ScreenImpl : ScreensBase<nint, WinScreen>
 
         return screens;
 
-        static winmdroot.Foundation.BOOL EnumDisplayMonitorsCallback(
-            winmdroot.Graphics.Gdi.HMONITOR monitor,
-            winmdroot.Graphics.Gdi.HDC hdcMonitor,
-            winmdroot.Foundation.RECT* lprcMonitor,
-            winmdroot.Foundation.LPARAM dwData)
+        static Win32Interop.Foundation.BOOL EnumDisplayMonitorsCallback(
+            Win32Interop.Graphics.Gdi.HMONITOR monitor,
+            Win32Interop.Graphics.Gdi.HDC hdcMonitor,
+            Win32Interop.Foundation.RECT* lprcMonitor,
+            Win32Interop.Foundation.LPARAM dwData)
         {
             if (GCHandle.FromIntPtr(dwData).Target is List<nint> screens)
             {

--- a/tests/Avalonia.Controls.UnitTests/Platform/ScreensTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Platform/ScreensTests.cs
@@ -67,6 +67,7 @@ public class ScreensTests : ScopedTestBase
 
         var screen = screens.GetScreen(1);
 
+        Assert.NotNull(screen);
         Assert.Equal(1, screen.Generation);
         Assert.Equal(new IntPtr(1), screen.TryGetPlatformHandle()!.Handle);
 
@@ -131,6 +132,8 @@ public class ScreensTests : ScopedTestBase
 
         var hasChangedTimes = 0;
         var screen = screens.GetScreen(2);
+        Assert.NotNull(screen);
+
         screens.Changed = () =>
         {
             Assert.True(screen.Generation < 0);
@@ -155,7 +158,7 @@ public class ScreensTests : ScopedTestBase
             OnChanged();
         }
 
-        public TestScreen GetScreen(int key) => TryGetScreen(key, out var screen) ? screen : null;
+        public TestScreen? GetScreen(int key) => TryGetScreen(key, out var screen) ? screen : null;
 
         protected override int GetScreenCount() => _count;
 


### PR DESCRIPTION
It's been a while since my last wave!

This PR fixes some warnings in the solution:
 - Nullability warnings (in projects where we still have conditional `#nullable enable`)
 - Duplicated using directives
 - A never used field
 - Incorrectly hidden members
 - [CS8981](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves#cs8981---the-type-name-only-contains-lower-cased-ascii-characters) regarding lowercase types: ignored for interop code, fixed otherwise