### PR TITLE
Make `UniformGrid` account for layout rounding.

### DIFF
--- a/src/Avalonia.Controls/Primitives/UniformGrid.cs
+++ b/src/Avalonia.Controls/Primitives/UniformGrid.cs
@@ -89,27 +89,45 @@ namespace Avalonia.Controls.Primitives
 
         protected override Size ArrangeOverride(Size finalSize)
         {
-            var x = FirstColumn;
-            var y = 0;
-
-            var width = finalSize.Width / _columns;
-            var height = finalSize.Height / _rows;
+            var columnIndex = FirstColumn;
+            var columnWidth = finalSize.Width / _columns;
+            var rowIndex = 0;
+            var rowHeight = finalSize.Height / _rows;
+            var x = 0.0;
+            var y = 0.0;
+            var nextY = 0.0;
 
             foreach (var child in Children)
             {
-                if (!child.IsVisible)
+                if (child.IsVisible)
                 {
-                    continue;
+                    // Layout scaling may cause the child to take a different size than the one
+                    // requested. Layout each each child with it's top-left aligned against the
+                    // previous column/row bounds and request the bottom-right to be placed in
+                    // the ideal position.
+                    var topLeft = new Point(x, y);
+                    var bottomRight = new Point((columnIndex + 1) * columnWidth, (rowIndex + 1) * rowHeight);
+
+                    child.Arrange(new Rect(topLeft, bottomRight));
+
+                    x = child.Bounds.Right;
+                    nextY = Math.Max(nextY, child.Bounds.Bottom);
+                }
+                else
+                {
+                    x += columnWidth;
+                    nextY = Math.Max(nextY, rowHeight);
                 }
 
-                child.Arrange(new Rect(x * width, y * height, width, height));
+                columnIndex++;
 
-                x++;
-
-                if (x >= _columns)
+                if (columnIndex >= _columns)
                 {
                     x = 0;
-                    y++;
+                    y = nextY;
+                    nextY = 0;
+                    columnIndex = 0;
+                    rowIndex++;
                 }
             }
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/UniformGridTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/UniformGridTests.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Controls.Primitives;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Primitives
@@ -139,6 +140,76 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
             // 2 * 2 grid
             Assert.Equal(new Size(2 * 50, 2 * 70), target.Bounds.Size);
+        }
+
+        [Fact]
+        public void Children_Do_Not_Overlap_With_125_Percent_Scaling_1()
+        {
+            // Issue #17699
+            var target = new UniformGrid
+            {
+                Columns = 2,
+                Children =
+                {
+                    new Border(),
+                    new Border(),
+                    new Border(),
+                    new Border(),
+                }
+            };
+
+            var root = new TestRoot
+            {
+                LayoutScaling = 1.25,
+                Child = new Border
+                {
+                    Width = 100,
+                    Height = 100,
+                    Child = target,
+                }
+            };
+
+            root.ExecuteInitialLayoutPass();
+
+            Assert.Equal(new(0, 0, 50.4, 50.4), target.Children[0].Bounds);
+            Assert.Equal(new(50.4, 0, 49.6, 50.4), target.Children[1].Bounds);
+            Assert.Equal(new(0, 50.4, 50.4, 49.6), target.Children[2].Bounds);
+            Assert.Equal(new(50.4, 50.4, 49.6, 49.6), target.Children[3].Bounds);
+        }
+
+        [Fact]
+        public void Children_Do_Not_Overlap_With_125_Percent_Scaling_2()
+        {
+            // Issue #17699
+            var target = new UniformGrid
+            {
+                Columns = 4,
+                Children =
+                {
+                    new Border(),
+                    new Border(),
+                    new Border(),
+                    new Border(),
+                }
+            };
+
+            var root = new TestRoot
+            {
+                LayoutScaling = 1.25,
+                Child = new Border
+                {
+                    Width = 100,
+                    Height = 100,
+                    Child = target,
+                }
+            };
+
+            root.ExecuteInitialLayoutPass();
+
+            Assert.Equal(new(0, 0, 25.6, 100), target.Children[0].Bounds);
+            Assert.Equal(new(25.6, 0, 24.8, 100), target.Children[1].Bounds);
+            Assert.Equal(new(50.4, 0, 24.8, 100), target.Children[2].Bounds);
+            Assert.Equal(new(75.2, 0, 24.8, 100), target.Children[3].Bounds);
         }
     }
 }

--- a/tests/Avalonia.UnitTests/TestRoot.cs
+++ b/tests/Avalonia.UnitTests/TestRoot.cs
@@ -55,7 +55,7 @@ namespace Avalonia.UnitTests
         internal ILayoutManager LayoutManager { get; set; }
         ILayoutManager ILayoutRoot.LayoutManager => LayoutManager;
 
-        public double RenderScaling => 1;
+        public double RenderScaling => LayoutScaling;
 
         internal IRenderer Renderer { get; set; }
         internal IHitTester HitTester { get; set; }


### PR DESCRIPTION
## What does the pull request do?

As described in #17699, `UniformGrid` was ported from WPF but Avalonia's layout rounding is slightly different. Update `ArrangeOverride` to account for this.

Instead of arranging each child without considering whether it was snapped to the pixel grid, layout each each child with it's top-left aligned against the previous column/row, with the bottom-right placed in the ideal position. This ensures that there are no overlapping/spaces between controls, and also ensures that the overall uniform grid is preserved.

## Fixed issues

Fixes #17699