### PR TITLE
Rework how TextBlock skips redundant measure and arrange calls

### DIFF
--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -701,7 +701,6 @@ namespace Avalonia.Controls
         {
             var scale = LayoutHelper.GetLayoutScale(this);
             var padding = LayoutHelper.RoundLayoutThickness(Padding, scale, scale);
-
             var deflatedSize = availableSize.Deflate(padding);
 
             if(_constraint != deflatedSize)
@@ -715,6 +714,8 @@ namespace Avalonia.Controls
                 InvalidateArrange();
             }
 
+            //This implicitly recreated the TextLayout with a new constraint if we previously reset it.
+            var textLayout = TextLayout;
             var inlines = Inlines;
 
             if (HasComplexContent)
@@ -729,9 +730,9 @@ namespace Avalonia.Controls
                 _textRuns = textRuns;
             }
 
-            var width = TextLayout.OverhangLeading + TextLayout.WidthIncludingTrailingWhitespace + TextLayout.OverhangTrailing;
+            var width = textLayout.OverhangLeading + textLayout.WidthIncludingTrailingWhitespace + textLayout.OverhangTrailing;
 
-            var size = LayoutHelper.RoundLayoutSizeUp(new Size(width, TextLayout.Height).Inflate(padding), 1, 1);   
+            var size = LayoutHelper.RoundLayoutSizeUp(new Size(width, textLayout.Height).Inflate(padding), 1, 1);   
 
             _constraint = size;
 
@@ -751,13 +752,16 @@ namespace Avalonia.Controls
                 _textLayout?.Dispose();
                 _textLayout = null;
                 _constraint = availableSize;
-            }    
+            }
+
+            //This implicitly recreated the TextLayout with a new constraint if we previously reset it.
+            var textLayout = TextLayout;
 
             if (HasComplexContent)
             {             
                 var currentY = padding.Top;
 
-                foreach (var textLine in TextLayout.TextLines)
+                foreach (var textLine in textLayout.TextLines)
                 {
                     var currentX = padding.Left + textLine.Start;
 

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -715,6 +715,8 @@ namespace Avalonia.Controls
             _textLayout?.Dispose();
             _textLayout = null;
 
+            InvalidateVisual();
+
             var inlines = Inlines;
 
             if (HasComplexContent)
@@ -749,6 +751,7 @@ namespace Avalonia.Controls
                 _textLayout?.Dispose();
                 _textLayout = null;
                 _constraint = availableSize;
+                InvalidateVisual();
             }
 
             if (HasComplexContent)

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -713,9 +713,7 @@ namespace Avalonia.Controls
                 //Force arrange so text will be properly alligned.
                 InvalidateArrange();
             }
-
-            //This implicitly recreated the TextLayout with a new constraint if we previously reset it.
-            var textLayout = TextLayout;
+           
             var inlines = Inlines;
 
             if (HasComplexContent)
@@ -729,6 +727,9 @@ namespace Avalonia.Controls
 
                 _textRuns = textRuns;
             }
+
+            //This implicitly recreated the TextLayout with a new constraint if we previously reset it.
+            var textLayout = TextLayout;
 
             var width = textLayout.OverhangLeading + textLayout.WidthIncludingTrailingWhitespace + textLayout.OverhangTrailing;
 

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -702,7 +702,14 @@ namespace Avalonia.Controls
             var scale = LayoutHelper.GetLayoutScale(this);
             var padding = LayoutHelper.RoundLayoutThickness(Padding, scale, scale);
 
-            _constraint = availableSize.Deflate(padding);
+            var deflatedSize = availableSize.Deflate(padding);
+
+            if(deflatedSize == _constraint)
+            {
+                return _constraint;
+            }
+
+            _constraint = deflatedSize;
 
             //Reset TextLayout otherwise constraint might be outdated.
             _textLayout?.Dispose();
@@ -724,7 +731,9 @@ namespace Avalonia.Controls
 
             var width = TextLayout.OverhangLeading + TextLayout.WidthIncludingTrailingWhitespace + TextLayout.OverhangTrailing;
 
-            return new Size(width, TextLayout.Height).Inflate(padding);
+            _constraint = LayoutHelper.RoundLayoutSizeUp(new Size(width, TextLayout.Height).Inflate(padding), 1, 1);
+
+            return _constraint;
         }
 
         protected override Size ArrangeOverride(Size finalSize)
@@ -732,12 +741,14 @@ namespace Avalonia.Controls
             var scale = LayoutHelper.GetLayoutScale(this);
             var padding = LayoutHelper.RoundLayoutThickness(Padding, scale, scale);
 
