### PR TITLE
Try to infer DataContext type from the $parent and #named compiled binding path parts

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
@@ -177,7 +177,8 @@
                     <MultiBinding Converter="{x:Static BoolConverters.And}">
                       <MultiBinding Converter="{x:Static BoolConverters.Or}" >
                         <Binding Path="IsActive" />
-                        <Binding Path="#Main.((vm:ControlDetailsViewModel)DataContext).ShowInactiveFrames" />
+                        <!-- Rider marks it as an error, because it doesn't know about new binding rules yet. -->
+                        <Binding Path="#Main.DataContext.ShowInactiveFrames" />
                       </MultiBinding>
                       <Binding Path="IsVisible" />
                     </MultiBinding>

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -2229,6 +2229,64 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             }
         }
 
+        [Fact]
+        public void ResolvesParentDataContextTypeBasedOnContext()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        x:DataType='local:TestDataContext'
+        x:Name='MyWindow'>
+    <Panel>
+        <TextBlock Text='{CompiledBinding $parent[Panel].DataContext.StringProperty}' Name='textBlock' />
+    </Panel>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = window.GetControl<TextBlock>("textBlock");
+
+                var dataContext = new TestDataContext
+                {
+                    StringProperty = "foobar"
+                };
+
+                window.DataContext = dataContext;
+
+                Assert.Equal(dataContext.StringProperty, textBlock.Text);
+            }
+        }
+
+        [Fact]
+        public void ResolvesParentDataContextTypeBasedOnContextShortSyntax()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        x:DataType='local:TestDataContext'
+        x:Name='MyWindow'>
+    <Panel>
+        <TextBlock Text='{CompiledBinding $parent.DataContext.StringProperty}' Name='textBlock' />
+    </Panel>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = window.GetControl<TextBlock>("textBlock");
+
+                var dataContext = new TestDataContext
+                {
+                    StringProperty = "foobar"
+                };
+
+                window.DataContext = dataContext;
+
+                Assert.Equal(dataContext.StringProperty, textBlock.Text);
+            }
+        }
+
         static void Throws(string type, Action cb)
         {
             try

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -1283,6 +1283,28 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
 
         [Fact]
+        public void SupportsParentInPathWithTypeAndLevelFilter()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(@"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <Border x:Name='p2'>
+        <Border x:Name='p1'>
+            <Button x:Name='p0'>
+                <TextBlock x:Name='textBlock' Text='{CompiledBinding $parent[Control;1].Name}' />
+            </Button>
+        </Border>
+    </Border>
+</Window>");
+                var textBlock = window.GetControl<TextBlock>("textBlock");
+
+                Assert.Equal("p1", textBlock.Text);
+            }
+        }
+
+        [Fact]
         public void SupportConverterWithParameter()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -2175,6 +2175,60 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             }
         }
 
