### PR TITLE
Enable TemplateBinding inside ItemsPanelTemplate

### DIFF
--- a/src/Avalonia.Base/Metadata/ControlTemplateScopeAttribute.cs
+++ b/src/Avalonia.Base/Metadata/ControlTemplateScopeAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Avalonia.Metadata;
+
+/// <summary>
+/// Indicates that a type acts as a control template scope (for example, TemplateBindings are expected to work).
+/// Types annotated with this attribute may provide a TargetType property.
+/// </summary>
+[AttributeUsage(
+    AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+    AllowMultiple = false,
+    Inherited = true)]
+public sealed class ControlTemplateScopeAttribute : Attribute;

--- a/src/Avalonia.Controls/Templates/IControlTemplate.cs
+++ b/src/Avalonia.Controls/Templates/IControlTemplate.cs
@@ -1,10 +1,12 @@
 using Avalonia.Controls.Primitives;
+using Avalonia.Metadata;
 
 namespace Avalonia.Controls.Templates
 {
     /// <summary>
     /// Interface representing a template used to build a <see cref="TemplatedControl"/>.
     /// </summary>
+    [ControlTemplateScope]
     public interface IControlTemplate : ITemplate<TemplatedControl, TemplateResult<Control>?>
     {
     }

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlControlTemplateTargetTypeMetadataTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlControlTemplateTargetTypeMetadataTransformer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using XamlX.Ast;
 using XamlX.Transform;
@@ -11,8 +12,9 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlAstNode Transform(AstTransformationContext context, IXamlAstNode node)
         {
             if (!(node is XamlAstObjectNode on
-                  && context.GetAvaloniaTypes().IControlTemplate.IsAssignableFrom(on.Type.GetClrType())))
+                  && ControlTemplateScopeCache.GetOrCreate(context).IsControlTemplateScope(on.Type.GetClrType())))
                 return node;
+
             var tt = on.Children.OfType<XamlAstXamlPropertyValueNode>().FirstOrDefault(ch =>
                                               ch.Property.GetClrProperty().Name == "TargetType");
 
@@ -39,6 +41,57 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
 
             return new AvaloniaXamlIlTargetTypeMetadataNode(on, targetType,
                 AvaloniaXamlIlTargetTypeMetadataNode.ScopeTypes.ControlTemplate);
+        }
+
+        private sealed class ControlTemplateScopeCache
+        {
+            private readonly IXamlType _controlTemplateScopeAttributeType;
+            private readonly Dictionary<IXamlType, bool> _isScopeByType = new();
+
+            private ControlTemplateScopeCache(IXamlType controlTemplateScopeAttributeType)
+                => _controlTemplateScopeAttributeType = controlTemplateScopeAttributeType;
+
+            public static ControlTemplateScopeCache GetOrCreate(AstTransformationContext context)
+            {
+                if (!context.TryGetItem(out ControlTemplateScopeCache? cache))
+                {
+                    cache = new ControlTemplateScopeCache(context.GetAvaloniaTypes().ControlTemplateScopeAttribute);
+                    context.SetItem(cache);
+                }
+
+                return cache;
+            }
+
+            private bool HasScopeAttribute(IXamlType type)
+                => type.CustomAttributes.Any(attr => attr.Type == _controlTemplateScopeAttributeType);
+
+            private bool IsControlTemplateScopeCore(IXamlType type)
+            {
+                for (var t = type; t is not null; t = t.BaseType)
+                {
+                    if (HasScopeAttribute(t))
+                        return true;
+                }
+
+                foreach (var iface in type.Interfaces)
+                {
+                    if (HasScopeAttribute(iface))
+                        return true;
+                }
+
+                return false;
+            }
+
+            public bool IsControlTemplateScope(IXamlType type)
+            {
+                if (!_isScopeByType.TryGetValue(type, out var isScope))
+                {
+                    isScope = IsControlTemplateScopeCore(type);
+                    _isScopeByType[type] = isScope;
+                }
+
+                return isScope;
+            }
         }
     }
 

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -36,6 +36,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType InheritDataTypeFromAttribute { get; }
         public IXamlType MarkupExtensionOptionAttribute { get; }
         public IXamlType MarkupExtensionDefaultOptionAttribute { get; }
+        public IXamlType ControlTemplateScopeAttribute { get; }
         public IXamlType AvaloniaListAttribute { get; }
         public IXamlType AvaloniaList { get; }
         public IXamlType OnExtensionType { get; }
@@ -129,7 +130,6 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType WindowTransparencyLevel { get; }
         public IXamlType IReadOnlyListOfT { get; }
         public IXamlType ControlTemplate { get; }
-        public IXamlType IControlTemplate { get; }
         public IXamlType EventHandlerT {  get; }
         public IXamlMethod GetClassProperty { get; }
 
@@ -204,6 +204,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             InheritDataTypeFromAttribute = cfg.TypeSystem.GetType("Avalonia.Metadata.InheritDataTypeFromAttribute");
             MarkupExtensionOptionAttribute = cfg.TypeSystem.GetType("Avalonia.Metadata.MarkupExtensionOptionAttribute");
             MarkupExtensionDefaultOptionAttribute = cfg.TypeSystem.GetType("Avalonia.Metadata.MarkupExtensionDefaultOptionAttribute");
+            ControlTemplateScopeAttribute = cfg.TypeSystem.GetType("Avalonia.Metadata.ControlTemplateScopeAttribute");
             AvaloniaListAttribute = cfg.TypeSystem.GetType("Avalonia.Metadata.AvaloniaListAttribute");
             AvaloniaList = cfg.TypeSystem.GetType("Avalonia.Collections.AvaloniaList`1");
             OnExtensionType = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.MarkupExtensions.On");
