### PR TITLE
Fix TreeViewItem Expand/Collapse event source

### DIFF
--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -85,7 +85,7 @@ namespace Avalonia.Controls
         {
             var routedEvent = args.NewValue.Value ? ExpandedEvent : CollapsedEvent;
             var eventArgs = new RoutedEventArgs() { RoutedEvent = routedEvent, Source = this };
-            TreeViewOwner?.RaiseEvent(eventArgs);
+            RaiseEvent(eventArgs);
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
@@ -1528,6 +1528,48 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(selected[0], target.SelectedItem);
             Assert.Equal(selected, target.SelectedItems);
         }
+        
+        [Fact]
+        public void CollapseEvent_Can_Be_Captured_By_TreeView_When_Collapsing_TreeViewItem()
+        {
+            using var app = Start();
+            var data = CreateTestTreeData();
+            var target = CreateTarget(data: data);
+            var item = data[0];
+            var container = Assert.IsType<TreeViewItem>(target.TreeContainerFromItem(item));
+
+            var raised = false;
+            object? source = null;
+            target.AddHandler(TreeViewItem.CollapsedEvent, (o, e) =>
+            {
+                raised = true;
+                source = e.Source;
+            });
+            container.IsExpanded = false;
+            Assert.True(raised);
+            Assert.Equal(container, source);
+        }
+        
+        [Fact]
+        public void CollapseEvent_Should_Be_Raised_When_Collapsing_TreeViewItem()
+        {
+            using var app = Start();
+            var data = CreateTestTreeData();
+            var target = CreateTarget(data: data);
+            var item = data[0];
+            var container = Assert.IsType<TreeViewItem>(target.TreeContainerFromItem(item));
+
+            var raised = false;
+            object? source = null;
+            container.AddHandler(TreeViewItem.CollapsedEvent, (o, e) =>
+            {
+                raised = true;
+                source = e.Source;
+            });
+            container.IsExpanded = false;
+            Assert.True(raised);
+            Assert.Equal(container, source);
+        }
 
         private static TreeView CreateTarget(Optional<IList<Node>?> data = default,
             bool expandAll = true,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

After #16984, TreeView can now subscribe to children Expand/Collapse event. But there are two issues for the implementation.
1. The event source is coerced to TreeView
2. The `TreeViewItem` itself doesn't raise any event to subscribe.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
By subscribing to the `TreeViewItem.Expand` or `TreeViewItem.Collapse` event, developer should know which exactly TreeViewItem is raising the event. 

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Simply raise the event from TreeViewItem. since it's `Bubble|Tunnel`, `TreeView` can still catch it. 

Two fail unit tests have been added to address the issue.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