+        [Fact]
+        public void ResolvesElemementNameDataContextTypeBasedOnContext()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        x:DataType='local:TestDataContext'
+        x:Name='MyWindow'>
+    <TextBlock Text='{CompiledBinding ElementName=MyWindow, Path=DataContext.StringProperty}' Name='textBlock' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = window.GetControl<TextBlock>("textBlock");
+
+                var dataContext = new TestDataContext
+                {
+                    StringProperty = "foobar"
+                };
+
+                window.DataContext = dataContext;
+
+                Assert.Equal(dataContext.StringProperty, textBlock.Text);
+            }
+        }
+
+        [Fact]
+        public void ResolvesElemementNameDataContextTypeBasedOnContextShortSyntax()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        x:DataType='local:TestDataContext'
+        x:Name='MyWindow'>
+    <TextBlock Text='{CompiledBinding #MyWindow.DataContext.StringProperty}' Name='textBlock' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = window.GetControl<TextBlock>("textBlock");
+
+                var dataContext = new TestDataContext
+                {
+                    StringProperty = "foobar"
+                };
+
+                window.DataContext = dataContext;
+
+                Assert.Equal(dataContext.StringProperty, textBlock.Text);
+            }
+        }
+
         static void Throws(string type, Action cb)
         {
             try

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -2202,15 +2202,14 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
-                var xaml = @"
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(@"
 <Window xmlns='https://github.com/avaloniaui'
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
         x:DataType='local:TestDataContext'
         x:Name='MyWindow'>
     <TextBlock Text='{CompiledBinding ElementName=MyWindow, Path=DataContext.StringProperty}' Name='textBlock' />
-</Window>";
-                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+</Window>");
                 var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 var dataContext = new TestDataContext
@@ -2228,16 +2227,15 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         public void ResolvesElementNameDataContextTypeBasedOnContextShortSyntax()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            {
-                var xaml = @"
+            { 
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(@"
 <Window xmlns='https://github.com/avaloniaui'
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
         x:DataType='local:TestDataContext'
         x:Name='MyWindow'>
     <TextBlock Text='{CompiledBinding #MyWindow.DataContext.StringProperty}' Name='textBlock' />
-</Window>";
-                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+</Window>");
                 var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 var dataContext = new TestDataContext
@@ -2258,7 +2256,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             // But developer should be able to re-define this type via type casing, if they know better.
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
-                var xaml = @"
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(@"
 <Window xmlns='https://github.com/avaloniaui'
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
@@ -2267,8 +2265,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
     <Panel>
         <TextBlock Text='{CompiledBinding $parent.((Button)DataContext).Tag}' Name='textBlock' />
     </Panel>
-</Window>";
-                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+</Window>");
                 var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 var panelDataContext = new Button { Tag = "foo" };
@@ -2283,7 +2280,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
-                var xaml = @"
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(@"
 <Window xmlns='https://github.com/avaloniaui'
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
@@ -2292,8 +2289,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
     <Panel>
         <TextBlock Text='{CompiledBinding $parent[Panel].DataContext.StringProperty}' Name='textBlock' />
     </Panel>
-</Window>";
-                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+</Window>");
                 var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 var dataContext = new TestDataContext
@@ -2312,7 +2308,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
-                var xaml = @"
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(@"
 <Window xmlns='https://github.com/avaloniaui'
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
@@ -2321,8 +2317,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
     <Panel>
         <TextBlock Text='{CompiledBinding $parent.DataContext.StringProperty}' Name='textBlock' />
     </Panel>
-</Window>";
-                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+</Window>");
                 var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 var dataContext = new TestDataContext

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -2176,7 +2176,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
 
         [Fact]
-        public void ResolvesElemementNameDataContextTypeBasedOnContext()
+        public void ResolvesElementNameDataContextTypeBasedOnContext()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
@@ -2203,7 +2203,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
 
         [Fact]
-        public void ResolvesElemementNameDataContextTypeBasedOnContextShortSyntax()
+        public void ResolvesElementNameDataContextTypeBasedOnContextShortSyntax()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
@@ -2226,6 +2226,33 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 window.DataContext = dataContext;
 
                 Assert.Equal(dataContext.StringProperty, textBlock.Text);
+            }
+        }
+
+        [Fact]
+        public void TypeCastWorksWithElementNameDataContext()
+        {
+            // By default, DataContext will infer DataType from the XAML context, which will be local:TestDataContext here.
+            // But developer should be able to re-define this type via type casing, if they know better.
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        x:DataType='local:TestDataContext'
+        x:Name='MyWindow'>
+    <Panel>
+        <TextBlock Text='{CompiledBinding $parent.((Button)DataContext).Tag}' Name='textBlock' />
+    </Panel>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = window.GetControl<TextBlock>("textBlock");
+
+                var panelDataContext = new Button { Tag = "foo" };
+                ((Panel)window.Content!).DataContext = panelDataContext;
+
+                Assert.Equal(panelDataContext.Tag, textBlock.Text);
             }
         }
 


### PR DESCRIPTION
## What is the updated/expected behavior with this PR?

Enables shorter and cleaner syntax without explicit casts. Compiler can infer data context type from the same XAML file.
```xaml
<Window x:Name="MyWindow" x:DataType="vm:TestDataContext">
    <TextBlock Text="{Binding #MyWindow.DataContext.StringProperty}" />
    <TextBlock Text="{Binding $parent[Window].DataContext.StringProperty}" />
```

## What is the current behavior?

Developers need to cast DataContext to specific view model type, because DataContext is an object.
```xaml
<Window x:Name="MyWindow" x:DataType="vm:TestDataContext">
    <TextBlock Text="{Binding #MyWindow.((vm:TestDataContext)DataContext).StringProperty}" />
    <TextBlock Text="{Binding $parent[Window].((vm:TestDataContext)DataContext).StringProperty}" />
```

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/10957