### PR TITLE
Add SpanStringTokenizer and avoid many string allocations in FontCollectionBase

### DIFF
--- a/src/Avalonia.Base/Animation/KeySpline.cs
+++ b/src/Avalonia.Base/Animation/KeySpline.cs
@@ -83,7 +83,7 @@ namespace Avalonia.Animation
         {
             culture ??= CultureInfo.InvariantCulture;
 
-            using var tokenizer = new StringTokenizer(value, culture, exceptionMessage: $"Invalid KeySpline string: \"{value}\".");
+            using var tokenizer = new SpanStringTokenizer(value, culture, exceptionMessage: $"Invalid KeySpline string: \"{value}\".");
             return new KeySpline(tokenizer.ReadDouble(), tokenizer.ReadDouble(), tokenizer.ReadDouble(), tokenizer.ReadDouble());
         }
 

--- a/src/Avalonia.Base/Animation/Spring.cs
+++ b/src/Avalonia.Base/Animation/Spring.cs
@@ -61,7 +61,7 @@ internal class Spring
             culture = CultureInfo.InvariantCulture;
         }
 
-        using var tokenizer = new StringTokenizer(value, culture, exceptionMessage: $"Invalid Spring string: \"{value}\".");
+        using var tokenizer = new SpanStringTokenizer(value, culture, exceptionMessage: $"Invalid Spring string: \"{value}\".");
         return new Spring(tokenizer.ReadDouble(), tokenizer.ReadDouble(), tokenizer.ReadDouble(), tokenizer.ReadDouble());
     }
 

