### PR TITLE
Fix KnownFolder for x86 Windows

### DIFF
--- a/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageProvider.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageProvider.cs
@@ -153,20 +153,15 @@ internal abstract class BclStorageProvider : IStorageProvider
         char* path = null;
         string? result = null;
 
-        try
+        var hr = SHGetKnownFolderPath(&guid, 0, null, &path);
+        if (hr == 0)
         {
-            var hr = SHGetKnownFolderPath(&guid, 0, null, &path);
-            if (hr == 0)
-            {
-                result = Marshal.PtrToStringUni((IntPtr)path);
-            }
+            result = Marshal.PtrToStringUni((IntPtr)path);
         }
-        finally
+
+        if (path != null)
         {
-            if (path != null)
-            {
-                Marshal.FreeCoTaskMem((IntPtr)path);
-            }
+            Marshal.FreeCoTaskMem((IntPtr)path);
         }
 
         return result;

--- a/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageProvider.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageProvider.cs
@@ -150,22 +150,22 @@ internal abstract class BclStorageProvider : IStorageProvider
 
     private static unsafe string? TryGetWindowsKnownFolder(Guid guid)
     {
-        nint path = IntPtr.Zero;
+        char* path = null;
         string? result = null;
 
         try
         {
-            var hr = SHGetKnownFolderPath(guid, 0, 0, &path);
+            var hr = SHGetKnownFolderPath(&guid, 0, null, &path);
             if (hr == 0)
             {
-                result = Marshal.PtrToStringUni(path);
+                result = Marshal.PtrToStringUni((IntPtr)path);
             }
         }
         finally
         {
-            if (path != IntPtr.Zero)
+            if (path != null)
             {
-                Marshal.FreeCoTaskMem(path);
+                Marshal.FreeCoTaskMem((IntPtr)path);
             }
         }
 
@@ -173,6 +173,6 @@ internal abstract class BclStorageProvider : IStorageProvider
     }
 
     private static readonly Guid s_folderDownloads = new Guid("374DE290-123F-4565-9164-39C4925E467B");
-    [DllImport("shell32.dll")]
-    private static unsafe extern int SHGetKnownFolderPath([MarshalAs(UnmanagedType.LPStruct)] Guid id, int flags, nint token, nint* ppszPath);
+    [DllImport("shell32.dll", ExactSpelling = true)]
+    private static unsafe extern int SHGetKnownFolderPath(Guid* rfid, uint dwFlags, void* hToken, char** ppszPath);
 }


### PR DESCRIPTION
## What does the pull request do?

Fixes an `AccessViolationException` when `StorageProvider.TryGetWellKnownFolderAsync(WellKnownFolder.Downloads)` is called on Windows x86.

## What is the current behavior?

`AccessViolationException` on Windows x86, works on Windows x64. Unknown on Windows ARM.

## What is the updated/expected behavior with this PR?

Works on Windows x86/x64. Untested on Windows ARM (no device to test with).

## How was the solution implemented (if it's not obvious)?

Eliminate `MarshalAs(UnmanagedType.LPStruct)] Guid` in favor of `Guid*`. Suspect some marshaling difference is at play and prefer the directly blittable type.

Thanks to @tannergooding for guidance and overall style cleanups.

Removed try-finally as there aren't any exceptions to handle -- prototype version used an early return.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Fixes #17679
