### PR TITLE
Fix DataGrid native aot crash when sorting.

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridSortDescription.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridSortDescription.cs
@@ -173,7 +173,7 @@ namespace Avalonia.Collections
                     return GetComparerForNotStringType(type);
             }
 
-            public static IComparer GetComparerForNotStringType(Type type)
+            internal static IComparer GetComparerForNotStringType(Type type)
             {
 #if NET6_0_OR_GREATER
                 if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>) && type.GetGenericArguments()[0].IsAssignableTo(typeof(IComparable)))

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridSortDescription.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridSortDescription.cs
@@ -176,21 +176,25 @@ namespace Avalonia.Collections
             internal static IComparer GetComparerForNotStringType(Type type)
             {
 #if NET6_0_OR_GREATER
-                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>) && type.GetGenericArguments()[0].IsAssignableTo(typeof(IComparable)))
-                    return Comparer<object>.Create((x, y) => 
-                    {
-                        if (x == null)
-                            return y == null ? 0 : -1;
-                        else
-                            return (x as IComparable)!.CompareTo(y);
-                    });
-                else if (type.IsAssignableTo(typeof(IComparable)))
-                    return Comparer<object>.Create((x, y) => (x as IComparable)!.CompareTo(y));
+                if(System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported == false)
+                {
+                    if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>) && type.GetGenericArguments()[0].IsAssignableTo(typeof(IComparable)))
+                        return Comparer<object>.Create((x, y) => 
+                        {
+                            if (x == null)
+                                return y == null ? 0 : -1;
+                            else
+                                return (x as IComparable)!.CompareTo(y);
+                        });
+                    else if (type.IsAssignableTo(typeof(IComparable))) //enum should be here
+                        return Comparer<object>.Create((x, y) => (x as IComparable)!.CompareTo(y));
+                    else
+                        return Comparer<object>.Create((x, y) => 0); //avoid using reflection to avoid crash on AOT
+                }
                 else
-                    return Comparer<object>.Create((x, y) => 0); //avoid using reflection to avoid crash on AOT
-#else
-                    return (typeof(Comparer<>).MakeGenericType(type).GetProperty("Default")).GetValue(null, null) as IComparer;
 #endif
+                return (typeof(Comparer<>).MakeGenericType(type).GetProperty("Default")).GetValue(null, null) as IComparer;
+
             }
 
             private Type GetPropertyType(object o)

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridSortDescription.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridSortDescription.cs
@@ -187,8 +187,10 @@ namespace Avalonia.Collections
                 else if (type.IsAssignableTo(typeof(IComparable)))
                     return Comparer<object>.Create((x, y) => (x as IComparable)!.CompareTo(y));
                 else
-#endif
+                    return Comparer<object>.Create((x, y) => 0); //avoid using reflection to avoid crash on AOT
+#else
                     return (typeof(Comparer<>).MakeGenericType(type).GetProperty("Default")).GetValue(null, null) as IComparer;
+#endif
             }
 
             private Type GetPropertyType(object o)

