### PR TITLE
Handle previously missing event types in PenDevice

### DIFF
--- a/src/Avalonia.Base/Input/PenDevice.cs
+++ b/src/Avalonia.Base/Input/PenDevice.cs
@@ -64,9 +64,17 @@ namespace Avalonia.Input
                         shouldReleasePointer = true;
                         break;
                     case RawPointerEventType.LeftButtonDown:
+                    case RawPointerEventType.RightButtonDown:
+                    case RawPointerEventType.MiddleButtonDown:
+                    case RawPointerEventType.XButton1Down:
+                    case RawPointerEventType.XButton2Down:
                         e.Handled = PenDown(pointer, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult.firstEnabledAncestor);
                         break;
                     case RawPointerEventType.LeftButtonUp:
+                    case RawPointerEventType.RightButtonUp:
+                    case RawPointerEventType.MiddleButtonUp:
+                    case RawPointerEventType.XButton1Up:
+                    case RawPointerEventType.XButton2Up:
                         if (_releasePointerOnPenUp)
                         {
                             shouldReleasePointer = true;


### PR DESCRIPTION
## What does the pull request do?

As per title.
Fixes right/barrel button handling with surface/wacom stylus.
Old-style pens with tables were emulating right button as a WM_RMOUSEDOWN, instead of using proper API, which is why this bug wasn't noticed before.