### PR TITLE
[MacOS] fix small memory leak when TopLevel closes.

### DIFF
--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -78,8 +78,7 @@ namespace Avalonia.Native
         public override void Dispose()
         {
             Native?.Close();
-            Native?.Dispose();
-            _handle = null;
+            base.Dispose();
         }
 
         public virtual void Show(bool activate, bool isDialog)


### PR DESCRIPTION
In `WindowBaseImpl.cs` the dispose method doesn't call base.Dispose.

This leaves _nativeControlHost and _mouse not disposed, potentially a small memory leak, _nativeControlHost retains some COM objects from the native backend)