### PR TITLE
Raise the `EffectiveViewPortChanged` when a control is added to the tree that has already has a valid layout

### DIFF
--- a/src/Avalonia.Base/Layout/LayoutManager.cs
+++ b/src/Avalonia.Base/Layout/LayoutManager.cs
@@ -213,9 +213,7 @@ namespace Avalonia.Layout
         void ILayoutManager.RegisterEffectiveViewportListener(Layoutable control)
         {
             _effectiveViewportChangedListeners ??= new List<EffectiveViewportChangedListener>();
-            _effectiveViewportChangedListeners.Add(new EffectiveViewportChangedListener(
-                control,
-                CalculateEffectiveViewport(control)));
+            _effectiveViewportChangedListeners.Add(new EffectiveViewportChangedListener(control));
         }
 
         void ILayoutManager.UnregisterEffectiveViewportListener(Layoutable control)
@@ -438,14 +436,13 @@ namespace Avalonia.Layout
 
         private class EffectiveViewportChangedListener
         {
-            public EffectiveViewportChangedListener(Layoutable listener, Rect viewport)
+            public EffectiveViewportChangedListener(Layoutable listener)
             {
                 Listener = listener;
-                Viewport = viewport;
             }
 
             public Layoutable Listener { get; }
-            public Rect Viewport { get; set; }
+            public Rect? Viewport { get; set; }
         }
 
         private enum ArrangeResult

--- a/tests/Avalonia.Base.UnitTests/Layout/LayoutableTests_EffectiveViewportChanged.cs
+++ b/tests/Avalonia.Base.UnitTests/Layout/LayoutableTests_EffectiveViewportChanged.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Base.UnitTests.Layout
     public class LayoutableTests_EffectiveViewportChanged
     {
         [Fact]
-        public async Task EffectiveViewportChanged_Not_Raised_When_Control_Added_To_Tree()
+        public async Task EffectiveViewportChanged_Not_Raised_When_Control_Added_To_Tree_And_Layout_Pass_Has_Not_Run()
         {
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
             await RunOnUIThread.Execute(async () =>
@@ -32,6 +32,60 @@ namespace Avalonia.Base.UnitTests.Layout
                 root.Child = target;
 
                 Assert.Equal(0, raised);
+            });
+        }
+        
+        [Fact]
+        public async Task EffectiveViewportChanged_Raised_When_Control_Added_To_Tree_And_Layout_Pass_Has_Run()
+        {
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+            await RunOnUIThread.Execute(async () =>
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+            {
+                var root = CreateRoot();
+                var target = new Canvas();
+                var raised = 0;
+
+                target.EffectiveViewportChanged += (s, e) =>
+                {
+                    ++raised;
+                };
+
+                root.Child = target;
+
+                Assert.Equal(0, raised);
+
+                await ExecuteInitialLayoutPass(root);
+
+                Assert.Equal(1, raised);
+            });
+        }
+        
+        [Fact]
+        public async Task EffectiveViewportChanged_Raised_When_Root_LayedOut_And_Then_Control_Added_To_Tree_And_Layout_Pass_Runs()
+        {
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+            await RunOnUIThread.Execute(async () =>
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+            {
+                var root = CreateRoot();
+                var target = new Canvas();
+                var raised = 0;
+
+                target.EffectiveViewportChanged += (s, e) =>
+                {
+                    ++raised;
+                };
+
+                await ExecuteInitialLayoutPass(root);
+
+                root.Child = target;
+
+                Assert.Equal(0, raised);
+
+                await ExecuteInitialLayoutPass(root);
+
+                Assert.Equal(1, raised);
             });
         }
 
@@ -268,8 +322,11 @@ namespace Avalonia.Base.UnitTests.Layout
 
                 root.Child = parent;
 
-                await ExecuteInitialLayoutPass(root);
                 target.EffectiveViewportChanged += (s, e) => ++raised;
+                await ExecuteInitialLayoutPass(root);
+                
+                raised = 0; // The initial layout pass is expected to raise.
+                
                 target.RenderTransform = new TranslateTransform { X = 8 };
                 target.InvalidateMeasure();
                 await ExecuteLayoutPass(root);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Fix the raising of the EffectiveViewPortChanged event.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

If you add a control that expects the `EffectiveViewPortChanged` event to a tree that has already has a valid layout, it never receives the event, giving the initial value.

The reason is because when the listener is added 

new EffectiveViewportChangedListener(
        control,
        CalculateEffectiveViewport(control));
        
        an initial value is calculated for the viewport.
        
When this is being added to a parent that has a size a size here is calculated.

Now when the actual layout pass happens

LayoutManager -> RaiseEffectiveViewportChanged()
``` 
var viewport = CalculateEffectiveViewport(l.Listener);

if (viewport != l.Viewport)
{
    l.Listener.RaiseEffectiveViewportChanged(new EffectiveViewportChangedEventArgs(viewport));
    l.Viewport = viewport;
}
```

viewport and l.Viewport are equal and the event is skipped.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

We now match the UWP behavior of raising the event.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

1. don't initialise the Listener `ViewPort` property.
2. make the Listener `ViewPort` property nullable, so that it has to raise it the first time.

This other PR updates the UWP tests that prove our behaviour is the same.
https://github.com/grokys/EffectiveBoundsTestsUWP/pull/1

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
