### PR TITLE
Don't use GLib helper functions introduced in 2.74

### DIFF
--- a/src/Avalonia.X11/Interop/Glib.cs
+++ b/src/Avalonia.X11/Interop/Glib.cs
@@ -43,10 +43,7 @@ internal static unsafe class Glib
     
     [DllImport(GlibName)]
     public static extern void g_main_loop_unref(IntPtr loop);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void GOnceSourceFunc(IntPtr userData);
-
+    
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int GSourceFunc(IntPtr userData);
     
@@ -54,25 +51,26 @@ internal static unsafe class Glib
     public delegate void GDestroyNotify(IntPtr userData);
 
     [DllImport(GlibName)]
-    private static extern int g_idle_add_once(GOnceSourceFunc cb, IntPtr userData);
+    private static extern int g_idle_add(GSourceFunc cb, IntPtr userData);
 
-    private static readonly GOnceSourceFunc s_onceSourceCb = (userData) =>
+    private static readonly GSourceFunc s_onceSourceCb = (userData) =>
     {
         var h = GCHandle.FromIntPtr(userData);
         var cb = (Action)h.Target!;
 
         h.Free();
         cb();
+        return 0;
     };
 
     public static void g_idle_add_once(Action cb) =>
-        g_idle_add_once(s_onceSourceCb, GCHandle.ToIntPtr(GCHandle.Alloc(cb)));
+        g_idle_add(s_onceSourceCb, GCHandle.ToIntPtr(GCHandle.Alloc(cb)));
     
     [DllImport(GlibName)]
-    private static extern uint g_timeout_add_once(uint interval, GOnceSourceFunc cb, IntPtr userData);
+    private static extern uint g_timeout_add(uint interval, GSourceFunc cb, IntPtr userData);
     
     public static uint g_timeout_add_once(uint interval, Action cb) =>
-        g_timeout_add_once(interval, s_onceSourceCb, GCHandle.ToIntPtr(GCHandle.Alloc(cb)));
+        g_timeout_add(interval, s_onceSourceCb, GCHandle.ToIntPtr(GCHandle.Alloc(cb)));
 
     private static readonly GDestroyNotify s_gcHandleDestroyNotify = handle => GCHandle.FromIntPtr(handle).Free();
 


### PR DESCRIPTION
This raises the minimum Linux distro version requirements and we can avoid this.

#17390