### PR TITLE
Fix InlineUIContainer clipping in text when ArrangeOverride called. (#17183)

### DIFF
--- a/samples/ControlCatalog/Pages/TextBlockPage.xaml
+++ b/samples/ControlCatalog/Pages/TextBlockPage.xaml
@@ -133,7 +133,7 @@
           <Run Text="ABC" FontFeatures="+c2sc, +smcp"/>
           <Run Text="DEF"/>
           <Run Text="0123" FontFeatures="frac"/>
-        </TextBlock>
+        </TextBlock> 
       </Border>
     </WrapPanel>
   </StackPanel>

--- a/samples/ControlCatalog/Pages/TextBlockPage.xaml
+++ b/samples/ControlCatalog/Pages/TextBlockPage.xaml
@@ -133,7 +133,7 @@
           <Run Text="ABC" FontFeatures="+c2sc, +smcp"/>
           <Run Text="DEF"/>
           <Run Text="0123" FontFeatures="frac"/>
-        </TextBlock> 
+        </TextBlock>
       </Border>
     </WrapPanel>
   </StackPanel>

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Avalonia.Automation.Peers;
 using Avalonia.Collections;
@@ -727,8 +728,6 @@ namespace Avalonia.Controls
             return new Size(width, TextLayout.Height).Inflate(padding);
         }
 
-        List<Control> _embeddedControlRunControls = new();
-
         protected override Size ArrangeOverride(Size finalSize)
         {
             var scale = LayoutHelper.GetLayoutScale(this);
@@ -746,10 +745,21 @@ namespace Avalonia.Controls
             {
                 var currentY = padding.Top;
 
-                foreach (var cont in _embeddedControlRunControls)
+                foreach (var visual in VisualChildren)
                 {
-                    cont.Arrange(
-                       new Rect(-cont.Bounds.Width, -cont.Bounds.Height, cont.Bounds.Width, cont.Bounds.Height));
+                    if (visual is Control control)
+                    {
+                        if (control.Bounds.Width != 0 && control.Bounds.Height != 0)
+                        {
+                            if (control.Bounds.Width + control.Bounds.Position.X > this.Bounds.Width)
+                            {
+                                control.IsVisible = false;
+                            }
+                            control.IsVisible = true;
+                        }
+                        /*visual.Arrange(
+                            new Rect(-visual.Bounds.Width, -cont.Bounds.Height, cont.Bounds.Width, cont.Bounds.Height));*/
+                    }
                 }
 
                 foreach (var textLine in TextLayout.TextLines)
@@ -766,8 +776,6 @@ namespace Avalonia.Controls
                                 control.Arrange(
                                     new Rect(new Point(currentX, currentY),
                                     new Size(control.DesiredSize.Width, textLine.Height)));
-                                if (!_embeddedControlRunControls.Contains(control))
-                                    _embeddedControlRunControls.Add(control);
                             }
 
                             currentX += drawable.Size.Width;
@@ -956,6 +964,6 @@ namespace Avalonia.Controls
 
                 return new TextEndOfParagraph();
             }
-         }
+        }
     }
 }

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Avalonia.Automation.Peers;
 using Avalonia.Collections;
@@ -743,24 +742,10 @@ namespace Avalonia.Controls
 
             if (HasComplexContent)
             {
-                var currentY = padding.Top;
+                //Clear visual children before complex run arrangement
+                VisualChildren.Clear();
 
-                foreach (var visual in VisualChildren)
-                {
-                    if (visual is Control control)
-                    {
-                        if (control.Bounds.Width != 0 && control.Bounds.Height != 0)
-                        {
-                            if (control.Bounds.Width + control.Bounds.Position.X > this.Bounds.Width)
-                            {
-                                control.IsVisible = false;
-                            }
-                            control.IsVisible = true;
-                        }
-                        /*visual.Arrange(
-                            new Rect(-visual.Bounds.Width, -cont.Bounds.Height, cont.Bounds.Width, cont.Bounds.Height));*/
-                    }
-                }
+                var currentY = padding.Top;
 
                 foreach (var textLine in TextLayout.TextLines)
                 {
@@ -773,6 +758,17 @@ namespace Avalonia.Controls
                             if (drawable is EmbeddedControlRun controlRun
                                 && controlRun.Control is Control control)
                             {
+                                //Add again to prevent clipping
+                                //Fixes: #17194
+                                foreach (var inline in Inlines!)
+                                {
+                                    if (inline is InlineUIContainer UIContainer)
+                                    {
+                                        if (!VisualChildren.Contains(UIContainer.Child))
+                                            VisualChildren.Add(UIContainer.Child);
+                                    }
+                                }
+
                                 control.Arrange(
                                     new Rect(new Point(currentX, currentY),
                                     new Size(control.DesiredSize.Width, textLine.Height)));

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -727,6 +727,8 @@ namespace Avalonia.Controls
             return new Size(width, TextLayout.Height).Inflate(padding);
         }
 
+        List<Control> _embeddedControlRunControls = new();
+
         protected override Size ArrangeOverride(Size finalSize)
         {
             var scale = LayoutHelper.GetLayoutScale(this);
@@ -741,8 +743,14 @@ namespace Avalonia.Controls
             }
 
             if (HasComplexContent)
-            {             
+            {
                 var currentY = padding.Top;
+
+                foreach (var cont in _embeddedControlRunControls)
+                {
+                    cont.Arrange(
+                       new Rect(-cont.Bounds.Width, -cont.Bounds.Height, cont.Bounds.Width, cont.Bounds.Height));
+                }
 
                 foreach (var textLine in TextLayout.TextLines)
                 {
@@ -758,6 +766,8 @@ namespace Avalonia.Controls
                                 control.Arrange(
                                     new Rect(new Point(currentX, currentY),
                                     new Size(control.DesiredSize.Width, textLine.Height)));
+                                if (!_embeddedControlRunControls.Contains(control))
+                                    _embeddedControlRunControls.Add(control);
                             }
 
                             currentX += drawable.Size.Width;

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -760,14 +760,7 @@ namespace Avalonia.Controls
                             {
                                 //Add again to prevent clipping
                                 //Fixes: #17194
-                                foreach (var inline in Inlines!)
-                                {
-                                    if (inline is InlineUIContainer UIContainer)
-                                    {
-                                        if (!VisualChildren.Contains(UIContainer.Child))
-                                            VisualChildren.Add(UIContainer.Child);
-                                    }
-                                }
+                                VisualChildren.Add(control);
 
                                 control.Arrange(
                                     new Rect(new Point(currentX, currentY),


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Issue #17183
This pr fixes problem with InlineUIContainer clipping inside a text and stuck on coordinates.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Currently InlineUIContainer will be rendered on top of other Run when Width of control will be changed.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
InlineUIContainer will be rendered outside of textblock when it's not present in collection of inlines.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
Changes the behavior of Avalonia.ArrangeOverride int TextBlock.

## Obsoletions / Deprecations

## Fixed issues
Fixes #17183
