### PR TITLE
Fixed an issue RTL wrapped text calculates an extra line for the control desired size

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/BidiReorderer.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/BidiReorderer.cs
@@ -169,7 +169,7 @@ namespace Avalonia.Media.TextFormatting
 
             if (run is TextEndOfLine)
             {
-                return defaultLevel;
+                return 0;
             }
 
             if(previousLevel is not null)

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
@@ -156,7 +156,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 Assert.Equal(14, textLine.Length);
 
-                var second = textLine.TextRuns[1] as ShapedTextRun;
+                var second = textLine.TextRuns[0] as ShapedTextRun;
 
                 Assert.NotNull(second);
 

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
@@ -156,11 +156,15 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 Assert.Equal(14, textLine.Length);
 
-                var second = textLine.TextRuns[0] as ShapedTextRun;
+                var first = textLine.TextRuns[0] as ShapedTextRun;
 
-                Assert.NotNull(second);
+                var last = textLine.TextRuns[4] as TextEndOfParagraph;
 
-                Assert.Equal("Hello".AsMemory(), second.Text);
+                Assert.NotNull(first);
+
+                Assert.NotNull(last);
+
+                Assert.Equal("Hello".AsMemory(), first.Text);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
This PR fixes an issue that RTL wrapped text calculates an extra line for the control desired size


## What is the current behavior?
RTL wrapped text calculates an extra line for control desired size


## What is the updated/expected behavior with this PR?
The text will take the required size without the empty line at end


## How was the solution implemented (if it's not obvious)?
In-depth investigation reveals that issue occurs because `TextEndOfParagraph` jumps to start of the text-runs array after bidi-reorder operation, causing the `TextLayout.CreateTextLines()` to add an unnecessary extra line at end.
The PR ensures that `TextEndOfParagraph` remains at end of the text-run array. Additionally, it corrects a unit test that was written in relation to this bug.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation


## Fixed issues
Fixes #16165 
Fixes partly #17175