@@ -326,7 +327,6 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             Style = cfg.TypeSystem.GetType("Avalonia.Styling.Style");
             ControlTheme = cfg.TypeSystem.GetType("Avalonia.Styling.ControlTheme");
             ControlTemplate = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.Templates.ControlTemplate");
-            IControlTemplate = cfg.TypeSystem.GetType("Avalonia.Controls.Templates.IControlTemplate");
             IReadOnlyListOfT = cfg.TypeSystem.GetType("System.Collections.Generic.IReadOnlyList`1");
             EventHandlerT = cfg.TypeSystem.GetType("System.EventHandler`1");
             Interactivity = new InteractivityWellKnownTypes(cfg);

--- a/src/Markup/Avalonia.Markup.Xaml/Templates/ItemsPanelTemplate.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Templates/ItemsPanelTemplate.cs
@@ -4,6 +4,7 @@ using Avalonia.Styling;
 
 namespace Avalonia.Markup.Xaml.Templates
 {
+    [ControlTemplateScope]
     public class ItemsPanelTemplate : ITemplate<Panel?>
     {
         [Content]

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ItemsPanelTemplateTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ItemsPanelTemplateTests.cs
@@ -1,0 +1,100 @@
+﻿using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Media;
+using Avalonia.UnitTests;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Markup.Xaml.UnitTests.Xaml;
+
+public class ItemsPanelTemplateTests
+{
+    [Fact]
+    public void ItemsPanelTemplate_In_Style_Allows_TemplateBinding()
+    {
+        using (UnitTestApplication.Start(TestServices.StyledWindow))
+        {
+            var window = (Window)AvaloniaRuntimeXamlLoader.Load(
+                """
+                <Window xmlns="https://github.com/avaloniaui"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    <Window.Styles>
+                        <Style Selector="ListBox">
+                            <Setter Property="Template">
+                                <ControlTemplate>
+                                    <ItemsPresenter Name="PART_ItemsPresenter"
+                                                    ItemsPanel="{TemplateBinding ItemsPanel}" />
+                                </ControlTemplate>
+                            </Setter>
+                            <Setter Property="ItemsPanel">
+                                <ItemsPanelTemplate>
+                                    <Panel Background="{TemplateBinding Background}"
+                                           Tag="{TemplateBinding ItemsSource}" />
+                                </ItemsPanelTemplate>
+                            </Setter>
+                        </Style>
+                    </Window.Styles>
+                    <ListBox Background="DodgerBlue" />
+                </Window>
+                """);
+            var listBox = Assert.IsType<ListBox>(window.Content);
+            var items = new[] { "foo", "bar" };
+            listBox.ItemsSource = items;
+
+            window.ApplyTemplate();
+            listBox.ApplyTemplate();
+
+            var itemsPresenter = listBox.FindDescendantOfType<ItemsPresenter>();
+            Assert.NotNull(itemsPresenter);
+            itemsPresenter.ApplyTemplate();
+
+            var panel = itemsPresenter.Panel;
+            Assert.NotNull(panel);
+            Assert.Equal(Brushes.DodgerBlue, panel.Background);
+            Assert.Same(items, panel.Tag);
+        }
+    }
+
+    [Fact]
+    public void ItemsPanelTemplate_In_Control_Allows_TemplateBinding()
+    {
+        using (UnitTestApplication.Start(TestServices.StyledWindow))
+        {
+            var window = (Window)AvaloniaRuntimeXamlLoader.Load(
+                """
+                <Window xmlns="https://github.com/avaloniaui"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    <ListBox Background="DodgerBlue">
+                        <ListBox.Template>
+                            <ControlTemplate>
+                                <ItemsPresenter Name="PART_ItemsPresenter"
+                                                ItemsPanel="{TemplateBinding ItemsPanel}" />
+                            </ControlTemplate>
+                        </ListBox.Template>
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <Panel Background="{TemplateBinding Background}"
+                                       Tag="{TemplateBinding ItemsSource}" />
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                    </ListBox>
+                </Window>
+                """);
+            var listBox = Assert.IsType<ListBox>(window.Content);
+            var items = new[] { "foo", "bar" };
+            listBox.ItemsSource = items;
+
+            window.ApplyTemplate();
+            listBox.ApplyTemplate();
+
+            var itemsPresenter = listBox.FindDescendantOfType<ItemsPresenter>();
+            Assert.NotNull(itemsPresenter);
+            itemsPresenter.ApplyTemplate();
+
+            var panel = itemsPresenter.Panel;
+            Assert.NotNull(panel);
+            Assert.Equal(Brushes.DodgerBlue, panel.Background);
+            Assert.Same(items, panel.Tag);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
This PR allows `TemplateBinding` to work inside `ItemsPanelTemplate`, or any specially annotated template type.

## What is the current behavior?
In avalonia 11.2, when trying to use `TemplateBinding` inside an `ItemsPanelTemplate`, this fails with _AVLN3000: Unable to find the ControlTemplate scope for AvaloniaProperty lookup_.

## What is the updated/expected behavior with this PR?
`TemplateBinding` works in `ItemsPanelTemplate`. The target type is found on the parent `Style` or control.

## How was the solution implemented (if it's not obvious)?
A new attribute `[ControlTemplateScope]` has been added. Any template type annotated with this attribute is considered to be in control template scope: `TemplateBinding` works, binding priorities are set to `Template`, etc. (same behavior as a standard `ControlTemplate`)

This attribute has been applied to `IControlTemplate` (effectively superseding #17427) and `ItemsPanelTemplate`.

New unit tests have been added for `ItemsPanelTemplate` containing `TemplateBinding`s.
