### PR TITLE
#17675 - AfterPlatformServicesSetup callbacks are not called by the A…

### DIFF
--- a/src/Avalonia.Controls/AppBuilder.cs
+++ b/src/Avalonia.Controls/AppBuilder.cs
@@ -167,7 +167,7 @@ namespace Avalonia
         [PrivateApi]
         public AppBuilder AfterApplicationSetup(Action<AppBuilder> callback)
         {
-            AfterApplicationSetupCallback = (Action<AppBuilder>)Delegate.Combine(AfterPlatformServicesSetupCallback, callback);
+            AfterApplicationSetupCallback = (Action<AppBuilder>)Delegate.Combine(AfterApplicationSetupCallback, callback);
             return Self;
         }
 


### PR DESCRIPTION
…fterApplicationSetup callbacks anymore

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
This PR fixes the issue #17675 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
AfterApplicationServicesSetup delegate is not errorneously combined with the AfterPlatformServicesSetup  anymore.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
... it _is_ obvious, believe me ;-)

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
This was just a one-line typo fix. No doc required I guess.

## Breaking changes
<!--- List any breaking changes here. -->
None

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #17675
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
