### PR TITLE
Made OneTime bindings update on DataContext changes

### DIFF
--- a/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.GetValue.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.GetValue.cs
@@ -95,13 +95,13 @@ public abstract partial class BindingExpressionTests
     }
 
     [Fact]
-    public void TargetNullValue_Should_Not_Be_Used_When_Source_Is_Data_Context_And_Null()
+    public void TargetNullValue_Should_Be_Used_When_Source_Is_Data_Context_And_Null()
     {
         var target = CreateTarget<string?, string?>(
             o => o,
             targetNullValue: "bar");
 
-        Assert.Equal(null, target.String);
+        Assert.Equal("bar", target.String);
     }
 
     [Fact]
@@ -150,5 +150,17 @@ public abstract partial class BindingExpressionTests
         target.DataContext = data;
 
         Assert.Equal("fooBar", target.String);
+    }
+
+    [Fact]
+    public void Should_Use_Converter_For_Null_DataContext_Without_Path()
+    {
+        var converter = new PrefixConverter();
+        var target = CreateTarget<string?, string?>(
+            o => o,
+            converter: converter,
+            converterParameter: "foo");
+
+        Assert.Equal("foo", target.String);
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.Mode.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.Mode.cs
@@ -1,6 +1,5 @@
 using Avalonia.Data;
 using Xunit;
-using Xunit.Sdk;
 
 #nullable enable
 
@@ -9,21 +8,64 @@ namespace Avalonia.Base.UnitTests.Data.Core;
 public partial class BindingExpressionTests
 {
     [Fact]
-    public void OneTime_Binding_Sets_Target_Only_Once()
+    public void OneTime_Binding_Sets_Target_Only_Once_If_Data_Context_Does_Not_Change()
     {
-        var data = new ViewModel { StringValue = "foo" };
-        var target = CreateTargetWithSource(data, x => x.StringValue, mode: BindingMode.OneTime);
+        var data = new ViewModel { Next = new ViewModel { StringValue = "foo" } };
+        var target = CreateTarget<ViewModel, string?>(x => x.Next!.StringValue, mode: BindingMode.OneTime);
+        target.DataContext = data;
 
         Assert.Equal("foo", target.String);
 
-        data.StringValue = "bar";
+        data.Next!.StringValue = "bar";
         Assert.Equal("foo", target.String);
+
+        data.Next = new ViewModel { StringValue = "baz" };
+        Assert.Equal("foo", target.String);
+    }
+
+    [Fact]
+    public void OneTime_Binding_With_Simple_Path_Sets_Target_When_Data_Context_Changes()
+    {
+        var data1 = new ViewModel { StringValue = "foo" };
+        var target = CreateTarget<ViewModel, string?>(x => x.StringValue, mode: BindingMode.OneTime);
+        target.DataContext = data1;
+
+        Assert.Equal("foo", target.String);
+
+        var data2 = new ViewModel { StringValue = "bar" };
+        target.DataContext = data2;
+        Assert.Equal("bar", target.String);
+    }
+
+    [Fact]
+    public void OneTime_Binding_With_Complex_Path_Sets_Target_When_Data_Context_Changes()
+    {
+        var data1 = new ViewModel { Next = new ViewModel { StringValue = "foo" } };
+        var target = CreateTarget<ViewModel, string?>(x => x.Next!.StringValue, mode: BindingMode.OneTime);
+        target.DataContext = data1;
+
+        Assert.Equal("foo", target.String);
+
+        var data2 = new ViewModel { Next = new ViewModel { StringValue = "bar" } };
+        target.DataContext = data2;
+        Assert.Equal("bar", target.String);
+    }
+
+    [Fact]
+    public void OneTime_Binding_Without_Path_Sets_Target_When_Data_Context_Changes()
+    {
+        var target = CreateTarget<string, string?>(x => x, mode: BindingMode.OneTime);
+        target.DataContext = "foo";
+
+        Assert.Equal("foo", target.String);
+
+        target.DataContext = "bar";
+        Assert.Equal("bar", target.String);
     }
 
     [Fact]
     public void OneTime_Binding_Waits_For_DataContext()
     {
-        var data = new ViewModel { StringValue = "foo" };
         var target = CreateTarget<ViewModel, string?>(
             x => x.StringValue,
             mode: BindingMode.OneTime);

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
@@ -152,21 +152,6 @@ namespace Avalonia.Markup.UnitTests.Data
         }
 
         [Fact]
-        public void OneTime_Binding_Releases_Subscription_If_DataContext_Set_Later()
-        {
-            var target = new TextBlock();
-            var source = new Source { Foo = "foo" };
-
-            target.Bind(TextBlock.TextProperty, new Binding("Foo", BindingMode.OneTime));
-            target.DataContext = source;
-
-            // Forces WeakEvent compact
-            Dispatcher.UIThread.RunJobs();
-
-            Assert.Equal(0, source.SubscriberCount);
-        }
-
-        [Fact]
         public void OneWayToSource_Binding_Should_Be_Set_Up()
         {
             var source = new Source { Foo = "foo" };


### PR DESCRIPTION
## What does the pull request do?
This PR changes how bindings with a `OneTime` mode work, to behave the same way as in WPF (and as currently documented), updating their target not only a single time, but once per data context change.

In addition, `null` data contexts are now considered valid values for bindings without a path.

## What is the current behavior?
`OneTime` bindings are evaluated only once.
Bindings without a path (`{Binding}`) are considered "pending" (they don't update their target nor call their converter) while their data context is `null`.

## What is the updated/expected behavior with this PR?
`OneTime` bindings are evaluated once _per data context_, like in WPF.
`null` is now a valid `DataContext` for pathless bindings, and will use the configured `TargetNullValue` and `Converter`, also matching WPF.

## Notes
As explained in https://github.com/AvaloniaUI/Avalonia/issues/17587#issuecomment-2493943363, the two changes are entangled: with the previous behavior we can't have `null` be a valid data context without breaking `OneTime` bindings using them.

Unit tests have been added.
One unit test has been deleted, since one-time bindings now don't stop on the first update.

## Fixed issues
 - Fixes #17587
 - Fixes #17474
 - Fixes #17649