### PR TITLE
Fix InlineDictionary Behavior for Single Item Reassignment

### DIFF
--- a/src/Avalonia.Base/Utilities/SmallDictionary.cs
+++ b/src/Avalonia.Base/Utilities/SmallDictionary.cs
@@ -77,7 +77,15 @@ internal struct InlineDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, 
         }
         else
         {
-            // We have a single element, upgrade to array
+            // We have a single element, check if we should update the value.
+            if((TKey)_data == key && overwrite)
+            {
+                _data = key;
+                _value = value;
+
+                return;
+            }
+            // If we do not replace it, upgrade to array.
             arr = new KeyValuePair[6];
             arr[0] = new KeyValuePair((TKey)_data, _value);
             arr[1] = new KeyValuePair(key, value);

--- a/src/Avalonia.Base/Utilities/SmallDictionary.cs
+++ b/src/Avalonia.Base/Utilities/SmallDictionary.cs
@@ -81,7 +81,6 @@ internal struct InlineDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, 
             var data = (TKey)_data;
             if (data == key && overwrite)
             {
-                _data = key;
                 _value = value;
 
                 return;

--- a/src/Avalonia.Base/Utilities/SmallDictionary.cs
+++ b/src/Avalonia.Base/Utilities/SmallDictionary.cs
@@ -78,7 +78,8 @@ internal struct InlineDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, 
         else
         {
             // We have a single element, check if we should update the value.
-            if((TKey)_data == key && overwrite)
+            var data = (TKey)_data;
+            if (data == key && overwrite)
             {
                 _data = key;
                 _value = value;
@@ -87,7 +88,7 @@ internal struct InlineDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, 
             }
             // If we do not replace it, upgrade to array.
             arr = new KeyValuePair[6];
-            arr[0] = new KeyValuePair((TKey)_data, _value);
+            arr[0] = new KeyValuePair(data, _value);
             arr[1] = new KeyValuePair(key, value);
             _data = arr;
             _value = default;

--- a/tests/Avalonia.Base.UnitTests/Utilities/InlineDictionaryTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Utilities/InlineDictionaryTests.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Base.UnitTests.Utilities;
 public class InlineDictionaryTests
 {
     [Fact]
-    public void Set_Twice_With_Internal_Array_Works()
+    public void Set_Twice_With_Single_Item_Works()
     {
         var dic = new InlineDictionary<string, int>();
         dic["foo"] = 1;

--- a/tests/Avalonia.Base.UnitTests/Utilities/InlineDictionaryTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Utilities/InlineDictionaryTests.cs
@@ -9,6 +9,17 @@ namespace Avalonia.Base.UnitTests.Utilities;
 public class InlineDictionaryTests
 {
     [Fact]
+    public void Set_Twice_With_Internal_Array_Works()
+    {
+        var dic = new InlineDictionary<string, int>();
+        dic["foo"] = 1;
+        Assert.Equal(1, dic["foo"]);
+
+        dic["foo"] = 2;
+        Assert.Equal(2, dic["foo"]);
+    }
+
+    [Fact]
     public void Enumeration_After_Add_With_Internal_Array_Works()
     {
         var dic = new InlineDictionary<string, int>();


### PR DESCRIPTION


<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

This PR addresses an issue with the `InlineDictionary` when handling reassignment of a single item.



## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Current Behavior:

- When the `Set` method was called, it ignored the `overwrite` parameter if the dictionary contained only one item.
- This caused the `Set` method to behave like the `Add` method, leading to unexpected behavior in composition animations.
- Specifically, the second composition animation would not play because it could not replace the first animation. Instead, it was added after the first animation, preventing it from being executed.

See https://github.com/AvaloniaUI/Avalonia/blob/68a626f678b7fa4b1d1497cf7f419f7aebf703ee/src/Avalonia.Base/Rendering/Composition/Server/ServerObjectAnimations.cs#L109-L120

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


Updated Behavior:

- The `InlineDictionary` now respects the `overwrite` parameter even when it contains only one item.
- This ensures that the second composition animation can overwrite the first one, allowing it to play correctly.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes https://github.com/AvaloniaUI/Avalonia/issues/17368
