### PR TITLE
Fix double build of Avalonia.Build.Tasks

### DIFF
--- a/packages/Avalonia/Avalonia.csproj
+++ b/packages/Avalonia/Avalonia.csproj
@@ -7,11 +7,8 @@
   <ItemGroup>
       <PackageReference Include="Avalonia.BuildServices" Version="0.0.29" />
       <ProjectReference Include="../../src/Avalonia.Remote.Protocol/Avalonia.Remote.Protocol.csproj" />
-      <ProjectReference Include="../../src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj">
-        <PrivateAssets>all</PrivateAssets>
-        <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-        <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
-      </ProjectReference>
+      <ProjectReference Include="../../src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj"
+                        PrivateAssets="all" />
       <ProjectReference Include="..\..\src\tools\Avalonia.Generators\Avalonia.Generators.csproj"
                         ReferenceOutputAssembly="false"
                         PrivateAssets="all"

--- a/src/Avalonia.Base/Avalonia.Base.csproj
+++ b/src/Avalonia.Base/Avalonia.Base.csproj
@@ -64,6 +64,8 @@
   </ItemGroup>
   
   <ItemGroup Label="Build dependency">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Avalonia.Build.Tasks\Avalonia.Build.Tasks.csproj" SetTargetFramework="TargetFramework=netstandard2.0" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Avalonia.Build.Tasks\Avalonia.Build.Tasks.csproj"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Avalonia.MicroCom/Avalonia.MicroCom.csproj
+++ b/src/Avalonia.MicroCom/Avalonia.MicroCom.csproj
@@ -5,12 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MicroCom.Runtime" Version="0.11.0" />
-    <ProjectReference Include="..\Avalonia.Build.Tasks\Avalonia.Build.Tasks.csproj">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <ExcludeAssets>all</ExcludeAssets>
-      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
-    </ProjectReference>
+    <ProjectReference Include="..\Avalonia.Build.Tasks\Avalonia.Build.Tasks.csproj"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
   </ItemGroup>
   <Import Project="..\..\build\BuildTargets.targets" />
   <Import Project="..\..\build\TrimmingEnable.props" />


### PR DESCRIPTION
## What does the pull request do?
This PR cleans up the build-only dependencies to `Avalonia.Build.Tasks`.

Magical MSBuild incantations have accumulated through the years, notably the `SkipGetTargetFrameworkProperties` property (which may or may not have been necessary in the past). This property causes the `Avalonia.Build.Tasks` to be in its own "build batch" each time, effectively building that project several times. On parallel builds, this can cause a build failure.

(On my computer, a full solution rebuild fails about 9 times out of 10 due to this issue. After this PR, it works every time.)

Note: this only changes building the Avalonia solution itself and doesn't affect users who use the NuGet packages.
