### PR TITLE
[Text] Make BreakUnit a readonly struct

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/LineBreakEnumerator.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/LineBreakEnumerator.cs
@@ -323,14 +323,14 @@ namespace Avalonia.Media.TextFormatting.Unicode
         {
             if (state.Current.LineBreakClass == LineBreakClass.CombiningMark)
             {
-                state.Current = state.Current.WithLineBreakClass(LineBreakClass.Alphabetic);
+                state.Current = state.Current with { LineBreakClass = LineBreakClass.Alphabetic, Inherited = true };
             }
 
             var next = state.Next(text);
 
             if (next.LineBreakClass == LineBreakClass.CombiningMark)
             {
-                state.ReplaceNext(next.WithLineBreakClass(LineBreakClass.Alphabetic));
+                state.ReplaceNext(next with { LineBreakClass = LineBreakClass.Alphabetic, Inherited = true });
             }
             return RuleResult.Pass;
         }
@@ -1438,16 +1438,6 @@ namespace Avalonia.Media.TextFormatting.Unicode
             public bool Ignored { get; init; }
             public bool Inherited { get; init; }
 
-            public BreakUnit WithLineBreakClass(LineBreakClass lineBreakClass)
-            {
-                return new BreakUnit(this, lineBreakClass) { Inherited = true };
-            }
-
-            public BreakUnit Ignore()
-            {
-                return new BreakUnit(this, LineBreakClass) { Ignored = true };
-            }
-
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private static LineBreakClass MapClass(Codepoint cp)
             {
@@ -1562,7 +1552,7 @@ namespace Avalonia.Media.TextFormatting.Unicode
 
             public void IgnoreNext(ReadOnlySpan<char> text)
             {
-                _next = Next(text).Ignore();
+                _next = Next(text) with { Ignored = true };
             }
 
             public void ReplaceNext(BreakUnit next)
@@ -1634,7 +1624,7 @@ namespace Avalonia.Media.TextFormatting.Unicode
 
                 if (Current.Ignored)
                 {
-                    Current = Current.WithLineBreakClass(Previous.LineBreakClass);
+                    Current = Current with { LineBreakClass = Previous.LineBreakClass, Inherited = true };
                 }
 
                 return next;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR makes BreakUnit a struct to avoid allocations within the LineBreakEnumerator

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
