### PR TITLE
Improve Refresh-Container usability

### DIFF
--- a/samples/ControlCatalog/Pages/RefreshContainerPage.axaml
+++ b/samples/ControlCatalog/Pages/RefreshContainerPage.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModels="using:ControlCatalog.ViewModels"
+             xmlns:generic="clr-namespace:System.Collections.Generic;assembly=netstandard"
              mc:Ignorable="d"
              d:DesignWidth="800"
              d:DesignHeight="450"
@@ -11,12 +12,27 @@
   <DockPanel HorizontalAlignment="Stretch"
              Height="600"
              VerticalAlignment="Top">
-    <Label DockPanel.Dock="Top">A control that supports pull to refresh</Label>
+    <StackPanel DockPanel.Dock="Top">
+      <Label>A control that supports pull to refresh on touch inputs</Label>
+      <StackPanel Orientation="Horizontal" Margin="3" Spacing="5">
+        <TextBlock VerticalAlignment="Center">Used pull direction:</TextBlock>
+        <ComboBox x:Name="PullDirections" SelectedIndex="0">
+          <ComboBox.ItemsSource>
+            <generic:List x:TypeArguments="PullDirection">
+              <PullDirection>TopToBottom</PullDirection>
+              <PullDirection>LeftToRight</PullDirection>
+              <PullDirection>RightToLeft</PullDirection>
+              <PullDirection>BottomToTop</PullDirection>
+            </generic:List>
+          </ComboBox.ItemsSource>
+        </ComboBox>
+      </StackPanel>
+    </StackPanel>
     <RefreshContainer Name="Refresh"
                       DockPanel.Dock="Bottom"
                       HorizontalAlignment="Stretch"
                       VerticalAlignment="Stretch"
-                      PullDirection="TopToBottom"
+                      PullDirection="{Binding #PullDirections.SelectedItem}"
                       RefreshRequested="RefreshContainerPage_RefreshRequested"
                       Margin="5">
       <ListBox HorizontalAlignment="Stretch"

--- a/src/Avalonia.Controls/PullToRefresh/RefreshContainer.cs
+++ b/src/Avalonia.Controls/PullToRefresh/RefreshContainer.cs
@@ -119,9 +119,9 @@ namespace Avalonia.Controls
 
         private void OnVisualizerSizeChanged(Rect obj)
         {
-            if (_hasDefaultRefreshInfoProviderAdapter)
-            {
-                _refreshInfoProviderAdapter = new ScrollViewerIRefreshInfoProviderAdapter(PullDirection);
+            if (_hasDefaultRefreshInfoProviderAdapter && _refreshInfoProviderAdapter != null)
+            {                
+                _refreshInfoProviderAdapter.UpdateVisualizerSize(obj.Size);
                 RaisePropertyChanged(RefreshInfoProviderAdapterProperty, null, _refreshInfoProviderAdapter);
             }
         }
@@ -231,12 +231,15 @@ namespace Avalonia.Controls
                         break;
                 }
 
-                if (_hasDefaultRefreshInfoProviderAdapter &&
-                    _hasDefaultRefreshVisualizer &&
-                    _refreshVisualizer.Bounds.Height == DefaultPullDimensionSize &&
-                    _refreshVisualizer.Bounds.Width == DefaultPullDimensionSize)
-                {
-                    _refreshInfoProviderAdapter = new ScrollViewerIRefreshInfoProviderAdapter(PullDirection);
+                if (_hasDefaultRefreshInfoProviderAdapter)
+                {                
+                    if (_hasDefaultRefreshVisualizer)
+                    {                   
+                        var size = new Size(_refreshVisualizer.Width, _refreshVisualizer.Height);
+                        _refreshInfoProviderAdapter?.UpdateVisualizerSize(size);
+                    }
+
+                    _refreshInfoProviderAdapter?.UpdatePullDirection(PullDirection);
                     RaisePropertyChanged(RefreshInfoProviderAdapterProperty, null, _refreshInfoProviderAdapter);
                 }
             }

