### PR TITLE
Fix crashing after opening a uri on browser

### DIFF
--- a/src/Browser/Avalonia.Browser/Interop/NavigationHelper.cs
+++ b/src/Browser/Avalonia.Browser/Interop/NavigationHelper.cs
@@ -16,7 +16,7 @@ internal static partial class NavigationHelper
             .OnBackRequested() ?? false;
         return Task.FromResult(handled);
     }
-    
-    [JSImport("globalThis.open")]
-    public static partial JSObject? WindowOpen(string uri, string target);
+
+    [JSImport("NavigationHelper.openUri")]
+    public static partial bool WindowOpen(string uri, string target);
 }

--- a/src/Browser/Avalonia.Browser/Interop/NavigationHelper.cs
+++ b/src/Browser/Avalonia.Browser/Interop/NavigationHelper.cs
@@ -17,6 +17,6 @@ internal static partial class NavigationHelper
         return Task.FromResult(handled);
     }
 
-    [JSImport("NavigationHelper.openUri")]
+    [JSImport("NavigationHelper.openUri", AvaloniaModule.MainModuleName)]
     public static partial bool WindowOpen(string uri, string target);
 }

--- a/src/Browser/Avalonia.Browser/Storage/BrowserLauncher.cs
+++ b/src/Browser/Avalonia.Browser/Storage/BrowserLauncher.cs
@@ -13,8 +13,7 @@ internal class BrowserLauncher : ILauncher
 
         if (uri.IsAbsoluteUri)
         {
-            var window = NavigationHelper.WindowOpen(uri.AbsoluteUri, "_blank");
-            return Task.FromResult(window is not null);
+            return Task.FromResult(NavigationHelper.WindowOpen(uri.AbsoluteUri, "_blank"));
         }
         return Task.FromResult(false);
     }

--- a/src/Browser/Avalonia.Browser/webapp/modules/avalonia/navigationHelper.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/avalonia/navigationHelper.ts
@@ -11,4 +11,8 @@ export class NavigationHelper {
             }
         };
     }
+
+    public static openUri(uri?: string, target?: string) {
+        return !!window.open(uri, target);
+    }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Return the `boolean` result directly instead an window `JSObject` in `WindowOpen`, otherwise some properties of the `JSObject` may be accessed while the object being collected by the GC, and failed due to a security error, which will terminate the whole process:

```
Uncaught SecurityError: Failed to read a named property from 'Window': Blocked a frame with origin "http://..." from accessing a cross-origin frame.
```

This is also more performant as we no longer need to marshal the `JSObject`.

## What is the current behavior?
The whole process crash after opening a uri and the returned JSObject being collected by the GC.

## What is the updated/expected behavior with this PR?
No longer crash.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
