### PR TITLE
Added basic date/time picker automation peers.

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/DatePickerAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/DatePickerAutomationPeer.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Avalonia.Automation.Provider;
+using Avalonia.Controls;
+
+namespace Avalonia.Automation.Peers;
+
+public class DatePickerAutomationPeer : ControlAutomationPeer, IValueProvider
+{
+    public DatePickerAutomationPeer(DatePicker owner)
+        : base(owner)
+    {
+    }
+
+    public bool IsReadOnly => false;
+    public new DatePicker Owner => (DatePicker)base.Owner;
+    public string? Value => Owner.SelectedDate?.ToString();
+
+    public void SetValue(string? value)
+    {
+        if (DateTimeOffset.TryParse(value, out var result))
+            Owner.SelectedDate = result;
+    }
+
+    protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Custom;
+}

--- a/src/Avalonia.Controls/Automation/Peers/TimePickerAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TimePickerAutomationPeer.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Avalonia.Automation.Provider;
+using Avalonia.Controls;
+
+namespace Avalonia.Automation.Peers;
+
+public class TimePickerAutomationPeer : ControlAutomationPeer, IValueProvider
+{
+    public TimePickerAutomationPeer(TimePicker owner)
+        : base(owner)
+    {
+    }
+
+    public bool IsReadOnly => false;
+    public new TimePicker Owner => (TimePicker)base.Owner;
+    public string? Value => Owner.SelectedTime?.ToString();
+
+    public void SetValue(string? value)
+    {
+        if (TimeSpan.TryParse(value, out var result))
+            Owner.SelectedTime = result;
+    }
+
+    protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Custom;
+}

--- a/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls.Metadata;
+﻿using Avalonia.Automation.Peers;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Data;
@@ -266,6 +267,8 @@ namespace Avalonia.Controls
                 _presenter[!DatePickerPresenter.YearFormatProperty] = this[!YearFormatProperty];
             }
         }
+
+        protected override AutomationPeer OnCreateAutomationPeer() => new DatePickerAutomationPeer(this);
 
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {

--- a/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
@@ -6,6 +6,7 @@ using Avalonia.Layout;
 using System;
 using System.Globalization;
 using Avalonia.Controls.Utils;
+using Avalonia.Automation.Peers;
 
 namespace Avalonia.Controls
 {
@@ -329,6 +330,8 @@ namespace Avalonia.Controls
                 _periodText.Text = DateTime.Now.Hour >= 12 ?  TimeUtils.GetPMDesignator() :  TimeUtils.GetAMDesignator();
             }
         }
+
+        protected override AutomationPeer OnCreateAutomationPeer() => new TimePickerAutomationPeer(this);
 
         protected virtual void OnSelectedTimeChanged(TimeSpan? oldTime, TimeSpan? newTime)
         {


### PR DESCRIPTION
## What does the pull request do?

Currently, `DatePicker` and `TimePicker` have no automation peer, meaning that they don't show up in the automation tree[^1].

This PR adds basic automation peers for these controls, causing them to show up as controls of type `Custom` in the automation tree. This matches how they show up in WPF (though in WinUI they show up as "Group" for some reason). UIA and NSAccessibility don't have a control type/role for date/time pickers.

The peers implement `IValueProvider` allowing the value to be set through automation. The parsing of the date/time is done using a simple `DateTimeOffset.TryParse` or `TimeSpan.TryParse`, so will use the OS/application culture.

Ideally, the automation peers should also implement `IExpandCollapseProvider` but this was not done here because:

- There is no `IsDropDownOpen` or equivalent API for opening/closing the date/time picker
- The date/time pickers in WinUI don't implement this provider either, so I doubt it's important

[^1]: More accurately, they will show up only in the Raw view in UIA and `isAccessibilityElement` will return `false` on macOS