### PR TITLE
Win32: fix position being changed on Resize while minimized

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -596,13 +596,27 @@ namespace Avalonia.Win32
                 return;
             }
 
-            var position = Position;
-            requestedWindowRect.left = position.X;
-            requestedWindowRect.top = position.Y;
-            requestedWindowRect.right = position.X + windowWidth;
-            requestedWindowRect.bottom = position.Y + windowHeight;
+            // If the window is minimized, don't change the restore position, because this.Position is currently
+            // out of screen with values similar to -32000,-32000. Windows considers such a position invalid on restore
+            // and instead moves the window back to 0,0.
+            if (windowPlacement.ShowCmd == ShowWindowCommand.ShowMinimized)
+            {
+                // The window is minimized but will be restored to maximized: don't change our normal size,
+                // or it will incorrectly be set to the maximized size.
+                if ((windowPlacement.Flags & WindowPlacementFlags.RestoreToMaximized) != 0)
+                {
+                    return;
+                }
+            }
+            else
+            {
+                var position = Position;
+                windowPlacement.NormalPosition.left = position.X;
+                windowPlacement.NormalPosition.top = position.Y;
+            }
 
-            windowPlacement.NormalPosition = requestedWindowRect;
+            windowPlacement.NormalPosition.right = windowPlacement.NormalPosition.left + windowWidth;
+            windowPlacement.NormalPosition.bottom = windowPlacement.NormalPosition.top + windowHeight;
 
             windowPlacement.ShowCmd = !_shown ? ShowWindowCommand.Hide : _lastWindowState switch
             {


### PR DESCRIPTION
## What does the pull request do?
On Windows, this PR fixes the window's bounds being incorrectly changed if `WindowImpl.Resize()` gets called while the window is minimized (this can happen as a result of `InvalidateMeasure()`). This issue was introduced in #14470.

Two things were wrong in this case:
 - The restore position was being set to the minimized position (-32000,-32000), causing Windows to always reposition the window at 0,0 instead when restoring it. This effectively always moved the window to the main screen.
 - If the window was maximized before being minimized, the restore size was incorrectly set to the maximized size.