### PR TITLE
Fix: Handle rolling events.

### DIFF
--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -658,6 +658,11 @@ namespace Avalonia.Controls.Presenters
         /// <inheritdoc/>
         protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
         {
+            if(e.KeyModifiers != KeyModifiers.None && e.KeyModifiers != KeyModifiers.Shift)
+            {
+                base.OnPointerWheelChanged(e);
+                return;
+            }
             if (Extent.Height > Viewport.Height || Extent.Width > Viewport.Width)
             {
                 var scrollable = Child as ILogicalScrollable;
@@ -673,7 +678,7 @@ namespace Avalonia.Controls.Presenters
                 {
                     delta = new Vector(delta.Y, delta.X);
                 }
-                
+
                 if (Extent.Height > Viewport.Height)
                 {
                     double height = isLogical ? scrollable!.ScrollSize.Height : 50;


### PR DESCRIPTION


## What does the pull request do?
Handle rolling events accurately.


## What is the current behavior?
Pressing any key while scrolling the mouse will scroll (excluding the normal Shift key - horizontal scrolling).


## What is the updated/expected behavior with this PR?
Handle scroll events when no keyboard keys are pressed, and handle other keyboard + mouse wheel events externally, such as zooming (excluding normal Shift key - horizontal scrolling)

