### PR TITLE
Fix ThemeVariant equality

### DIFF
--- a/src/Avalonia.Base/Styling/ThemeVariant.cs
+++ b/src/Avalonia.Base/Styling/ThemeVariant.cs
@@ -91,7 +91,7 @@ public sealed record ThemeVariant
 
     public bool Equals(ThemeVariant? other)
     {
-        return Key == other?.Key;
+        return other is not null && Equals(Key, other.Key);
     }
 
     public static explicit operator ThemeVariant(PlatformThemeVariant themeVariant)

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ThemeDictionariesTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ThemeDictionariesTests.cs
@@ -45,7 +45,8 @@ public class ThemeDictionariesTests : XamlTestBase
         
         Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background)!.Color);
 
-        themeVariantScope.RequestedThemeVariant = ThemeVariant.Dark;
+        var themeVariantKey = new string(['D', 'a', 'r', 'k']); // Ensure that a non-interned string works
+        themeVariantScope.RequestedThemeVariant = new ThemeVariant(themeVariantKey, null);
 
         Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background)!.Color);
     }


### PR DESCRIPTION
This PR fixes `ThemeVariant.Equals` which was incorrectly using reference equality for its key.
An existing unit test has been updated.
