### PR TITLE
Ignore key modifiers on text editing if field is a password field.

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1425,6 +1425,7 @@ namespace Avalonia.Controls
             }
             else
             {
+                // It's not secure to rely on password field content when moving.
                 bool hasWholeWordModifiers = modifiers.HasAllFlags(keymap.WholeWordTextActionModifiers) && !IsPasswordBox;
                 switch (e.Key)
                 {

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1425,7 +1425,7 @@ namespace Avalonia.Controls
             }
             else
             {
-                bool hasWholeWordModifiers = modifiers.HasAllFlags(keymap.WholeWordTextActionModifiers);
+                bool hasWholeWordModifiers = modifiers.HasAllFlags(keymap.WholeWordTextActionModifiers) && !IsPasswordBox;
                 switch (e.Key)
                 {
                     case Key.Left:

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -130,6 +130,27 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void TextBox_Ignore_Word_Move_In_Password_Field()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var target = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    PasswordChar = '*',
+                    Text = "passw0rd"
+                };
+
+                target.ApplyTemplate();
+                target.Measure(Size.Infinity);
+                target.CaretIndex = 8;
+                RaiseKeyEvent(target, Key.Left, KeyModifiers.Control);
+
+                Assert.Equal(7, target.CaretIndex);
+            }
+        }
+
+        [Fact]
         public void CaretIndex_Can_Moved_To_Position_After_The_End_Of_Text_With_Arrow_Key()
         {
             using (UnitTestApplication.Start(Services))


### PR DESCRIPTION
## What does the pull request do?
It's not secure to rely on password field content when moving. It's should give no information what so ever.

## What is the current behavior?
When you press ctrl+left on the password field with content `some passw0rd`, cursor jumps to `0`. It can give some information about password, which is bad.

## What is the updated/expected behavior with this PR?
You press ctrl+left and it moves one char left.

## How was the solution implemented (if it's not obvious)?
Just added `IsPasswordBox` check. 

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

## Obsoletions / Deprecations

## Fixed issues
Can't find any.
