### PR TITLE
DevTools should not add visual elements to its logical tree

### DIFF
--- a/src/Avalonia.Controls/ContentControl.cs
+++ b/src/Avalonia.Controls/ContentControl.cs
@@ -106,6 +106,8 @@ namespace Avalonia.Controls
             set => SetValue(VerticalContentAlignmentProperty, value);
         }
 
+        internal virtual bool AddContentToLogicalTree => true; 
+
         /// <inheritdoc/>
         IAvaloniaList<ILogical> IContentPresenterHost.LogicalChildren => LogicalChildren;
 
@@ -142,6 +144,11 @@ namespace Avalonia.Controls
 
         private void ContentChanged(AvaloniaPropertyChangedEventArgs e)
         {
+            if (!AddContentToLogicalTree)
+            {
+                return;
+            }
+            
             if (e.OldValue is ILogical oldChild)
             {
                 LogicalChildren.Remove(oldChild);

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/ControlDetailsContentControl.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/ControlDetailsContentControl.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Avalonia.Controls;
+
+namespace Avalonia.Diagnostics.Controls
+{
+    internal class ControlDetailsContentControl : ContentControl
+    {
+        protected override Type StyleKeyOverride => typeof(ContentControl);
+
+        internal override bool AddContentToLogicalTree => false;
+    }
+}

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
@@ -261,13 +261,13 @@
                             <StackPanel Orientation="Horizontal" Spacing="2" HorizontalAlignment="Left">
                               <TextBlock Classes="property-name" PointerPressed="PropertyNamePressed" Text="{Binding Name}" />
                               <TextBlock Text=":" />
-                              <ContentControl Content="{Binding Value}">
+                              <controls:ControlDetailsContentControl Content="{Binding Value}">
                                 <ContentControl.ContentTemplate>
                                   <DataTemplate x:DataType="system:Object">
                                     <TextBlock Text="{Binding}" />
                                   </DataTemplate>
                                 </ContentControl.ContentTemplate>
-                              </ContentControl>
+                              </controls:ControlDetailsContentControl>
                               <TextBlock>(</TextBlock>
                               <Ellipse Height="8" Width="8" VerticalAlignment="Center" Fill="{Binding Tint}" ToolTip.Tip="{Binding ValueTypeTooltip}"/>
                               <TextBlock FontStyle="Italic" Text="{Binding Key}" />
@@ -288,13 +288,13 @@
                             <StackPanel Orientation="Horizontal" Spacing="2">
                               <TextBlock Classes="property-name" PointerPressed="PropertyNamePressed" Text="{Binding Name}" />
                               <TextBlock Text=":" />
-                              <ContentControl Content="{Binding Value}">
+                              <controls:ControlDetailsContentControl Content="{Binding Value}">
                                 <ContentControl.ContentTemplate>
                                   <DataTemplate x:DataType="system:Object">
                                     <TextBlock Text="{Binding}" />
                                   </DataTemplate>
                                 </ContentControl.ContentTemplate>
-                              </ContentControl>
+                              </controls:ControlDetailsContentControl>
                             </StackPanel>
                             <Rectangle Classes="property-inactive" IsVisible="{Binding !IsActive}" />
                           </Panel>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR makes sure that the visual elements are not added to the DevTools logical tree.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Currently in 11.2, visual elements can be added to the DevTools logical tree. This can causes the app's visual tree to break.

```xaml
    <TabControl>
        <TabItem Header="Item1">
            <Button>button1</Button>
        </TabItem>
        <TabItem Header="Item2">
            <Button>button2</Button>
        </TabItem>
    </TabControl>
```

https://github.com/user-attachments/assets/cb0a5940-8967-4935-b276-e32d2bab5ee2

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