--- a/src/Avalonia.Controls/PullToRefresh/RefreshInfoProvider.cs
+++ b/src/Avalonia.Controls/PullToRefresh/RefreshInfoProvider.cs
@@ -9,8 +9,8 @@ namespace Avalonia.Controls.PullToRefresh
     {
         internal const double DefaultExecutionRatio = 0.8;
 
-        private readonly PullDirection _refreshPullDirection;
-        private readonly Size _refreshVisualizerSize;
+        private PullDirection _refreshPullDirection;
+        private Size _refreshVisualizerSize;
 
         private readonly CompositionVisual? _visual;
         private bool _isInteractingForRefresh;
@@ -29,6 +29,14 @@ namespace Avalonia.Controls.PullToRefresh
         public static readonly DirectProperty<RefreshInfoProvider, double> InteractionRatioProperty =
             AvaloniaProperty.RegisterDirect<RefreshInfoProvider, double>(nameof(InteractionRatio),
                 s => s.InteractionRatio, (s, o) => s.InteractionRatio = o);
+
+        public static readonly DirectProperty<RefreshInfoProvider, PullDirection> PullDirectionProperty =
+            AvaloniaProperty.RegisterDirect<RefreshInfoProvider, PullDirection>(nameof(PullDirection),
+                s => s.PullDirection, (s, o) => s.PullDirection = o);
+
+        public static readonly DirectProperty<RefreshInfoProvider, Size> RefreshVisualizerSizeProperty =
+            AvaloniaProperty.RegisterDirect<RefreshInfoProvider, Size>(nameof(RefreshVisualizerSize),
+                s => s.RefreshVisualizerSize, (s, o) => s.RefreshVisualizerSize = o);
 
         /// <summary>
         /// Defines the <see cref="RefreshStarted"/> event.
@@ -62,6 +70,18 @@ namespace Avalonia.Controls.PullToRefresh
         {
             get => _interactionRatio;
             set => SetAndRaise(InteractionRatioProperty, ref _interactionRatio, value);
+        }
+
+        public Size RefreshVisualizerSize
+        {
+            get => _refreshVisualizerSize;
+            set => SetAndRaise(RefreshVisualizerSizeProperty, ref _refreshVisualizerSize, value);
+        }
+
+        public PullDirection PullDirection
+        {
+            get => _refreshPullDirection;
+            set => SetAndRaise(PullDirectionProperty, ref _refreshPullDirection, value);
         }
 
         public double ExecutionRatio

--- a/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
+++ b/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
@@ -226,11 +226,11 @@ namespace Avalonia.Controls
                             Vector3D offset = default;
                             if (IsPullDirectionVertical)
                             {
-                                offset = new Vector3D(0, (_interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Height), 0);
+                                offset = new Vector3D(visual.Offset.X, (_interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Height), visual.Offset.Z);
                             }
                             else
                             {
-                                offset = new Vector3D((_interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Width), 0, 0);
+                                offset = new Vector3D((_interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Width), visual.Offset.Y, visual.Offset.Z);
                             }
                             visual.Offset = offset;
                             visualizerVisual.Offset = IsPullDirectionVertical ? 
@@ -242,11 +242,11 @@ namespace Avalonia.Controls
                             contentVisual.RotationAngle = _startingRotationAngle + (float)(2 * Math.PI);
                             if (IsPullDirectionVertical)
                             {
-                                offset = new Vector3D(0, (_interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Height), 0);
+                                offset = new Vector3D(visual.Offset.X, (_interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Height), visual.Offset.Z);
                             }
                             else
                             {
-                                offset = new Vector3D((_interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Width), 0, 0);
+                                offset = new Vector3D((_interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Width), visual.Offset.Y, visual.Offset.Z);
                             }
                             visual.Offset = offset;
                             visualizerVisual.Offset = IsPullDirectionVertical ? 
@@ -280,11 +280,11 @@ namespace Avalonia.Controls
                                 * (IsPullDirectionFar ? -1f : 1f);
                             if (IsPullDirectionVertical)
                             {
-                                offset = new Vector3D(0, (_executingRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Height), 0);
+                                offset = new Vector3D(visual.Offset.X, (_executingRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Height), visual.Offset.Z);
                             }
                             else
                             {
-                                offset = new Vector3D((_executingRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Width), 0, 0);
+                                offset = new Vector3D((_executingRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Width), visual.Offset.Y, visual.Offset.Z);
                             }
                             visual.Offset = offset;
                             contentVisual.Offset += IsPullDirectionVertical ? new Vector3D(0, (translationRatio * root.Bounds.Height), 0) :

--- a/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
+++ b/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
@@ -217,7 +217,9 @@ namespace Avalonia.Controls
                             contentVisual.Opacity = MinimumIndicatorOpacity;
                             contentVisual.RotationAngle = _startingRotationAngle;
 
+                            visual.Offset = _initialVisualOffset;
                             visualizerVisual.Offset = new Vector3D(0, 0, 0);
+
                             _content.InvalidateMeasure();
 
                             break;

--- a/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
+++ b/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
@@ -18,6 +18,8 @@ namespace Avalonia.Controls
         private const float ParallaxPositionRatio = 0.5f;
         private double _executingRatio = 0.8;
 
+        private Vector3D _initialVisualOffset = default;
+
         private RefreshVisualizerState _refreshVisualizerState;
         private RefreshInfoProvider? _refreshInfoProvider;
         private IDisposable? _isInteractingSubscription;
@@ -211,47 +213,27 @@ namespace Avalonia.Controls
                                 _rotateAnimation.IterationBehavior = AnimationIterationBehavior.Count;
                                 _rotateAnimation = null;
                             }
