### PR TITLE
CalendarDatePicker - use CustomDateFormatString for parsing the text input

### DIFF
--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -730,8 +730,8 @@ namespace Avalonia.Controls
             // the TextParseError event
             try
             {
-                newSelectedDate = !string.IsNullOrEmpty(this.CustomDateFormatString) ?
-                    DateTime.ParseExact(text, this.CustomDateFormatString, DateTimeHelper.GetCurrentDateFormat()) :
+                newSelectedDate = SelectedDateFormat == CalendarDatePickerFormat.Custom && !string.IsNullOrEmpty(CustomDateFormatString) ?
+                    DateTime.ParseExact(text, CustomDateFormatString, DateTimeHelper.GetCurrentDateFormat()) :
                     DateTime.Parse(text, DateTimeHelper.GetCurrentDateFormat());
 
                 if (Calendar.IsValidDateSelection(this._calendar!, newSelectedDate))

--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -901,6 +901,11 @@ namespace Avalonia.Controls
 
                     switch (SelectedDateFormat)
                     {
+                        case CalendarDatePickerFormat.Custom:
+                            {
+                                watermarkText = string.Format(CultureInfo.CurrentCulture, watermarkFormat, CustomDateFormatString);
+                                break;
+                            }
                         case CalendarDatePickerFormat.Long:
                             {
                                 watermarkText = string.Format(CultureInfo.CurrentCulture, watermarkFormat, dtfi.LongDatePattern.ToString());
@@ -913,6 +918,7 @@ namespace Avalonia.Controls
                                 break;
                             }
                     }
+
                     _textBox.Watermark = watermarkText;
                 }
                 else

--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -730,7 +730,9 @@ namespace Avalonia.Controls
             // the TextParseError event
             try
             {
-                newSelectedDate = DateTime.Parse(text, DateTimeHelper.GetCurrentDateFormat());
+                newSelectedDate = !string.IsNullOrEmpty(this.CustomDateFormatString) ?
+                    DateTime.ParseExact(text, this.CustomDateFormatString, DateTimeHelper.GetCurrentDateFormat()) :
+                    DateTime.Parse(text, DateTimeHelper.GetCurrentDateFormat());
 
                 if (Calendar.IsValidDateSelection(this._calendar!, newSelectedDate))
                 {

--- a/tests/Avalonia.Controls.UnitTests/CalendarDatePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CalendarDatePickerTests.cs
@@ -1,17 +1,13 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using Avalonia.Controls.Primitives;
-using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
-using Avalonia.Data;
-using Avalonia.Markup.Data;
+using Avalonia.Input;
 using Avalonia.Platform;
 using Avalonia.UnitTests;
 using Moq;
 using Xunit;
+using System.Globalization;
 
 namespace Avalonia.Controls.UnitTests
 {
@@ -73,6 +69,34 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        [Fact]
+        public void Setting_Date_Manually_With_CustomDateFormatString_Should_Be_Accepted()
+        {
+            CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+            using (UnitTestApplication.Start(Services))
+            {
+                CalendarDatePicker datePicker = CreateControl();
+                datePicker.SelectedDateFormat = CalendarDatePickerFormat.Custom;
+                datePicker.CustomDateFormatString = "dd.MM.yyyy";
+
+                var tb = GetTextBox(datePicker);
+
+                tb.Clear();
+                RaiseTextEvent(tb, "17.10.2024");
+                RaiseKeyEvent(tb, Key.Enter, KeyModifiers.None);
+                
+                Assert.Equal("17.10.2024", datePicker.Text);
+                Assert.True(CompareDates(datePicker.SelectedDate.Value, new DateTime(2024, 10, 17)));
+
+                tb.Clear();
+                RaiseTextEvent(tb, "12.10.2024");
+                RaiseKeyEvent(tb, Key.Enter, KeyModifiers.None);
+
+                Assert.Equal("12.10.2024", datePicker.Text);
+                Assert.True(CompareDates(datePicker.SelectedDate.Value, new DateTime(2024, 10, 12)));
+            }
+        }
+
         private static TestServices Services => TestServices.MockThreadingInterface.With(
             standardCursorFactory: Mock.Of<ICursorFactory>());
 
@@ -127,5 +151,32 @@ namespace Avalonia.Controls.UnitTests
             });
 
         }
+
+        private TextBox GetTextBox(CalendarDatePicker control)
+        {
+            return control.GetTemplateChildren()
+                .OfType<TextBox>()
+                .First();
+        }
+
+        private static void RaiseKeyEvent(TextBox textBox, Key key, KeyModifiers inputModifiers)
+        {
+            textBox.RaiseEvent(new KeyEventArgs
+            {
+                RoutedEvent = InputElement.KeyDownEvent,
+                KeyModifiers = inputModifiers,
+                Key = key
+            });
+        }
+
+        private static void RaiseTextEvent(TextBox textBox, string text)
+        {
+            textBox.RaiseEvent(new TextInputEventArgs
+            {
+                RoutedEvent = InputElement.TextInputEvent,
+                Text = text
+            });
+        }
+
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/CalendarDatePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CalendarDatePickerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
@@ -84,7 +84,7 @@ namespace Avalonia.Controls.UnitTests
                 tb.Clear();
                 RaiseTextEvent(tb, "17.10.2024");
                 RaiseKeyEvent(tb, Key.Enter, KeyModifiers.None);
-                
+
                 Assert.Equal("17.10.2024", datePicker.Text);
                 Assert.True(CompareDates(datePicker.SelectedDate.Value, new DateTime(2024, 10, 17)));
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

This PR looks for possible existing CustomDateFormatString and use it for parsing text input. Also the watermark will use now the CustomDateFormatString.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

The CustomDateFormatString is ignored and will also throw exceptions. See #17291 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Now exception is throen and the text is parsed to the excpected DateTime.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #17291 
