### PR TITLE
Clamp progress bar indicator width and height to never drop below zero when calculating size.

### DIFF
--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -378,16 +378,16 @@ namespace Avalonia.Controls
                 // Indicator size calculation should consider the ProgressBar's Padding property setting
                 if (Orientation == Orientation.Horizontal)
                 {
-                    _indicator.Width = (barSize.Width - _indicator.Margin.Left - _indicator.Margin.Right) * percent;
+                    var width = (barSize.Width - _indicator.Margin.Left - _indicator.Margin.Right) * percent;
+                    _indicator.Width = width > 0 ? width : 0;
                     _indicator.Height = double.NaN;
                 }
                 else
                 {
                     _indicator.Width = double.NaN;
-                    _indicator.Height = (barSize.Height - _indicator.Margin.Top - _indicator.Margin.Bottom) *
-                                        percent;
+                    var height = (barSize.Height - _indicator.Margin.Top - _indicator.Margin.Bottom) * percent;
+                    _indicator.Height = height > 0 ? height : 0;
                 }
-
 
                 Percentage = percent * 100;
             }


### PR DESCRIPTION

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Simply clamps the width and height values to never go under zero when calculating indicator size.


## What is the current behavior?
If padding is set, an exception is thrown on first draw as the control has no bounds yet (`0, 0`) and the padding offset * the percent results in a negative value.
i.e 
```
(barSize.Width - _indicator.Margin.Left - _indicator.Margin.Right) * percent = width
(0             - 1                      - 1                      ) * 0.1     = -0.2
```


## What is the updated/expected behavior with this PR?
The clamping of the values means that the control should never calculate its indicator size to drop below zero and thus never throw an exception.


## How was the solution implemented (if it's not obvious)?
`Math.Clamp(...)` isn't available in netstandard2.0 thus a simple ternary assignment is used to check if the value is below zero, if so, assign zero, else assign the calculated value.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #17393