+
                             contentVisual.Opacity = MinimumIndicatorOpacity;
                             contentVisual.RotationAngle = _startingRotationAngle;
-                            visualizerVisual.Offset = IsPullDirectionVertical ?
-                                new Vector3D(visualizerVisual.Offset.X, 0, 0) :
-                                new Vector3D(0, visualizerVisual.Offset.Y, 0);
-                            visual.Offset = visualizerVisual.Offset;
+
+                            visualizerVisual.Offset = new Vector3D(0, 0, 0);
                             _content.InvalidateMeasure();
+
                             break;
                         case RefreshVisualizerState.Interacting:
                             _played = false;
                             contentVisual.Opacity = MinimumIndicatorOpacity;
                             contentVisual.RotationAngle = (float)(_startingRotationAngle + _interactionRatio * 2 * Math.PI);
-                            Vector3D offset = default;
-                            if (IsPullDirectionVertical)
-                            {
-                                offset = new Vector3D(visual.Offset.X, (_interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Height), visual.Offset.Z);
-                            }
-                            else
-                            {
-                                offset = new Vector3D((_interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Width), visual.Offset.Y, visual.Offset.Z);
-                            }
-                            visual.Offset = offset;
-                            visualizerVisual.Offset = IsPullDirectionVertical ? 
-                                new Vector3D(visualizerVisual.Offset.X, offset.Y, 0) :
-                                new Vector3D(offset.X, visualizerVisual.Offset.Y, 0);
+                            
+                            CalculateAndSetOffsets(root, visual, visualizerVisual);
+
                             break;
                         case RefreshVisualizerState.Pending:
                             contentVisual.Opacity = 1;
                             contentVisual.RotationAngle = _startingRotationAngle + (float)(2 * Math.PI);
