### PR TITLE
Fix adapter selection in Vulkan demo

### DIFF
--- a/samples/GpuInterop/VulkanDemo/D3DMemoryHelper.cs
+++ b/samples/GpuInterop/VulkanDemo/D3DMemoryHelper.cs
@@ -17,7 +17,7 @@ public class D3DMemoryHelper
         var longLuid = MemoryMarshal.Cast<byte, long>(luid)[0];
         for (var c = 0; c < factory.GetAdapterCount1(); c++)
         {
-            using var adapter = factory.GetAdapter1(0);
+            using var adapter = factory.GetAdapter1(c);
             if (adapter.Description1.Luid != longLuid)
                 continue;
 


### PR DESCRIPTION
Changed the adapter index in the for loop to correctly iterate through available adapters. This ensures that the correct adapter is selected based on its Luid.

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This request fixes an index error in D3DMemoryHelper.cs that prevented usage of any graphics adapters other than the one in slot 0.


## What is the current behavior?
`factory.GetAdapter1()` was hard-coded to always use index zero when iterating through graphics devices


## What is the updated/expected behavior with this PR?
`factory.GetAdapter1()` now properly uses the iterator index when iterating through graphics devices


## How was the solution implemented (if it's not obvious)?
Changed hard-coded '0' value to the index variable.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
