### PR TITLE
Implement TryGetFeature on secondary previewer windows

### DIFF
--- a/src/Avalonia.DesignerSupport/Remote/Stubs.cs
+++ b/src/Avalonia.DesignerSupport/Remote/Stubs.cs
@@ -197,7 +197,20 @@ namespace Avalonia.DesignerSupport.Remote
         public void SetFrameThemeVariant(PlatformThemeVariant themeVariant) { }
 
         public AcrylicPlatformCompensationLevels AcrylicCompensationLevels { get; } = new AcrylicPlatformCompensationLevels(1, 1, 1);
-        public object TryGetFeature(Type featureType) => null;
+        public object TryGetFeature(Type featureType)
+        {
+            if (featureType == typeof(IStorageProvider))
+            {
+                return new NoopStorageProvider();
+            }
+
+            if (featureType == typeof(IScreenImpl))
+            {
+                return new ScreenStub();
+            }
+
+            return null;
+        }
         public void TakeFocus() { }
     }
 


### PR DESCRIPTION
## What does the pull request do?

A corner case, but still a regression.

With previewer, we have two different IWindowImpl implementations: PreviewerWindowImpl and WindowStub.
Where first one is actually used to render previewer contents, and second is only used for secondary windows opened on side, not rendered anywhere.

In one of my previous Screen PRs I moved IScreenImpl initialization to the TryGetFeature method, but haven't noticed this second WindowStub implementation. Which regressed in https://github.com/AvaloniaUI/Avalonia/issues/17401.

Note for future: consider removing all these stubs, and instead basing previewer protocol on top of Avalonia.Headless.

## Fixed issues

Fixes #17401