### PR TITLE
Fix WrapPanel when ItemWidth < Available Size

### DIFF
--- a/src/Avalonia.Controls/WrapPanel.cs
+++ b/src/Avalonia.Controls/WrapPanel.cs
@@ -140,7 +140,7 @@ namespace Avalonia.Controls
             var childConstraint = new Size(
                 itemWidthSet ? itemWidth : constraint.Width,
                 itemHeightSet ? itemHeight : constraint.Height);
-            
+
             for (int i = 0, count = children.Count; i < count; i++)
             {
                 var child = children[i];
@@ -213,14 +213,18 @@ namespace Avalonia.Controls
                     if (MathUtilities.GreaterThan(sz.U, uvFinalSize.U)) // The element is wider then the constraint - give it a separate line
                     {
                         // Switch to next line which only contain one element
-                        ArrangeLine(accumulatedV, sz.V, i, ++i, useItemU, itemU);
+                        ArrangeLine(accumulatedV, sz.V, i, i + 1, useItemU, itemU);
 
                         accumulatedV += sz.V;
                         curLineSize = new UVSize(orientation);
+                        firstInLine = i + 1;
                     }
-                    firstInLine = i;
+                    else
+                    {
+                        firstInLine = i;
+                    }
                 }
-                else // Continue to accumulate a line
+                else // Continue to accumulate in the current line
                 {
                     curLineSize.U += sz.U;
                     curLineSize.V = Max(sz.V, curLineSize.V);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes WrapPanel when ItemWith < Available Size.


## What is the current behavior?
Children aren't arranged correctly. They become invisible.


## What is the updated/expected behavior with this PR?
Children should display.


## How was the solution implemented (if it's not obvious)?
Changing the ArrangeOverride method. 


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation