### PR TITLE
Make app lifetime windows property an observable collection

### DIFF
--- a/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
@@ -41,7 +41,7 @@ namespace Avalonia.Controls.ApplicationLifetimes
         public Window? MainWindow { get; set; }
 
         /// <inheritdoc />
-        public IReadOnlyList<Window> Windows => _windows;
+        public IAvaloniaReadOnlyList<Window> Windows => _windows;
 
         private void HandleWindowClosed(Window? window)
         {

--- a/src/Avalonia.Controls/ApplicationLifetimes/IClassicDesktopStyleApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/IClassicDesktopStyleApplicationLifetime.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Avalonia.Collections;
 using Avalonia.Metadata;
 
 namespace Avalonia.Controls.ApplicationLifetimes
@@ -44,7 +45,7 @@ namespace Avalonia.Controls.ApplicationLifetimes
         /// <summary>
         /// Gets the list of all open windows in the application.
         /// </summary>
-        IReadOnlyList<Window> Windows { get; }
+        IAvaloniaReadOnlyList<Window> Windows { get; }
 
         /// <summary>
         /// Raised by the platform when an application shutdown is requested.


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR updates the `Windows` collection in `ClassicDesktopStyleApplicationLifetime` from a read-only list to a read-only observable list. With this change, you can now subscribe to the `CollectionChanged` event to track when open windows are added or removed.


## What is the current behavior?
At present, there's no way to track when windows are opened or closed.


## What is the updated/expected behavior with this PR?
With this PR, the `Windows` collection in `ClassicDesktopStyleApplicationLifetime` becomes a read-only observable list, enabling you to monitor changes to the open windows. By subscribing to the `CollectionChanged` event, you can now detect when windows are added to or removed from the collection, allowing you to track when windows are opened or closed in real time.


## How was the solution implemented (if it's not obvious)?
The solution was implemented by updating the type of the `Windows` collection in `ClassicDesktopStyleApplicationLifetime` from `IReadOnlyList` to `IAvaloniaReadOnlyList`. Since the private field declaration (`_windows`) is already an `AvaloniaList`, this change simply makes the public API an observable collection.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
N/A

## Obsoletions / Deprecations
N/A

## Fixed issues
N/A
