### PR TITLE
Align bitmap memory to 4 bytes

### DIFF
--- a/src/Avalonia.Base/Media/Imaging/BitmapMemory.cs
+++ b/src/Avalonia.Base/Media/Imaging/BitmapMemory.cs
@@ -14,7 +14,11 @@ internal class BitmapMemory : IDisposable
         Format = format;
         AlphaFormat = alphaFormat;
         Size = size;
-        RowBytes = (size.Width * format.BitsPerPixel + 7) / 8;
+
+        var bytesPerPixel = (format.BitsPerPixel + 7) / 8;
+        
+        RowBytes =  4 * (size.Width * bytesPerPixel + 3);
+        
         _memorySize = RowBytes * size.Height;
         Address = Marshal.AllocHGlobal(_memorySize);
         GC.AddMemoryPressure(_memorySize);

--- a/src/Avalonia.Base/Media/Imaging/BitmapMemory.cs
+++ b/src/Avalonia.Base/Media/Imaging/BitmapMemory.cs
@@ -17,7 +17,7 @@ internal class BitmapMemory : IDisposable
 
         var bytesPerPixel = (format.BitsPerPixel + 7) / 8;
         
-        RowBytes =  4 * (size.Width * bytesPerPixel + 3);
+        RowBytes =  4 * ((size.Width * bytesPerPixel + 3) / 4);
         
         _memorySize = RowBytes * size.Height;
         Address = Marshal.AllocHGlobal(_memorySize);

--- a/tests/Avalonia.RenderTests/Media/BitmapMemoryTests.cs
+++ b/tests/Avalonia.RenderTests/Media/BitmapMemoryTests.cs
@@ -1,0 +1,20 @@
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Xunit;
+
+namespace Avalonia.Skia.RenderTests;
+
+public class BitmapMemoryTests
+{
+    [InlineData(PixelFormatEnum.Bgr24, AlphaFormat.Opaque)]
+    [InlineData(PixelFormatEnum.Bgr555, AlphaFormat.Opaque)]
+    [InlineData(PixelFormatEnum.Bgr565, AlphaFormat.Opaque)]
+    [InlineData(PixelFormatEnum.BlackWhite, AlphaFormat.Opaque)]
+    [Theory]
+    internal void Should_Align_RowBytes_To_Four_Bytes(PixelFormatEnum pixelFormatEnum, AlphaFormat alphaFormat)
+    {
+        var bitmapMemory = new BitmapMemory(new PixelFormat(pixelFormatEnum), alphaFormat, new PixelSize(33, 1));
+        
+        Assert.True(bitmapMemory.RowBytes % 4 == 0);
+    }
+}

--- a/tests/Avalonia.Skia.RenderTests/Avalonia.Skia.RenderTests.csproj
+++ b/tests/Avalonia.Skia.RenderTests/Avalonia.Skia.RenderTests.csproj
@@ -16,6 +16,9 @@
     <Compile Update="..\Avalonia.RenderTests\Media\EffectTests.cs">
       <Link>Media\EffectTests.cs</Link>
     </Compile>
+    <Compile Update="..\Avalonia.RenderTests\Media\BitmapMemoryTests.cs">
+      <Link>Media\BitmapMemoryTests.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\Avalonia.RenderTests\*\*.ttf" />


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR makes sure our BitmapMemory is always aligned to four bytes (DWORD). Previously this was only aligned to bytes. Some external processing requires this alignment and the cost isn't high so we should just fulfill this requirement.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
