### PR TITLE
Try fix Korean IME on iOS

### DIFF
--- a/src/iOS/Avalonia.iOS/TextInputResponder.cs
+++ b/src/iOS/Avalonia.iOS/TextInputResponder.cs
@@ -208,7 +208,6 @@ partial class AvaloniaView
             }
 
             TextInput(text);
-            _isInUpdate = false;
         }
 
         void IUIKeyInput.DeleteBackward() => KeyPress(Key.Back, PhysicalKey.Backspace, "\b");
@@ -227,7 +226,7 @@ partial class AvaloniaView
             string result = "";
             if (string.IsNullOrEmpty(_markedText))
             {
-                if (surroundingText != null && r.EndIndex < surroundingText.Length)
+                if (surroundingText != null && r.EndIndex <= surroundingText.Length)
                 {
                     result = surroundingText[r.StartIndex..r.EndIndex];
                 }

--- a/src/iOS/Avalonia.iOS/TextInputResponder.cs
+++ b/src/iOS/Avalonia.iOS/TextInputResponder.cs
@@ -219,8 +219,6 @@ partial class AvaloniaView
             var r = (AvaloniaTextRange)range;
             var surroundingText = _client.SurroundingText;
 
-            var currentSelection = _client.Selection;
-
             Logger.TryGet(LogEventLevel.Debug, ImeLog)?.Log(null, "IUIKeyInput.TextInRange {start} {end}", r.StartIndex, r.EndIndex);
 
             string result = "";
@@ -233,9 +231,10 @@ partial class AvaloniaView
             }
             else
             {
-                var span = new CombinedSpan3<char>(surroundingText.AsSpan().Slice(0, currentSelection.Start),
+                var currentSelection = _client.Selection;
+                var span = new CombinedSpan3<char>(surroundingText.AsSpan(0, currentSelection.Start),
                     _markedText,
-                    surroundingText.AsSpan().Slice(currentSelection.Start, currentSelection.End - currentSelection.Start));
+                    surroundingText.AsSpan(currentSelection.Start, currentSelection.End - currentSelection.Start));
                 var buf = new char[r.EndIndex - r.StartIndex];
                 span.CopyTo(buf, r.StartIndex);
                 result = new string(buf);


### PR DESCRIPTION
## What does the pull request do?

Tries to fix #16956 on iOS.


## What is the current behavior?
## What is the updated/expected behavior with this PR?

See #16956


## How was the solution implemented (if it's not obvious)?

With `ㅅ` in a text box, when the user types `ㅓ`, iOS invokes `IUIKeyInput.DeleteBackward` to remove `ㅅ`, and then `IUIKeyInput.InsertText` with `서`. Further typing `ㄴ` should result in another delete followed by the insertion of `선`.

However, the second `IUIKeyInput.DeleteBackward` does not currently happen and `ㄴ` is inserted instead, producing `서ㄴ`, probably due to how the previous delete was handled internally (resulting in the wrong return value from `IUITextInput.TextInRange`). With my change it is possible to type 3- and 4-character Korean syllabic blocks, but on only the first syllable. Additionally, manual deletion does not remove the entire syllable but only its last part (`선` becomes `서` when deleting), which is the norm for Korean.

Sadly, further syllables continue to be broken, and manual deletes without calling keydown only select the final character. I'd appreciate any tips, especially describing why and how the double key up/down backspace invocation is required.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

