### PR TITLE
Fix #17186

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -1033,6 +1033,15 @@ namespace Avalonia.X11
         public void Show(bool activate, bool isDialog)
         {
             _wasMappedAtLeastOnce = true;
+            var data = new List<nint>();
+            if (activate)
+            {
+                data.Add(_x11.Atoms.WM_TAKE_FOCUS);
+            }
+            
+            XChangeProperty(_x11.Display, _handle, _x11.Atoms.WM_PROTOCOLS, _x11.Atoms.XA_ATOM, 32,
+                PropertyMode.Replace, data.ToArray(), data.Count);
+            
             XMapWindow(_x11.Display, _handle);
             XFlush(_x11.Display);
         }


### PR DESCRIPTION
## What does the pull request do?
Fixes #17186.

## What is the current behavior?
Setting ShowActivated = false does not make window not activated on showing.

## What is the updated/expected behavior with this PR?
Now ShowActivated = false make window not activated on showing.

## Breaking changes
Calling XChangeProperty to set a new value of WM_PROTOCOLS before XMapWindow.