### PR TITLE
Fix .NET 9 WASM incompatibility by updating SkiaSharp.WASM package

### DIFF
--- a/build/HarfBuzzSharp.props
+++ b/build/HarfBuzzSharp.props
@@ -2,6 +2,6 @@
   <ItemGroup>
     <PackageReference Include="HarfBuzzSharp" Version="7.3.0.2" />
     <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.2" />
-    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="7.3.0.2" />
+    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="7.3.0.3-preview.2.2" />
   </ItemGroup>
 </Project>

--- a/build/SkiaSharp.props
+++ b/build/SkiaSharp.props
@@ -2,11 +2,11 @@
   <ItemGroup Condition="'$(AvsIncludeSkiaSharp3)' != 'true'">
     <PackageReference Include="SkiaSharp" Version="2.88.8" />
     <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="SkiaSharp.NativeAssets.Linux" Version="2.88.8" />
-    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.8" />
+    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.9-preview.2.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(AvsIncludeSkiaSharp3)' == 'true'">
-    <PackageReference Include="SkiaSharp" Version="3.0.0-preview.3.1" />
-    <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="SkiaSharp.NativeAssets.Linux" Version="3.0.0-preview.3.1" />
-    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.0.0-preview.3.1" />
+    <PackageReference Include="SkiaSharp" Version="3.0.0-preview.5.4" />
+    <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="SkiaSharp.NativeAssets.Linux" Version="3.0.0-preview.5.4" />
+    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.0.0-preview.5.4" />
   </ItemGroup>
 </Project>

--- a/src/Browser/Avalonia.Browser/build/Avalonia.Browser.props
+++ b/src/Browser/Avalonia.Browser/build/Avalonia.Browser.props
@@ -1,12 +1,12 @@
 <Project>
   <PropertyGroup>
     <AvaloniaAllowWebGl2 Condition="'$(AvaloniaAllowWebGl2)' == ''">true</AvaloniaAllowWebGl2>
-    <ShouldIncludeAvaloniaAssets Condition=" '$(ShouldIncludeAvaloniaAssets)' == '' ">True</ShouldIncludeAvaloniaAssets>
-    <ShouldIncludeAvaloniaLegacyAssets Condition=" '$(ShouldIncludeAvaloniaLegacyAssets)' == '' AND '$(ShouldIncludeAvaloniaAssets)' == 'True'">True</ShouldIncludeAvaloniaLegacyAssets>
-    <ShouldIncludeAvaloniaStaticAssets Condition=" '$(ShouldIncludeAvaloniaStaticAssets)' == '' AND '$(ShouldIncludeAvaloniaAssets)' == 'True'">True</ShouldIncludeAvaloniaStaticAssets>
-
-    <ShouldIncludeNativeSkiaSharp Condition=" '$(ShouldIncludeNativeSkiaSharp)' == '' ">True</ShouldIncludeNativeSkiaSharp>
-    <ShouldIncludeNativeHarfBuzzSharp Condition=" '$(ShouldIncludeNativeHarfBuzzSharp)' == '' ">True</ShouldIncludeNativeHarfBuzzSharp>
+    <ShouldIncludeAvaloniaAssets Condition=" '$(ShouldIncludeAvaloniaAssets)' == '' ">true</ShouldIncludeAvaloniaAssets>
+    <ShouldIncludeAvaloniaLegacyAssets Condition=" '$(ShouldIncludeAvaloniaLegacyAssets)' == '' AND '$(ShouldIncludeAvaloniaAssets)' == 'true'">true</ShouldIncludeAvaloniaLegacyAssets>
+    <ShouldIncludeAvaloniaStaticAssets Condition=" '$(ShouldIncludeAvaloniaStaticAssets)' == '' AND '$(ShouldIncludeAvaloniaAssets)' == 'true'">true</ShouldIncludeAvaloniaStaticAssets>
+    
+    <ShouldIncludeNativeSkiaSharp Condition=" '$(ShouldIncludeNativeSkiaSharp)' == '' ">true</ShouldIncludeNativeSkiaSharp>
+    <ShouldIncludeNativeHarfBuzzSharp Condition=" '$(ShouldIncludeNativeHarfBuzzSharp)' == '' ">true</ShouldIncludeNativeHarfBuzzSharp>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)/../build/Microsoft.AspNetCore.StaticWebAssets.props" />