-                            if (IsPullDirectionVertical)
-                            {
-                                offset = new Vector3D(visual.Offset.X, (_interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Height), visual.Offset.Z);
-                            }
-                            else
-                            {
-                                offset = new Vector3D((_interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Width), visual.Offset.Y, visual.Offset.Z);
-                            }
-                            visual.Offset = offset;
-                            visualizerVisual.Offset = IsPullDirectionVertical ? 
-                                new Vector3D(visualizerVisual.Offset.X, offset.Y, 0) : 
-                                new Vector3D(offset.X, visualizerVisual.Offset.Y, 0);
+
+                            CalculateAndSetOffsets(root, visual, visualizerVisual);
 
                             if (!_played)
                             {
@@ -278,20 +260,8 @@ namespace Avalonia.Controls
                             contentVisual.Opacity = 1;
                             float translationRatio = (float)(_refreshInfoProvider != null ?  (1.0f - _refreshInfoProvider.ExecutionRatio) * ParallaxPositionRatio : 1.0f) 
                                 * (IsPullDirectionFar ? -1f : 1f);
-                            if (IsPullDirectionVertical)
-                            {
-                                offset = new Vector3D(visual.Offset.X, (_executingRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Height), visual.Offset.Z);
-                            }
-                            else
-                            {
-                                offset = new Vector3D((_executingRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Width), visual.Offset.Y, visual.Offset.Z);
-                            }
-                            visual.Offset = offset;
-                            contentVisual.Offset += IsPullDirectionVertical ? new Vector3D(0, (translationRatio * root.Bounds.Height), 0) :
-                                new Vector3D((translationRatio * root.Bounds.Width), 0, 0);
-                            visualizerVisual.Offset = IsPullDirectionVertical ?
-                                new Vector3D(visualizerVisual.Offset.X, offset.Y, 0) :
-                                new Vector3D(offset.X, visualizerVisual.Offset.Y, 0);
+
+                            CalculateAndSetOffsets(root, visual, visualizerVisual);
                             break;
                         case RefreshVisualizerState.Peeking:
                             contentVisual.Opacity = 1;
@@ -302,13 +272,43 @@ namespace Avalonia.Controls
             }
         }
 
+        private void CalculateAndSetOffsets(Grid root, CompositionVisual visual, CompositionVisual indicatorVisualizer)
+        {
+            if (IsPullDirectionVertical)
+            {
+                // As long as the indicator-container isn't visible,
+                // the initial offset is the current offset
+                if (indicatorVisualizer.Offset.Y == 0)
+                {
+                    _initialVisualOffset = visual.Offset;
+                }
+
+                var offset = _interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Height;
+                indicatorVisualizer.Offset = indicatorVisualizer.Offset with { Y = offset };
+
+                visual.Offset = _initialVisualOffset with { Y = _initialVisualOffset.Y + offset };         
+            }
+            else
+            {
+                if (indicatorVisualizer.Offset.X == 0)
+                {
+                    _initialVisualOffset = visual.Offset;
+                }
+
+                var offset = _interactionRatio * (IsPullDirectionFar ? -1 : 1) * root.Bounds.Width;
+                indicatorVisualizer.Offset = indicatorVisualizer.Offset with { X = offset };
+
+                visual.Offset = _initialVisualOffset with { X = _initialVisualOffset.X + offset }; 
+            }
+        }
+
         /// <summary>
         /// Initiates an update of the content.
         /// </summary>
         public void RequestRefresh()
         {
             RefreshVisualizerState = RefreshVisualizerState.Refreshing;
-            RefreshInfoProvider?.OnRefreshStarted();
+            RefreshInfoProvider?.OnRefreshStarted();            
 
             RaiseRefreshRequested();
         }

--- a/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
+++ b/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
@@ -217,8 +217,11 @@ namespace Avalonia.Controls
                             contentVisual.Opacity = MinimumIndicatorOpacity;
                             contentVisual.RotationAngle = _startingRotationAngle;
 
