### PR TITLE
Remove Tizen workload; use the Tizen SDK package directly instead

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,13 +44,6 @@ jobs:
        dotnet workload install android macos wasm-tools
 
   - task: CmdLine@2
-    displayName: 'Install Tizen Workload'
-    inputs:
-      targetType: 'inline'
-      script: |
-       curl -sSL https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.sh | sudo bash -s -- -d "/opt/hostedtoolcache/dotnet"
-
-  - task: CmdLine@2
     displayName: 'Run Build'
     inputs:
       script: |
@@ -88,13 +81,6 @@ jobs:
     inputs:
       script: |
        dotnet workload install android ios macos wasm-tools
-
-  - task: CmdLine@2
-    displayName: 'Install Tizen Workload'
-    inputs:
-      targetType: 'inline'
-      script: |
-       curl -sSL https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.sh | sudo bash
   
   - task: CmdLine@2
     displayName: 'Generate avalonia-native'
@@ -169,13 +155,6 @@ jobs:
     inputs:
       script: |
        dotnet workload install android ios tvos wasm-tools
-
-  - task: PowerShell@2
-    displayName: 'Install Tizen Workload'
-    inputs:
-      targetType: 'inline'
-      script: |
-       (New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.ps1') | Invoke-Expression
 
   - task: CmdLine@2
     displayName: 'Install Nuke'

--- a/build/TargetFrameworks.props
+++ b/build/TargetFrameworks.props
@@ -8,6 +8,7 @@
     <AvsCurrentTvOSTargetFramework>$(AvsCurrentTargetFramework)-tvos17.0</AvsCurrentTvOSTargetFramework>
     <AvsCurrentBrowserTargetFramework>$(AvsCurrentTargetFramework)-browser</AvsCurrentBrowserTargetFramework>
     <AvsCurrentTizenTargetFramework>$(AvsCurrentTargetFramework)-tizen</AvsCurrentTizenTargetFramework>
+    <AvsCurrentTizenTargetSdk>8.0.155</AvsCurrentTizenTargetSdk>
   </PropertyGroup>
   <PropertyGroup Condition="'$(AvsSkipBuildingLegacyTargetFrameworks)' != 'True'">
     <AvsLegacyTargetFrameworks>net6.0</AvsLegacyTargetFrameworks>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.204",
+    "version": "8.0.404",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {

--- a/samples/ControlCatalog.Tizen/ControlCatalog.Tizen.csproj
+++ b/samples/ControlCatalog.Tizen/ControlCatalog.Tizen.csproj
@@ -1,20 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>$(AvsCurrentTizenTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
+
+  <Import Project="AutoImport.props" Sdk="Samsung.Tizen.Sdk" Version="$(AvsCurrentTizenTargetSdk)" />
   
   <ItemGroup>
     <TizenSharedResource Remove="shared\res\Avalonia.png" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Tizen\Avalonia.Tizen\Avalonia.Tizen.csproj" />
     <ProjectReference Include="..\ControlCatalog\ControlCatalog.csproj" />
   </ItemGroup>
 
+  <Import Project="Sdk.targets" Sdk="Samsung.Tizen.Sdk" Version="$(AvsCurrentTizenTargetSdk)" />
 
   <ItemGroup>
-    <Folder Include="lib\" />
-    <Folder Include="res\" />
+    <KnownFrameworkReference Update="Samsung.Tizen" TargetingPackVersion="$(AvsCurrentTizenTargetSdk)" />
   </ItemGroup>
+
 </Project>

--- a/src/Tizen/Avalonia.Tizen/Avalonia.Tizen.csproj
+++ b/src/Tizen/Avalonia.Tizen/Avalonia.Tizen.csproj
@@ -6,6 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <Import Project="AutoImport.props" Sdk="Samsung.Tizen.Sdk" Version="$(AvsCurrentTizenTargetSdk)" />
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />
     <ProjectReference Include="..\..\Skia\Avalonia.Skia\Avalonia.Skia.csproj" />
@@ -14,4 +16,11 @@
   <Import Project="..\..\..\build\DevAnalyzers.props" />
   <Import Project="..\..\..\build\TrimmingEnable.props" />
   <Import Project="..\..\..\build\NullableEnable.props" />
+
+  <Import Project="Sdk.targets" Sdk="Samsung.Tizen.Sdk" Version="$(AvsCurrentTizenTargetSdk)" />
+
+  <ItemGroup>
+    <KnownFrameworkReference Update="Samsung.Tizen" TargetingPackVersion="$(AvsCurrentTizenTargetSdk)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## What does the pull request do?
This PR removes the Tizen workload from the solution.

Not a week goes by without the solution being broken locally for one of the team's member.

Any local .NET SDK update always causes issues with the Tizen workload failing to restore properly, even if it's not related to the 
workloads being updated. Workloads are terrible.

Instead, this PR directly references the Tizen SDK nuget package matching our current .NET SDK version.
The .NET SDK in global.json has also been updated to the latest 8.0.404.