### PR TITLE
Nullable annotations for X11

### DIFF
--- a/src/Avalonia.X11/Avalonia.X11.csproj
+++ b/src/Avalonia.X11/Avalonia.X11.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <Import Project="..\..\build\SourceGenerators.props" />
   <Import Project="..\..\build\TrimmingEnable.props" />
+  <Import Project="..\..\build\NullableEnable.props" />
 
   <ItemGroup>
     <Compile Remove="..\Shared\SourceGeneratorAttributes.cs"/>

--- a/src/Avalonia.X11/Dispatching/GLibDispatcherImpl.cs
+++ b/src/Avalonia.X11/Dispatching/GLibDispatcherImpl.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Avalonia.X11/Dispatching/X11PlatformThreading.cs
+++ b/src/Avalonia.X11/Dispatching/X11PlatformThreading.cs
@@ -186,8 +186,8 @@ namespace Avalonia.X11
 
         public bool CurrentThreadIsLoopThread => Thread.CurrentThread == _mainThread;
         
-        public event Action Signaled;
-        public event Action Timer;
+        public event Action? Signaled;
+        public event Action? Timer;
 
         public void UpdateTimer(long? dueTimeInMs)
         {

--- a/src/Avalonia.X11/Glx/Glx.cs
+++ b/src/Avalonia.X11/Glx/Glx.cs
@@ -115,6 +115,9 @@ namespace Avalonia.X11.Glx
         public string[] GetExtensions(IntPtr display)
         {
             var s = Marshal.PtrToStringAnsi(QueryExtensionsString(display, 0));
+            if (string.IsNullOrEmpty(s))
+                return [];
+
             return s.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x.Trim()).ToArray();
 

--- a/src/Avalonia.X11/Glx/GlxContext.cs
+++ b/src/Avalonia.X11/Glx/GlxContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Avalonia.X11/Glx/GlxDisplay.cs
+++ b/src/Avalonia.X11/Glx/GlxDisplay.cs
@@ -119,13 +119,13 @@ namespace Avalonia.X11.Glx
         public GlxContext CreateContext(IGlContext share) => CreateContext(CreatePBuffer(), share,
             share.SampleCount, share.StencilSize, true);
 
-        private GlxContext CreateContext(IntPtr defaultXid, IGlContext share,
+        private GlxContext CreateContext(IntPtr defaultXid, IGlContext? share,
             int sampleCount, int stencilSize, bool ownsPBuffer)
         {
-            var sharelist = ((GlxContext)share)?.Handle ?? IntPtr.Zero;
+            var sharelist = ((GlxContext?)share)?.Handle ?? IntPtr.Zero;
             IntPtr handle = default;
             
-            GlxContext Create(GlVersion profile)
+            GlxContext? Create(GlVersion profile)
             {
                 var profileMask = GLX_CONTEXT_CORE_PROFILE_BIT_ARB;
                 if (profile.Type == GlProfileType.OpenGL && 
@@ -149,7 +149,7 @@ namespace Avalonia.X11.Glx
                     if (handle != IntPtr.Zero)
                     {
                         _version = profile;
-                        return new GlxContext(new GlxInterface(), handle, this, (GlxContext)share, profile,
+                        return new GlxContext(new GlxInterface(), handle, this, (GlxContext?)share, profile,
                             sampleCount, stencilSize, _x11, defaultXid, ownsPBuffer);
                         
                     }
@@ -162,7 +162,7 @@ namespace Avalonia.X11.Glx
                 return null;
             }
 
-            GlxContext rv = null;
+            GlxContext? rv = null;
             if (_version.HasValue)
             {
                 rv = Create(_version.Value);

--- a/src/Avalonia.X11/Glx/GlxGlPlatformSurface.cs
+++ b/src/Avalonia.X11/Glx/GlxGlPlatformSurface.cs
@@ -96,7 +96,7 @@ namespace Avalonia.X11.Glx
 
                 public PixelSize Size => _size ?? _info.Size;
                 public double Scaling => _info.Scaling;
-                public bool IsYFlipped { get; }
+                public bool IsYFlipped => false;
             }
         }
     }

--- a/src/Avalonia.X11/Glx/GlxPlatformFeature.cs
+++ b/src/Avalonia.X11/Glx/GlxPlatformFeature.cs
@@ -8,23 +8,25 @@ namespace Avalonia.X11.Glx
 {
     internal class GlxPlatformGraphics : IPlatformGraphics
     {
-        public GlxDisplay Display { get; private set; }
+        public GlxDisplay Display { get; }
         public bool CanCreateContexts => true;
         public bool CanShareContexts => true;
         public bool UsesSharedContext => false;
         IPlatformGraphicsContext IPlatformGraphics.CreateContext() => Display.CreateContext();
 
         public IPlatformGraphicsContext GetSharedContext() => throw new NotSupportedException();
-        
-        public static GlxPlatformGraphics TryCreate(X11Info x11, IList<GlVersion> glProfiles)
+
+        public GlxPlatformGraphics(GlxDisplay display)
+        {
+            Display = display;
+        }
+
+        public static GlxPlatformGraphics? TryCreate(X11Info x11, IList<GlVersion> glProfiles)
         {
             try
             {
                 var disp = new GlxDisplay(x11, glProfiles);
-                return new GlxPlatformGraphics
-                {
-                    Display = disp
-                };
+                return new GlxPlatformGraphics(disp);
             }
             catch(Exception e)
             {

--- a/src/Avalonia.X11/Interop/Glib.cs
+++ b/src/Avalonia.X11/Interop/Glib.cs
@@ -1,9 +1,10 @@
 #nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia.Platform.Interop;
-using static Avalonia.X11.Interop.Glib;
+
 namespace Avalonia.X11.Interop;
 
 internal static unsafe class Glib
@@ -75,7 +76,7 @@ internal static unsafe class Glib
     private static readonly GDestroyNotify s_gcHandleDestroyNotify = handle => GCHandle.FromIntPtr(handle).Free();
 
     private static readonly GSourceFunc s_sourceFuncDispatchCallback =
-        handle => ((Func<bool>)GCHandle.FromIntPtr(handle).Target)() ? 1 : 0;
+        handle => ((Func<bool>)GCHandle.FromIntPtr(handle).Target!)() ? 1 : 0;
     
     [DllImport(GlibName)]
     private static extern uint g_idle_add_full (int priority, GSourceFunc function, IntPtr data, GDestroyNotify notify);
@@ -108,7 +109,7 @@ internal static unsafe class Glib
     public delegate int GUnixFDSourceFunc(int fd, GIOCondition condition, IntPtr user_data);
 
     private static readonly GUnixFDSourceFunc s_unixFdSourceCallback = (fd, cond, handle) =>
-        ((Func<int, GIOCondition, bool>)GCHandle.FromIntPtr(handle).Target)(fd, cond) ? 1 : 0;
+        ((Func<int, GIOCondition, bool>)GCHandle.FromIntPtr(handle).Target!)(fd, cond) ? 1 : 0;
     
     [DllImport(GlibName)]
     public static extern uint g_unix_fd_add_full (int priority,
@@ -152,6 +153,7 @@ internal static unsafe class Glib
     }
 
     public static IDisposable ConnectSignal<T>(IntPtr obj, string name, T handler)
+        where T : notnull
     {
         var handle = GCHandle.Alloc(handler);
         var ptr = Marshal.GetFunctionPointerForDelegate(handler);

--- a/src/Avalonia.X11/NativeDialogs/Gtk.cs
+++ b/src/Avalonia.X11/NativeDialogs/Gtk.cs
@@ -1,10 +1,10 @@
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Platform.Interop;
-using Avalonia.Threading;
-using Avalonia.X11.Dispatching;
 using Avalonia.X11.Interop;
 
 // ReSharper disable IdentifierTypo
@@ -142,7 +142,7 @@ namespace Avalonia.X11.NativeDialogs
         public static IntPtr GetForeignWindow(IntPtr xid) => gdk_x11_window_foreign_new_for_display(s_display, xid);
 
         static object s_startGtkLock = new();
-        static Task<bool> s_startGtkTask;
+        static Task<bool>? s_startGtkTask;
 
         public static Task<bool> StartGtk()
         {

--- a/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
+++ b/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
@@ -1,11 +1,8 @@
-﻿#nullable enable
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Avalonia.Controls.Platform;
 using Avalonia.Platform;
 using Avalonia.Platform.Interop;
 using Avalonia.Platform.Storage;

--- a/src/Avalonia.X11/SMLib.cs
+++ b/src/Avalonia.X11/SMLib.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/Avalonia.X11/Screens/X11Screen.Providers.cs
+++ b/src/Avalonia.X11/Screens/X11Screen.Providers.cs
@@ -1,10 +1,9 @@
-
-#nullable enable
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Avalonia.Platform;
 using static Avalonia.X11.XLib;
+
 namespace Avalonia.X11.Screens;
 
 internal partial class X11Screens
@@ -44,7 +43,7 @@ internal partial class X11Screens
 
         private unsafe Size? GetPhysicalMonitorSizeFromEDID(IntPtr rrOutput)
         {
-            if (rrOutput == IntPtr.Zero || x11 == null)
+            if (rrOutput == IntPtr.Zero)
                 return null;
             var properties = XRRListOutputProperties(x11.Display, rrOutput, out int propertyCount);
             var hasEDID = false;
@@ -130,7 +129,7 @@ internal partial class X11Screens
     {
         nint[] ScreenKeys { get; }
         event Action? Changed;
-        X11Screen? CreateScreenFromKey(nint key);
+        X11Screen CreateScreenFromKey(nint key);
     }
 
     internal unsafe struct MonitorInfo
@@ -211,20 +210,18 @@ internal partial class X11Screens
             }
         }
 
-        public X11Screen? CreateScreenFromKey(nint key)
+        public X11Screen CreateScreenFromKey(nint key)
         {
-            var info = MonitorInfos.Where(x => x.Name == key).FirstOrDefault();
-
             var infos = MonitorInfos;
             for (var i = 0; i < infos.Length; i++)
             {
                 if (infos[i].Name == key)
                 {
-                    return new X11Screen(info, _x11, _scalingProvider, i);
+                    return new X11Screen(infos[i], _x11, _scalingProvider, i);
                 }
             }
 
-            return null;
+            return new FallBackScreen(default, _x11);
         }
     }
 
@@ -248,7 +245,7 @@ internal partial class X11Screens
 
         private bool UpdateRootWindowGeometry() => XGetGeometry(_info.Display, _info.RootWindow, out _geo);
 
-        public X11Screen? CreateScreenFromKey(nint key)
+        public X11Screen CreateScreenFromKey(nint key)
         {
             return new FallBackScreen(new PixelRect(0, 0, _geo.width, _geo.height), _info);
         }

--- a/src/Avalonia.X11/Screens/X11Screen.Providers.cs
+++ b/src/Avalonia.X11/Screens/X11Screen.Providers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Avalonia.Platform;
@@ -221,7 +222,7 @@ internal partial class X11Screens
                 }
             }
 
-            return new FallBackScreen(default, _x11);
+            throw new ArgumentOutOfRangeException(nameof(key));
         }
     }
 

--- a/src/Avalonia.X11/Screens/X11Screens.Scaling.cs
+++ b/src/Avalonia.X11/Screens/X11Screens.Scaling.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/Avalonia.X11/Screens/X11Screens.cs
+++ b/src/Avalonia.X11/Screens/X11Screens.cs
@@ -1,12 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using Avalonia.Platform;
 using static Avalonia.X11.Screens.X11Screens;
-using static Avalonia.X11.XLib;
 
 namespace Avalonia.X11.Screens
 {

--- a/src/Avalonia.X11/TransparencyHelper.cs
+++ b/src/Avalonia.X11/TransparencyHelper.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using Avalonia.Controls;
 
-#nullable enable
-
 namespace Avalonia.X11
 {
     internal class TransparencyHelper :  IDisposable

--- a/src/Avalonia.X11/Vulkan/VulkanSupport.cs
+++ b/src/Avalonia.X11/Vulkan/VulkanSupport.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;

--- a/src/Avalonia.X11/X11Atoms.cs
+++ b/src/Avalonia.X11/X11Atoms.cs
@@ -222,7 +222,7 @@ namespace Avalonia.X11
             return atom;
         }
 
-        public string GetAtomName(IntPtr atom)
+        public string? GetAtomName(IntPtr atom)
         {
             if (_atomsToNames.TryGetValue(atom, out var rv))
                 return rv;

--- a/src/Avalonia.X11/X11CursorFactory.cs
+++ b/src/Avalonia.X11/X11CursorFactory.cs
@@ -6,8 +6,6 @@ using Avalonia.Input;
 using Avalonia.Platform;
 using Avalonia.Platform.Internal;
 
-#nullable enable
-
 namespace Avalonia.X11
 {
     internal partial class X11CursorFactory : ICursorFactory

--- a/src/Avalonia.X11/X11FramebufferSurface.cs
+++ b/src/Avalonia.X11/X11FramebufferSurface.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Avalonia.Controls.Platform.Surfaces;
 using Avalonia.Platform;

--- a/src/Avalonia.X11/X11Globals.cs
+++ b/src/Avalonia.X11/X11Globals.cs
@@ -1,8 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 using static Avalonia.X11.XLib;
+
 namespace Avalonia.X11
 {
     internal unsafe class X11Globals
@@ -13,14 +12,14 @@ namespace Avalonia.X11
         private readonly IntPtr _rootWindow;
         private readonly IntPtr _compositingAtom;
         
-        private string _wmName;
+        private string? _wmName;
         private IntPtr _compositionAtomOwner;
         private bool _isCompositionEnabled;
 
-        public event Action WindowManagerChanged;
-        public event Action CompositionChanged;
-        public event Action<IntPtr> RootPropertyChanged;
-        public event Action RootGeometryChangedChanged;
+        public event Action? WindowManagerChanged;
+        public event Action? CompositionChanged;
+        public event Action<IntPtr>? RootPropertyChanged;
+        public event Action? RootGeometryChangedChanged;
 
         public X11Globals(AvaloniaX11Platform plat)
         {
@@ -36,7 +35,7 @@ namespace Avalonia.X11
             UpdateCompositingAtomOwner();
         }
         
-        public string WmName
+        public string? WmName
         {
             get => _wmName;
             private set
@@ -131,7 +130,7 @@ namespace Avalonia.X11
 
         private void UpdateWmName() => WmName = GetWmName();
 
-        private string GetWmName()
+        private string? GetWmName()
         {
             var wm = GetSupportingWmCheck(_rootWindow);
             if (wm == IntPtr.Zero || wm != GetSupportingWmCheck(wm))

--- a/src/Avalonia.X11/X11IconLoader.cs
+++ b/src/Avalonia.X11/X11IconLoader.cs
@@ -33,7 +33,7 @@ namespace Avalonia.X11
     {
         private int _width;
         private int _height;
-        private uint[] _bdata;
+        private uint[]? _bdata;
         public UIntPtr[]  Data { get; }
         
         public X11IconData(Bitmap bitmap)

--- a/src/Avalonia.X11/X11Info.cs
+++ b/src/Avalonia.X11/X11Info.cs
@@ -19,13 +19,13 @@ namespace Avalonia.X11
         public int RandrEventBase { get; }
         public int RandrErrorBase { get; }
         
-        public Version RandrVersion { get; }
+        public Version? RandrVersion { get; }
         
         public int XInputOpcode { get; }
         public int XInputEventBase { get; }
         public int XInputErrorBase { get; }
         
-        public Version XInputVersion { get; }
+        public Version? XInputVersion { get; }
 
         public IntPtr LastActivityTimestamp { get; set; }
         public XVisualInfo? TransparentVisualInfo { get; }

--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -28,18 +28,18 @@ namespace Avalonia.X11
         private Lazy<KeyboardDevice> _keyboardDevice = new Lazy<KeyboardDevice>(() => new KeyboardDevice());
         public KeyboardDevice KeyboardDevice => _keyboardDevice.Value;
         public Dictionary<IntPtr, X11EventDispatcher.EventHandler> Windows { get; } = new ();
-        public XI2Manager? XI2 { get; }
-        public X11Info Info { get; }
-        public X11Screens X11Screens { get; }
-        public Compositor Compositor { get; }
-        public IScreenImpl Screens { get; }
-        public X11PlatformOptions Options { get; }
-        public IntPtr OrphanedWindow { get; }
-        public X11Globals Globals { get; }
-        public XResources Resources { get; }
+        public XI2Manager? XI2 { get; private set; }
+        public X11Info Info { get; private set; } = null!;
+        public X11Screens X11Screens { get; private set; } = null!;
+        public Compositor Compositor { get; private set; } = null!;
+        public IScreenImpl Screens { get; private set; } = null!;
+        public X11PlatformOptions Options { get; private set; } = null!;
+        public IntPtr OrphanedWindow { get; private set; }
+        public X11Globals Globals { get; private set; } = null!;
+        public XResources Resources { get; private set; } = null!;
         public ManualRawEventGrouperDispatchQueue EventGrouperDispatchQueue { get; } = new();
 
-        public AvaloniaX11Platform(X11PlatformOptions options)
+        public void Initialize(X11PlatformOptions options)
         {
             Options = options;
 
@@ -405,15 +405,13 @@ namespace Avalonia
             builder
                 .UseStandardRuntimePlatformSubsystem()
                 .UseWindowingSubsystem(() =>
-                {
-                    var options = AvaloniaLocator.Current.GetService<X11PlatformOptions>() ?? new X11PlatformOptions();
-                    _ = new AvaloniaX11Platform(options);
-                });
+                new AvaloniaX11Platform().Initialize(AvaloniaLocator.Current.GetService<X11PlatformOptions>() ??
+                                                     new X11PlatformOptions()));
             return builder;
         }
 
         public static void InitializeX11Platform(X11PlatformOptions? options = null) =>
-            _ = new AvaloniaX11Platform(options ?? new X11PlatformOptions());
+            new AvaloniaX11Platform().Initialize(options ?? new X11PlatformOptions());
     }
 
 }

--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -28,18 +28,18 @@ namespace Avalonia.X11
         private Lazy<KeyboardDevice> _keyboardDevice = new Lazy<KeyboardDevice>(() => new KeyboardDevice());
         public KeyboardDevice KeyboardDevice => _keyboardDevice.Value;
         public Dictionary<IntPtr, X11EventDispatcher.EventHandler> Windows { get; } = new ();
-        public XI2Manager XI2 { get; private set; }
-        public X11Info Info { get; private set; }
-        public X11Screens X11Screens { get; private set; }
-        public Compositor Compositor { get; private set; }
-        public IScreenImpl Screens { get; private set; }
-        public X11PlatformOptions Options { get; private set; }
-        public IntPtr OrphanedWindow { get; private set; }
-        public X11Globals Globals { get; private set; }
-        public XResources Resources { get; private set; }
+        public XI2Manager? XI2 { get; }
+        public X11Info Info { get; }
+        public X11Screens X11Screens { get; }
+        public Compositor Compositor { get; }
+        public IScreenImpl Screens { get; }
+        public X11PlatformOptions Options { get; }
+        public IntPtr OrphanedWindow { get; }
+        public X11Globals Globals { get; }
+        public XResources Resources { get; }
         public ManualRawEventGrouperDispatchQueue EventGrouperDispatchQueue { get; } = new();
 
-        public void Initialize(X11PlatformOptions options)
+        public AvaloniaX11Platform(X11PlatformOptions options)
         {
             Options = options;
 
@@ -90,9 +90,7 @@ namespace Avalonia.X11
             Screens = X11Screens = new X11Screens(this);
             if (Info.XInputVersion != null)
             {
-                var xi2 = new XI2Manager();
-                if (xi2.Init(this))
-                    XI2 = xi2;
+                XI2 = XI2Manager.TryCreate(this);
             }
 
             var graphics = InitializeGraphics(options, Info);
@@ -108,7 +106,7 @@ namespace Avalonia.X11
         public IntPtr DeferredDisplay { get; set; }
         public IntPtr Display { get; set; }
 
-        private static uint[] X11IconConverter(IWindowIconImpl icon)
+        private static uint[] X11IconConverter(IWindowIconImpl? icon)
         {
             if (!(icon is X11IconData x11icon))
                 return Array.Empty<uint>();
@@ -187,7 +185,7 @@ namespace Avalonia.X11
             return false;
         }
         
-        private static IPlatformGraphics InitializeGraphics(X11PlatformOptions opts, X11Info info)
+        private static IPlatformGraphics? InitializeGraphics(X11PlatformOptions opts, X11Info info)
         {
             if (opts.RenderingMode is null || !opts.RenderingMode.Any())
             {
@@ -354,7 +352,7 @@ namespace Avalonia
         };
 
         
-        public string WmClass { get; set; }
+        public string? WmClass { get; set; }
 
         /// <summary>
         /// Enables multitouch support. The default value is true.
@@ -392,7 +390,7 @@ namespace Avalonia
         {
             try
             {
-                WmClass = Assembly.GetEntryAssembly()?.GetName()?.Name;
+                WmClass = Assembly.GetEntryAssembly()?.GetName().Name;
             }
             catch
             {
@@ -407,13 +405,15 @@ namespace Avalonia
             builder
                 .UseStandardRuntimePlatformSubsystem()
                 .UseWindowingSubsystem(() =>
-                new AvaloniaX11Platform().Initialize(AvaloniaLocator.Current.GetService<X11PlatformOptions>() ??
-                                                     new X11PlatformOptions()));
+                {
+                    var options = AvaloniaLocator.Current.GetService<X11PlatformOptions>() ?? new X11PlatformOptions();
+                    _ = new AvaloniaX11Platform(options);
+                });
             return builder;
         }
 
-        public static void InitializeX11Platform(X11PlatformOptions options = null) =>
-            new AvaloniaX11Platform().Initialize(options ?? new X11PlatformOptions());
+        public static void InitializeX11Platform(X11PlatformOptions? options = null) =>
+            _ = new AvaloniaX11Platform(options ?? new X11PlatformOptions());
     }
 
 }

--- a/src/Avalonia.X11/X11PlatformLifetimeEvents.cs
+++ b/src/Avalonia.X11/X11PlatformLifetimeEvents.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Text;
 using System.Collections.Concurrent;
@@ -232,7 +231,7 @@ namespace Avalonia.X11
             {
                 var e = new ShutdownRequestedEventArgs();
 
-                if (_platform.Options?.EnableSessionManagement ?? false)
+                if (_platform.Options.EnableSessionManagement)
                 {
                     ShutdownRequested?.Invoke(this, e);
                 }

--- a/src/Avalonia.X11/X11Structs.cs
+++ b/src/Avalonia.X11/X11Structs.cs
@@ -666,7 +666,7 @@ namespace Avalonia.X11 {
 				if (!string.IsNullOrEmpty(result)) {
 					result += ", ";
 				}
-				object value = fields [i].GetValue (ev);
+				var value = fields [i].GetValue(ev);
 				result += fields [i].Name + "=" + (value == null ? "<null>" : value.ToString ());
 			}
 			return type.Name + " (" + result + ")";

--- a/src/Avalonia.X11/X11Window.Ime.cs
+++ b/src/Avalonia.X11/X11Window.Ime.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;

--- a/src/Avalonia.X11/X11Window.Xim.cs
+++ b/src/Avalonia.X11/X11Window.Xim.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 using Avalonia.FreeDesktop;

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -30,8 +30,6 @@ using Avalonia.Platform.Storage.FileIO;
 // ReSharper disable IdentifierTypo
 // ReSharper disable StringLiteralTypo
 
-#nullable enable
-
 namespace Avalonia.X11
 {
     internal unsafe partial class X11Window : IWindowImpl, IPopupImpl, IXI2Client,
@@ -95,7 +93,7 @@ namespace Avalonia.X11
             _mode = mode;
             _mode.Init(this);
             _popup = popupParent != null;
-			_overrideRedirect = _popup || overrideRedirect;
+            _overrideRedirect = _popup || overrideRedirect;
             _x11 = platform.Info;
             _mouse = new MouseDevice();
             _touch = new TouchDevice();
@@ -1256,7 +1254,7 @@ namespace Avalonia.X11
             }
         }
 
-        public void SetWmClass(IntPtr handle, string wmClass)
+        public void SetWmClass(IntPtr handle, string? wmClass)
         {
             // See https://tronche.com/gui/x/icccm/sec-4.html#WM_CLASS
             // We don't actually parse the application's command line, so we only use RESOURCE_NAME and argv[0]

--- a/src/Avalonia.X11/X11WindowModes/InputProxyWindowMode.cs
+++ b/src/Avalonia.X11/X11WindowModes/InputProxyWindowMode.cs
@@ -8,7 +8,7 @@ partial class X11Window
 {
     public class InputProxyWindowMode : DefaultTopLevelWindowMode
     {
-        private X11FocusProxy _focusProxy;
+        private X11FocusProxy? _focusProxy;
 
         public override void OnHandleCreated(IntPtr handle)
         {

--- a/src/Avalonia.X11/X11WindowModes/WindowMode.cs
+++ b/src/Avalonia.X11/X11WindowModes/WindowMode.cs
@@ -7,10 +7,10 @@ partial class X11Window
 {
     public abstract class X11WindowMode
     {
-        public X11Window Window { get; private set; }
+        public X11Window Window { get; private set; } = null!;
         protected IntPtr Display;
-        protected X11Info X11;
-        protected AvaloniaX11Platform Platform;
+        protected X11Info X11 = null!;
+        protected AvaloniaX11Platform Platform = null!;
         protected IntPtr Handle => Window._handle;
         protected IntPtr RenderHandle => Window._renderHandle;
         public virtual bool BlockInput => false;

--- a/src/Avalonia.X11/X11WindowModes/XEmbedClientWindowMode.cs
+++ b/src/Avalonia.X11/X11WindowModes/XEmbedClientWindowMode.cs
@@ -1,6 +1,4 @@
-#nullable enable
 using System;
-using System.ComponentModel;
 using Avalonia.Controls;
 using Avalonia.Controls.Embedding;
 using Avalonia.Input;
@@ -73,7 +71,10 @@ partial class X11Window
         
         static XEmbedClientWindowMode()
         {
-            KeyboardDevice.Instance.PropertyChanged += (_, args) =>
+            if (KeyboardDevice.Instance is not { } keyboardDevice)
+                return;
+
+            keyboardDevice.PropertyChanged += (_, args) =>
             {
                 if (args.PropertyName == nameof(KeyboardDevice.Instance.FocusedElement))
                 {

--- a/src/Avalonia.X11/XEmbedPlug.cs
+++ b/src/Avalonia.X11/XEmbedPlug.cs
@@ -9,14 +9,14 @@ namespace Avalonia.X11;
 
 public class XEmbedPlug : IDisposable
 {
-    private EmbeddableControlRoot _root;
+    private EmbeddableControlRoot? _root;
     private Color _backgroundColor;
     private readonly X11Info _x11;
     private readonly X11Window.XEmbedClientWindowMode _mode;
 
     private XEmbedPlug(IntPtr? parentXid)
     {
-        var platform = AvaloniaLocator.Current.GetService<AvaloniaX11Platform>();
+        var platform = AvaloniaLocator.Current.GetRequiredService<AvaloniaX11Platform>();
         _mode = new X11Window.XEmbedClientWindowMode();
         _root = new EmbeddableControlRoot(new X11Window(platform, null, _mode));
         _root.Prepare();
@@ -28,13 +28,16 @@ public class XEmbedPlug : IDisposable
         XLib.XSync(platform.Display, false);
     }
 
+    private EmbeddableControlRoot Root
+        => _root ?? throw new ObjectDisposedException(nameof(XEmbedPlug));
+
     public IntPtr Handle =>
-        _root?.PlatformImpl!.Handle!.Handle ?? throw new ObjectDisposedException(nameof(XEmbedPlug));
+        Root.PlatformImpl!.Handle!.Handle;
     
-    public object Content
+    public object? Content
     {
-        get => _root.Content;
-        set => _root.Content = value;
+        get => Root.Content;
+        set => Root.Content = value;
     }
 
     public Color BackgroundColor
@@ -58,7 +61,7 @@ public class XEmbedPlug : IDisposable
     public void ProcessInteractiveResize(PixelSize size)
     {
         
-        var events = (IX11PlatformDispatcher)AvaloniaLocator.Current.GetService<IDispatcherImpl>();
+        var events = (IX11PlatformDispatcher)AvaloniaLocator.Current.GetRequiredService<IDispatcherImpl>();
         events.EventDispatcher.DispatchX11Events(CancellationToken.None);
         _mode.ProcessInteractiveResize(size);
         Dispatcher.UIThread.RunJobs(DispatcherPriority.UiThreadRender);

--- a/src/Avalonia.X11/XEmbedTrayIconImpl.cs
+++ b/src/Avalonia.X11/XEmbedTrayIconImpl.cs
@@ -26,12 +26,12 @@ namespace Avalonia.X11
             NotImplemented();
         }
 
-        public void SetIcon(IWindowIconImpl icon)
+        public void SetIcon(IWindowIconImpl? icon)
         {
              NotImplemented();
         }
 
-        public void SetToolTipText(string text)
+        public void SetToolTipText(string? text)
         {
             NotImplemented();
         }
@@ -41,7 +41,7 @@ namespace Avalonia.X11
             NotImplemented();
         }
 
-        public INativeMenuExporter MenuExporter { get; }
-        public Action OnClicked { get; set; }
+        public INativeMenuExporter? MenuExporter { get; }
+        public Action? OnClicked { get; set; }
     }
 }

--- a/src/Avalonia.X11/XLib.cs
+++ b/src/Avalonia.X11/XLib.cs
@@ -148,7 +148,7 @@ namespace Avalonia.X11
         [DllImport(libX11)]
         public static extern IntPtr XGetAtomName(IntPtr display, IntPtr atom);
 
-        public static string GetAtomName(IntPtr display, IntPtr atom)
+        public static string? GetAtomName(IntPtr display, IntPtr atom)
         {
             var ptr = XGetAtomName(display, atom);
             if (ptr == IntPtr.Zero)
@@ -511,8 +511,8 @@ namespace Avalonia.X11
         
         [DllImport(libX11)]
         public static extern IntPtr XCreateIC(IntPtr xim, string xnClientWindow, IntPtr handle, string xnFocusWindow,
-            IntPtr value2, string xnInputStyle, IntPtr value3, string xnResourceName, string optionsWmClass,
-            string xnResourceClass, string wmClass, string xnPreeditAttributes, IntPtr list, IntPtr zero);
+            IntPtr value2, string xnInputStyle, IntPtr value3, string xnResourceName, string? optionsWmClass,
+            string xnResourceClass, string? wmClass, string xnPreeditAttributes, IntPtr list, IntPtr zero);
 
         [DllImport(libX11)]
         public static extern void XSetICFocus(IntPtr xic);

--- a/src/Avalonia.X11/XResources.cs
+++ b/src/Avalonia.X11/XResources.cs
@@ -1,8 +1,8 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using static Avalonia.X11.XLib;
+
 namespace Avalonia.X11;
 
 internal class XResources


### PR DESCRIPTION
## What does the pull request do?
This PR enables and fixes nullable annotations for the Avalonia.X11 project.

## Remarks

While most of the changes are straightforward, `X11Screens.Randr15ScreensImpl.CreateScreenFromKey()` has been changed to return an empty `FallBackScreen` instead of `null` in case of failure. This code path is called from `ScreensBase<TKey,TScreen>.EnsureScreens()`, where null is definitely _not_ expected, as that would insert a null screen into `AllScreens`, causing NREs:

https://github.com/AvaloniaUI/Avalonia/blob/33bd02c2f69cdbe048cb99c459fbf620103f5099/src/Avalonia.Controls/Platform/IScreenImpl.cs#L164