-                            visual.Offset = _initialVisualOffset;
-                            visualizerVisual.Offset = new Vector3D(0, 0, 0);
+                            if (visualizerVisual.Offset.X != 0 || visualizerVisual.Offset.Y != 0)
+                            {
+                                visual.Offset = _initialVisualOffset;
+                                visualizerVisual.Offset = new Vector3D(0, 0, 0);
+                            }
 
                             _content.InvalidateMeasure();
 
@@ -373,29 +376,36 @@ namespace Avalonia.Controls
             }
             else if (change.Property == BoundsProperty)
             {
-                switch (PullDirection)
-                {
-                    case PullDirection.TopToBottom:
-                        RenderTransform = new TranslateTransform(0, -Bounds.Height);
-                        break;
-                    case PullDirection.BottomToTop:
-                        RenderTransform = new TranslateTransform(0, Bounds.Height);
-                        break;
-                    case PullDirection.LeftToRight:
-                        RenderTransform = new TranslateTransform(-Bounds.Width, 0);
-                        break;
-                    case PullDirection.RightToLeft:
-                        RenderTransform = new TranslateTransform(Bounds.Width, 0);
-                        break;
-                }
+                OnBoundsChanged();
 
                 UpdateContent();
             }
-            else if(change.Property == PullDirectionProperty)
+            else if (change.Property == PullDirectionProperty)
             {
                 OnOrientationChanged();
 
+                OnBoundsChanged();
+
                 UpdateContent();
+            }
+        }
+
+        private void OnBoundsChanged()
+        {
+            switch (PullDirection)
+            {
+                case PullDirection.TopToBottom:
+                    RenderTransform = new TranslateTransform(0, -Bounds.Height);
+                    break;
+                case PullDirection.BottomToTop:
+                    RenderTransform = new TranslateTransform(0, Bounds.Height);
+                    break;
+                case PullDirection.LeftToRight:
+                    RenderTransform = new TranslateTransform(-Bounds.Width, 0);
+                    break;
+                case PullDirection.RightToLeft:
+                    RenderTransform = new TranslateTransform(Bounds.Width, 0);
+                    break;
             }
         }
 

--- a/src/Avalonia.Controls/PullToRefresh/ScrollViewerGestureRecognizer.cs
+++ b/src/Avalonia.Controls/PullToRefresh/ScrollViewerGestureRecognizer.cs
@@ -9,6 +9,8 @@ namespace Avalonia.Controls.PullToRefresh
         private int _gestureId;
         private bool _pullInProgress;
 
+        private double _delta = 1;
+
         private Point _initialPosition;
         private IPointer? _tracking;
 
@@ -56,7 +58,7 @@ namespace Avalonia.Controls.PullToRefresh
 
                 var delta = CalculateDelta(currentPosition);
 
-                bool pulling = delta.X > 0 || delta.Y > 0;
+                bool pulling = delta.Y > 0 || delta.X > 0;
                 _pullInProgress = (_pullInProgress, pulling) switch
                 {
                     (false, false) => false,
@@ -113,10 +115,10 @@ namespace Avalonia.Controls.PullToRefresh
 
         private bool CanPull(ScrollViewer visual) => PullDirection switch
         {
-            PullDirection.TopToBottom => visual.Offset.Y == 0,
-            PullDirection.BottomToTop => Math.Abs(visual.Offset.Y + visual.Viewport.Height - visual.Extent.Height) <= 0.01,
-            PullDirection.LeftToRight => true,
-            PullDirection.RightToLeft => true,
+            PullDirection.TopToBottom => visual.Offset.Y < _delta,
+            PullDirection.BottomToTop => Math.Abs(visual.Offset.Y + visual.Viewport.Height - visual.Extent.Height) <= _delta,
+            PullDirection.LeftToRight => visual.Offset.X < _delta,
+            PullDirection.RightToLeft => Math.Abs(visual.Offset.X + visual.Viewport.Width - visual.Extent.Width) <= _delta,
             _ => false,
         };
     }

