### PR TITLE
Fix: RadioButton IsChecked displayed incorrectly when switching ViewModel.

### DIFF
--- a/src/Avalonia.Controls/RadioButton.cs
+++ b/src/Avalonia.Controls/RadioButton.cs
@@ -101,14 +101,21 @@ namespace Avalonia.Controls
             if (value.GetValueOrDefault())
             {
                 EnsureRadioGroupManager();
-                _groupManager.OnCheckedChanged(this);
+                _groupManager?.OnCheckedChanged(this);
             }
         }
         
-        [MemberNotNull(nameof(_groupManager))]
         private void EnsureRadioGroupManager(IRenderRoot? root = null)
         {
-            _groupManager = RadioButtonGroupManager.GetOrCreateForRoot(root ?? this.GetVisualRoot());
+            root = root ?? this.GetVisualRoot();
+
+            if (root == null) 
+            {
+                return;
+            }
+
+            _groupManager = RadioButtonGroupManager.GetOrCreateForRoot(root);
+
             _groupManager.Add(this);
         }
     }

--- a/src/Avalonia.Controls/RadioButtonGroupManager.cs
+++ b/src/Avalonia.Controls/RadioButtonGroupManager.cs
@@ -17,16 +17,13 @@ internal interface IRadioButton : ILogical
 
 internal class RadioButtonGroupManager
 {
-    private static readonly RadioButtonGroupManager s_default = new();
     private static readonly ConditionalWeakTable<IRenderRoot, RadioButtonGroupManager> s_registeredVisualRoots = new();
 
     private readonly Dictionary<string, List<WeakReference<IRadioButton>>> _registeredGroups = new();
     private bool _ignoreCheckedChanges;
 
-    public static RadioButtonGroupManager GetOrCreateForRoot(IRenderRoot? root)
+    public static RadioButtonGroupManager GetOrCreateForRoot(IRenderRoot root)
     {
-        if (root == null)
-            return s_default;
         return s_registeredVisualRoots.GetValue(root, key => new RadioButtonGroupManager());
     }
 
@@ -41,6 +38,19 @@ internal class RadioButtonGroupManager
                 _registeredGroups.Add(groupName, group);
             }
 
+            foreach(var item in group)
+            {
+                if (!item.TryGetTarget(out var button))
+                {
+                    continue;
+                }
+
+                //Return if the button is already in the group
+                if (button == radioButton)
+                {
+                    return;
+                }
+            }
             group.Add(new WeakReference<IRadioButton>(radioButton));
         }
     }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What is the current behavior?



https://github.com/user-attachments/assets/50435d98-1e3b-445b-b59d-6d76321cf4fb


## What is the updated/expected behavior with this PR?
RadioButton IsChecked displayed incorrectly when switching ViewModel.


## How was the solution implemented (if it's not obvious)?
1. Remove RadioButtonGroupManager.s_default.
2. Add RadioButton to RadioButtonGroup only when it is mounted to VisualTree.
3. Do not add RadioButton to RadioButtonGroup when it already exists.


## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
#5612