### PR TITLE
Fix PopupRoot.ConfigurePosition being called unnecessary

### DIFF
--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -1244,9 +1244,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 popup.Open();
                 root.LayoutManager.ExecuteLayoutPass();
 
-                // Ideally, callback should be executed only once for this test.
-                // But currently PlacementTargetLayoutUpdated triggers second update either way.
-                Assert.Equal(2, callbackExecuted);
+                Assert.Equal(1, callbackExecuted);
             }
         }
 


### PR DESCRIPTION
This PR fixes `PopupRoot.ConfigurePosition` that was being called on each `LayoutUpdated` even if the bounds of the `PlacementTarget` weren't changing.

An existing unit test has been updated.

A double position update has also been removed for `VerticalOffset` and `HorizontalOffset`, which had two handlers for the same thing (`AddClassHandler` and `OnPropertyChanged`).

`HandlePositionChange()` has been simplified to avoid duplicate code.