--- a/src/Avalonia.Controls/PullToRefresh/ScrollViewerGestureRecognizer.cs
+++ b/src/Avalonia.Controls/PullToRefresh/ScrollViewerGestureRecognizer.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using Avalonia.Input;
+using Avalonia.Input.GestureRecognizers;
+
+namespace Avalonia.Controls.PullToRefresh
+{
+    internal class ScrollViewerGestureRecognizer : GestureRecognizer
+    {
+        private int _gestureId;
+        private bool _pullInProgress;
+
+        private Point _initialPosition;
+        private IPointer? _tracking;
+
+        /// <summary>
+        /// Defines the <see cref="PullDirection"/> property.
+        /// </summary>
+        public static readonly StyledProperty<PullDirection> PullDirectionProperty =
+            AvaloniaProperty.Register<ScrollViewerGestureRecognizer, PullDirection>(nameof(PullDirection));
+
+        public PullDirection PullDirection
+        {
+            get => GetValue(PullDirectionProperty);
+            set => SetValue(PullDirectionProperty, value);
+        }
+
+        public ScrollViewerGestureRecognizer(PullDirection pullDirection)
+        {
+            PullDirection = pullDirection;
+        }
+
+        public ScrollViewerGestureRecognizer() { }
+
+        protected override void PointerCaptureLost(IPointer pointer)
+        {
+            if (_tracking == pointer)
+            {
+                EndPull();
+            }
+        }
+
+        protected override void PointerPressed(PointerPressedEventArgs e)
+        {
+            if (Target != null && Target is ScrollViewer visual && (e.Pointer.Type == PointerType.Touch || e.Pointer.Type == PointerType.Pen))
+            {
+                _tracking = e.Pointer;
+                _initialPosition = e.GetPosition(visual);
+            }
+        }
+
+        protected override void PointerMoved(PointerEventArgs e)
+        {
+            if (_tracking == e.Pointer && Target is ScrollViewer viewer && CanPull(viewer))
+            {
+                var currentPosition = e.GetPosition(viewer);
+
+                var delta = CalculateDelta(currentPosition);
+
+                bool pulling = delta.X > 0 || delta.Y > 0;
+                _pullInProgress = (_pullInProgress, pulling) switch
+                {
+                    (false, false) => false,
+                    (false, true ) => BeginPull(e, delta),
+                    (true , true ) => HandlePull(e, delta),
+                    (true , false) => EndPull(),
+                };
+            }
+        }
+
+        protected override void PointerReleased(PointerReleasedEventArgs e)
+        {
+            if (_pullInProgress == true)
+            {
+                EndPull();
+            }
+
+            _tracking = null;
+            _initialPosition = default;
+            _pullInProgress = false;
+        }
+
+        private bool BeginPull(PointerEventArgs e, Vector delta)
+        {
+            _gestureId = PullGestureEventArgs.GetNextFreeId();
+            return HandlePull(e, delta);
+        }
+
+        private bool HandlePull(PointerEventArgs e, Vector delta)
+        {
+            Capture(e.Pointer);
+
+            var pullEventArgs = new PullGestureEventArgs(_gestureId, delta, PullDirection);
+            Target?.RaiseEvent(pullEventArgs);
+
+            e.Handled = pullEventArgs.Handled;
+            return true;
+        }
+
+        private bool EndPull()
+        {
+            Target?.RaiseEvent(new PullGestureEndedEventArgs(_gestureId, PullDirection));
+            return false;
+        }
+
+        private Vector CalculateDelta(Point currentPosition) => PullDirection switch
+        {
+            PullDirection.TopToBottom => new Vector(0, currentPosition.Y - _initialPosition.Y),
+            PullDirection.BottomToTop => new Vector(0, _initialPosition.Y - currentPosition.Y),
+            PullDirection.LeftToRight => new Vector(currentPosition.X - _initialPosition.X, 0),
+            PullDirection.RightToLeft => new Vector(_initialPosition.X - currentPosition.X, 0),
+            _ => default,
+        };
+
+        private bool CanPull(ScrollViewer visual) => PullDirection switch
+        {
+            PullDirection.TopToBottom => visual.Offset.Y == 0,
+            PullDirection.BottomToTop => Math.Abs(visual.Offset.Y + visual.Viewport.Height - visual.Extent.Height) <= 0.01,
+            PullDirection.LeftToRight => true,
+            PullDirection.RightToLeft => true,
+            _ => false,
+        };
+    }
+}

