### PR TITLE
Fix FontCollection glyph typeface caching

### DIFF
--- a/src/Avalonia.Base/Media/Fonts/EmbeddedFontCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/EmbeddedFontCollection.cs
@@ -76,6 +76,9 @@ namespace Avalonia.Media.Fonts
                         glyphTypeface = syntheticGlyphTypeface;
                     }
 
+                    //Make sure we cache the found match
+                    glyphTypefaces.TryAdd(key, glyphTypeface);
+
                     return true;
                 }
             }

--- a/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
@@ -81,6 +81,9 @@ namespace Avalonia.Media.Fonts
             //No exact match
             if (createdKey != key)
             {
+                //Add the created glyph typeface to the cache so we can match it.
+                glyphTypefaces.TryAdd(createdKey, glyphTypeface);
+
                 //Try to find nearest match if possible
                 if (TryGetNearestMatch(glyphTypefaces, key, out var nearestMatch))
                 {

--- a/tests/Avalonia.Skia.UnitTests/Media/EmbeddedFontCollectionTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/EmbeddedFontCollectionTests.cs
@@ -109,6 +109,10 @@ namespace Avalonia.Skia.UnitTests.Media
                 Assert.True(fontCollection.GlyphTypefaceCache.TryGetValue("Manrope", out var glyphTypefaces));
 
                 Assert.Equal(2, glyphTypefaces.Count);
+
+                fontCollection.TryGetGlyphTypeface("Manrope", FontStyle.Normal, FontWeight.ExtraBlack, FontStretch.Normal, out var otherGlyphTypeface);
+
+                Assert.Equal(glyphTypeface, otherGlyphTypeface);
             }
         }
 

--- a/tests/Avalonia.Skia.UnitTests/Media/EmbeddedFontCollectionTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/EmbeddedFontCollectionTests.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Avalonia.Media;
 using Avalonia.Media.Fonts;
 using Avalonia.UnitTests;
@@ -88,6 +91,34 @@ namespace Avalonia.Skia.UnitTests.Media
 
                 Assert.Equal("Manrope", glyphTypeface2.TypographicFamilyName);
             }
+        }
+
+        [Fact]
+        public void Should_Cache_Synthetic_GlyphTypeface()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var source = new Uri(s_manrope, UriKind.Absolute);
+
+                var fontCollection = new TestEmbeddedFontCollection(source, source);
+
+                fontCollection.Initialize(new CustomFontManagerImpl());
+
+                Assert.True(fontCollection.TryGetGlyphTypeface("Manrope", FontStyle.Normal, FontWeight.ExtraBlack, FontStretch.Normal, out var glyphTypeface));
+
+                Assert.True(fontCollection.GlyphTypefaceCache.TryGetValue("Manrope", out var glyphTypefaces));
+
+                Assert.Equal(2, glyphTypefaces.Count);
+            }
+        }
+
+        private class TestEmbeddedFontCollection : EmbeddedFontCollection
+        {
+            public TestEmbeddedFontCollection(Uri key, Uri source) : base(key, source)
+            {
+            }
+
+            public IDictionary<string, ConcurrentDictionary<FontCollectionKey, IGlyphTypeface?>> GlyphTypefaceCache => _glyphTypefaceCache;
         }
     }
 }

--- a/tests/Avalonia.Skia.UnitTests/Media/FontCollectionTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontCollectionTests.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Avalonia.Media;
 using Avalonia.Media.Fonts;
-using Avalonia.Platform;
 using Avalonia.UnitTests;
-using SkiaSharp;
 using Xunit;
 
 namespace Avalonia.Skia.UnitTests.Media

--- a/tests/Avalonia.Skia.UnitTests/Media/FontCollectionTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontCollectionTests.cs
@@ -46,6 +46,10 @@ namespace Avalonia.Skia.UnitTests.Media
                 Assert.Equal(2, glyphTypefaces.Count);
 
                 Assert.True(glyphTypefaces.ContainsKey(new FontCollectionKey(FontStyle.Normal, FontWeight.Black, FontStretch.Normal)));
+
+                fontCollection.TryGetGlyphTypeface("Arial", FontStyle.Normal, FontWeight.ExtraBlack, FontStretch.Normal, out var otherGlyphTypeface);
+
+                Assert.Equal(glyphTypeface, otherGlyphTypeface);
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR ensures the current IFontCollection implementations properly cache glyph typeface when they create a synthetic typeface.

This also changes the SystemFontCollection so created glyph typefaces are added to the cache before the nearest match is attempted to be found.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
