### PR TITLE
Make MarkupExtension.ProvideValue method inlinable for StaticResourceExtension and ResolveByNameExtension

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResolveByNameExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResolveByNameExtension.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Avalonia.Controls;
 using Avalonia.Data.Core;
 
@@ -13,14 +14,17 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
 
         public string Name { get; }
 
-        public object? ProvideValue(IServiceProvider serviceProvider)
+        public object? ProvideValue(IServiceProvider serviceProvider) => ProvideValue(serviceProvider, Name);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static object? ProvideValue(IServiceProvider serviceProvider, string name)
         {
             var nameScope = serviceProvider.GetService<INameScope>();
 
             if (nameScope is null)
                 return null;
-            
-            var value = nameScope.FindAsync(Name);
+
+            var value = nameScope.FindAsync(name);
 
             if(value.IsCompleted)
                 return value.GetResult();


### PR DESCRIPTION
## What does the pull request do?

There is no XAML magic in this PR, just making extensions implementation easier to digest for JIT compiler.
With .NET 9 optimizations, extension object allocation can be eliminated, if it's simple enough for JIT compiler.
I was able to confirm it with Disasmo https://github.com/AvaloniaUI/Avalonia/issues/17622#issuecomment-2510311039
These changes didn't really improve our existing benchmarks to a measurable degree. Likely because we lazily evaluate most of static resources in our themes.

## What is the current behavior?

`{StaticResource}` object can't be inlined by JIT.

## What is the updated/expected behavior with this PR?

`{StaticResource}` object can be inlined by JIT.

## How was the solution implemented (if it's not obvious)?

Moves complex implementation details to a static stateless method, which we forcefully don't inline. Making instance extension method as simple, as possible (just a simple single `call`), allowing JIT to eliminate instance object creation completely.
Note: this improvement is in effect only with .NET 9 target.


Example of affected code:
```c#
public static object Build_664(IServiceProvider P_0)
{
    var context = CreateContext(P_0);
    SolidColorBrush solidColorBrush;
    SolidColorBrush result = (solidColorBrush = new SolidColorBrush());
    context.PushParent(solidColorBrush);
    StaticResourceExtension staticResourceExtension = new StaticResourceExtension("SystemAltHighColor");
    context.ProvideTargetProperty = SolidColorBrush.ColorProperty;
    object? obj = staticResourceExtension.ProvideValue(context);
    context.ProvideTargetProperty = null;
    XamlDynamicSetter_21(solidColorBrush, obj);
    context.PopParent();
    return result;
}
```

And generated assembly code (.NET 9). Left 11.2.2, right this PR.
Notable changes:
1. CORINFO_HELP_NEWSFAST and object allocation is removed.
2. Before `const string key` (0xD1FFAB1E) was assigned during object creation, after `const string key` is directly passed to the static method as a parameter.
![image](https://github.com/user-attachments/assets/14e2f84c-b732-4bd5-b4c6-7c00fe086fd3)