--- a/src/Avalonia.Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter.cs
+++ b/src/Avalonia.Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Controls.PullToRefresh
         private PullDirection _refreshPullDirection;
         private ScrollViewer? _scrollViewer;
         private RefreshInfoProvider? _refreshInfoProvider;
-        private ScrollViewerGestureRecognizer? _pullGestureRecognizer;
+        private ScrollablePullGestureRecognizer? _pullGestureRecognizer;
         private InputElement? _interactionSource;
         private bool _isVisualizerInteractionSourceAttached;
 
@@ -124,7 +124,7 @@ namespace Avalonia.Controls.PullToRefresh
 
             _refreshInfoProvider = new RefreshInfoProvider(_refreshPullDirection, refreshVIsualizerSize, ElementComposition.GetElementVisual(content));
 
-            _pullGestureRecognizer = new ScrollViewerGestureRecognizer(_refreshPullDirection);
+            _pullGestureRecognizer = new ScrollablePullGestureRecognizer(_refreshPullDirection);
 
             if (_interactionSource != null)
             {
@@ -259,6 +259,29 @@ namespace Avalonia.Controls.PullToRefresh
             }
 
             return false;
+        }
+
+        public void UpdatePullDirection(PullDirection pullDirection)
+        {
+            _refreshPullDirection = pullDirection;
+
+            if (_refreshInfoProvider != null)
+            {
+                _refreshInfoProvider.PullDirection = pullDirection;
+            }
+
+            if (_pullGestureRecognizer != null)
+            {
+                _pullGestureRecognizer.PullDirection = pullDirection;
+            }
+        }
+
+        public void UpdateVisualizerSize(Size? refreshVisualizerSize)
+        {
+            if (_refreshInfoProvider != null)
+            {
+                _refreshInfoProvider.RefreshVisualizerSize = refreshVisualizerSize ?? default;
+            }
         }
 
         private void CleanUpScrollViewer()

--- a/src/Avalonia.Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter.cs
+++ b/src/Avalonia.Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Controls.PullToRefresh
         private PullDirection _refreshPullDirection;
         private ScrollViewer? _scrollViewer;
         private RefreshInfoProvider? _refreshInfoProvider;
-        private PullGestureRecognizer? _pullGestureRecognizer;
+        private ScrollViewerGestureRecognizer? _pullGestureRecognizer;
         private InputElement? _interactionSource;
         private bool _isVisualizerInteractionSourceAttached;
 
@@ -124,7 +124,7 @@ namespace Avalonia.Controls.PullToRefresh
 
             _refreshInfoProvider = new RefreshInfoProvider(_refreshPullDirection, refreshVIsualizerSize, ElementComposition.GetElementVisual(content));
 
-            _pullGestureRecognizer = new PullGestureRecognizer(_refreshPullDirection);
+            _pullGestureRecognizer = new ScrollViewerGestureRecognizer(_refreshPullDirection);
 
             if (_interactionSource != null)
             {

--- a/src/Avalonia.Themes.Fluent/Controls/ScrollViewer.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ScrollViewer.xaml
@@ -37,7 +37,10 @@
             <ScrollContentPresenter.GestureRecognizers>
               <ScrollGestureRecognizer CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
                                        CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}"
