### PR TITLE
Disable Metal as a default rendering mode for 11.2

### DIFF
--- a/src/Avalonia.Native/AvaloniaNativePlatformExtensions.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatformExtensions.cs
@@ -65,8 +65,8 @@ namespace Avalonia
         /// <exception cref="System.InvalidOperationException">Thrown if no values were matched.</exception>
         public IReadOnlyList<AvaloniaNativeRenderingMode> RenderingMode { get; set; } = new[]
         {
-            AvaloniaNativeRenderingMode.Metal,
             AvaloniaNativeRenderingMode.OpenGl,
+            AvaloniaNativeRenderingMode.Metal,
             AvaloniaNativeRenderingMode.Software
         };
 


### PR DESCRIPTION
## What does the pull request do?

For 11.2 we enabled Metal by default on macOS.
But it has several major issues:
- Resizing has poor performance comparing to OpenGL, see #17415 
- Metal rendering backend had a memory leak on resizing, which was already fixed.
- Metal rendering backend has much higher memory consumption on larger window sizes. It's not a leak, as memory is reducing, once window is resized back to smaller sizes.

## How was the solution implemented (if it's not obvious)?

Re-enabled OpenGL as a default for 11.2 builds. 
Note, this PR targets 11.2 branch directly, and for nightly 11.3 builds we still have metal as default.