--- a/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
+++ b/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
@@ -1,6 +1,8 @@
 <Project>
   <PropertyGroup>
     <EmccFlags Condition="'$(AvaloniaAllowWebGl2)' == 'true'">$(EmccFlags) -sUSE_WEBGL2=1 -sMAX_WEBGL_VERSION=2 -lGL </EmccFlags>
+    <_AvNativeBinaryType Condition="'$(WasmEnableThreads)' == 'True'">mt</_AvNativeBinaryType>
+    <_AvNativeBinaryType Condition="'$(WasmEnableThreads)' != 'True'">st</_AvNativeBinaryType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,22 +12,27 @@
   </ItemGroup>
   
   <!-- Fallback for applications without StaticWebAssetsEnabled (legacy WASM SDK) -->
-  <ItemGroup Condition="'$(ShouldIncludeAvaloniaLegacyAssets)' == 'True'">
+  <ItemGroup Condition="'$(ShouldIncludeAvaloniaLegacyAssets)' == 'true'">
     <WasmExtraFilesToDeploy Condition="'$(WasmRuntimeAssetsLocation)' == ''" Include="$(MSBuildThisFileDirectory)/../staticwebassets/**/*.*" />
     <WasmExtraFilesToDeploy Condition="'$(WasmRuntimeAssetsLocation)' != ''" Include="$(MSBuildThisFileDirectory)/../staticwebassets/**/*.*" TargetPath="$(WasmRuntimeAssetsLocation)/%(FileName)%(Extension)" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(ShouldIncludeNativeSkiaSharp)' == 'True' or '$(ShouldIncludeNativeHarfBuzzSharp)' == 'True'">
+  <PropertyGroup Condition="'$(ShouldIncludeNativeSkiaSharp)' == 'true' or '$(ShouldIncludeNativeHarfBuzzSharp)' == 'true'">
     <WasmBuildNative Condition="'$(WasmBuildNative)' == ''">true</WasmBuildNative>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeSkiaSharp)' == 'True'">
-    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)/3.1.34/mt/*.a" Condition="'$(WasmEnableThreads)' == 'True'" />
-    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)/3.1.34/st/*.a" Condition="'$(WasmEnableThreads)' != 'True'" />
+  <!-- Revisit after https://github.com/mono/SkiaSharp/pull/2620 is merged and released. -->
+  <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeSkiaSharp)' == 'true'">
+    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.34\$(_AvNativeBinaryType)\*.a"
+                         Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0'))" />
+    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.56\$(_AvNativeBinaryType)\*.a"
+                         Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeHarfBuzzSharp)' == 'True'">
-    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)/3.1.34/st/*.a" Condition="'$(WasmEnableThreads)' != 'True'" />
-    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)/3.1.34/mt/*.a" Condition="'$(WasmEnableThreads)' == 'True'" />
+    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.34\$(_AvNativeBinaryType)\*.a"
+                         Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0'))" />
+    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.56\$(_AvNativeBinaryType)\*.a"
+                         Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))" />
   </ItemGroup>
 </Project>

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
@@ -458,7 +458,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 
                 var finder = new ScopeRegistrationFinder(name);
                 namescopeRoot.Visit(finder);
-                return finder.TargetType is not null ? (finder.TargetType, DataType: finder.DataContextType) : null;
+                return finder.TargetType is not null ? (finder.TargetType, finder.DataContextType) : null;
             }
 
             void IXamlAstVisitor.Pop()


### PR DESCRIPTION
## What does the pull request do?

.NET 9 uses different Emscripten version. Relevant native packages should be updated as well.
This PR also updates SkiaSharp 3.0 test packages. Manually tested 3.0, and it still works.

## Fixed issues

Fixes #16989
Fixes #17036
