### PR TITLE
[macOS]: Don't set IsModal when changing window parent.

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
@@ -106,7 +106,6 @@ protected:
     AvnPoint lastPositionSet;
     bool _shown;
     std::list<WindowBaseImpl*> _children;
-    bool _isModal;
 
 public:
     WindowBaseImpl* Parent = nullptr;

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -498,9 +498,7 @@ HRESULT WindowBaseImpl::SetParent(IAvnWindowBase *parent) {
         auto cparent = dynamic_cast<WindowImpl *>(parent);
         
         Parent = cparent;
-
-        _isModal = Parent != nullptr;
-        
+       
         if(Parent != nullptr && Window != nullptr){
             // If one tries to show a child window with a minimized parent window, then the parent window will be
             // restored but macOS isn't kind enough to *tell* us that, so the window will be left in a non-interactive

--- a/native/Avalonia.Native/src/OSX/WindowImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.h
@@ -101,6 +101,7 @@ private:
     bool _transitioningWindowState;
     bool _isClientAreaExtended;
     AvnExtendClientAreaChromeHints _extendClientHints;
+    bool _isModal;
 };
 
 #endif //AVALONIA_NATIVE_OSX_WINDOWIMPL_H


### PR DESCRIPTION
## What does the pull request do?

Don't set a window's `_isModal` flag when changing window parent. This caused non-modal windows to behave as modal windows if their owner was changed.

The modality of a window is decided at the time it is shown, and indicated by the `isDialog` parameter to `WindowImpl::Show`. This state doesn't change if its owner changes.

The code was also rather confusing in that `_isModal` was defined in `WindowBaseImpl` but `WindowBaseImpl.IsModal` always returned false. `WindowImpl.IsModal` then overrode `IsModal` to return WindowBaseImpl._isModal. That's messed up. Just define `_isModal` in `WindowImpl` not `WindowBaseImpl`.

Fixes an issue with AvalonDock on XPF.