### PR TITLE
Add missing ItemGroup to build tasks

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -119,8 +119,10 @@
   </Target>
 
   <Target Name="AvaloniaCollectUpToDateCheckInputDesignTime" BeforeTargets="CollectUpToDateCheckInputDesignTime">
-    <UpToDateCheckInput Include="@(AvaloniaResource)" />
-    <UpToDateCheckInput Include="@(AvaloniaXaml)" />
+    <ItemGroup>
+      <UpToDateCheckInput Include="@(AvaloniaResource)" />
+      <UpToDateCheckInput Include="@(AvaloniaXaml)" />
+    </ItemGroup>
   </Target>
 
   <Target


### PR DESCRIPTION
## What does the pull request do?
An `ItemGroup` was missing from the `AvaloniaCollectUpToDateCheckInputDesignTime` target, added in #17539.
It was affecting VS quick up-to-date check, displaying a warning instead.