### PR TITLE
Fix build Clean target

### DIFF
--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -108,7 +108,6 @@ partial class Build : NukeBuild
     Target Clean => _ => _.Executes(() =>
     {
         Parameters.BuildDirs.ForEach(DeleteDirectory);
-        Parameters.BuildDirs.ForEach(EnsureCleanDirectory);
         EnsureCleanDirectory(Parameters.ArtifactsDir);
         EnsureCleanDirectory(Parameters.NugetIntermediateRoot);
         EnsureCleanDirectory(Parameters.NugetRoot);

--- a/nukebuild/BuildParameters.cs
+++ b/nukebuild/BuildParameters.cs
@@ -145,7 +145,11 @@ public partial class Build
             NugetIntermediateRoot = RootDirectory / "build-intermediate" / "nuget";
             ZipRoot = ArtifactsDir / "zip";
             TestResultsRoot = ArtifactsDir / "test-results";
-            BuildDirs = GlobDirectories(RootDirectory, "**bin").Concat(GlobDirectories(RootDirectory, "**obj")).ToList();
+            BuildDirs = GlobDirectories(RootDirectory, "**/bin")
+                .Concat(GlobDirectories(RootDirectory, "**/obj"))
+                .Where(dir => !dir.Contains("nukebuild"))
+                .Concat(GlobDirectories(RootDirectory, "**/node_modules"))
+                .ToList();
             DirSuffix = Configuration;
             FileZipSuffix = Version + ".zip";
             ZipCoreArtifacts = ZipRoot / ("Avalonia-" + FileZipSuffix);


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the Clean build target:
 - It wasn't cleaning any of the `bin`/`obj` folders due to an incorrect glob (this probably worked in an older Nuke version).
 - It now also removes the `node_modules` folders.
 - It doesn't recreate the empty `bin`/`obj` folders immediately after deleting them.