### PR TITLE
Fix TimePicker breaking change, when using pre-11.2 styles

### DIFF
--- a/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
@@ -259,12 +259,13 @@ namespace Avalonia.Controls
                 return;
 
             var use24HourClock = ClockIdentifier == "24HourClock";
+            var canUseSeconds = _secondText is not null && _fourthPickerHost is not null && _thirdSplitter is not null;
 
             var columnsD = new ColumnDefinitions();
             columnsD.Add(new ColumnDefinition(GridLength.Star));
             columnsD.Add(new ColumnDefinition(GridLength.Auto));
             columnsD.Add(new ColumnDefinition(GridLength.Star));
-            if (UseSeconds)
+            if (canUseSeconds && UseSeconds)
             {
                 columnsD.Add(new ColumnDefinition(GridLength.Auto));
                 columnsD.Add(new ColumnDefinition(GridLength.Star));
@@ -274,30 +275,45 @@ namespace Avalonia.Controls
                 columnsD.Add(new ColumnDefinition(GridLength.Auto));
                 columnsD.Add(new ColumnDefinition(GridLength.Star));
             }
-            
+
             _contentGrid.ColumnDefinitions = columnsD;
-            
-            _thirdPickerHost!.IsVisible = UseSeconds;
-            _secondSplitter!.IsVisible = UseSeconds;
 
-            _fourthPickerHost!.IsVisible = !use24HourClock;
-            _thirdSplitter!.IsVisible = !use24HourClock;
-
-            var amPmColumn = (UseSeconds) ? 6 : 4;
+            if (canUseSeconds)
+            {
+                _thirdPickerHost!.IsVisible = UseSeconds;
+                _secondSplitter!.IsVisible = UseSeconds;
+                _fourthPickerHost!.IsVisible = !use24HourClock;
+                _thirdSplitter!.IsVisible = !use24HourClock;
+            }
+            else
+            {
+                _thirdPickerHost!.IsVisible = !use24HourClock;
+                _secondSplitter!.IsVisible = !use24HourClock;
+            }
 
             Grid.SetColumn(_firstPickerHost!, 0);
             Grid.SetColumn(_secondPickerHost!, 2);
-            Grid.SetColumn(_thirdPickerHost!, UseSeconds ? 4 : 0);
-            Grid.SetColumn(_fourthPickerHost, use24HourClock ? 0 : amPmColumn);
 
-            Grid.SetColumn(_firstSplitter!, 1);
-            Grid.SetColumn(_secondSplitter!, UseSeconds ? 3 : 0);
-            Grid.SetColumn(_thirdSplitter, use24HourClock ? 0 : amPmColumn-1);
+            if (canUseSeconds)
+            {
+                var amPmColumn = (UseSeconds) ? 6 : 4;
+                Grid.SetColumn(_thirdPickerHost!, UseSeconds ? 4 : 0);
+                Grid.SetColumn(_fourthPickerHost!, use24HourClock ? 0 : amPmColumn);
+                Grid.SetColumn(_firstSplitter!, 1);
+                Grid.SetColumn(_secondSplitter!, UseSeconds ? 3 : 0);
+                Grid.SetColumn(_thirdSplitter!, use24HourClock ? 0 : amPmColumn-1);
+            }
+            else
+            {
+                Grid.SetColumn(_thirdPickerHost, use24HourClock ? 0 : 4);
+                Grid.SetColumn(_firstSplitter!, 1);
+                Grid.SetColumn(_secondSplitter, use24HourClock ? 0 : 3);
+            }
         }
 
         private void SetSelectedTimeText()
         {
-            if (_hourText == null || _minuteText == null || _secondText ==  null || _periodText == null)
+            if (_hourText == null || _minuteText == null || _periodText == null)
                 return;
 
             var time = SelectedTime;
@@ -314,7 +330,11 @@ namespace Avalonia.Controls
 
                 _hourText.Text = newTime.ToString("%h");
                 _minuteText.Text = newTime.ToString("mm");
-                _secondText.Text = newTime.ToString("ss");
+                if (_secondText is not null)
+                {
+                    _secondText.Text = newTime.ToString("ss");
+                }
+
                 PseudoClasses.Set(":hasnotime", false);
 
                 _periodText.Text = time.Value.Hours >= 12 ? TimeUtils.GetPMDesignator() : TimeUtils.GetAMDesignator();
@@ -324,7 +344,11 @@ namespace Avalonia.Controls
                 // By clearing local value, we reset text property to the value from the template.
                 _hourText.ClearValue(TextBlock.TextProperty);
                 _minuteText.ClearValue(TextBlock.TextProperty);
-                _secondText.ClearValue(TextBlock.TextProperty);
+                if (_secondText is not null)
+                {
+                    _secondText.ClearValue(TextBlock.TextProperty);
+                }
+
                 PseudoClasses.Set(":hasnotime", true);
 
                 _periodText.Text = DateTime.Now.Hour >= 12 ?  TimeUtils.GetPMDesignator() :  TimeUtils.GetAMDesignator();


### PR DESCRIPTION
## What does the pull request do?

In 11.2 TimePicker got a new feature with seconds picker option.
Unfortunately, TimePicker templates are very limiting, and any such change breaks templates from third party themes, which weren't updated at the exact time (so, all of them).

This PR adds a check, whether template is up-to date or not, before trying to access second template parts.

For the better fix see https://github.com/AvaloniaUI/Avalonia/issues/17515

## What is the current behavior?

NullReferenceException, if pre-11.2 template is used with 11.2 control.

## What is the updated/expected behavior with this PR?

Seconds are ignored, if pre-11.2 template is used with 11.2 control.

Tested by applying 11.1 control theme to the control.