### PR TITLE
BoolConverters.Not should support ConvertBack

### DIFF
--- a/src/Avalonia.Base/Data/Converters/BoolConverters.cs
+++ b/src/Avalonia.Base/Data/Converters/BoolConverters.cs
@@ -1,3 +1,6 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
 
 namespace Avalonia.Data.Converters
@@ -23,6 +26,27 @@ namespace Avalonia.Data.Converters
         /// A value converter that returns true when input is false and false when input is true.
         /// </summary>
         public static readonly IValueConverter Not =
-            new FuncValueConverter<bool, bool>(x => !x);
+            new NotConverter();
+
+        private class NotConverter : IValueConverter
+        {
+            public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+            {
+                if (value is bool val)
+                {
+                    return !val;
+                }
+                return AvaloniaProperty.UnsetValue;
+            }
+
+            public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+            {
+                if (value is bool val)
+                {
+                    return !val;
+                }
+                return AvaloniaProperty.UnsetValue;
+            }
+        }
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Data/BoolConvertersTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/BoolConvertersTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Globalization;
+using Avalonia.Data.Converters;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Data;
+
+public class BoolConvertersTests
+{
+    [Fact]
+    public void BoolConverters_Not_Works_TwoWay()
+    {
+        var converter = BoolConverters.Not;
+        var result = converter.Convert(true, typeof(bool), null, CultureInfo.CurrentCulture);
+        Assert.False(Assert.IsType<bool>(result));
+
+        result = converter.ConvertBack(false, typeof(bool), null, CultureInfo.CurrentCulture);
+        Assert.True(Assert.IsType<bool>(result));
+    }
+
+    [Fact]
+    public void BoolConverters_Not_Returns_Unset_On_Invalid_Input()
+    {
+        var converter = BoolConverters.Not;
+        var result = converter.Convert(1234, typeof(bool), null, CultureInfo.CurrentCulture);
+        Assert.Equal(AvaloniaProperty.UnsetValue, result);
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, true)]
+    public void BoolConverters_And_Works(bool a, bool b, bool y)
+    {
+        var converter = BoolConverters.And;
+        var result = converter.Convert([a, b], typeof(bool), null, CultureInfo.CurrentCulture);
+        Assert.Equal(y, Assert.IsType<bool>(result));
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, true)]
+    public void BoolConverters_Or_Works(bool a, bool b, bool y)
+    {
+        var converter = BoolConverters.Or;
+        var result = converter.Convert([a, b], typeof(bool), null, CultureInfo.CurrentCulture);
+        Assert.Equal(y, Assert.IsType<bool>(result));
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/Data/BoolConvertersTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/BoolConvertersTests.cs
@@ -39,7 +39,7 @@ public class BoolConvertersTests
 
     [Theory]
     [InlineData(false, false, false)]
-    [InlineData(false, true, false)]
+    [InlineData(false, true, true)]
     [InlineData(true, false, true)]
     [InlineData(true, true, true)]
     public void BoolConverters_Or_Works(bool a, bool b, bool y)

--- a/tests/Avalonia.Base.UnitTests/Data/StringConvertersTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/StringConvertersTests.cs
@@ -1,0 +1,31 @@
+﻿using System.Globalization;
+using Avalonia.Data.Converters;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Data;
+
+public class StringConvertersTests
+{
+    [Theory]
+    [InlineData("hello", false)]
+    [InlineData("", true)]
+    [InlineData(null, true)]
+    public void StringConverters_IsNullOrEmpty_Works(string input, bool expected)
+    {
+        var converter = StringConverters.IsNullOrEmpty;
+        var result = converter.Convert(input, typeof(bool), null, CultureInfo.CurrentCulture);
+        Assert.Equal(expected, Assert.IsType<bool>(result));
+    }
+
+    [Theory]
+    [InlineData("hello", true)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void StringConverters_IsNotNullOrEmpty_Works(string input, bool expected)
+    {
+        var converter = StringConverters.IsNotNullOrEmpty;
+        var result = converter.Convert(input, typeof(bool), null, CultureInfo.CurrentCulture);
+        Assert.Equal(expected, Assert.IsType<bool>(result));
+    }
+
+}


### PR DESCRIPTION
## What does the pull request do?

As per title. Before this PR BoolConverters.Not worked only in one direction.
Also this PR adds missing tests for these converters.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

