### PR TITLE
Fix LayoutUpdated and EffectiveViewportChanged double registration

### DIFF
--- a/src/Avalonia.Base/Layout/Layoutable.cs
+++ b/src/Avalonia.Base/Layout/Layoutable.cs
@@ -135,6 +135,7 @@ namespace Avalonia.Layout
         private Rect? _previousArrange;
         private EventHandler<EffectiveViewportChangedEventArgs>? _effectiveViewportChanged;
         private EventHandler? _layoutUpdated;
+        private bool _isAttachingToVisualTree;
 
         /// <summary>
         /// Initializes static members of the <see cref="Layoutable"/> class.
@@ -164,7 +165,7 @@ namespace Avalonia.Layout
         {
             add
             {
-                if (_effectiveViewportChanged is null && VisualRoot is ILayoutRoot r)
+                if (_effectiveViewportChanged is null && VisualRoot is ILayoutRoot r && !_isAttachingToVisualTree)
                 {
                     r.LayoutManager.RegisterEffectiveViewportListener(this);
                 }
@@ -190,7 +191,7 @@ namespace Avalonia.Layout
         {
             add
             {
-                if (_layoutUpdated is null && VisualRoot is ILayoutRoot r)
+                if (_layoutUpdated is null && VisualRoot is ILayoutRoot r && !_isAttachingToVisualTree)
                 {
                     r.LayoutManager.LayoutUpdated += LayoutManagedLayoutUpdated;
                 }
@@ -735,9 +736,18 @@ namespace Avalonia.Layout
             InvalidateMeasure();
         }
 
+        /// <inheritdoc />
         protected override void OnAttachedToVisualTreeCore(VisualTreeAttachmentEventArgs e)
         {
-            base.OnAttachedToVisualTreeCore(e);
+            _isAttachingToVisualTree = true;
+            try
+            {
+                base.OnAttachedToVisualTreeCore(e);
+            }
+            finally
+            {
+                _isAttachingToVisualTree = false;
+            }
 
             if (e.Root is ILayoutRoot r)
             {

--- a/tests/Avalonia.Base.UnitTests/Layout/LayoutableTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Layout/LayoutableTests.cs
@@ -292,6 +292,30 @@ namespace Avalonia.Base.UnitTests.Layout
         }
 
         [Fact]
+        public void LayoutManager_LayoutUpdated_Should_Not_Be_Subscribed_Twice_In_AttachedToVisualTree()
+        {
+            Border border1;
+            var layoutManager = new Mock<ILayoutManager>();
+            layoutManager.SetupAdd(m => m.LayoutUpdated += (_, _) => { });
+
+            _ = new TestRoot
+            {
+                Child = border1 = new Border(),
+                LayoutManager = layoutManager.Object,
+            };
+
+            var border2 = new Border();
+            border2.AttachedToVisualTree += (_, _) => border2.LayoutUpdated += (_, _) => { };
+
+            layoutManager.Invocations.Clear();
+            border1.Child = border2;
+
+            layoutManager.VerifyAdd(
+                x => x.LayoutUpdated += It.IsAny<EventHandler>(),
+                Times.Once);
+        }
+
+        [Fact]
         public void Making_Control_Invisible_Should_Invalidate_Parent_Measure()
         {
             Border child;

--- a/tests/Avalonia.Base.UnitTests/Layout/LayoutableTests_EffectiveViewportChanged.cs
+++ b/tests/Avalonia.Base.UnitTests/Layout/LayoutableTests_EffectiveViewportChanged.cs
@@ -58,6 +58,28 @@ namespace Avalonia.Base.UnitTests.Layout
         }
 
         [Fact]
+        public async Task EffectiveViewportChanged_Should_Not_Be_Raised_Twice_If_Subcribed_In_AttachedToVisualTree()
+        {
+            await RunOnUIThread.Execute(async () =>
+            {
+                var root = CreateRoot();
+                var target = new Canvas();
+                var raised = 0;
+
+                target.AttachedToVisualTree += (_, _) =>
+                {
+                    target.EffectiveViewportChanged += (_, _) => ++raised;
+                };
+
+                root.Child = target;
+
+                await ExecuteInitialLayoutPass(root);
+
+                Assert.Equal(1, raised);
+            });
+        }
+
+        [Fact]
         public async Task Parent_Affects_EffectiveViewport()
         {
             await RunOnUIThread.Execute(async () =>


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that `Layoutable` events `LayoutUpdated` and `EffectiveViewportChanged` aren't subscribed twice if they are registered in `OnAttachedToVisualTree()` or the `AttachedToVisualTree` event.

Unit tests have been added.

## What is the current behavior?
Subscribing to `LayoutUpdated` or `EffectiveViewportChanged` while inside `OnAttachedToVisualTree` effectively adds the handler twice to the underlying `LayoutManager`.

## What is the updated/expected behavior with this PR?
The handler is added only once to `LayoutManager`.
