### PR TITLE
Don't check if intent is declared by app before launch

### DIFF
--- a/src/Android/Avalonia.Android/Platform/AndroidLauncher.cs
+++ b/src/Android/Avalonia.Android/Platform/AndroidLauncher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Android.Content;
+using Android.OS;
 using Avalonia.Android.Platform.Storage;
 using Avalonia.Platform.Storage;
 using AndroidUri = Android.Net.Uri;
@@ -15,20 +16,23 @@ internal class AndroidLauncher : ILauncher
     {
         _context = context;
     }
-    
+
     public Task<bool> LaunchUriAsync(Uri uri)
     {
         _ = uri ?? throw new ArgumentNullException(nameof(uri));
         if (uri.IsAbsoluteUri && _context.PackageManager is { } packageManager)
         {
             var intent = new Intent(Intent.ActionView, AndroidUri.Parse(uri.OriginalString));
-            if (intent.ResolveActivity(packageManager) is not null)
+
+            try
             {
                 var flags = ActivityFlags.ClearTop | ActivityFlags.NewTask;
                 intent.SetFlags(flags);
                 _context.StartActivity(intent);
                 return Task.FromResult(true);
             }
+            catch (ActivityNotFoundException) { }
+            catch (FileUriExposedException) { }
         }
         return Task.FromResult(false);
     }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
In general, on newer android apps, Google recommends that any intent an app will launch be declared at build time in the apps manifest. Apps then check availability of app that can handle that intent before launching. This avoids having to write exception handlers to catch failed intents.
This works fine for normal apps with limited scope. But for a general purpose app framework like Avalonia, it limits the types of  applications it can create. File managers, browsers and text editors may not know at build time all the possible intents a Uri could support. In this case, simply starting the intent, catching any exception that may be thrown from missing activities and hoping the user has an app to handle it is more preferable.

For security reasons, it's still recommended for apps to declare intents they use when they can.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
No longer try to resolve whether an intent can be handled by an activity, but instead  try to start an activity anyway and catch expected errors from wrong intents or missing activity.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/17265
