### PR TITLE
Update pipelines to macOS 13

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,7 @@ jobs:
   variables:
     SolutionDir: '$(Build.SourcesDirectory)'
   pool:
-    vmImage: 'macos-12'
+    vmImage: 'macos-13'
   steps:
   - task: UseDotNet@2
     displayName: 'Use .NET 6.0 Runtime'
@@ -109,10 +109,11 @@ jobs:
     inputs:
       actions: 'build'
       scheme: ''
-      sdk: 'macosx12.3'
+      sdk: 'macosx13.0'
       configuration: 'Release'
       xcWorkspacePath: '**/*.xcodeproj/project.xcworkspace'
-      xcodeVersion: '13' # Options: 8, 9, default, specifyPath
+      xcodeVersion: 'specifyPath' # Options: 8, 9, default, specifyPath
+      xcodeDeveloperDir: '/Applications/Xcode_14.1.app/Contents/Developer'
       args: '-derivedDataPath ./'
 
   - task: CmdLine@2


### PR DESCRIPTION
This PR updates the Azure pipelines to use macOS 13, since version 12 is [now deprecated](https://github.com/actions/runner-images/issues/10721).