### PR TITLE
AutoCompleteBox don't lose text selection when contextmenu opens

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
@@ -812,7 +812,11 @@ namespace Avalonia.Controls
                 }
 
                 _userCalledPopulate = false;
-                ClearTextBoxSelection();
+
+                if (ContextMenu is not { IsOpen: true })
+                {
+                    ClearTextBoxSelection();
+                }
             }
 
             _isFocused = hasFocus;
@@ -1732,7 +1736,7 @@ namespace Avalonia.Controls
 
         private void ClearTextBoxSelection()
         {
-            if (TextBox != null && ContextMenu is not { IsOpen: true })
+            if (TextBox != null)
             {
                 int length = TextBox.Text?.Length ?? 0;
                 TextBox.SelectionStart = length;

--- a/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
@@ -1732,7 +1732,7 @@ namespace Avalonia.Controls
 
         private void ClearTextBoxSelection()
         {
-            if (TextBox != null)
+            if (TextBox != null && ContextMenu is not { IsOpen: true })
             {
                 int length = TextBox.Text?.Length ?? 0;
                 TextBox.SelectionStart = length;

--- a/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Controls.Primitives;
@@ -9,7 +9,10 @@ using Avalonia.UnitTests;
 using Xunit;
 using System.Collections.ObjectModel;
 using System.Reactive.Subjects;
+using Avalonia.Headless;
 using Avalonia.Input;
+using Avalonia.Platform;
+using Moq;
 
 namespace Avalonia.Controls.UnitTests
 {
@@ -518,6 +521,42 @@ namespace Avalonia.Controls.UnitTests
                 // DropDown can now be opened.
                 Assert.True(control.IsDropDownOpen);
             });
+        }
+
+        [Fact]
+        public void Opening_Context_Menu_Does_not_Lose_Selection()
+        {
+            using (UnitTestApplication.Start(FocusServices))
+            {
+                var target1 = CreateControl();
+                target1.ContextMenu = new TestContextMenu();
+                var textBox1 = GetTextBox(target1);
+                textBox1.Text = "1234";
+
+                var target2 = CreateControl();
+                var textBox2 = GetTextBox(target2);
+                textBox2.Text = "5678";
+
+                var sp = new StackPanel();
+                sp.Children.Add(target1);
+                sp.Children.Add(target2);
+
+                target1.ApplyTemplate();
+                target2.ApplyTemplate();
+
+                var root = new TestRoot() { Child = sp };
+
+                textBox1.SelectionStart = 0;
+                textBox1.SelectionEnd = 3;
+
+                target1.Focus();
+                Assert.False(target2.IsFocused);
+                Assert.True(target1.IsFocused);
+
+                target2.Focus();
+
+                Assert.Equal("123", textBox1.SelectedText);
+            }
         }
 
         /// <summary>
@@ -1197,6 +1236,23 @@ namespace Avalonia.Controls.UnitTests
 
                 return panel;
             });
+        }
+
+        private static TestServices FocusServices => TestServices.MockThreadingInterface.With(
+            focusManager: new FocusManager(),
+            keyboardDevice: () => new KeyboardDevice(),
+            keyboardNavigation: () => new KeyboardNavigationHandler(),
+            inputManager: new InputManager(),
+            standardCursorFactory: Mock.Of<ICursorFactory>(),
+            textShaperImpl: new HeadlessTextShaperStub(),
+            fontManagerImpl: new HeadlessFontManagerStub());
+
+        private class TestContextMenu : ContextMenu
+        {
+            public TestContextMenu()
+            {
+                IsOpen = true;
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

When implementing copy and paste context menu items for AutoCompleteBox it's not possible because text selection gets lost.

This issue was solved also for TextBox in #4498 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Selection is gone.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Selection should be the same.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #17453 
