### PR TITLE
Fix TextAlignment="DetectFromContent"

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
@@ -18,6 +18,9 @@ namespace Avalonia.Media.TextFormatting
         private TextLineBreak? _textLineBreak;
         private readonly FlowDirection _resolvedFlowDirection;
 
+        private Rect _inkBounds;
+        private Rect _bounds;
+
         public TextLineImpl(TextRun[] textRuns, int firstTextSourceIndex, int length, double paragraphWidth,
             TextParagraphProperties paragraphProperties, FlowDirection resolvedFlowDirection = FlowDirection.LeftToRight,
             TextLineBreak? lineBreak = null, bool hasCollapsed = false)
@@ -85,10 +88,20 @@ namespace Avalonia.Media.TextFormatting
         /// <inheritdoc/>
         public override double WidthIncludingTrailingWhitespace => _textLineMetrics.WidthIncludingTrailingWhitespace;
 
+        /// <summary>
+        /// Get the logical text bounds.
+        /// </summary>
+        internal Rect Bounds => _bounds;
+
+        /// <summary>
+        /// Get the bounding box that is covered with black pixels.
+        /// </summary>
+        internal Rect InkBounds => _inkBounds;
+
         /// <inheritdoc/>
         public override void Draw(DrawingContext drawingContext, Point lineOrigin)
         {
-            var (currentX, currentY) = lineOrigin + new Point(Start, 0);
+            var (currentX, currentY) = lineOrigin + new Point(Start, 0);           
 
             foreach (var textRun in _textRuns)
             {
@@ -1376,6 +1389,10 @@ namespace Avalonia.Media.TextFormatting
             }
 
             var start = GetParagraphOffsetX(width, widthIncludingWhitespace);
+
+            _inkBounds = new Rect(bounds.Position + new Point(start, 0), bounds.Size);
+
+            _bounds = new Rect(start, 0, widthIncludingWhitespace, height);
 
             return new TextLineMetrics
             {

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -740,9 +740,7 @@ namespace Avalonia.Controls
             //This implicitly recreated the TextLayout with a new constraint if we previously reset it.
             var textLayout = TextLayout;
 
-            var width = textLayout.OverhangLeading + textLayout.WidthIncludingTrailingWhitespace + textLayout.OverhangTrailing;
-
-            var size = LayoutHelper.RoundLayoutSizeUp(new Size(width, textLayout.Height).Inflate(padding), 1, 1);
+            var size = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.MinTextWidth, textLayout.Height).Inflate(padding), 1, 1);
 
             return size;
         }

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Avalonia.Controls.Documents;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
@@ -6,6 +6,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.UnitTests;
 using Xunit;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace Avalonia.Controls.UnitTests
 {
@@ -45,6 +46,29 @@ namespace Avalonia.Controls.UnitTests
                 textBlock.Measure(new Size(50, 100));
 
                 Assert.NotEqual(textLayout, textBlock.TextLayout);
+            }
+        }
+
+        [Fact]
+        public void Should_Measure_MinTextWith()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var textBlock = new TextBlock
+                {
+                    Text = "Hello&#10;שלום&#10;Really really really really long line",
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    TextAlignment = TextAlignment.DetectFromContent,
+                    TextWrapping = TextWrapping.Wrap
+                };
+
+                textBlock.Measure(new Size(1920, 1080));
+
+                var textLayout = textBlock.TextLayout;
+
+                var constraint = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.MinTextWidth, textLayout.Height), 1, 1);
+
+                Assert.Equal(textBlock.DesiredSize, constraint);
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR reworks the way TextLayout computes its metrics. It now builds a union of all text line bounds and calculates the minimal required width of the TextLayout to render all lines without wrapping or trimming. This is required to horizontally align text constrained by a width greater than the required width.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Currently, the TextLayout takes all the available space and there is no way to know what the minimal required width is so text gets layout bigger than it should be.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes: #16009