### PR TITLE
Access single file or folder from IStorageFolder by name

### DIFF
--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -51,6 +51,18 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Avalonia.Platform.Storage.IStorageFolder.GetFileAsync(System.String)</Target>
+    <Left>baseline/netstandard2.0/Avalonia.Base.dll</Left>
+    <Right>target/netstandard2.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Avalonia.Platform.Storage.IStorageFolder.GetFolderAsync(System.String)</Target>
+    <Left>baseline/netstandard2.0/Avalonia.Base.dll</Left>
+    <Right>target/netstandard2.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Avalonia.Controls.Notifications.IManagedNotificationManager.Close(System.Object)</Target>
     <Left>baseline/netstandard2.0/Avalonia.Controls.dll</Left>
     <Right>target/netstandard2.0/Avalonia.Controls.dll</Right>

--- a/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageFolder.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageFolder.cs
@@ -19,4 +19,10 @@ internal sealed class BclStorageFolder(DirectoryInfo directoryInfo)
 
     public Task<IStorageFolder?> CreateFolderAsync(string name) => Task.FromResult(
         (IStorageFolder?)WrapFileSystemInfo(CreateFolderCore(directoryInfo, name)));
+
+    public Task<IStorageFolder?> GetFolderAsync(string name) => Task.FromResult(
+        (IStorageFolder?)WrapFileSystemInfo(GetFolderCore(directoryInfo, name)));
+
+    public Task<IStorageFile?> GetFileAsync(string name) => Task.FromResult(
+       (IStorageFile?)WrapFileSystemInfo(GetFileCore(directoryInfo, name)));
 }

--- a/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageItem.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageItem.cs
@@ -127,6 +127,28 @@ internal abstract class BclStorageItem(FileSystemInfo fileSystemInfo) : IStorage
         .OfType<FileSystemInfo>()
         .Concat(directoryInfo.EnumerateFiles());
 
+    internal static FileSystemInfo? GetFolderCore(DirectoryInfo directoryInfo, string name)
+    {
+        var path = System.IO.Path.Combine(directoryInfo.FullName, name);
+        if (Directory.Exists(path))
+        {
+            return new DirectoryInfo(path);
+        }
+
+        return null;
+    }
+
+    internal static FileSystemInfo? GetFileCore(DirectoryInfo directoryInfo, string name)
+    {
+        var path = System.IO.Path.Combine(directoryInfo.FullName, name);
+        if (File.Exists(path))
+        {
+            return new FileInfo(path);
+        }
+
+        return null;
+    }
+
     internal static FileInfo CreateFileCore(DirectoryInfo directoryInfo, string name)
     {
         var fileName = System.IO.Path.Combine(directoryInfo.FullName, name);

--- a/src/Avalonia.Base/Platform/Storage/IStorageFolder.cs
+++ b/src/Avalonia.Base/Platform/Storage/IStorageFolder.cs
@@ -19,6 +19,24 @@ public interface IStorageFolder : IStorageItem
     IAsyncEnumerable<IStorageItem> GetItemsAsync();
 
     /// <summary>
+    /// Gets the folder with the specified name from the current folder.
+    /// </summary>
+    /// <param name="name">The name of the folder to get</param>
+    /// <returns>
+    /// When this method completes successfully, it returns the folder with the specified name from the current folder.
+    /// </returns>
+    Task<IStorageFolder?> GetFolderAsync(string name);
+
+    /// <summary>
+    /// Gets the file with the specified name from the current folder.
+    /// </summary>
+    /// <param name="name">The name of the file to get</param>
+    /// <returns>
+    /// When this method completes successfully, it returns the file with the specified name from the current folder.
+    /// </returns>
+    Task<IStorageFile?> GetFileAsync(string name);
+
+    /// <summary>
     /// Creates a file with specified name as a child of the current storage folder
     /// </summary>
     /// <param name="name">The display name</param>

--- a/src/Avalonia.Native/StorageItem.cs
+++ b/src/Avalonia.Native/StorageItem.cs
@@ -149,4 +149,18 @@ internal class StorageFolder(
         var folder = BclStorageItem.CreateFolderCore(directoryInfo, name);
         return Task.FromResult((IStorageFolder?)WrapFileSystemInfo(folder, ScopeOwnerUri));
     }
+
+    public Task<IStorageFolder?> GetFolderAsync(string name)
+    {
+        using var scope = OpenScope();
+        var item = BclStorageItem.GetFolderCore(directoryInfo, name);
+        return Task.FromResult((IStorageFolder?)WrapFileSystemInfo(item, ScopeOwnerUri));
+    }
+
+    public Task<IStorageFile?> GetFileAsync(string name)
+    {
+        using var scope = OpenScope();
+        var item = BclStorageItem.GetFileCore(directoryInfo, name);
+        return Task.FromResult((IStorageFile?)WrapFileSystemInfo(item, ScopeOwnerUri));
+    }
 }

--- a/src/Browser/Avalonia.Browser/Interop/StorageHelper.cs
+++ b/src/Browser/Avalonia.Browser/Interop/StorageHelper.cs
@@ -67,4 +67,10 @@ internal static partial class StorageHelper
     
     [JSImport("StorageProvider.createFolder", AvaloniaModule.StorageModuleName)]
     public static partial Task<JSObject?> CreateFolder(JSObject folderHandle, string name);
+
+    [JSImport("StorageItem.getFile", AvaloniaModule.StorageModuleName)]
+    public static partial Task<JSObject?> GetFile(JSObject folderHandle, string name);
+
+    [JSImport("StorageItem.getFolder", AvaloniaModule.StorageModuleName)]
+    public static partial Task<JSObject?> GetFolder(JSObject folderHandle, string name);
 }

