### PR TITLE
Fix npm install for parallel builds

### DIFF
--- a/src/Browser/Avalonia.Browser/Avalonia.Browser.csproj
+++ b/src/Browser/Avalonia.Browser/Avalonia.Browser.csproj
@@ -46,7 +46,7 @@
     <!-- Write the stamp file, so incremental builds work -->
     <Touch Files="webapp/node_modules/.install-stamp" AlwaysCreate="true" />
   </Target>
-  <Target Name="NpmRunBuild" DependsOnTargets="NpmInstall" BeforeTargets="BeforeBuild">
+  <Target Name="NpmRunBuild" DependsOnTargets="NpmInstall" BeforeTargets="DispatchToInnerBuilds">
     <Exec Command="npm run build" WorkingDirectory="webapp" />
   </Target>
 


### PR DESCRIPTION
## What does the pull request do?
After #17452, we now have multiple target frameworks for the Avalonia.Browser project.

Building these in parallel often causes `npm install` or `npm run build` to run twice at the same time, causing various errors.
Since these commands don't depend on a specific TFM, they're now executed before the inner framework-specific builds.