-                                       IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_ContentPresenter}"/>
+                                       IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_ContentPresenter}"
+                                       Offset="{Binding Offset, ElementName=PART_ContentPresenter}"
+                                       Viewport="{Binding Viewport, ElementName=PART_ContentPresenter}"
+                                       Extent="{Binding Extent, ElementName=PART_ContentPresenter}"/>
             </ScrollContentPresenter.GestureRecognizers>
           </ScrollContentPresenter>
           <ScrollBar Name="PART_HorizontalScrollBar"

--- a/src/Avalonia.Themes.Simple/Controls/ScrollViewer.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ScrollViewer.xaml
@@ -20,7 +20,10 @@
             <ScrollContentPresenter.GestureRecognizers>
               <ScrollGestureRecognizer CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
                                        CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}"
-                                       IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_ContentPresenter}"/>
+                                       IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_ContentPresenter}"
+                                       Offset="{Binding Offset, ElementName=PART_ContentPresenter}"
+                                       Viewport="{Binding Viewport, ElementName=PART_ContentPresenter}"
+                                       Extent="{Binding Extent, ElementName=PART_ContentPresenter}"/>
             </ScrollContentPresenter.GestureRecognizers>
           </ScrollContentPresenter>
           <ScrollBar Name="PART_HorizontalScrollBar"


### PR DESCRIPTION
**Important**: this is a first draft to get more feedback and discuss some behavior that is expected to happen.
The behaviour of the RefreshContainer is unintuitive for mobile users. This was picket up by this issue: #15529. 

## What does the pull request do?

This improved the drag-to-refresh behavior especially for mobile users and allows for a smoother experience. You are now able to start the refresh independent on the clicked position. For TopToBottom pulls it is only required that you scrolled to the top.

## What is the current behavior?
#15529 goes into great detail but tldr: 

1. You can only trigger a refresh in a small treshold (mostly the first item)

![Aufzeichnung2024-11-13153238-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/84c5f661-cf40-4685-ad3e-cbf9593dfa07)

2. Weard behaviour where the items get scaled away from the container when refreshing at diffrent positions

This is especially noticable when you have configured the PullDirection to be anything than TopToBottom
![Aufzeichnung2-ezgif com-optimize](https://github.com/user-attachments/assets/7d689454-ce09-4b61-a94f-33827e426623)

## What is the updated/expected behavior with this PR?
You are now able to trigger a refresh independen on the position you clicked, as long as you didnt scroll down (or up when the scroll behavior is BottomToTop). Left and Right scroll can be triggerd at any time right now (because it is a List that goes from top to bottom but I didnt think about Lists or things that go from left to right).

I show the desktop version here because I could easily capture the output. On mobile the experience is a lot smoother:

![Aufzeichnung3-ezgif com-optimize](https://github.com/user-attachments/assets/5ac72cc5-113a-4f00-a8d6-4b8cd461ed38)

I was not able to fix the weard scroll-behavior but I will still try to find the bug.

## How was the solution implemented (if it's not obvious)?
I created a new implementation of the `GestureRecognizer` where I moved more logic into the `touch-moved` event to allow for a smoother scroll and refresh behavior. Just fixing the `canPull` condition describet in the issue was not possible because it would hinder the scroll-down and making the refresh more 'reactive' is only possible in the `touch-moved` event.

## Checklist

- [x] Allow for dragging on any position, when the view is scrolled to the end
- [x] Fix offset mismatch when refreshing on different heights 
- [x] You can refresh without clicking an item first
- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

- Different refresh and scroll behavior than before

## Discussion

There are some points I want to discuss first befor I cleaned up the implementation:

1. Shouldn"t it be possible to refresh with the mouse as well (like shown in the GIFs) ?
2. I was not able the fix the weard behavior in number 2. Any Tipps ?
3. I create a new GestureRecognizer for the ScrollViewer because I needed to get the Offset reliable ? Is it possible to make it generic ?

## Fixed issues
Fixes #15529
