### PR TITLE
bugfix: ScrollBar will be hidden when ScrollBarVisibility is specified as Visible

### DIFF
--- a/src/Avalonia.Controls/Converters/MenuScrollingVisibilityConverter.cs
+++ b/src/Avalonia.Controls/Converters/MenuScrollingVisibilityConverter.cs
@@ -57,6 +57,9 @@ namespace Avalonia.Controls.Converters
                 return true;
             }
 
+            if (visibility == ScrollBarVisibility.Visible) 
+                return true;
+            
             return false;
         }
     }

--- a/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
@@ -469,6 +469,15 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Vector(0, 0), target.Offset);
         }
 
+        [Fact]
+        public void MenuScrollBar_Should_Be_Visible_When_Specified_Visible()
+        {
+            Converters.MenuScrollingVisibilityConverter converter = Converters.MenuScrollingVisibilityConverter.Instance;
+            IList<object> args = new List<object> {ScrollBarVisibility.Visible,400d,1800d,500d};
+            var result = converter.Convert(args, typeof(ScrollBarVisibility), "0", System.Globalization.CultureInfo.CurrentCulture);
+            Assert.Equal(true, result);
+        }
+        
         private Point GetRootPoint(Visual control, Point p)
         {
             if (control.GetVisualRoot() is Visual root &&


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This pull request fixes the bug that when ***SimpleMenuScrollViewer***'s `ScrollBarVisibility` is specified as `ScrollBarVisibility.Visible`,  ***MenuScrollingVisibilityConverter*** returns `false`, which is counterintuitive.

## What is the current behavior?
When ***SimpleMenuScrollViewer***'s `ScrollBarVisibility` is specified as `ScrollBarVisibility.Visible`, 
 ***MenuScrollingVisibilityConverter*** returns `false`


## What is the updated/expected behavior with this PR?
If `ScrollBarVisibility` is specified as `ScrollBarVisibility.Visible`,  the converter will return `true` now.
**Any other behavior was unchanged.**


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Fixes #17715 
