### PR TITLE
Create an autorelease pool for every render timer tick

### DIFF
--- a/native/Avalonia.Native/src/OSX/PlatformRenderTimer.mm
+++ b/native/Avalonia.Native/src/OSX/PlatformRenderTimer.mm
@@ -72,6 +72,7 @@ public:
     
     static CVReturn OnTick(CVDisplayLinkRef displayLink, const CVTimeStamp *inNow, const CVTimeStamp *inOutputTime, CVOptionFlags flagsIn, CVOptionFlags *flagsOut, void *displayLinkContext)
     {
+        START_ARP_CALL;
         PlatformRenderTimer *object = (PlatformRenderTimer *)displayLinkContext;
         object->_callback->Run();
         return kCVReturnSuccess;


### PR DESCRIPTION
Since render timer is ticking on a background thread that has no implicit autorelease pools, we should always have one before calling managed code that can technically make arbitrary callbacks to ObjC.