### PR TITLE
Fixed indented lines in diff flow direction text

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/ShapedBuffer.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/ShapedBuffer.cs
@@ -49,7 +49,7 @@ namespace Avalonia.Media.TextFormatting
         /// <summary>
         /// The buffer's bidi level.
         /// </summary>
-        public sbyte BidiLevel { get; }
+        public sbyte BidiLevel { get; private set; }
 
         /// <summary>
         /// The buffer's reading direction.
@@ -168,6 +168,8 @@ namespace Avalonia.Media.TextFormatting
 
             return new SplitResult<ShapedBuffer>(first, second);
         }
+
+        internal void ChangeBidiLevel(sbyte value) => BidiLevel = value;
 
         int IReadOnlyCollection<GlyphInfo>.Count => _glyphInfos.Length;
 

--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Media.TextFormatting
     internal sealed class TextFormatterImpl : TextFormatter
     {
         private static readonly char[] s_empty = { ' ' };
-        private static readonly string s_defaultText = new string('a', TextRun.DefaultTextSourceLength);
+        private static readonly string s_defaultText = new string(' ', TextRun.DefaultTextSourceLength);
 
         [ThreadStatic] private static BidiData? t_bidiData;
         [ThreadStatic] private static BidiAlgorithm? t_bidiAlgorithm;
@@ -209,7 +209,7 @@ namespace Avalonia.Media.TextFormatting
                     text = s_defaultText.AsSpan();
                 else
                 {
-                    text = new string('a', textRun.Length).AsSpan();
+                    text = new string(' ', textRun.Length).AsSpan();
                 }
 
                 bidiData.Append(text);

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
@@ -167,6 +167,78 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                 Assert.Equal("Hello".AsMemory(), first.Text);
             }
         }
+        
+        [Fact]
+        public void Should_Position_Whitespace_Correctly_In_RightToLeft_Paragraph()
+        {
+            using (Start())
+            {
+                const string text = "Hello ";
+
+                var defaultProperties = new GenericTextRunProperties(Typeface.Default);
+
+                var textSource = new SimpleTextSource(text, defaultProperties);
+
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, double.PositiveInfinity,
+                        new GenericTextParagraphProperties(FlowDirection.RightToLeft, TextAlignment.Right, true, true, defaultProperties, TextWrapping.NoWrap, 0, 0, 0));
+
+                Assert.NotNull(textLine);
+
+                Assert.Equal(3, textLine.TextRuns.Count);
+
+                var first = textLine.TextRuns[0] as ShapedTextRun;
+
+                var second = textLine.TextRuns[1] as ShapedTextRun;
+
+                Assert.NotNull(first);
+
+                Assert.NotNull(second);
+
+                Assert.Equal(" ", first.Text.ToString());
+
+                Assert.Equal("Hello", second.Text.ToString());
+
+                Assert.NotNull(textLine.TextRuns[2] as TextEndOfParagraph);
+            }
+        }
+
+        [Fact]
+        public void Should_Coalesce_Bidi_Levels_After_TextWrapping()
+        {
+            using (Start())
+            {
+                const string text = "Hello World";
+
+                var defaultProperties = new GenericTextRunProperties(Typeface.Default);
+
+                var textSource = new SimpleTextSource(text, defaultProperties);
+
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, 50,
+                        new GenericTextParagraphProperties(FlowDirection.RightToLeft, TextAlignment.Right, true, true, defaultProperties, TextWrapping.Wrap, 0, 0, 0));
+
+                Assert.NotNull(textLine);
+
+                Assert.Equal(2, textLine.TextRuns.Count);
+
+                var first = textLine.TextRuns[0] as ShapedTextRun;
+
+                var second = textLine.TextRuns[1] as ShapedTextRun;
+
+                Assert.NotNull(first);
+
+                Assert.NotNull(second);
+
+                Assert.Equal(" ", first.Text.ToString());
+
+                Assert.Equal("Hello", second.Text.ToString());
+            }
+        }
 
         [Fact]
         public void Should_Format_TextRuns_With_TextRunStyles()


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixed a bug in text layout causing indented lines in text with reverse flow directions due to incorrect positioning of whitespace characters.


## What is the current behavior?
No wrap text:
![no-wrapped-text-before](https://github.com/user-attachments/assets/db7bb3d9-9b72-4ff6-b4f9-e8354d70b7c4)

Wrapped text:
![wrapped-text-before](https://github.com/user-attachments/assets/84462d00-1a42-4ba7-9000-14aa98187628)


## What is the updated/expected behavior with this PR?
No wrap text:
![no-wrapped-text-after](https://github.com/user-attachments/assets/b0205c8f-3ee6-48c0-8d14-88a1da1119e3)

Wrapped text:
![wrapped-text-after](https://github.com/user-attachments/assets/bd942667-5e1c-4c3e-b409-dab8df3c9ccd)


## How was the solution implemented (if it's not obvious)?
**For no-wrap text:**
The default text for a text-run without content is currently `'a'`, an explicit LTR character. This fix replaces it with a neutral character, enabling the bidi algorithm to consider the direction of preceding RTL characters.

**For wrapped text:**
In wrapped text, the issue occurs because `CoalesceLevels` is called only once before performing text wrapping. After this fix, bidi text will be processed again for each line.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #17175
