### PR TITLE
add automation peer for UserControl

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/UserControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/UserControlAutomationPeer.cs
@@ -3,7 +3,7 @@ using Avalonia.Automation.Peers;
 
 namespace Avalonia.Controls.Automation.Peers;
 
-public class UserControlAutomationPeer : ContentControlAutomationPeer
+public class UserControlAutomationPeer : ControlAutomationPeer
 {
     public UserControlAutomationPeer(UserControl owner)
         : base(owner)
@@ -11,16 +11,4 @@ public class UserControlAutomationPeer : ContentControlAutomationPeer
     }
     
     protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Custom;
-
-    protected override string? GetNameCore()
-    {
-        var result = AutomationProperties.GetName(Owner);
-
-        if (string.IsNullOrWhiteSpace(result) && GetLabeledBy() is AutomationPeer labeledBy)
-        {
-            result = labeledBy.GetName();
-        }
-
-        return result;
-    }
 }

--- a/src/Avalonia.Controls/Automation/Peers/UserControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/UserControlAutomationPeer.cs
@@ -1,0 +1,13 @@
+using Avalonia.Automation.Peers;
+
+namespace Avalonia.Controls.Automation.Peers;
+
+public class UserControlAutomationPeer : ContentControlAutomationPeer
+{
+    public UserControlAutomationPeer(UserControl owner)
+        : base(owner)
+    {
+    }
+    
+    protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Custom;
+}

--- a/src/Avalonia.Controls/Automation/Peers/UserControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/UserControlAutomationPeer.cs
@@ -1,3 +1,4 @@
+using Avalonia.Automation;
 using Avalonia.Automation.Peers;
 
 namespace Avalonia.Controls.Automation.Peers;
@@ -10,4 +11,16 @@ public class UserControlAutomationPeer : ContentControlAutomationPeer
     }
     
     protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Custom;
+
+    protected override string? GetNameCore()
+    {
+        var result = AutomationProperties.GetName(Owner);
+
+        if (string.IsNullOrWhiteSpace(result) && GetLabeledBy() is AutomationPeer labeledBy)
+        {
+            result = labeledBy.GetName();
+        }
+
+        return result;
+    }
 }

--- a/src/Avalonia.Controls/UserControl.cs
+++ b/src/Avalonia.Controls/UserControl.cs
@@ -1,3 +1,5 @@
+using Avalonia.Automation.Peers;
+using Avalonia.Controls.Automation.Peers;
 using Avalonia.Styling;
 
 namespace Avalonia.Controls
@@ -7,6 +9,6 @@ namespace Avalonia.Controls
     /// </summary>
     public class UserControl : ContentControl
     {
-
+        protected override AutomationPeer OnCreateAutomationPeer() => new UserControlAutomationPeer(this);
     }
 }


### PR DESCRIPTION
This patch adds automation peer for `UserControl`.

## What does the pull request do?
As #17423 described, Windows UI automation can not determine the correct control type of `UserControl`. The root cause is that no corresponding automation peer for it.


## What is the current behavior?
LocalizedControlType is "none".


## What is the updated/expected behavior with this PR?
LocalizedControlType is "custom".


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #17423
