### PR TITLE
invalidate text layout when bounds changes

### DIFF
--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -733,7 +733,7 @@ namespace Avalonia.Controls
             var padding = LayoutHelper.RoundLayoutThickness(Padding, scale, scale);
 
             //Fixes: #11019
-            if (finalSize.Width < _constraint.Width)
+            if (!MathUtilities.AreClose(finalSize.Width, _constraint.Width))
             {
                 _textLayout?.Dispose();
                 _textLayout = null;
@@ -811,7 +811,6 @@ namespace Avalonia.Controls
                 case nameof(TextDecorations):
                 case nameof(FontFeatures):
                 case nameof(Foreground):
-                case nameof(Bounds):
                     {
                         InvalidateTextLayout();
                         break;

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -811,6 +811,7 @@ namespace Avalonia.Controls
                 case nameof(TextDecorations):
                 case nameof(FontFeatures):
                 case nameof(Foreground):
+                case nameof(Bounds):
                     {
                         InvalidateTextLayout();
                         break;


### PR DESCRIPTION
A SharedSizeGroup in a Grid will properly change the Bounds of a TextBlock, but this did not cause the TextLayout to invalidate, leaving columns with TextAlignment.Right left justified until something forced the redraw.  The bug issue fixed contains screenshots and the example XAML we used to reproduce and test.

## Fixed issues

This PR fixes #13777