--- a/src/Avalonia.Base/CornerRadius.cs
+++ b/src/Avalonia.Base/CornerRadius.cs
@@ -94,7 +94,7 @@ namespace Avalonia
         {
             const string exceptionMessage = "Invalid CornerRadius.";
 
-            using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage))
+            using (var tokenizer = new SpanStringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage))
             {
                 if (tokenizer.TryReadDouble(out var a))
                 {

--- a/src/Avalonia.Base/Matrix.cs
+++ b/src/Avalonia.Base/Matrix.cs
@@ -504,7 +504,7 @@ namespace Avalonia
             double v8 = 0;
             double v9 = 0;
 
-            using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid Matrix."))
+            using (var tokenizer = new SpanStringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid Matrix."))
             {
                 var v1 = tokenizer.ReadDouble();
                 var v2 = tokenizer.ReadDouble();

--- a/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
+++ b/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
@@ -12,49 +12,6 @@ namespace Avalonia.Media.Fonts
 {
     public abstract class FontCollectionBase : IFontCollection
     {
-        // Compile-time mappings to avoid string allocations while parsing font names with modifiers.
-        private static readonly (string, FontStyle)[] s_fontStyles =
-        [
-            ("Normal", FontStyle.Normal),
-            ("Italic", FontStyle.Italic),
-            ("Oblique", FontStyle.Oblique)
-        ];
-
-        private static readonly (string, FontWeight)[] s_fontWeights =
-        [
-            ("Thin", FontWeight.Thin),
-            ("ExtraLight", FontWeight.ExtraLight),
-            ("UltraLight", FontWeight.UltraLight),
-            ("Light", FontWeight.Light),
-            ("SemiLight", FontWeight.SemiLight),
-            ("Normal", FontWeight.Normal),
-            ("Regular", FontWeight.Regular),
-            ("Medium", FontWeight.Medium),
-            ("DemiBold", FontWeight.DemiBold),
-            ("SemiBold", FontWeight.SemiBold),
-            ("Bold", FontWeight.Bold),
-            ("ExtraBold", FontWeight.ExtraBold),
-            ("UltraBold", FontWeight.UltraBold),
-            ("Black", FontWeight.Black),
-            ("Heavy", FontWeight.Heavy),
-            ("Solid", FontWeight.Solid),
-            ("ExtraBlack", FontWeight.ExtraBlack),
-            ("UltraBlack", FontWeight.UltraBlack),
-        ];
-
-        private static readonly (string, FontStretch)[] s_fontStretches =
-        [
-            ("Normal", FontStretch.Normal),
-            ("UltraCondensed", FontStretch.UltraCondensed),
-            ("ExtraCondensed", FontStretch.ExtraCondensed),
-            ("Condensed", FontStretch.Condensed),
-            ("SemiCondensed", FontStretch.SemiCondensed),
-            ("SemiExpanded", FontStretch.SemiExpanded),
-            ("Expanded", FontStretch.Expanded),
-            ("ExtraExpanded", FontStretch.ExtraExpanded),
-            ("UltraExpanded", FontStretch.UltraExpanded),
-        ];
-
         protected readonly ConcurrentDictionary<string, ConcurrentDictionary<FontCollectionKey, IGlyphTypeface?>> _glyphTypefaceCache = new();
 
         public abstract Uri Key { get; }
@@ -333,17 +290,17 @@ namespace Avalonia.Media.Fonts
 
                 // Try match with font style, weight or stretch and update accordingly.
                 var match = false;
-                if (TryParseEnumItem(s_fontStyles, token, out var newStyle))
+                if (EnumHelper.TryParse<FontStyle>(token, true, out var newStyle))
                 {
                     style = newStyle;
                     match = true;
                 }
-                else if (TryParseEnumItem(s_fontWeights, token, out var newWeight))
+                else if (EnumHelper.TryParse<FontWeight>(token, true, out var newWeight))
                 {
                     weight = newWeight;
                     match = true;
                 }
-                else if (TryParseEnumItem(s_fontStretches, token, out var newStretch))
+                else if (EnumHelper.TryParse<FontStretch>(token, true, out var newStretch))
                 {
                     stretch = newStretch;
                     match = true;
@@ -363,22 +320,6 @@ namespace Avalonia.Media.Fonts
 
             //Preserve old font source
             return new Typeface(typeface.FontFamily, style, weight, stretch);
-        }
-
-        private static bool TryParseEnumItem<T>((string, T)[] mapping, ReadOnlySpan<char> token, out T value)
-            where T : struct, Enum
-        {
-            foreach (var (key, candidate) in mapping)
-            {
-                if (token.Equals(key.AsSpan(), StringComparison.OrdinalIgnoreCase))
-                {
-                    value = candidate;
-                    return true;
-                }
-            }
-
-            value = default;
-            return false;
         }
     }
 }

--- a/src/Avalonia.Base/Media/TextDecorationCollection.cs
+++ b/src/Avalonia.Base/Media/TextDecorationCollection.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Media
         {
             var locations = new List<TextDecorationLocation>();
 
-            using (var tokenizer = new StringTokenizer(s, ',', "Invalid text decoration."))
+            using (var tokenizer = new SpanStringTokenizer(s, ',', "Invalid text decoration."))
             {
                 while (tokenizer.TryReadSpan(out var name))
                 {

--- a/src/Avalonia.Base/PixelPoint.cs
+++ b/src/Avalonia.Base/PixelPoint.cs
@@ -117,7 +117,7 @@ namespace Avalonia
         /// <returns>The <see cref="PixelPoint"/>.</returns>
         public static PixelPoint Parse(string s)
         {
-            using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid PixelPoint."))
+            using (var tokenizer = new SpanStringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid PixelPoint."))
             {
                 return new PixelPoint(
                     tokenizer.ReadInt32(),

--- a/src/Avalonia.Base/PixelRect.cs
+++ b/src/Avalonia.Base/PixelRect.cs
@@ -433,7 +433,7 @@ namespace Avalonia
         /// <returns>The parsed <see cref="PixelRect"/>.</returns>
         public static PixelRect Parse(string s)
         {
-            using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid PixelRect."))
+            using (var tokenizer = new SpanStringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid PixelRect."))
             {
                 return new PixelRect(
                     tokenizer.ReadInt32(),

--- a/src/Avalonia.Base/PixelSize.cs
+++ b/src/Avalonia.Base/PixelSize.cs
@@ -92,7 +92,7 @@ namespace Avalonia
             {
                 return false;
             }
-            using (var tokenizer = new StringTokenizer(source, exceptionMessage: "Invalid PixelSize."))
+            using (var tokenizer = new SpanStringTokenizer(source, exceptionMessage: "Invalid PixelSize."))
             {
                 if (tokenizer.TryReadInt32(out var w) && tokenizer.TryReadInt32(out var h))
                 {

--- a/src/Avalonia.Base/Point.cs
+++ b/src/Avalonia.Base/Point.cs
@@ -184,7 +184,7 @@ namespace Avalonia
         /// <returns>The <see cref="Point"/>.</returns>
         public static Point Parse(string s)
         {
-            using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid Point."))
+            using (var tokenizer = new SpanStringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid Point."))
             {
                 return new Point(
                     tokenizer.ReadDouble(),

--- a/src/Avalonia.Base/Rect.cs
+++ b/src/Avalonia.Base/Rect.cs
@@ -592,7 +592,7 @@ namespace Avalonia
         /// <returns>The parsed <see cref="Rect"/>.</returns>
         public static Rect Parse(string s)
         {
-            using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid Rect."))
+            using (var tokenizer = new SpanStringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid Rect."))
             {
                 return new Rect(
                     tokenizer.ReadDouble(),

--- a/src/Avalonia.Base/RelativePoint.cs
+++ b/src/Avalonia.Base/RelativePoint.cs
@@ -169,7 +169,7 @@ namespace Avalonia
         /// <returns>The parsed <see cref="RelativePoint"/>.</returns>
         public static RelativePoint Parse(string s)
         {
-            using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid RelativePoint."))
+            using (var tokenizer = new SpanStringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid RelativePoint."))
             {
                 var x = tokenizer.ReadString();
                 var y = tokenizer.ReadString();

--- a/src/Avalonia.Base/RelativeRect.cs
+++ b/src/Avalonia.Base/RelativeRect.cs
@@ -176,7 +176,7 @@ namespace Avalonia
         /// <returns>The parsed <see cref="RelativeRect"/>.</returns>
         public static RelativeRect Parse(string s)
         {
-            using (var tokenizer = new StringTokenizer(s, exceptionMessage: "Invalid RelativeRect."))
+            using (var tokenizer = new SpanStringTokenizer(s, exceptionMessage: "Invalid RelativeRect."))
             {
                 var x = tokenizer.ReadSpan();
                 var y = tokenizer.ReadSpan();

--- a/src/Avalonia.Base/Size.cs
+++ b/src/Avalonia.Base/Size.cs
@@ -161,7 +161,7 @@ namespace Avalonia
         /// <returns>The <see cref="Size"/>.</returns>
         public static Size Parse(string s)
         {
-            using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid Size."))
+            using (var tokenizer = new SpanStringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid Size."))
             {
                 return new Size(
                     tokenizer.ReadDouble(),

--- a/src/Avalonia.Base/Thickness.cs
+++ b/src/Avalonia.Base/Thickness.cs
@@ -197,7 +197,7 @@ namespace Avalonia
         {
             const string exceptionMessage = "Invalid Thickness.";
 
-            using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage))
+            using (var tokenizer = new SpanStringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage))
             {
                 if (tokenizer.TryReadDouble(out var a))
                 {

--- a/src/Avalonia.Base/Utilities/EnumHelper.cs
+++ b/src/Avalonia.Base/Utilities/EnumHelper.cs
@@ -9,10 +9,25 @@ namespace Avalonia.Utilities
         {
             return Enum.Parse<T>(key, ignoreCase);
         }
+
+        public static bool TryParse<T>(ReadOnlySpan<char> key, bool ignoreCase, out T result) where T : struct
+        {
+            return Enum.TryParse(key, ignoreCase, out result);
+        }
 #else
         public static T Parse<T>(string key, bool ignoreCase) where T : struct
         {
             return (T)Enum.Parse(typeof(T), key, ignoreCase);
+        }
+
+        public static bool TryParse<T>(string key, bool ignoreCase, out T result) where T : struct
+        {
+            return Enum.TryParse(key, ignoreCase, out result);
+        }
+
+        public static bool TryParse<T>(ReadOnlySpan<char> key, bool ignoreCase, out T result) where T : struct
+        {
+            return Enum.TryParse(key.ToString(), ignoreCase, out result);
         }
 #endif
     }

--- a/src/Avalonia.Base/Vector.cs
+++ b/src/Avalonia.Base/Vector.cs
@@ -101,7 +101,7 @@ namespace Avalonia
         /// <returns>The <see cref="Vector"/>.</returns>
         public static Vector Parse(string s)
         {
-            using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid Vector."))
+            using (var tokenizer = new SpanStringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid Vector."))
             {
                 return new Vector(
                     tokenizer.ReadDouble(),

--- a/src/Avalonia.Base/Vector3D.cs
+++ b/src/Avalonia.Base/Vector3D.cs
@@ -15,7 +15,7 @@ public readonly record struct Vector3D(double X, double Y, double Z)
     /// <returns>The <see cref="Vector3D"/>.</returns>
     public static Vector3D Parse(string s)
     {
-        using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid Vector."))
+        using (var tokenizer = new SpanStringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid Vector."))
         {
             return new Vector3D(
                 tokenizer.ReadDouble(),

--- a/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
+++ b/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
@@ -20,6 +20,9 @@
       <Compile Include="../Avalonia.Base/Utilities/AvaloniaResourcesIndex.cs">
         <Link>Shared/AvaloniaResourcesIndex.cs</Link>
       </Compile>
+      <Compile Include="../Avalonia.Base/Utilities/SpanStringTokenizer.cs">
+        <Link>Shared/SpanStringTokenizer.cs</Link>
+      </Compile>
       <Compile Include="../Avalonia.Base/Platform/Internal/Constants.cs">
         <Link>Shared/Constants.cs</Link>
       </Compile>

--- a/src/Avalonia.Controls/GridLength.cs
+++ b/src/Avalonia.Controls/GridLength.cs
@@ -217,13 +217,17 @@ namespace Avalonia.Controls
         /// <returns>The <see cref="GridLength"/>.</returns>
         public static IEnumerable<GridLength> ParseLengths(string s)
         {
-            using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture))
+            var result = new List<GridLength>();
+
+            using (var tokenizer = new SpanStringTokenizer(s, CultureInfo.InvariantCulture))
             {
                 while (tokenizer.TryReadString(out var item))
                 {
-                    yield return Parse(item);
+                    result.Add(Parse(item));
                 }
             }
+
+            return result;
         }
     }
 }

--- a/src/Markup/Avalonia.Markup.Xaml/Converters/PointsListTypeConverter.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Converters/PointsListTypeConverter.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Markup.Xaml.Converters
         {
             var points = new List<Point>();
 
-            using (var tokenizer = new StringTokenizer((string)value, CultureInfo.InvariantCulture, exceptionMessage: "Invalid PointsList."))
+            using (var tokenizer = new SpanStringTokenizer((string)value, CultureInfo.InvariantCulture, exceptionMessage: "Invalid PointsList."))
             {
                 while (tokenizer.TryReadDouble(out double x))
                 {

--- a/tests/Avalonia.Base.UnitTests/Utilities/SpanStringTokenizerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Utilities/SpanStringTokenizerTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using Avalonia.Utilities;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Utilities
+{
+    public class SpanStringTokenizerTests
+    {
+        // Explicit delegate because C# generics do not allow ref structs.
+        private delegate void TokenizerAction(SpanStringTokenizer tokenizer);
+
+        private static TException AssertThrows<TException>(SpanStringTokenizer tokenizer, TokenizerAction action)
+            where TException : Exception
+        {
+            try
+            {
+                action(tokenizer);
+            }
+            catch (Exception ex)
+            {
+                if (ex.GetType() == typeof(TException))
+                    return (TException)ex;
+
+                throw Xunit.Sdk.ThrowsException.ForIncorrectExceptionType(typeof(TException), ex);
+            }
+
+            throw Xunit.Sdk.ThrowsException.ForNoException(typeof(TException));
+        }
+
+        [Fact]
+        public void ReadInt32_Reads_Values()
+        {
+            var target = new SpanStringTokenizer("123,456");
+
+            Assert.Equal(123, target.ReadInt32());
+            Assert.Equal(456, target.ReadInt32());
+            AssertThrows<FormatException>(target, t => t.ReadInt32());
+        }
+
+        [Fact]
+        public void ReadDouble_Reads_Values()
+        {
+            var target = new SpanStringTokenizer("12.3,45.6");
+
+            Assert.Equal(12.3, target.ReadDouble());
+            Assert.Equal(45.6, target.ReadDouble());
+            AssertThrows<FormatException>(target, t => t.ReadDouble());
+        }
+
+        [Fact]
+        public void TryReadInt32_Reads_Values()
+        {
+            var target = new SpanStringTokenizer("123,456");
+
+            Assert.True(target.TryReadInt32(out var value));
+            Assert.Equal(123, value);
+            Assert.True(target.TryReadInt32(out value));
+            Assert.Equal(456, value);
+            Assert.False(target.TryReadInt32(out value));
+        }
+
+        [Fact]
+        public void TryReadInt32_Doesnt_Throw()
+        {
+            var target = new SpanStringTokenizer("abc");
+
+            Assert.False(target.TryReadInt32(out var value));
+        }
+
+        [Fact]
+        public void TryReadDouble_Reads_Values()
+        {
+            var target = new SpanStringTokenizer("12.3,45.6");
+
+            Assert.True(target.TryReadDouble(out var value));
+            Assert.Equal(12.3, value);
+            Assert.True(target.TryReadDouble(out value));
+            Assert.Equal(45.6, value);
+            Assert.False(target.TryReadDouble(out value));
+        }
+
+        [Fact]
+        public void TryReadDouble_Doesnt_Throw()
+        {
+            var target = new SpanStringTokenizer("abc");
+
+            Assert.False(target.TryReadDouble(out var value));
+        }
+
+        [Fact]
+        public void ReadSpan_And_ReadString_Reads_Same()
+        {
+            var target1 = new SpanStringTokenizer("abc,def");
+            var target2 = new SpanStringTokenizer("abc,def");
+
+            Assert.Equal(target1.ReadString(), target2.ReadSpan().ToString());
+            Assert.True(target1.ReadSpan().SequenceEqual(target2.ReadString()));
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

This PR creates a `ref struct` variant of `StringTokenizer` called `SpanStringTokenizer`, which holds a `ReadOnlySpan<char>` instead of a `System.String`. Additionally, this also adds `EnumHelpers::TryParse` shims accepting spans as input parameter. This drastically reduces the number of allocations of unnecessary `System.String` objects in `FontCollectionBase` and friends.


## What is the current behavior?

When creating a `TextRunProperties` (e.g., a `GenericTextRunProperties`), somewhere down the line Avalonia.Skia accesses `Typeface.GlyphTypeface`. This in turn eventually bubbles down all the way to `FontCollectionBase::GetImplicitTypeface`, which tries to normalize the typeface by carving out the font style, weight and stretch out of the full family name. It does so with the help of `StringTokenizer`.

For example, below is the logic for carving out the font weight out of the full family name:

https://github.com/AvaloniaUI/Avalonia/blob/44a784a8af2a4a9073e0979eaa27c1c7cdc00649/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs#L294-L320

`StringTokenizer` takes in a `System.String` object, meaning that all parsing needs to have a fully concretized string. This requires every single token returned by the tokenizer to be fully concretized to a `System.String`, or else we cannot determine whether it was an integer, nor can we pass it into `Enum.TryParse` to match it with font modifiers. Additionally, even more new string allocations are made by concatenating strings and calling `Replace` and `TrimEnd`. Finally, since there are three types of modifiers, there are three very similar parsing functions that all do extensive string object allocations. This all to simply parse a font family name.

![image](https://github.com/user-attachments/assets/21d5f291-2a27-4e34-9c7e-d02536adf6fc)

While the glyph typeface is cached in the internal `CachedGlyphTypeface` property, only slightly adjusting the visual appearance of text requires a new `TextRunProperties`, and thus results in the creation of a new cached glyph typeface. This happens in projects such as [AvaloniaEdit](https://github.com/AvaloniaUI/AvaloniaEdit) and [AvaloniaHex](https://github.com/Washi1337/AvaloniaHex), which need to create many `TextRunProperties` instances to implement syntax highlighting. Additionally, every [TextBlock](https://github.com/AvaloniaUI/Avalonia/blob/44a784a8af2a4a9073e0979eaa27c1c7cdc00649/src/Avalonia.Controls/TextBlock.cs#L656) control creates a new instance as well. As far as I know, this property is not exposed nor can a `TextRunProperties` be cloned efficiently with this cached glyph typeface either. Even though, out of scope for this PR, this potentially could also be an interesting avenue for further optimizations.


## What is the updated/expected behavior with this PR?

Drastically reduced observed `System.String` allocations when creating many `TextRunProperties`:

![image2](https://github.com/user-attachments/assets/6c9cbd22-d99e-4af8-8e8d-7902062c4d9f)


## How was the solution implemented (if it's not obvious)?

- A new `internal ref struct SpanStringTokenizer` which is an exact copy of `StringTokenizer` but stores a `ReadOnlySpan<char>` as opposed to a `string`.
- References to `StringTokenizer` were updated to `SpanStringTokenizer` throughout the entire Avalonia solution.
- `StringTokenizer` is now marked obsolete.
- `EnumHelpers` now include `TryParse` shims.
- Carving out the modifiers is now done via a lazy initialized `StringBuilder`. 


## Checklist

- [x] Added unit tests (if possible)?

Added a copy of `StringTokenizerTests` but specifically for `SpanStringTokenizer`.


## Breaking changes

The only technically publicly visible breaking change is turning `GridLength::ParseLenghts` into eagerly materializing a `List<GridLength>`, as `ref struct`s are not allowed in conjunction with `yield return`. However I don't think this should be much of an issue:

```diff
         public static IEnumerable<GridLength> ParseLengths(string s)
         {
-            using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture))
+            var result = new List<GridLength>();
+
+            using (var tokenizer = new SpanStringTokenizer(s, CultureInfo.InvariantCulture))
             {
                 while (tokenizer.TryReadString(out var item))
                 {
-                    yield return Parse(item);
+                    result.Add(Parse(item));
                 }
             }
+
+            return result;
```

## Issues

- Related: #16390 