### PR TITLE
Fix macOS ActivatableLifetime events

### DIFF
--- a/native/Avalonia.Native/src/OSX/app.mm
+++ b/native/Avalonia.Native/src/OSX/app.mm
@@ -59,6 +59,16 @@ ComPtr<IAvnApplicationEvents> _events;
     _events->OnUnhide();
 }
 
+- (void) applicationDidBecomeActive:(NSNotification *) notification
+{
+    _events->OnActivate();
+}
+
+- (void) applicationDidResignActive:(NSNotification *) notification
+{
+    _events->OnDeactivate();
+}
+
 - (void)application:(NSApplication *)sender openFiles:(NSArray<NSString *> *)filenames
 {
     auto array = CreateAvnStringArray(filenames);

--- a/src/Avalonia.Native/AvaloniaNativeApplicationPlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativeApplicationPlatform.cs
@@ -88,17 +88,25 @@ namespace Avalonia.Native
 
         void IAvnApplicationEvents.OnHide()
         {
-            if (AvaloniaLocator.Current.GetService<IActivatableLifetime>() is ActivatableLifetimeBase lifetime)
-            {
-                lifetime.OnDeactivated(ActivationKind.Background);    
-            }
         }
 
         void IAvnApplicationEvents.OnUnhide()
         {
+        }
+
+        void IAvnApplicationEvents.OnActivate()
+        {
             if (AvaloniaLocator.Current.GetService<IActivatableLifetime>() is ActivatableLifetimeBase lifetime)
             {
-                lifetime.OnActivated(ActivationKind.Background);    
+                lifetime.OnActivated(ActivationKind.Background);
+            }
+        }
+
+        void IAvnApplicationEvents.OnDeactivate()
+        {
+            if (AvaloniaLocator.Current.GetService<IActivatableLifetime>() is ActivatableLifetimeBase lifetime)
+            {
+                lifetime.OnDeactivated(ActivationKind.Background);
             }
         }
 

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -1142,6 +1142,8 @@ interface IAvnApplicationEvents : IUnknown
      void OnReopen ();
      void OnHide ();
      void OnUnhide ();
+     void OnActivate();
+     void OnDeactivate();
 }
 
 [uuid(b4284791-055b-4313-8c2e-50f0a8c72ce9)]


### PR DESCRIPTION
## What does the pull request do?
This PR changes the `IActivableLifetime`.`Activated`/`Deactivated` events to be raised on `applicationDidBecomeActive`/`applicationDidResignActive` notifications instead of `applicationDidHide`/`applicationDidHide`.

## What is the current behavior?
Currently, the `Deactivated` event is only raised when the application is explicitly hidden through Dock > Hide or ⌘+H.

## What is the updated/expected behavior with this PR?
Instead, the `Deactivated` event is now raised when the application becomes inactive (because it's been hidden, or because another one is now active).
