### PR TITLE
DropShadowDirectionEffect: add AffectsRender for ShadowDepthProperty and DirectionProperty

### DIFF
--- a/src/Avalonia.Base/Media/Effects/DropShadowEffect.cs
+++ b/src/Avalonia.Base/Media/Effects/DropShadowEffect.cs
@@ -102,7 +102,7 @@ public sealed class DropShadowDirectionEffect : DropShadowEffectBase, IDirection
 
     static DropShadowDirectionEffect()
     {
-        AffectsRender<DropShadowEffect>(ShadowDepthProperty, DirectionProperty);
+        AffectsRender<DropShadowDirectionEffect>(ShadowDepthProperty, DirectionProperty);
     }
 
     public IImmutableEffect ToImmutable() => new ImmutableDropShadowDirectionEffect(OffsetX, OffsetY, BlurRadius, Color, Opacity);

--- a/src/Avalonia.Base/Media/Effects/DropShadowEffect.cs
+++ b/src/Avalonia.Base/Media/Effects/DropShadowEffect.cs
@@ -99,6 +99,11 @@ public sealed class DropShadowDirectionEffect : DropShadowEffectBase, IDirection
     
     public double OffsetX => Math.Cos(Direction * Math.PI / 180) * ShadowDepth;
     public double OffsetY => Math.Sin(Direction * Math.PI / 180) * ShadowDepth;
-    
+
+    static DropShadowDirectionEffect()
+    {
+        AffectsRender<DropShadowEffect>(ShadowDepthProperty, DirectionProperty);
+    }
+
     public IImmutableEffect ToImmutable() => new ImmutableDropShadowDirectionEffect(OffsetX, OffsetY, BlurRadius, Color, Opacity);
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixed an issue that value change on `Depth` and `Direction`will not trigger the re-render for the shadow


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Now the changes will affect the render


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
None

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
added a static ctor for DropShadowDirectionEffect:
```c#
static DropShadowDirectionEffect()
{
    AffectsRender<DropShadowEffect>(ShadowDepthProperty, DirectionProperty);
}
```


## Checklist

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
