### PR TITLE
Add NonPumpingLockHelper.Use to the SyncCommit

### DIFF
--- a/src/Avalonia.Base/Media/MediaContext.Compositor.cs
+++ b/src/Avalonia.Base/Media/MediaContext.Compositor.cs
@@ -5,6 +5,7 @@ using Avalonia.Platform;
 using Avalonia.Rendering.Composition;
 using Avalonia.Rendering.Composition.Transport;
 using Avalonia.Threading;
+using Avalonia.Utilities;
 
 namespace Avalonia.Media;
 
@@ -97,6 +98,7 @@ partial class MediaContext
         if (AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() == null)
             return;
 
+        using var _ = NonPumpingLockHelper.Use();
         if (compositor is
             {
                 UseUiThreadForSynchronousCommits: false,


### PR DESCRIPTION
## What does the pull request do?

No clear understanding why, but AOT threading is different enough to be caught in a race condition without extra NonPumpingLockHelper.

## Fixed issues

Should fix [#456](https://github.com/AvaloniaUI/Avalonia/issues/16840)