### PR TITLE
Fix macOS popup memory leak due to Close not being called

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -214,17 +214,17 @@
 - (void)windowWillClose:(NSNotification *_Nonnull)notification
 {
     _closed = true;
-    auto window = _parent.tryGetWithCast<WindowImpl>();
-    if(window)
+    auto parent = _parent.tryGetWithCast<WindowBaseImpl>();
+    if (parent)
     {
-        
-        if(window != nullptr)
+        auto window = parent.dynamicCast<WindowImpl>();
+        if (window)
         {
             window->SetParent(nullptr);
         }
         
-        window->BaseEvents->Closed();
-        [window->View onClosed];
+        parent->BaseEvents->Closed();
+        [parent->View onClosed];
     }
 }
 


### PR DESCRIPTION
## What does the pull request do?
This PR fixes `IAvnWindowBase.Close()` never being called for popups on macOS, causing a memory leak.

A slight change in #17041 caused this issue: `Close()` was only being called if the window was an `WindowImpl`, not a `WindowBaseImpl` (from which popup inherits).
