### PR TITLE
Optimization for Process.GetCurrentProcess() in Avalonia.Win32.Automation

### DIFF
--- a/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
+++ b/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
@@ -62,8 +62,14 @@ namespace Avalonia.Win32.Automation
 
         private readonly int[] _runtimeId;
 
+        private readonly int _pid;
         public AutomationNode(AutomationPeer peer)
         {
+#if NET6_0_OR_GREATER
+            _pid = Environment.ProcessId;
+#else
+            _pid = GetProcessId();
+#endif
             _runtimeId = new int[] { 3, GetHashCode() };
             Peer = peer;
             s_nodes.Add(peer, this);
@@ -136,7 +142,7 @@ namespace Avalonia.Win32.Automation
                 UiaPropertyId.LocalizedControlType => InvokeSync(() => Peer.GetLocalizedControlType()),
                 UiaPropertyId.Name => InvokeSync(() => Peer.GetName()),
                 UiaPropertyId.HelpText => InvokeSync(() => Peer.GetHelpText()),
-                UiaPropertyId.ProcessId => Process.GetCurrentProcess().Id,
+                UiaPropertyId.ProcessId => _pid,
                 UiaPropertyId.RuntimeId => _runtimeId,
                 _ => null,
             };
@@ -354,6 +360,12 @@ namespace Avalonia.Win32.Automation
                 AutomationControlType.Separator => UiaControlTypeId.Separator,
                 _ => UiaControlTypeId.Custom,
             };
+        }
+
+        private static int GetProcessId()
+        {
+            using var proccess = Process.GetCurrentProcess();
+            return proccess.Id;
         }
     }
 }

--- a/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
+++ b/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
@@ -62,14 +62,10 @@ namespace Avalonia.Win32.Automation
 
         private readonly int[] _runtimeId;
 
-        private readonly int _pid;
+        private static readonly int s_pid = GetProcessId();
+
         public AutomationNode(AutomationPeer peer)
         {
-#if NET6_0_OR_GREATER
-            _pid = Environment.ProcessId;
-#else
-            _pid = GetProcessId();
-#endif
             _runtimeId = new int[] { 3, GetHashCode() };
             Peer = peer;
             s_nodes.Add(peer, this);
@@ -142,7 +138,7 @@ namespace Avalonia.Win32.Automation
                 UiaPropertyId.LocalizedControlType => InvokeSync(() => Peer.GetLocalizedControlType()),
                 UiaPropertyId.Name => InvokeSync(() => Peer.GetName()),
                 UiaPropertyId.HelpText => InvokeSync(() => Peer.GetHelpText()),
-                UiaPropertyId.ProcessId => _pid,
+                UiaPropertyId.ProcessId => s_pid,
                 UiaPropertyId.RuntimeId => _runtimeId,
                 _ => null,
             };
@@ -364,8 +360,12 @@ namespace Avalonia.Win32.Automation
 
         private static int GetProcessId()
         {
+#if NET6_0_OR_GREATER
+            return Environment.ProcessId;
+#else
             using var proccess = Process.GetCurrentProcess();
             return proccess.Id;
+#endif
         }
     }
 }

--- a/src/Windows/Avalonia.Win32.Automation/InteropAutomationNode.cs
+++ b/src/Windows/Avalonia.Win32.Automation/InteropAutomationNode.cs
@@ -30,7 +30,7 @@ internal partial class InteropAutomationNode : AutomationNode, IRawElementProvid
     public override ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider | ProviderOptions.OverrideProvider;
 
     public override object? GetPatternProvider(int patternId) => null;
-    //public override object? GetPropertyValue(int propertyId) => null;
+    public override object? GetPropertyValue(int propertyId) => null;
 
     public override IRawElementProviderSimple? GetHostRawElementProvider()
     {

--- a/src/Windows/Avalonia.Win32.Automation/InteropAutomationNode.cs
+++ b/src/Windows/Avalonia.Win32.Automation/InteropAutomationNode.cs
@@ -30,7 +30,7 @@ internal partial class InteropAutomationNode : AutomationNode, IRawElementProvid
     public override ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider | ProviderOptions.OverrideProvider;
 
     public override object? GetPatternProvider(int patternId) => null;
-    public override object? GetPropertyValue(int propertyId) => null;
+    //public override object? GetPropertyValue(int propertyId) => null;
 
     public override IRawElementProviderSimple? GetHostRawElementProvider()
     {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
- In .NET 6 and later versions, using `Environment.ProcessId` is the recommended approach. 
- Repeatedly calling `Process.GetCurrentProcess()` introduces performance overhead.
- Process instances need to be manually disposed.

refer : https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1837

## What is the current behavior?
`GetPropertyValue` for `UiaPropertyId.ProcessId` will call `Process.GetCurrentProcess()` everytime.

## What is the updated/expected behavior with this PR?

Add a private variable : _pid to avoid creating process instance everytime.

.net6 and later: Use `Environment.ProcessId` instead of `Process.GetCurrentProcess().Id`
.net standard 2.0: Call `Process.GetCurrentProcess()` within `using`

## How was the solution implemented (if it's not obvious)?


## Checklist


## Breaking changes


## Obsoletions / Deprecations


## Fixed issues

