### PR TITLE
Set TimePicker.Time seconds to zero when UseSeconds is False

### DIFF
--- a/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
@@ -28,7 +28,9 @@ namespace Avalonia.Controls
     [TemplatePart("PART_PeriodSelector",   typeof(DateTimePickerPanel), IsRequired = true)]
     [TemplatePart("PART_PeriodUpButton",   typeof(RepeatButton))]
     [TemplatePart("PART_PickerContainer",  typeof(Grid), IsRequired = true)]
-    [TemplatePart("PART_ThirdSpacer",     typeof(Rectangle), IsRequired = true)]
+    [TemplatePart("PART_FirstSpacer",      typeof(Rectangle), IsRequired = true)]
+    [TemplatePart("PART_SecondSpacer",     typeof(Rectangle), IsRequired = true)]
+    [TemplatePart("PART_ThirdSpacer",      typeof(Rectangle), IsRequired = true)]
     public class TimePickerPresenter : PickerPresenterBase
     {
         /// <summary>
@@ -241,7 +243,7 @@ namespace Avalonia.Controls
                 hr = per == 1 ? (hr == 12) ? 12 : hr + 12 : per == 0 && hr == 12 ? 0 : hr;
             }
 
-            SetCurrentValue(TimeProperty, new TimeSpan(hr, min, sec));
+            SetCurrentValue(TimeProperty, new TimeSpan(hr, min, UseSeconds ? sec : 0));
 
             base.OnConfirmed();
         }
@@ -262,14 +264,14 @@ namespace Avalonia.Controls
             _minuteSelector!.MaximumValue = 59;
             _minuteSelector.MinimumValue = 0;
             _minuteSelector.Increment = MinuteIncrement;
-            _minuteSelector.SelectedValue = Time.Minutes;
             _minuteSelector.ItemFormat = "mm";
+            _minuteSelector.SelectedValue = Time.Minutes;
             
             _secondSelector!.MaximumValue = 59;
             _secondSelector.MinimumValue = 0;
             _secondSelector.Increment = SecondIncrement;
-            _secondSelector.SelectedValue = Time.Seconds;
             _secondSelector.ItemFormat = "ss";
+            _secondSelector.SelectedValue = Time.Seconds;
 
             _periodSelector!.MaximumValue = 1;
             _periodSelector.MinimumValue = 0;

--- a/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
@@ -28,7 +28,6 @@ namespace Avalonia.Controls
     [TemplatePart("PART_PeriodSelector",   typeof(DateTimePickerPanel), IsRequired = true)]
     [TemplatePart("PART_PeriodUpButton",   typeof(RepeatButton))]
     [TemplatePart("PART_PickerContainer",  typeof(Grid), IsRequired = true)]
-    [TemplatePart("PART_FirstSpacer",      typeof(Rectangle), IsRequired = true)]
     [TemplatePart("PART_SecondSpacer",     typeof(Rectangle), IsRequired = true)]
     [TemplatePart("PART_ThirdSpacer",      typeof(Rectangle), IsRequired = true)]
     public class TimePickerPresenter : PickerPresenterBase

--- a/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
@@ -433,11 +433,6 @@ namespace Avalonia.Controls.UnitTests
                     Name = "PART_PickerContainer"
                 }.RegisterInNameScope(scope);
 
-                var firstSpacer = new Rectangle
-                {
-                    Name = "PART_FirstSpacer"
-                }.RegisterInNameScope(scope);
-
                 var secondSpacer = new Rectangle
                 {
                     Name = "PART_SecondSpacer"
@@ -449,7 +444,7 @@ namespace Avalonia.Controls.UnitTests
                 }.RegisterInNameScope(scope);
 
                 var contentPanel = new StackPanel();
-                contentPanel.Children.AddRange(new Control[] { acceptButton, hourSelector, minuteSelector, secondHost, secondSelector, periodHost, periodSelector, pickerContainer, firstSpacer, secondSpacer, thirdSpacer });
+                contentPanel.Children.AddRange(new Control[] { acceptButton, hourSelector, minuteSelector, secondHost, secondSelector, periodHost, periodSelector, pickerContainer, secondSpacer, thirdSpacer });
                 return contentPanel;
             });
         }

--- a/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reactive.Subjects;
+using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
@@ -91,6 +92,67 @@ namespace Avalonia.Controls.UnitTests
 
                 timePicker.UseSeconds = false;
                 Assert.False(periodTextHost.IsVisible);
+            }
+        }
+
+        [Fact]
+        public void UseSeconds_Equals_False_Should_Have_Zero_Seconds()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                TimePicker timePicker = new TimePicker()
+                {
+                    UseSeconds = false,
+                    Template = CreateTemplate(includePopup: true)
+                };
+                timePicker.ApplyTemplate();
+
+                var desc = timePicker.GetVisualDescendants();
+                Assert.True(desc.Count() > 2);
+
+                // find button
+                Assert.True(desc.ElementAt(1) is Button);
+                var btn = (Button)desc.ElementAt(1);
+
+                Assert.True(desc.ElementAt(2) is Popup);
+                var popup = (Popup)desc.ElementAt(2);
+
+                Assert.True(popup.Child is TimePickerPresenter);
+                var timePickerPresenter = (TimePickerPresenter)popup.Child;
+
+                var panel = (Panel)timePickerPresenter.VisualChildren[0];
+                var acceptBtn = (Button)panel.VisualChildren[0];
+
+                Assert.False(popup.IsOpen);
+                btn.PerformClick();
+                Assert.True(popup.IsOpen);
+                Assert.False(timePickerPresenter.UseSeconds);
+
+                acceptBtn.PerformClick();
+
+                Assert.Equal(0, timePickerPresenter.Time.Seconds);
+                Assert.Equal(0, timePicker.SelectedTime?.Seconds);
+            }
+        }
+
+        [Fact]
+        public void TimePickerPresenter_UseSeconds_Equals_False_Should_Have_Zero_Seconds()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                TimePickerPresenter timePickerPresenter = new TimePickerPresenter()
+                {
+                    UseSeconds = false,
+                    Template = CreatePickerTemplate(),
+                };
+                timePickerPresenter.ApplyTemplate();
+
+                var panel = (Panel)timePickerPresenter.VisualChildren[0];
+                var acceptBtn = (Button)panel.VisualChildren[0];
+
+                acceptBtn.PerformClick();
+
+                Assert.Equal(0, timePickerPresenter.Time.Seconds);
             }
         }
 