--- a/tests/Avalonia.Controls.DataGrid.UnitTests/Collections/ComparerTests.cs
+++ b/tests/Avalonia.Controls.DataGrid.UnitTests/Collections/ComparerTests.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Avalonia.Collections;
+using Avalonia.Logging;
+using Xunit;
+
+namespace Avalonia.Controls.DataGridTests.Collections;
+
+public class NoStringTypeComparerTests
+{
+    public static IEnumerable<object[]> GetComparerForNotStringTypeParameters()
+    {
+        yield return
+        [
+            nameof(Item.IntProp1),
+            (object item, object value) =>
+            {
+                (item as Item)!.IntProp1 = (int)value;
+            },
+            (object item) => (object)(item as Item)!.IntProp1,
+            new object[] { 2, 3, 1 },
+            new object[] { 1, 2, 3 }
+        ];
+        yield return
+        [
+            nameof(Item.IntProp2),
+            (object item, object value) =>
+            {
+                (item as Item)!.IntProp2 = (int?)value;
+            },
+            (object item) => (object)(item as Item)!.IntProp2,
+            new object[] { 2, 3, null, 1 },
+            new object[] { null, 1, 2, 3 }
+        ];
+        yield return
+        [
+            nameof(Item.DoubleProp1),
+            (object item, object value) =>
+            {
+                (item as Item)!.DoubleProp1 = (double)value;
+            },
+            (object item) => (object)(item as Item)!.DoubleProp1,
+            new object[] { 2.1, 3.1, 1.1 },
+            new object[] { 1.1, 2.1, 3.1 }
+        ];
+        yield return
+        [
+            nameof(Item.DoubleProp2),
+            (object item, object value) =>
+            {
+                (item as Item)!.DoubleProp2 = (double?)value;
+            },
+            (object item) => (object)(item as Item)!.DoubleProp2,
+            new object[] { 2.1, 3.1, null, 1.1 },
+            new object[] { null, 1.1, 2.1, 3.1 }
+        ];
+        yield return
+        [
+            nameof(Item.DecimalProp1),
+            (object item, object value) =>
+            {
+                (item as Item)!.DecimalProp1 = (decimal)value;
+            },
+            (object item) => (object)(item as Item)!.DecimalProp1,
+            new object[] { 2.1M, 3.1M, 1.1M },
+            new object[] { 1.1M, 2.1M, 3.1M }
+        ];
+        yield return
+        [
+            nameof(Item.DecimalProp2),
+            (object item, object value) =>
+            {
+                (item as Item)!.DecimalProp2 = (decimal?)value;
+            },
+            (object item) => (object)(item as Item)!.DecimalProp2,
+            new object[] { 2.1M, 3.1M, null, 1.1M },
+            new object[] { null, 1.1M, 2.1M, 3.1M }
+        ];
+        yield return
+        [
+            nameof(Item.EnumProp1),
+            (object item, object value) =>
+            {
+                (item as Item)!.EnumProp1 = (LogEventLevel)value;
+            },
+            (object item) => (object)(item as Item)!.EnumProp1,
+            new object[] { LogEventLevel.Information, LogEventLevel.Debug, LogEventLevel.Error },
+            new object[] { LogEventLevel.Debug, LogEventLevel.Information, LogEventLevel.Error }
+        ];
+        yield return
+        [
+            nameof(Item.EnumProp2),
+            (object item, object value) =>
+            {
+                (item as Item)!.EnumProp2 = (LogEventLevel?)value;
+            },
+            (object item) => (object)(item as Item)!.EnumProp2,
+            new object[]
+            {
+                LogEventLevel.Information,
+                LogEventLevel.Debug,
+                null,
+                LogEventLevel.Error
+            },
+            new object[]
+            {
+                null,
+                LogEventLevel.Debug,
+                LogEventLevel.Information,
+                LogEventLevel.Error
+            }
+        ];
+    }
+
+    [Theory]
+    [MemberData(nameof(GetComparerForNotStringTypeParameters))]
+    public void GetComparerForNotStringType_Correctly_WhenSorting(
+        string pathName,
+        Action<object, object> setAction,
+        Func<object, object> getAction,
+        object[] orignal,
+        object[] ordered
+    )
+    {
+        List<Item> items = new();
+        for (int i = 0; i < orignal.Length; i++)
+        {
+            var item = new Item();
+            setAction(item, orignal[i]);
+            items.Add(item);
+        }
+
+        //Ascending
+        var sortDescription = DataGridSortDescription.FromPath(
+            pathName,
+            ListSortDirection.Ascending
+        );
+        sortDescription.Initialize(typeof(Item));
+        var result = sortDescription.OrderBy(items).ToList();
+
+        for (int i = 0; i < ordered.Length; i++)
+        {
+            Assert.Equal(ordered[i], getAction(result[i]));
+        }
+
+        //Descending
+        sortDescription = DataGridSortDescription.FromPath(pathName, ListSortDirection.Descending);
+        sortDescription.Initialize(typeof(Item));
+        result = sortDescription.OrderBy(items).ToList();
+
+        ordered = ordered.Reverse().ToArray();
+        for (int i = 0; i < ordered.Length; i++)
+        {
+            Assert.Equal(ordered[i], getAction(result[i]));
+        }
+    }
+
+    private class Item
+    {
+        public int IntProp1 { get; set; }
+        public int? IntProp2 { get; set; }
+        public double DoubleProp1 { get; set; }
+        public double? DoubleProp2 { get; set; }
+
+        public decimal DecimalProp1 { get; set; }
+        public decimal? DecimalProp2 { get; set; }
+
+        public LogEventLevel EnumProp1 { get; set; }
+        public LogEventLevel? EnumProp2 { get; set; }
+    }
+}

