### PR TITLE
feat: add hidesuggestions property to textbox

### DIFF
--- a/samples/ControlCatalog/Pages/TextBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/TextBoxPage.xaml
@@ -38,7 +38,7 @@
                  UseFloatingWatermark="True"
                  PasswordChar="*"
                  Text="Password" />
-        <TextBox Width="200" Watermark="Hide suggestions" TextInputOptions.HideSuggestions="True" />
+        <TextBox Width="200" Watermark="Suggestions are hidden" TextInputOptions.ShowSuggestions="False" />
         <TextBox Width="200" Text="Left aligned text" TextAlignment="Left" AcceptsTab="True" />
         <TextBox Width="200" Text="Center aligned text" TextAlignment="Center" />
         <TextBox Width="200" Text="Right aligned text" TextAlignment="Right" />

--- a/samples/ControlCatalog/Pages/TextBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/TextBoxPage.xaml
@@ -38,6 +38,7 @@
                  UseFloatingWatermark="True"
                  PasswordChar="*"
                  Text="Password" />
+        <TextBox Width="200" Watermark="Hide suggestions" TextInputOptions.HideSuggestions="True" />
         <TextBox Width="200" Text="Left aligned text" TextAlignment="Left" AcceptsTab="True" />
         <TextBox Width="200" Text="Center aligned text" TextAlignment="Center" />
         <TextBox Width="200" Text="Right aligned text" TextAlignment="Right" />

--- a/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
@@ -172,7 +172,7 @@ namespace Avalonia.Android.Platform.Input
                 if (options.Multiline)
                     outAttrs.InputType |= InputTypes.TextFlagMultiLine;
 
-                if (outAttrs.InputType is InputTypes.ClassText && options.HideSuggestions)
+                if (outAttrs.InputType is InputTypes.ClassText && options.ShowSuggestions == false)
                     outAttrs.InputType |= InputTypes.TextVariationPassword | InputTypes.TextFlagNoSuggestions;
                     
                 outAttrs.ImeOptions = options.ReturnKeyType switch

--- a/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
@@ -172,6 +172,9 @@ namespace Avalonia.Android.Platform.Input
                 if (options.Multiline)
                     outAttrs.InputType |= InputTypes.TextFlagMultiLine;
 
+                if (outAttrs.InputType is InputTypes.ClassText && options.HideSuggestions)
+                    outAttrs.InputType |= InputTypes.TextVariationPassword | InputTypes.TextFlagNoSuggestions;
+                    
                 outAttrs.ImeOptions = options.ReturnKeyType switch
                 {
                     TextInputReturnKeyType.Return => ImeFlags.NoEnterAction,

--- a/src/Avalonia.Base/Input/TextInput/TextInputOptions.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextInputOptions.cs
@@ -253,4 +253,37 @@ public class TextInputOptions
     /// Text contains sensitive data like card numbers and should not be stored  
     /// </summary>
     public bool IsSensitive { get; set; }
+    
+    /// <summary>
+    /// Defines the <see cref="HideSuggestions"/> property.
+    /// </summary>
+    public static readonly AttachedProperty<bool> HideSuggestionsProperty =
+        AvaloniaProperty.RegisterAttached<TextInputOptions, StyledElement, bool>(
+            "HideSuggestions",
+            inherits: true);
+    
+    /// <summary>
+    /// Sets the value of the attached <see cref="HideSuggestionsProperty"/> on a control.
+    /// </summary>
+    /// <param name="avaloniaObject">The control.</param>
+    /// <param name="value">The property value to set.</param>
+    public static void SetHideSuggestions(StyledElement avaloniaObject, bool value)
+    {
+        avaloniaObject.SetValue(HideSuggestionsProperty, value);
+    }
+
+    /// <summary>
+    /// Gets the value of the attached <see cref="HideSuggestionsProperty"/>.
+    /// </summary>
+    /// <param name="avaloniaObject">The target.</param>
+    /// <returns>true if HideSuggestions</returns>
+    public static bool GetHideSuggestions(StyledElement avaloniaObject)
+    {
+        return avaloniaObject.GetValue(HideSuggestionsProperty);
+    }
+    
+    /// <summary>
+    /// Hide virtual keyboard suggestions
+    /// </summary>
+    public bool HideSuggestions { get; set; }
 }

