### PR TITLE
Implement Matrix.CreateRotation with center point.

### DIFF
--- a/src/Avalonia.Base/Matrix.cs
+++ b/src/Avalonia.Base/Matrix.cs
@@ -215,6 +215,21 @@ namespace Avalonia
         }
 
         /// <summary>
+        /// Creates a rotation matrix using the given rotation in radians around center point. 
+        /// </summary>
+        /// <param name="radians">The amount of rotation, in radians. </param>
+        /// <param name="center">The location of center point. </param>
+        /// <returns></returns>
+        public static Matrix CreateRotation(double radians, Point center)
+        {
+            var cos = Math.Cos(radians);
+            var sin = Math.Sin(radians);
+            var x = center.X;
+            var y = center.Y;
+            return new Matrix(cos, sin, -sin, cos, x * (1.0 - cos) + y * sin, y * (1.0 - cos) - x * sin);
+        }
+
+        /// <summary>
         /// Creates a skew matrix from the given axis skew angles in radians.
         /// </summary>
         /// <param name="xAngle">The amount of skew along the X-axis, in radians.</param>

--- a/tests/Avalonia.Base.UnitTests/MatrixTests.cs
+++ b/tests/Avalonia.Base.UnitTests/MatrixTests.cs
@@ -61,6 +61,20 @@ public class MatrixTests
 
         AssertCoordinatesEqualWithReducedPrecision(expected, actual);
     }
+
+    [Fact]
+    public void Transform_Point_Should_Return_Correct_Value_For_Rotate_Matrix_With_Center_Point()
+    {
+        var expected = Vector2.Transform(
+            new Vector2(0, 10), 
+            Matrix3x2.CreateRotation((float)Matrix.ToRadians(30), new Vector2(3, 5)));
+
+        var matrix = Matrix.CreateRotation(Matrix.ToRadians(30), new Point(3, 5));
+        var point = new Point(0, 10);
+        var actual = matrix.Transform(point);
+
+        AssertCoordinatesEqualWithReducedPrecision(expected, actual);
+    }
     
     [Fact]
     public void Transform_Point_Should_Return_Correct_Value_For_Scaled_Matrix()


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Add new overload for Matrix.CreateRotation(double radians, Point center).
This is a valid and commonly used transformation in SVG see: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform#rotate
Also part of Systme.Numeric api. 

Notice: whether to use `Point` or `Vector` is not finalized yet, pending on team descision. 


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Closes #17307 