### PR TITLE
Fix: respect CanResize on macOS regardless of SystemDecorations

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -570,11 +570,11 @@ NSWindowStyleMask WindowImpl::CalculateStyleMask() {
 
         case SystemDecorationsFull:
             s = s | NSWindowStyleMaskTitled | NSWindowStyleMaskClosable;
-
-            if ((_canResize && _isEnabled) || _transitioningWindowState) {
-                s = s | NSWindowStyleMaskResizable;
-            }
             break;
+    }
+
+    if ((_canResize && _isEnabled) || _transitioningWindowState) {
+        s = s | NSWindowStyleMaskResizable;
     }
 
     if (!IsOwned()) {


### PR DESCRIPTION
## What does the pull request do?
This PR moves `NSWindowStyleMaskResizable` flag application from `SystemDecorationsFull` case outside of the switch, so this flag is applied also for other system decorations.

## What is the current behavior?
`NSWindowStyleMaskResizable` is applied only for `SystemDecorationsFull`. Other decorations make windows not resizable.

## What is the updated/expected behavior with this PR?
`NSWindowStyleMaskResizable` is applied regardless of SystemDecorations, it always follows `CanResize` property.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
Windows which have decorations set to `None` or `BorderOnly` and `CanResize=true` (default) will now become resizable, which can be unexpected for some people. But this behaviour is expected since CanResize is set to true, isn't it?

## Obsoletions / Deprecations

## Fixed issues
Fixes #17295