--- a/src/Avalonia.Base/Input/TextInput/TextInputOptions.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextInputOptions.cs
@@ -284,7 +284,7 @@ public class TextInputOptions
     }
     
     /// <summary>
-    /// Hide virtual keyboard suggestions
+    /// Show virtual keyboard suggestions
     /// </summary>
     public bool? ShowSuggestions { get; set; }
 }

--- a/src/Avalonia.Base/Input/TextInput/TextInputOptions.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextInputOptions.cs
@@ -12,7 +12,8 @@ public class TextInputOptions
             AutoCapitalization = GetAutoCapitalization(avaloniaObject),
             IsSensitive = GetIsSensitive(avaloniaObject),
             Lowercase = GetLowercase(avaloniaObject),
-            Uppercase = GetUppercase(avaloniaObject)
+            Uppercase = GetUppercase(avaloniaObject),
+            HideSuggestions = GetHideSuggestions(avaloniaObject),
         };
 
         return result;

--- a/src/Avalonia.Base/Input/TextInput/TextInputOptions.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextInputOptions.cs
@@ -13,7 +13,7 @@ public class TextInputOptions
             IsSensitive = GetIsSensitive(avaloniaObject),
             Lowercase = GetLowercase(avaloniaObject),
             Uppercase = GetUppercase(avaloniaObject),
-            HideSuggestions = GetHideSuggestions(avaloniaObject),
+            ShowSuggestions = GetShowSuggestions(avaloniaObject),
         };
 
         return result;
@@ -256,35 +256,35 @@ public class TextInputOptions
     public bool IsSensitive { get; set; }
     
     /// <summary>
-    /// Defines the <see cref="HideSuggestions"/> property.
+    /// Defines the <see cref="ShowSuggestions"/> property.
     /// </summary>
-    public static readonly AttachedProperty<bool> HideSuggestionsProperty =
-        AvaloniaProperty.RegisterAttached<TextInputOptions, StyledElement, bool>(
-            "HideSuggestions",
+    public static readonly AttachedProperty<bool?> ShowSuggestionsProperty =
+        AvaloniaProperty.RegisterAttached<TextInputOptions, StyledElement, bool?>(
+            "ShowSuggestions",
             inherits: true);
     
     /// <summary>
-    /// Sets the value of the attached <see cref="HideSuggestionsProperty"/> on a control.
+    /// Sets the value of the attached <see cref="ShowSuggestionsProperty"/> on a control.
     /// </summary>
     /// <param name="avaloniaObject">The control.</param>
     /// <param name="value">The property value to set.</param>
-    public static void SetHideSuggestions(StyledElement avaloniaObject, bool value)
+    public static void SetShowSuggestions(StyledElement avaloniaObject, bool? value)
     {
-        avaloniaObject.SetValue(HideSuggestionsProperty, value);
+        avaloniaObject.SetValue(ShowSuggestionsProperty, value);
     }
 
     /// <summary>
-    /// Gets the value of the attached <see cref="HideSuggestionsProperty"/>.
+    /// Gets the value of the attached <see cref="ShowSuggestionsProperty"/>.
     /// </summary>
     /// <param name="avaloniaObject">The target.</param>
-    /// <returns>true if HideSuggestions</returns>
-    public static bool GetHideSuggestions(StyledElement avaloniaObject)
+    /// <returns>true if ShowSuggestions</returns>
+    public static bool? GetShowSuggestions(StyledElement avaloniaObject)
     {
-        return avaloniaObject.GetValue(HideSuggestionsProperty);
+        return avaloniaObject.GetValue(ShowSuggestionsProperty);
     }
     
     /// <summary>
     /// Hide virtual keyboard suggestions
     /// </summary>
-    public bool HideSuggestions { get; set; }
+    public bool? ShowSuggestions { get; set; }
 }

--- a/src/iOS/Avalonia.iOS/TextInputResponder.Properties.cs
+++ b/src/iOS/Avalonia.iOS/TextInputResponder.Properties.cs
@@ -15,7 +15,7 @@ partial class AvaloniaView
         public UITextAutocorrectionType AutocorrectionType =>
             _view._options == null ?
                 UITextAutocorrectionType.Yes :
