### PR TITLE
Don't apply our weird window positioning hacks for clicks on traffic lights

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -452,6 +452,16 @@
     return pt;
 }
 
+- (NSView*) findRootView:(NSView*)view
+{
+    while (true) {
+        auto parent = [view superview];
+        if(parent == nil)
+            return view;
+        view = parent;
+    }
+}
+
 - (void)sendEvent:(NSEvent *_Nonnull)event
 {
     [super sendEvent:event];
@@ -467,7 +477,15 @@
                 AvnView* view = parent->View;
                 NSPoint windowPoint = [event locationInWindow];
                 NSPoint viewPoint = [view convertPoint:windowPoint fromView:nil];
-
+                
+                auto targetView = [[self findRootView:view] hitTest: windowPoint];
+                if(targetView)
+                {
+                    auto targetViewClass = [targetView className];
+                    if([targetViewClass containsString: @"_NSThemeWidget"])
+                        return;
+                }
+                
                 if (!NSPointInRect(viewPoint, view.bounds))
                 {
                     auto avnPoint = ToAvnPoint(windowPoint);


### PR DESCRIPTION
This hack fixes the minimize problem with macOS 15.0

In general we should reconsider our habit of calling BringToFront on every click since checking for hit-tested view can't be healthy.

Could also do an alternative check for the hit-test resulting somewhere in contentView hierarchy to avoid className comparisons.