### PR TITLE
[macOS] Prevent popups from stealing focus

### DIFF
--- a/native/Avalonia.Native/src/OSX/PopupImpl.mm
+++ b/native/Avalonia.Native/src/OSX/PopupImpl.mm
@@ -42,6 +42,15 @@ public:
         
         return WindowBaseImpl::Show(activate, true);
     }
+    
+    virtual bool ShouldTakeFocusOnShow() override
+    {
+        // Don't steal the focus from another windows if our parent is inactive
+        if (Parent != nullptr && Parent->Window != nullptr && ![Parent->Window isKeyWindow])
+            return false;
+
+        return WindowBaseImpl::ShouldTakeFocusOnShow();
+    }
 };
 
 


### PR DESCRIPTION
## What does the pull request do?
On macOS, this PR prevents popups from stealing the focus, when their parent are inactive windows.

## What is the current behavior?
Any tooltip or popup opening steals the focus from the active application (easy to trigger unexpectedly by hovering the mouse over an inactive window having a tooltip).

## What is the updated/expected behavior with this PR?
The popup now only gets the focus if its parent is active.
