### PR TITLE
Fix Gtk open file dialog returns folder

### DIFF
--- a/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
+++ b/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
@@ -45,7 +45,7 @@ namespace Avalonia.X11.NativeDialogs
                 var res = await ShowDialog(options.Title, _window, GtkFileChooserAction.Open,
                     options.AllowMultiple, options.SuggestedStartLocation, null, options.FileTypeFilter, null, false)
                     .ConfigureAwait(false);
-                return res?.Select(f => new BclStorageFile(new FileInfo(f))).ToArray() ?? Array.Empty<IStorageFile>();
+                return res?.Where(f => File.Exists(f)).Select(f => new BclStorageFile(new FileInfo(f))).ToArray() ?? Array.Empty<IStorageFile>();
             });
         }
 


### PR DESCRIPTION
## What does the pull request do?
Gtk open file dialog shows folders in recent list. User can select folder and Gtk will return its path. Avalonia open file dialog should return only files. Fix is checking if Gtk path is real file.


## What is the current behavior?
Gtk open file dialog returns folder path. Avalonia creates `FileInfo` from this path and returns `IStorageFile` to user. Then user can call `IStorageFile.Open*` methods or manually call any .NET file API and will get exception because path is folder.


## What is the updated/expected behavior with this PR?
Avalonia checks if path is file and returns only files.


## How was the solution implemented (if it's not obvious)?
Fix is checking if Gtk path is real file by `File.Exists()`.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

## Obsoletions / Deprecations

## Fixed issues
