### PR TITLE
Update pen tap settings

### DIFF
--- a/src/Avalonia.Base/Platform/DefaultPlatformSettings.cs
+++ b/src/Avalonia.Base/Platform/DefaultPlatformSettings.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Platform
         {
             return type switch
             {
-                PointerType.Touch => new(10, 10),
+                PointerType.Touch or PointerType.Pen => new(10, 10),
                 _ => new(4, 4),
             };
         }
@@ -27,7 +27,7 @@ namespace Avalonia.Platform
         {
             return type switch
             {
-                PointerType.Touch => new(16, 16),
+                PointerType.Touch or PointerType.Pen => new(16, 16),
                 _ => new(4, 4),
             };
         }

--- a/src/Windows/Avalonia.Win32/Win32PlatformSettings.cs
+++ b/src/Windows/Avalonia.Win32/Win32PlatformSettings.cs
@@ -18,8 +18,8 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
     {
         return type switch
         {
-            PointerType.Touch => new(10, 10),
-            _ => new(GetSystemMetrics(SystemMetric.SM_CXDRAG), GetSystemMetrics(SystemMetric.SM_CYDRAG)),
+            PointerType.Mouse => new(GetSystemMetrics(SystemMetric.SM_CXDRAG), GetSystemMetrics(SystemMetric.SM_CYDRAG)),
+            _ => base.GetTapSize(type)
         };
     }
 
@@ -27,8 +27,8 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
     {
         return type switch
         {
-            PointerType.Touch => new(16, 16),
-            _ => new(GetSystemMetrics(SystemMetric.SM_CXDOUBLECLK), GetSystemMetrics(SystemMetric.SM_CYDOUBLECLK)),
+            PointerType.Mouse => new(GetSystemMetrics(SystemMetric.SM_CXDOUBLECLK), GetSystemMetrics(SystemMetric.SM_CYDOUBLECLK)),
+            _ => base.GetDoubleTapSize(type)
         };
     }
 


### PR DESCRIPTION
## What does the pull request do?

Currently, double tap settings are not really user-friendly, requiring mouse-like precision.
This PR changes default settings to follow touch-like rules.
Unfortunately, Windows doesn't seem to have an API for these settings.