### PR TITLE
Fix xml-test error message being not culture-invariant

### DIFF
--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Xml;
 using Avalonia.Controls;
 using Avalonia.Data;
@@ -711,6 +713,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
         [Fact]
         public void Fails_Use_Classes_In_Setter_When_Selector_Is_Complex()
         {
+            // XmlException contains culture specific position message
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+            
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
                 var xaml = $"""


### PR DESCRIPTION
## What does the pull request do?
Running the unit-test `Fails_Use_Classes_In_Setter_When_Selector_Is_Complex()` will fail on non-english computers because the expected error-message contains the position of the error, which is translated in the current culture of the user.


## What is the current behavior?
Test `Fails_Use_Classes_In_Setter_When_Selector_Is_Complex()` fails on non-english pc's


## How was the solution implemented (if it's not obvious)?
Setting the threads culture to invariant in the test (which is "en") produces an complete english error message.


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes? (Inline comment for clarity)
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation (Not neccessary)


## Breaking changes
None


## Fixed issues
Fixes [#17359](https://github.com/AvaloniaUI/Avalonia/issues/17359)