### PR TITLE
Fix broken pre-edit markedText on iOS and solve #17523

### DIFF
--- a/src/iOS/Avalonia.iOS/CombinedSpan3.cs
+++ b/src/iOS/Avalonia.iOS/CombinedSpan3.cs
@@ -16,7 +16,7 @@ internal ref struct CombinedSpan3<T>
 
     public int Length => Span1.Length + Span2.Length + Span3.Length;
 
-    static void CopyFromSpan(ReadOnlySpan<T> from, int offset, ref Span<T> to)
+    static void CopyFromSpan(ReadOnlySpan<T> from, ref int offset, ref Span<T> to)
     {
         if(to.Length == 0)
             return;
@@ -33,8 +33,8 @@ internal ref struct CombinedSpan3<T>
     
     public void CopyTo(Span<T> to, int offset)
     {
-        CopyFromSpan(Span1, offset, ref to);
-        CopyFromSpan(Span2, offset, ref to);
-        CopyFromSpan(Span3, offset, ref to);
+        CopyFromSpan(Span1, ref offset, ref to);
+        CopyFromSpan(Span2, ref offset, ref to);
+        CopyFromSpan(Span3, ref offset, ref to);
     }
 }

--- a/src/iOS/Avalonia.iOS/TextInputResponder.cs
+++ b/src/iOS/Avalonia.iOS/TextInputResponder.cs
@@ -220,15 +220,17 @@ partial class AvaloniaView
 
             string result = "";
             if (string.IsNullOrEmpty(_markedText))
+            {
                 if(surroundingText != null && r.EndIndex < surroundingText.Length)
                 {
                     result = surroundingText[r.StartIndex..r.EndIndex];
                 }
+            }
             else
             {
                 var span = new CombinedSpan3<char>(surroundingText.AsSpan().Slice(0, currentSelection.Start),
                     _markedText,
-                    surroundingText.AsSpan().Slice(currentSelection.Start));
+                    surroundingText.AsSpan().Slice(currentSelection.Start, currentSelection.End - currentSelection.Start));
                 var buf = new char[r.EndIndex - r.StartIndex];
                 span.CopyTo(buf, r.StartIndex);
                 result = new string(buf);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix #17523. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Can't type any multisyllable language including Chinese, Korean etc.

### Bug Descrption
The `CombinedSpan3.CopyFromSpan` implementaion is wrong. 
```csharp

    static void CopyFromSpan(ReadOnlySpan<T> from, int offset, ref Span<T> to)
    {
        if(to.Length == 0)
            return;
        if (offset < from.Length)
        {
            var copyNow = Math.Min(from.Length - offset, to.Length);
            from.Slice(offset, copyNow).CopyTo(to);
            to = to.Slice(copyNow);
            offset = 0;
        }
        else
            offset -= from.Length;
    }


    public void CopyTo(Span<T> to, int offset)
    {
   // the offset is not updated, should use ref here
        CopyFromSpan(Span1, offset, ref to);
        CopyFromSpan(Span2, offset, ref to);
        CopyFromSpan(Span3, offset, ref to);
    }
```

Another bug occurs in `IUITextInput.TextInRange`
```csharp
        string IUITextInput.TextInRange(UITextRange range)
        {
            var r = (AvaloniaTextRange)range;
            var surroundingText = _client.SurroundingText;
            var currentSelection = _client.Selection;
            Logger.TryGet(LogEventLevel.Debug, ImeLog)?.Log(null, "IUIKeyInput.TextInRange {start} {end}", r.StartIndex, r.EndIndex);

            string result = "";
// wrong indent here, it will directly fallback when _markedText is empty or null
            if (string.IsNullOrEmpty(_markedText)) 
                if(surroundingText != null && r.EndIndex < surroundingText.Length)
                {
                    result = surroundingText[r.StartIndex..r.EndIndex];
                }
// this `else` is paired with the second `if`, not as expected
            else
            {
                var span = new CombinedSpan3<char>(surroundingText.AsSpan().Slice(0, currentSelection.Start),
                    _markedText,
                    surroundingText.AsSpan().Slice(currentSelection.Start));
                var buf = new char[r.EndIndex - r.StartIndex];
                span.CopyTo(buf, r.StartIndex);
                result = new string(buf);
            }
            Logger.TryGet(LogEventLevel.Debug, ImeLog)?.Log(null, "result: {res}", result);
            return result;
        }
```

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Able to input Chinese or other multisyllable languages using system IME on iOS

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Implementions are simple as commits showed.

## Checklist
Since this fix is simple, those steps could be omitted
- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
None
## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
None
## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
#17523 