+            var availableSize = finalSize.Deflate(padding);
+
             //Fixes: #11019
-            if (finalSize.Width < _constraint.Width)
+            if (availableSize != _constraint)
             {
                 _textLayout?.Dispose();
                 _textLayout = null;
-                _constraint = finalSize.Deflate(padding);
+                _constraint = availableSize;
             }
 
             if (HasComplexContent)

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -1,13 +1,9 @@
-using System;
 using Avalonia.Controls.Documents;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
-using Avalonia.Input;
+using Avalonia.Layout;
 using Avalonia.Media;
-using Avalonia.Metadata;
-using Avalonia.Rendering;
 using Avalonia.UnitTests;
-using Moq;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
@@ -48,6 +44,58 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(new Size(50, 100), textBlock.Constraint);
 
                 Assert.NotEqual(textLayout, textBlock.TextLayout);
+            }
+        }
+
+        [Fact]
+        public void Calling_Arrange_With_Different_Size_Should_Update_Constraint_And_TextLayout()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var textBlock = new TestTextBlock { Text = "Hello World" };
+
+                textBlock.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+
+                var textLayout = textBlock.TextLayout;
+
+                var constraint = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.WidthIncludingTrailingWhitespace, textLayout.Height), 1, 1);
+
+                Assert.Equal(constraint, textBlock.Constraint);
+
+                textBlock.Arrange(new Rect(constraint));
+
+                Assert.Equal(constraint, textBlock.Constraint);
+
+                Assert.Equal(textLayout, textBlock.TextLayout);
+
+                textBlock.Measure(constraint);
+
+                Assert.Equal(textLayout, textBlock.TextLayout);
+
+                constraint += new Size(50, 0);
+
+                textBlock.Measure(constraint);
+
+                Assert.NotEqual(textLayout, textBlock.TextLayout);
+            }
+        }
+
+        [Fact]
+        public void Calling_Measure_With_Infinite_Space_Should_Set_DesiredSize()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var textBlock = new TestTextBlock { Text = "Hello World" };
+
+                textBlock.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+
+                var textLayout = textBlock.TextLayout;
+
+                Assert.Equal(Size.Infinity, textBlock.Constraint);
+
+                var constraint = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.WidthIncludingTrailingWhitespace, textLayout.Height), 1, 1);
+
+                Assert.Equal(constraint, textBlock.DesiredSize);
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -37,11 +37,9 @@ namespace Avalonia.Controls.UnitTests
 
                 var textLayout = textBlock.TextLayout;
 
-                Assert.Equal(new Size(100,100), textBlock.Constraint);
+                Assert.Equal(new Size(110, 10), textBlock.Constraint);
 
                 textBlock.Measure(new Size(50, 100));
-
-                Assert.Equal(new Size(50, 100), textBlock.Constraint);
 
                 Assert.NotEqual(textLayout, textBlock.TextLayout);
             }
@@ -91,7 +89,7 @@ namespace Avalonia.Controls.UnitTests
 
                 var textLayout = textBlock.TextLayout;
 
-                Assert.Equal(Size.Infinity, textBlock.Constraint);
+                Assert.Equal(new Size(110, 10), textBlock.Constraint);
 
                 var constraint = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.WidthIncludingTrailingWhitespace, textLayout.Height), 1, 1);
 

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -33,6 +33,8 @@ namespace Avalonia.Controls.UnitTests
             {
                 var textBlock = new TestTextBlock { Text = "Hello World" };
 
+                Assert.Equal(Size.Infinity, textBlock.Constraint);
+
                 textBlock.Measure(new Size(100, 100));
 
                 var textLayout = textBlock.TextLayout;
@@ -52,7 +54,7 @@ namespace Avalonia.Controls.UnitTests
             {
                 var textBlock = new TestTextBlock { Text = "Hello World" };
 
-                textBlock.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                textBlock.Measure(Size.Infinity);
 
                 var textLayout = textBlock.TextLayout;
 
@@ -72,7 +74,9 @@ namespace Avalonia.Controls.UnitTests
 
                 constraint += new Size(50, 0);
 
-                textBlock.Measure(constraint);
+                textBlock.Arrange(new Rect(constraint));
+
+                Assert.Equal(constraint, textBlock.Constraint);
 
                 Assert.NotEqual(textLayout, textBlock.TextLayout);
             }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR attempts to improve the logic that skips the creation of new TextLayouts when Measure or Arrange is called.

Previously we only tested for smaller widths. This PR tests for changes to the constraining size in general.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
