### PR TITLE
macOS: Prevent crash with popups

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
@@ -109,7 +109,7 @@ protected:
     bool _isModal;
 
 public:
-    WindowBaseImpl* Parent;
+    WindowBaseImpl* Parent = nullptr;
     NSWindow * Window;
     ComPtr<IAvnWindowBaseEvents> BaseEvents;
 };


### PR DESCRIPTION
## What does the pull request do?

Avalonia started crashing on certain versions of macOS after #16365 when showing popups. This is strange because that PR doesn't actually change anything to do with popups. After debugging the issue on macOS 12 (I couldn't get it to repro with any more recent versions of macOS) I discovered that it was due to [this field not being initialized](https://github.com/AvaloniaUI/Avalonia/blob/master/native/Avalonia.Native/src/OSX/WindowBaseImpl.h#L112).

I've tried to make xcode detect places where we don't zero-initialize C++ fields to prevent this problem in other places, but I've failed to do so. Passing `-Wmissing-field-initializers` has no effect and xcode's C++ analyzer doesn't catch this problem either.

Given that this seems to be a problem that C++ can't warn for, I'm opening a PR with this fix and we'll keep our fingers crossed that we have remembered to initialize all other fields, and will remember to do so in future. If there's anyone out there who's better at C++ on macOS than me and who can manage to get it producing a warning for uninitialized fields: a PR would be appreciated.

## Fixed issues

Fixes #17018