### PR TITLE
[Browser] Add dotnet/runtime#109289 workaround

### DIFF
--- a/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
+++ b/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
@@ -38,7 +38,7 @@
 
   <!-- https://github.com/dotnet/runtime/issues/109289 -->
   <Target Name="Issue109289_Workaround"
-          Condition="'$(DisableIssue109289Workaround)' != 'true'"
+          Condition="'$(DisableIssue109289Workaround)' != 'true' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))"
           AfterTargets="_BrowserWasmWriteRspForLinking">
     <ItemGroup>
       <_WasmLinkStepArgs Remove="@(_EmccLinkStepArgs)" />

--- a/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
+++ b/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
@@ -35,4 +35,23 @@
     <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.56\$(_AvNativeBinaryType)\*.a"
                          Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))" />
   </ItemGroup>
+
+  <!-- https://github.com/dotnet/runtime/issues/109289 -->
+  <Target Name="Issue109289_Workaround"
+          Condition="'$(DisableIssue109289Workaround)' != 'true'"
+          AfterTargets="_BrowserWasmWriteRspForLinking">
+    <ItemGroup>
+      <_WasmLinkStepArgs Remove="@(_EmccLinkStepArgs)" />
+      <_EmccLinkStepArgs Remove="&quot;%(_WasmNativeFileForLinking.Identity)&quot;" />
+      <_WasmLinkDependencies Remove="@(_WasmNativeFileForLinking)" />
+
+      <_SkiaSharpToReorder Include="@(_WasmNativeFileForLinking)" Condition="$([System.String]::Copy('%(FullPath)').Contains('SkiaSharp'))" />
+      <_WasmNativeFileForLinking Remove="@(_SkiaSharpToReorder)" />
+      <_WasmNativeFileForLinking Include="@(_SkiaSharpToReorder)" />
+
+      <_EmccLinkStepArgs Include="&quot;%(_WasmNativeFileForLinking.Identity)&quot;" />
+      <_WasmLinkDependencies Include="@(_WasmNativeFileForLinking)" />
+      <_WasmLinkStepArgs Include="@(_EmccLinkStepArgs)" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
## What does the pull request do?

As it seems, this WASM bug was moved to .NET 10.0 milestone, making it unclear, if .NET 9 will ever work with SkiaSharp out of the box.
Thanks to the discussion in dotnet/runtime#109289, we have a workaround.

Workaround is automatically included on any .NET 9+ target, unless DisableIssue109289Workaround is set to true.

## Fixed issues

Fixes #17416