--- a/tests/Avalonia.Controls.DataGrid.UnitTests/Collections/ComparerTests.cs
+++ b/tests/Avalonia.Controls.DataGrid.UnitTests/Collections/ComparerTests.cs
@@ -112,6 +112,29 @@ public class NoStringTypeComparerTests
                 LogEventLevel.Error
             }
         ];
+        yield return
+        [
+            nameof(Item.CustomProp2),
+            (object item, object value) =>
+            {
+                (item as Item)!.CustomProp2 = (CustomType?)value;
+            },
+            (object item) => (object)(item as Item)!.CustomProp2,
+            new object[]
+            {
+                new CustomType() { Prop = 2 },
+                new CustomType() { Prop = 3 },
+                null,
+                new CustomType() { Prop = 1 }
+            },
+            new object[]
+            {
+                null,
+                new CustomType() { Prop = 1 },
+                new CustomType() { Prop = 2 },
+                new CustomType() { Prop = 3 }
+            }
+        ];
     }
 
     [Theory]
@@ -169,5 +192,32 @@ public class NoStringTypeComparerTests
 
         public LogEventLevel EnumProp1 { get; set; }
         public LogEventLevel? EnumProp2 { get; set; }
+        public CustomType? CustomProp2 { get; set; }
+    }
+
+    public struct CustomType : IComparable
+    {
+        public int Prop { get; set; }
+
+        public int CompareTo(object obj)
+        {
+            if (obj is CustomType other)
+            {
+                return Prop.CompareTo(other.Prop);
+            }
+            else
+            {
+                return 1;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is CustomType other)
+            {
+                return Prop == other.Prop;
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
When sorting datagrid with a non string type field, the application will crash as no metadata of `Comparer<int>`. This PR fix it.

Fixed: https://github.com/AvaloniaUI/Avalonia/issues/14059

## What is the current behavior?
- When user does not provide the ViewModel meta data (by [DynamicDependcy] or Rd.xml etc), the application does not crash when sorting int field. but the sort function is broken.

- When user provide the ViewModel meta data (by [DynamicDependcy] or Rd.xml etc), the application will crash when sorting int field.

## What is the updated/expected behavior with this PR?
- When user does not provide the ViewModel meta data (by [DynamicDependcy] or Rd.xml etc), the application will behave same as before when sorting.

- When user provide the ViewModel meta data (by [DynamicDependcy] or Rd.xml etc), the application will work normal when sorting `int`/`int?`/`Enum`/`Enum?` and other type which implements `IComparable` interface when using aot. Other type which does not implements `IComparable` should not crash, only does nothing when sorting.

## How was the solution implemented (if it's not obvious)?

Old solution:
```cs
return (typeof(Comparer<>).MakeGenericType(type).GetProperty("Default")).GetValue(null, null) as IComparer;
```

My solution:
```cs
#if NET6_0_OR_GREATER
if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>) && type.GetGenericArguments()[0].IsAssignableTo(typeof(IComparable)))
    return Comparer<object>.Create((x, y) => 
    {
        if (x == null)
            return y == null ? 0 : -1;
        else
            return (x as IComparable)!.CompareTo(y);
    });
else if (type.IsAssignableTo(typeof(IComparable)))
    return Comparer<object>.Create((x, y) => (x as IComparable)!.CompareTo(y));
else
    return Comparer<object>.Create((x, y) => 0);
#else
    return (typeof(Comparer<>).MakeGenericType(type).GetProperty("Default")).GetValue(null, null) as IComparer;
#endif
```

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

## Obsoletions / Deprecations

## Fixed issues
Fixed: https://github.com/AvaloniaUI/Avalonia/issues/14059 