--- a/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
+++ b/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
@@ -385,4 +385,40 @@ internal class JSStorageFolder : JSStorageItem, IStorageBookmarkFolder
             throw new UnauthorizedAccessException("User denied permissions to open the file", ex);
         }
     }
+
+    public async Task<IStorageFolder?> GetFolderAsync(string name)
+    {
+        try
+        {
+            var storageFile = await StorageHelper.GetFolder(FileHandle, name);
+            if (storageFile is null)
+            {
+                return null;
+            }
+
+            return new JSStorageFolder(storageFile);
+        }
+        catch (JSException ex) when (ex.Message == BrowserStorageProvider.NoPermissionsMessage)
+        {
+            throw new UnauthorizedAccessException("User denied permissions to open the folder", ex);
+        }
+    }
+
+    public async Task<IStorageFile?> GetFileAsync(string name)
+    {
+        try
+        {
+            var storageFile = await StorageHelper.GetFile(FileHandle, name);
+            if (storageFile is null)
+            {
+                return null;
+            }
+
+            return new JSStorageFile(storageFile);
+        }
+        catch (JSException ex) when (ex.Message == BrowserStorageProvider.NoPermissionsMessage)
+        {
+            throw new UnauthorizedAccessException("User denied permissions to open the file", ex);
+        }
+    }
 }

--- a/src/Browser/Avalonia.Browser/webapp/modules/storage/storageItem.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/storage/storageItem.ts
@@ -107,6 +107,16 @@ export class StorageItem {
         return await ((item.handle as any).getFileHandle(name, { create: true }) as Promise<any>);
     }
 
+    public static async getFile(item: StorageItem, name: string): Promise<any | null> {
+        if (item.kind !== "directory" || !item.handle) {
+            return null;
+        }
+
+        await item.verityPermissions("read");
+
+        return await ((item.handle as any).getFileHandle(name) as Promise<any>);
+    }
+
     public static async createFolder(item: StorageItem, name: string): Promise<any | null> {
         if (item.kind !== "directory" || !item.handle) {
             throw new TypeError("Unable to create item in the requested directory");
@@ -115,6 +125,16 @@ export class StorageItem {
         await item.verityPermissions("readwrite");
 
         return await ((item.handle as any).getDirectoryHandle(name, { create: true }) as Promise<any>);
+    }
+
+    public static async getFolder(item: StorageItem, name: string): Promise<any | null> {
+        if (item.kind !== "directory" || !item.handle) {
+            return null;
+        }
+
+        await item.verityPermissions("read");
+
+        return await ((item.handle as any).getDirectoryHandle(name) as Promise<any>);
     }
 
     public static async deleteAsync(item: StorageItem): Promise<any | null> {

--- a/src/iOS/Avalonia.iOS/Storage/IOSStorageItem.cs
+++ b/src/iOS/Avalonia.iOS/Storage/IOSStorageItem.cs
@@ -306,4 +306,36 @@ internal sealed class IOSStorageFolder : IOSStorageItem, IStorageBookmarkFolder
             SecurityScopedAncestorUrl.StopAccessingSecurityScopedResource();
         }
     }
+
+    private NSUrl? GetItem(string name, bool isDirectory)
+    {
+        try
+        {
+            SecurityScopedAncestorUrl.StartAccessingSecurityScopedResource();
+
+            var path = System.IO.Path.Combine(FilePath, name);
+            if (NSFileManager.DefaultManager.FileExists(path, ref isDirectory))
+            {
+                return new NSUrl(path, isDirectory);
+            }
+
+            return null;
+        }
+        finally
+        {
+            SecurityScopedAncestorUrl.StopAccessingSecurityScopedResource();
+        }
+    }
+
+    public Task<IStorageFolder?> GetFolderAsync(string name)
+    {
+        var url = GetItem(name, true);
+        return Task.FromResult<IStorageFolder?>(url is null ? null : new IOSStorageFolder(url));
+    }
+
+    public Task<IStorageFile?> GetFileAsync(string name)
+    {
+        var url = GetItem(name, false);
+        return Task.FromResult<IStorageFile?>(url is null ? null : new IOSStorageFile(url));
+    }
 }


### PR DESCRIPTION
## What does the pull request do?

This PR addresses #17276. It allows to access a single file or folder **by name** given you have already a folder (`IStorageFolder`).


## What is the current behavior?
You can currently archive this by iteration over the whole folder with `GetItemsAsync()` and pick the file with the given name. This has performance considerations and therefore, when applicable, the implementations tries to access the file directly.


## What is the updated/expected behavior with this PR?
When you get a folder (`IStorageFolder`) e.g through a file-picker, you can access the child file/folder by name directly, returning `IStorageFile` or `IStorageFolder` depending on the called method.


## How was the solution implemented (if it's not obvious)?
The interface `IStorageFolder` was extended as follows:
```
interface IStorageFolder
{
     Task<IStorageFolder> GetFolderAsync(string name);
     Task<IStorageFile> GetFileAsync(string name);
}
```

Therefore, an implementation for the following platforms was provided:

- Android (DocumentsContract and the query method)
- Browser (FileSystemDirectoryHandle)
- Desktop (.NET Path.Combine)
- IOS (.NET Path.Combine => NSUrl)


## Testing

Tested it on following platforms:

- [x] Desktop 
- [x] Android 
- [x] Browser 
- [ ] IOS (dont have an IOS device)

Extended the ControlCatalog for testing:

![image](https://github.com/user-attachments/assets/e666e668-10fb-4c43-9083-5238373acb6c)
 

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
No breaking changes, this only extends the public interface

## Fixed issues
Fixes #17276