### PR TITLE
Use URLWithString for pickers

### DIFF
--- a/native/Avalonia.Native/src/OSX/StorageProvider.mm
+++ b/native/Avalonia.Native/src/OSX/StorageProvider.mm
@@ -173,8 +173,7 @@ public:
             if(initialDirectory != nullptr)
             {
                 auto directoryString = [NSString stringWithUTF8String:initialDirectory];
-                panel.directoryURL = [NSURL fileURLWithPath:directoryString
-                                            isDirectory:true];
+                panel.directoryURL = [NSURL URLWithString:directoryString];
             }
             
             auto handler = ^(NSModalResponse result) {
@@ -239,8 +238,7 @@ public:
             if(initialDirectory != nullptr)
             {
                 auto directoryString = [NSString stringWithUTF8String:initialDirectory];
-                panel.directoryURL = [NSURL fileURLWithPath:directoryString
-                                            isDirectory:true];
+                panel.directoryURL = [NSURL URLWithString:directoryString];
             }
             
             if(initialFile != nullptr)
@@ -309,8 +307,7 @@ public:
             if(initialDirectory != nullptr)
             {
                 auto directoryString = [NSString stringWithUTF8String:initialDirectory];
-                panel.directoryURL = [NSURL fileURLWithPath:directoryString
-                                            isDirectory:true];
+                panel.directoryURL = [NSURL URLWithString:directoryString];
             }
             
             if(initialFile != nullptr)


### PR DESCRIPTION
## What does the pull request do?

`[NSURL fileURLWithPath]` is recommended to be used with file system paths, and that's how it was used previously.
But at some point, we changed managed code to send AbsoluteUri with full scheme and escaping, instead of local system path. Apparently, it worked fine, if suggested file didn't contain any escaped characters, like a whitespace.
But to support escaped symbols we should use `[NSURL URLWithString]`, which accepts input absolute Uri as is, without double escaping anything. 

## What is the current behavior?

Suggested file/folder paths with space don't work.

## What is the updated/expected behavior with this PR?

Suggested file/folder paths with space works.