-                _view._options.HideSuggestions ?
+                _view._options.ShowSuggestions == false ?
                     UITextAutocorrectionType.No :
                     UITextAutocorrectionType.Yes;
 
@@ -73,7 +73,7 @@ partial class AvaloniaView
         public UITextSpellCheckingType SpellCheckingType =>
             _view._options == null ?
                 UITextSpellCheckingType.Yes :
-                _view._options.HideSuggestions ?
+                _view._options.ShowSuggestions == false ?
                     UITextSpellCheckingType.No :
                     UITextSpellCheckingType.Yes;
 

--- a/src/iOS/Avalonia.iOS/TextInputResponder.Properties.cs
+++ b/src/iOS/Avalonia.iOS/TextInputResponder.Properties.cs
@@ -13,11 +13,9 @@ partial class AvaloniaView
 
         [Export("autocorrectionType")]
         public UITextAutocorrectionType AutocorrectionType =>
-            _view._options == null ?
-                UITextAutocorrectionType.Yes :
-                _view._options.ShowSuggestions == false ?
-                    UITextAutocorrectionType.No :
-                    UITextAutocorrectionType.Yes;
+            _view._options?.ShowSuggestions == false ?
+                UITextAutocorrectionType.No :
+                UITextAutocorrectionType.Yes;
 
         [Export("keyboardType")]
         public UIKeyboardType KeyboardType =>
@@ -70,12 +68,10 @@ partial class AvaloniaView
             || (_view._options?.IsSensitive ?? false);
 
         [Export("spellCheckingType")]
-        public UITextSpellCheckingType SpellCheckingType =>
-            _view._options == null ?
-                UITextSpellCheckingType.Yes :
-                _view._options.ShowSuggestions == false ?
-                    UITextSpellCheckingType.No :
-                    UITextSpellCheckingType.Yes;
+        public UITextSpellCheckingType SpellCheckingType => 
+            _view._options?.ShowSuggestions == false ?
+                UITextSpellCheckingType.No :
+                UITextSpellCheckingType.Yes;
 
         [Export("textContentType")] public NSString TextContentType { get; set; } = new NSString("text/plain");
 

--- a/src/iOS/Avalonia.iOS/TextInputResponder.Properties.cs
+++ b/src/iOS/Avalonia.iOS/TextInputResponder.Properties.cs
@@ -12,7 +12,12 @@ partial class AvaloniaView
         public UITextAutocapitalizationType AutocapitalizationType { get; private set; }
 
         [Export("autocorrectionType")]
-        public UITextAutocorrectionType AutocorrectionType => UITextAutocorrectionType.Yes;
+        public UITextAutocorrectionType AutocorrectionType =>
+            _view._options == null ?
+                UITextAutocorrectionType.Yes :
+                _view._options.HideSuggestions ?
+                    UITextAutocorrectionType.No :
+                    UITextAutocorrectionType.Yes;
 
         [Export("keyboardType")]
         public UIKeyboardType KeyboardType =>
@@ -64,7 +69,13 @@ partial class AvaloniaView
             _view._options?.ContentType is TextInputContentType.Password or TextInputContentType.Pin 
             || (_view._options?.IsSensitive ?? false);
 
-        [Export("spellCheckingType")] public UITextSpellCheckingType SpellCheckingType => UITextSpellCheckingType.Yes;
+        [Export("spellCheckingType")]
+        public UITextSpellCheckingType SpellCheckingType =>
+            _view._options == null ?
+                UITextSpellCheckingType.Yes :
+                _view._options.HideSuggestions ?
+                    UITextSpellCheckingType.No :
+                    UITextSpellCheckingType.Yes;
 
         [Export("textContentType")] public NSString TextContentType { get; set; } = new NSString("text/plain");
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Add a `ShowSuggestions` property to `TextInputOptions` that when set to false on a text box, the keyboard does not show the autocomplete/word suggestions above the keyboard on Android/iOS.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Android/iOS keyboards do not present suggestions when the new  `ShowSuggestions` property is set to `false`.

## Checklist

- [x] Added unit tests (if possible)? (please tell me if there's tests I'm missing here...)
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #16579
