### PR TITLE
Fix window resize jitter with Metal

### DIFF
--- a/native/Avalonia.Native/src/OSX/metal.mm
+++ b/native/Avalonia.Native/src/OSX/metal.mm
@@ -57,14 +57,19 @@ public:
 
     ~AvnMetalRenderSession()
     {
+        START_ARP_CALL;
         auto buffer = [_queue commandBuffer];
-        [buffer presentDrawable: _drawable];
         [buffer commit];
+        [buffer waitUntilCompleted];
+        [CATransaction begin];
+        [_drawable present];
+        [CATransaction commit];
     }
 };
 
 class AvnMetalRenderTarget : public ComSingleObject<IAvnMetalRenderTarget, &IID_IAvnMetalRenderTarget>
 {
+    CALayer* _hostLayer;
     CAMetalLayer* _layer;
     double _scaling = 1;
     AvnPixelSize _size = {1,1};
@@ -73,30 +78,38 @@ public:
     double PendingScaling = 1;
     AvnPixelSize PendingSize = {1,1};
     FORWARD_IUNKNOWN()
-    AvnMetalRenderTarget(CAMetalLayer* layer, ComPtr<AvnMetalDevice> device)
+    AvnMetalRenderTarget(CALayer* hostLayer, ComPtr<AvnMetalDevice> device)
     {
-        _layer = layer;
         _device = device;
+        _hostLayer = hostLayer;
+        _layer = [CAMetalLayer new];
+        _layer.opaque = false;
+        _layer.device = _device->device;
+        _layer.presentsWithTransaction = YES;
+        _layer.framebufferOnly = YES;
+        [_hostLayer addSublayer: _layer];
     }
 
     HRESULT BeginDrawing(IAvnMetalRenderingSession **ret) override {
+        START_ARP_CALL;
         if([NSThread isMainThread])
         {
-            // Flush all existing rendering
-            auto buffer = [_device->queue commandBuffer];
-            [buffer commit];
-            [buffer waitUntilCompleted];
             _size = PendingSize;
             _scaling= PendingScaling;
             CGSize layerSize = {(CGFloat)_size.Width, (CGFloat)_size.Height};
-
+            [CATransaction begin];
+            [CATransaction setDisableActions: YES];
             [_layer setDrawableSize: layerSize];
+            [_layer setFrame: [_hostLayer frame]];
+            [CATransaction commit];
         }
+        else if(PendingSize.Width != _size.Width || PendingSize.Height != _size.Height)
+            return AvnResultCodes::E_AVN_RENDER_TARGET_NOT_READY;
         auto drawable = [_layer nextDrawable];
         if(drawable == nil)
         {
             ret = nil;
-            return E_FAIL;
+            return AvnResultCodes::E_AVN_RENDER_TARGET_NOT_READY;
         }
         *ret = new AvnMetalRenderSession(_device, _layer, drawable, _size, _scaling);
         return 0;
@@ -111,9 +124,7 @@ public:
 }
 - (MetalRenderTarget *)initWithDevice:(IAvnMetalDevice *)device {
     _device = dynamic_cast<AvnMetalDevice*>(device);
-    _layer = [CAMetalLayer new];
-    _layer.opaque = false;
-    _layer.device = _device->device;
+    _layer = [CALayer new];
     _target.setNoAddRef(new AvnMetalRenderTarget(_layer, _device));
     return self;
 }

--- a/native/Avalonia.Native/src/OSX/metal.mm
+++ b/native/Avalonia.Native/src/OSX/metal.mm
@@ -119,7 +119,7 @@ public:
 @implementation MetalRenderTarget
 {
     ComPtr<AvnMetalDevice> _device;
-    CAMetalLayer* _layer;
+    CALayer* _layer;
     ComPtr<AvnMetalRenderTarget> _target;
 }
 - (MetalRenderTarget *)initWithDevice:(IAvnMetalDevice *)device {

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -148,8 +148,19 @@ namespace Avalonia.Rendering.Composition.Server
                             // Check if render target can be rendered to directly and preserves the previous frame
                             || !(renderTargetWithProperties?.Properties.RetainsPreviousFrameContents == true
                                 && renderTargetWithProperties?.Properties.IsSuitableForDirectRendering == true);
+
+            IDrawingContextImpl renderTargetContext;
+            RenderTargetDrawingContextProperties properties;
+            try
+            {
+                renderTargetContext = _renderTarget.CreateDrawingContextWithProperties(false, out properties);
+            }
+            catch (RenderTargetNotReadyException)
+            {
+                return;
+            }
             
-            using (var renderTargetContext = _renderTarget.CreateDrawingContextWithProperties(false, out var properties))
+            using (renderTargetContext)
             {
                 if(needLayer && (PixelSize != _layerSize || _layer == null || _layer.IsCorrupted))
                 {

--- a/src/Avalonia.Native/Metal.cs
+++ b/src/Avalonia.Native/Metal.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using Avalonia.Metal;
 using Avalonia.Native.Interop;
 using Avalonia.Platform;
@@ -84,8 +85,15 @@ internal class MetalRenderTarget : IMetalPlatformSurfaceRenderTarget
 
     public IMetalPlatformSurfaceRenderingSession BeginRendering()
     {
-        var session = _native.BeginDrawing();
-        return new MetalDrawingSession(session);
+        try
+        {
+            var session = _native.BeginDrawing();
+            return new MetalDrawingSession(session);
+        }
+        catch (COMException com) when (com.HResult == (int)AvnResultCodes.E_AVN_RENDER_TARGET_NOT_READY)
+        {
+            throw new RenderTargetNotReadyException();
+        }
     }
 }
 

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -7,6 +7,7 @@
 #pragma once
 #include "com.h"
 #include "stddef.h"
+#define unchecked(x) x
 @@
 
 enum AvnKey
@@ -1260,4 +1261,10 @@ interface IAvnPlatformRenderTimer : IUnknown
     void Start();
     void Stop();
     bool RunsInBackground();
+}
+
+enum AvnResultCodes
+{
+    // Codes are 0x80040200-based because vbObjectError is 0x80040000 but codes <0x200 still somehow got reserved
+    E_AVN_RENDER_TARGET_NOT_READY = unchecked((int)0x80040201)
 }


### PR DESCRIPTION
1) use `CAMetalLayer.presentsWithTransaction = YES;` and manually trigger `[CAMetalDrawable present]` while wrapping it into a `CATransaction` when drawing from a non-UI thread
2) Create a separate contentless layer as a backing layer for AvnView and let AppKit and CoreAnimation do their thing with it.  CAMetalLayer is now added as a sublayer and is manually updated to proper size inside of a separate CATransaction with disabled animations. 

Note that this needs extensive testing on multiple machines first (both Mx and Intel with and without dedicated GPU), unless it can be done quickly we should switch back to OpenGL as our default renderer).


Tested platforms:
- [x] M3 Max (MBP 2023) Sonoma
- [x] Intel + Radeon Pro 555 (MBP 2017) Ventura

Still need to test on Intel without dedicated GPU.