### PR TITLE
Expanding StringTokenizator with ReadOnlySpan.

### DIFF
--- a/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
+++ b/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
@@ -132,7 +132,7 @@ namespace Avalonia.Media.Fonts
                     glyphTypeface = typeface;
 
                     return true;
-                }            
+                }
             }
 
             return false;
@@ -297,7 +297,7 @@ namespace Avalonia.Media.Fonts
 
             var tokenizer = new StringTokenizer(familyName, ' ');
 
-            tokenizer.ReadString();
+            tokenizer.ReadSpan();
 
             while (tokenizer.TryReadString(out var weightString))
             {
@@ -325,7 +325,7 @@ namespace Avalonia.Media.Fonts
 
             var tokenizer = new StringTokenizer(familyName, ' ');
 
-            tokenizer.ReadString();
+            tokenizer.ReadSpan();
 
             while (tokenizer.TryReadString(out var styleString))
             {
@@ -354,7 +354,7 @@ namespace Avalonia.Media.Fonts
 
             var tokenizer = new StringTokenizer(familyName, ' ');
 
-            tokenizer.ReadString();
+            tokenizer.ReadSpan();
 
             while (tokenizer.TryReadString(out var stretchString))
             {

--- a/src/Avalonia.Base/Media/TextDecorationCollection.cs
+++ b/src/Avalonia.Base/Media/TextDecorationCollection.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Media
 
             using (var tokenizer = new StringTokenizer(s, ',', "Invalid text decoration."))
             {
-                while (tokenizer.TryReadString(out var name))
+                while (tokenizer.TryReadSpan(out var name))
                 {
                     var location = GetTextDecorationLocation(name);
 
@@ -59,9 +59,9 @@ namespace Avalonia.Media
         /// </summary>
         /// <param name="s">The string.</param>
         /// <returns>The <see cref="TextDecorationLocation"/>.</returns>
-        private static TextDecorationLocation GetTextDecorationLocation(string s)
+        private static TextDecorationLocation GetTextDecorationLocation(ReadOnlySpan<char> s)
         {
-            if (Enum.TryParse<TextDecorationLocation>(s,true, out var location))
+            if (SpanHelpers.TryParseEnum<TextDecorationLocation>(s,true, out var location))
             {
                 return location;
             }

--- a/src/Avalonia.Base/RelativeRect.cs
+++ b/src/Avalonia.Base/RelativeRect.cs
@@ -152,7 +152,7 @@ namespace Avalonia
                     Rect.Width * size.Width,
                     Rect.Height * size.Height);
         }
-        
+
         /// <summary>
         /// Converts a <see cref="RelativeRect"/> into pixels.
         /// </summary>
@@ -178,18 +178,18 @@ namespace Avalonia
         {
             using (var tokenizer = new StringTokenizer(s, exceptionMessage: "Invalid RelativeRect."))
             {
-                var x = tokenizer.ReadString();
-                var y = tokenizer.ReadString();
-                var width = tokenizer.ReadString();
-                var height = tokenizer.ReadString();
+                var x = tokenizer.ReadSpan();
+                var y = tokenizer.ReadSpan();
+                var width = tokenizer.ReadSpan();
+                var height = tokenizer.ReadSpan();
 
                 var unit = RelativeUnit.Absolute;
                 var scale = 1.0;
 
-                var xRelative = x.EndsWith("%", StringComparison.Ordinal);
-                var yRelative = y.EndsWith("%", StringComparison.Ordinal);
-                var widthRelative = width.EndsWith("%", StringComparison.Ordinal);
-                var heightRelative = height.EndsWith("%", StringComparison.Ordinal);
+                var xRelative = x.EndsWith(PercentChar, StringComparison.Ordinal);
+                var yRelative = y.EndsWith(PercentChar, StringComparison.Ordinal);
+                var widthRelative = width.EndsWith(PercentChar, StringComparison.Ordinal);
+                var heightRelative = height.EndsWith(PercentChar, StringComparison.Ordinal);
 
                 if (xRelative && yRelative && widthRelative && heightRelative)
                 {
@@ -207,10 +207,10 @@ namespace Avalonia
                 }
 
                 return new RelativeRect(
-                    double.Parse(x, CultureInfo.InvariantCulture) * scale,
-                    double.Parse(y, CultureInfo.InvariantCulture) * scale,
-                    double.Parse(width, CultureInfo.InvariantCulture) * scale,
-                    double.Parse(height, CultureInfo.InvariantCulture) * scale,
+                    SpanHelpers.ParseDouble(x, CultureInfo.InvariantCulture) * scale,
+                    SpanHelpers.ParseDouble(y, CultureInfo.InvariantCulture) * scale,
+                    SpanHelpers.ParseDouble(width, CultureInfo.InvariantCulture) * scale,
+                    SpanHelpers.ParseDouble(height, CultureInfo.InvariantCulture) * scale,
                     unit);
             }
         }

--- a/src/Avalonia.Base/Utilities/SpanHelpers.cs
+++ b/src/Avalonia.Base/Utilities/SpanHelpers.cs
@@ -30,6 +30,16 @@ namespace Avalonia.Utilities
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryParseInt(this ReadOnlySpan<char> span, NumberStyles style, IFormatProvider provider, out int value)
+        {
+#if NETSTANDARD2_0
+            return int.TryParse(span.ToString(), style, provider, out value);
+#else
+            return int.TryParse(span, style, provider, out value);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryParseDouble(this ReadOnlySpan<char> span, NumberStyles style, IFormatProvider provider, out double value)
         {
 #if NETSTANDARD2_0
@@ -40,12 +50,32 @@ namespace Avalonia.Utilities
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double ParseDouble(this ReadOnlySpan<char> span, IFormatProvider provider)
+        {
+#if NETSTANDARD2_0
+            return double.Parse(span.ToString(), provider);
+#else
+            return double.Parse(span, provider: provider);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryParseByte(this ReadOnlySpan<char> span, NumberStyles style, IFormatProvider provider, out byte value)
         {
 #if NETSTANDARD2_0
             return byte.TryParse(span.ToString(), style, provider, out value);
 #else
             return byte.TryParse(span, style, provider, out value);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryParseEnum<TEnum>(this ReadOnlySpan<char> span, bool ignoreCase, out TEnum value) where TEnum : struct
+        {
+#if NETSTANDARD2_0
+            return Enum.TryParse<TEnum>(span.ToString(), ignoreCase, out value);
+#else
+            return Enum.TryParse<TEnum>(span, ignoreCase, out value);
 #endif
         }
     }

--- a/src/Avalonia.Base/Utilities/StringTokenizer.cs
+++ b/src/Avalonia.Base/Utilities/StringTokenizer.cs
@@ -44,7 +44,9 @@ namespace Avalonia.Utilities
             }
         }
 
-        public ReadOnlySpan<char> CurrentToken => _tokenIndex < 0 ? ReadOnlySpan<char>.Empty : _s.AsSpan().Slice(_tokenIndex, _tokenLength);
+        public string? CurrentToken => _tokenIndex < 0 ? null : _s.Substring(_tokenIndex, _tokenLength);
+
+        public ReadOnlySpan<char> CurrentTokenSpan => _tokenIndex < 0 ? ReadOnlySpan<char>.Empty : _s.AsSpan().Slice(_tokenIndex, _tokenLength);
 
         public void Dispose()
         {
@@ -105,7 +107,7 @@ namespace Avalonia.Utilities
         public bool TryReadString([NotNull] out string result, char? separator = null)
         {
             var success = TryReadToken(separator ?? _separator);
-            result = CurrentToken.ToString();
+            result = CurrentTokenSpan.ToString();
             return success;
         }
 
@@ -122,7 +124,7 @@ namespace Avalonia.Utilities
         public bool TryReadSpan(out ReadOnlySpan<char> result, char? separator = null)
         {
             var success = TryReadToken(separator ?? _separator);
-            result = CurrentToken;
+            result = CurrentTokenSpan;
             return success;
         }
 

--- a/src/Avalonia.Base/Utilities/StringTokenizer.cs
+++ b/src/Avalonia.Base/Utilities/StringTokenizer.cs
@@ -44,7 +44,7 @@ namespace Avalonia.Utilities
             }
         }
 
-        public string? CurrentToken => _tokenIndex < 0 ? null : _s.Substring(_tokenIndex, _tokenLength);
+        public ReadOnlySpan<char> CurrentToken => _tokenIndex < 0 ? ReadOnlySpan<char>.Empty : _s.AsSpan().Slice(_tokenIndex, _tokenLength);
 
         public void Dispose()
         {
@@ -56,8 +56,8 @@ namespace Avalonia.Utilities
 
         public bool TryReadInt32(out Int32 result, char? separator = null)
         {
-            if (TryReadString(out var stringResult, separator) &&
-                int.TryParse(stringResult, NumberStyles.Integer, _formatProvider, out result))
+            if (TryReadSpan(out var stringResult, separator) &&
+                SpanHelpers.TryParseInt(stringResult, NumberStyles.Integer, _formatProvider, out result))
             {
                 return true;
             }
@@ -80,8 +80,8 @@ namespace Avalonia.Utilities
 
         public bool TryReadDouble(out double result, char? separator = null)
         {
-            if (TryReadString(out var stringResult, separator) &&
-                double.TryParse(stringResult, NumberStyles.Float, _formatProvider, out result))
+            if (TryReadSpan(out var stringResult, separator) &&
+                SpanHelpers.TryParseDouble(stringResult, NumberStyles.Float, _formatProvider, out result))
             {
                 return true;
             }
@@ -102,16 +102,33 @@ namespace Avalonia.Utilities
             return result;
         }
 
-        public bool TryReadString([MaybeNullWhen(false)] out string result, char? separator = null)
+        public bool TryReadString([NotNull] out string result, char? separator = null)
         {
             var success = TryReadToken(separator ?? _separator);
-            result = CurrentToken;
+            result = CurrentToken.ToString();
             return success;
         }
 
         public string ReadString(char? separator = null)
         {
             if (!TryReadString(out var result, separator))
+            {
+                throw GetFormatException();
+            }
+
+            return result;
+        }
+
+        public bool TryReadSpan(out ReadOnlySpan<char> result, char? separator = null)
+        {
+            var success = TryReadToken(separator ?? _separator);
+            result = CurrentToken;
+            return success;
+        }
+
+        public ReadOnlySpan<char> ReadSpan(char? separator = null)
+        {
+            if (!TryReadSpan(out var result, separator))
             {
                 throw GetFormatException();
             }

--- a/tests/Avalonia.Base.UnitTests/Utilities/StringTokenizerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Utilities/StringTokenizerTests.cs
@@ -65,5 +65,15 @@ namespace Avalonia.Base.UnitTests.Utilities
 
             Assert.False(target.TryReadDouble(out var value));
         }
+
+        [Fact]
+        public void ReadSpan_And_ReadString_Reads_Same()
+        {
+            var target1 = new StringTokenizer("abc,def");
+            var target2 = new StringTokenizer("abc,def");
+
+            Assert.Equal(target1.ReadString(), target2.ReadSpan().ToString());
+            Assert.True(target1.ReadSpan().SequenceEqual(target2.ReadString()));
+        }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Returns `ReadOnlySpan<char>` as `CurrentToken` instead of string substring.


## What is the current behavior?
`CurrentToken` always create new string instance (via `Substring`).


## What is the updated/expected behavior with this PR?
In new runtimes (greater than Standard), this reduces allocations by parsing `int` and `double` directly from Span.