@@ -219,7 +281,7 @@ namespace Avalonia.Controls.UnitTests
             textShaperImpl: new HeadlessTextShaperStub(),
             renderInterface: new HeadlessPlatformRenderInterface());
 
-        private static IControlTemplate CreateTemplate()
+        private static IControlTemplate CreateTemplate(bool includePopup = false)
         {
             return new FuncControlTemplate((control, scope) =>
             {
@@ -227,6 +289,7 @@ namespace Avalonia.Controls.UnitTests
                 {
                     Name = "LayoutRoot"
                 }.RegisterInNameScope(scope);
+
                 //Skip contentpresenter
                 var flyoutButton = new Button
                 {
@@ -288,7 +351,7 @@ namespace Avalonia.Controls.UnitTests
                     Name = "PART_SecondColumnDivider"
                 }.RegisterInNameScope(scope);
                 Grid.SetColumn(secondSpacer, 3);
-                
+
                 var thirdSpacer = new Rectangle
                 {
                     Name = "PART_ThirdColumnDivider"
@@ -298,7 +361,96 @@ namespace Avalonia.Controls.UnitTests
                 contentGrid.Children.AddRange(new Control[] { firstPickerHost, firstSpacer, secondPickerHost, secondSpacer, thirdPickerHost, thirdSpacer, fourthPickerHost });
                 flyoutButton.Content = contentGrid;
                 layoutRoot.Children.Add(flyoutButton);
+
+                if (includePopup)
+                {
+                    var popup = new Popup
+                    {
+                        Name = "PART_Popup"
+                    }.RegisterInNameScope(scope);
+
+                    var pickerPresenter = new TimePickerPresenter
+                    {
+                        Name = "PART_PickerPresenter",
+                        Template = CreatePickerTemplate()
+                    }.RegisterInNameScope(scope);
+                    pickerPresenter.ApplyTemplate();
+
+                    popup.Child = pickerPresenter;
+
+                    layoutRoot.Children.Add(popup);
+                }
+
                 return layoutRoot;
+            });
+        }
+
+        private static IControlTemplate CreatePickerTemplate()
+        {
+            return new FuncControlTemplate((control, scope) =>
+            {
+                var acceptButton = new Button
+                {
+                    Name = "PART_AcceptButton"
+                }.RegisterInNameScope(scope);
+
+                var hourSelector = new DateTimePickerPanel
+                {
+                    Name = "PART_HourSelector",
+                    PanelType = DateTimePickerPanelType.Hour,
+                }.RegisterInNameScope(scope);
+
+                var minuteSelector = new DateTimePickerPanel
+                {
+                    Name = "PART_MinuteSelector",
+                    PanelType = DateTimePickerPanelType.Minute,
+                }.RegisterInNameScope(scope);
+
+                var secondHost = new Panel
+                {
+                    Name = "PART_SecondHost"
+                }.RegisterInNameScope(scope);
+
+                var secondSelector = new DateTimePickerPanel
+                {
+                    Name = "PART_SecondSelector",
+                    PanelType = DateTimePickerPanelType.Second,
+                }.RegisterInNameScope(scope);
+
+                var periodHost = new Panel
+                {
+                    Name = "PART_PeriodHost"
+                }.RegisterInNameScope(scope);
+
+                var periodSelector = new DateTimePickerPanel
+                {
+                    Name = "PART_PeriodSelector",
+                    PanelType = DateTimePickerPanelType.TimePeriod,
+                }.RegisterInNameScope(scope);
+
+                var pickerContainer = new Grid
+                {
+                    Name = "PART_PickerContainer"
+                }.RegisterInNameScope(scope);
+
+                var firstSpacer = new Rectangle
+                {
+                    Name = "PART_FirstSpacer"
+                }.RegisterInNameScope(scope);
+
+                var secondSpacer = new Rectangle
+                {
+                    Name = "PART_SecondSpacer"
+                }.RegisterInNameScope(scope);
+
+                var thirdSpacer = new Rectangle
+                {
+                    Name = "PART_ThirdSpacer"
+                }.RegisterInNameScope(scope);
+
+                var contentPanel = new StackPanel();
+                contentPanel.Children.AddRange(new Control[] { acceptButton, hourSelector, minuteSelector, secondHost, secondSelector, periodHost, periodSelector, pickerContainer, firstSpacer, secondSpacer, thirdSpacer });
+                return contentPanel;
             });
         }
     }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Addresses the most significant issue (breaking change) discussed in https://github.com/AvaloniaUI/Avalonia/issues/17024


## What is the current behavior?
The seconds component of the Time property is always set to an uncontrolled value when `UseSeconds` is false.


## What is the updated/expected behavior with this PR?
When `UseSeconds` is false, the Time property has its seconds component set to zero


## How was the solution implemented (if it's not obvious)?
N/A


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
N/A

## Obsoletions / Deprecations
N/A

## Fixed issues
Fixes part of #17024

