### PR TITLE
Fixed TextBlock disappearing when inline used and measure is invalidated

### DIFF
--- a/src/Avalonia.Controls/SelectableTextBlock.cs
+++ b/src/Avalonia.Controls/SelectableTextBlock.cs
@@ -213,6 +213,8 @@ namespace Avalonia.Controls
                     };
             }
 
+            UpdateTextRuns();
+            
             ITextSource textSource;
 
             if (_textRuns != null)

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -889,7 +889,7 @@ namespace Avalonia.Controls
 
         void IInlineHost.Invalidate()
         {
-            InvalidateTextLayout();
+            InvalidateMeasure();
         }
 
         IAvaloniaList<Visual> IInlineHost.VisualChildren => VisualChildren;

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -725,7 +725,7 @@ namespace Avalonia.Controls
                 InvalidateArrange();
             }
             
-            UpdateTextRuns();
+            UpdateTextRuns(true);
 
             //This implicitly recreated the TextLayout with a new constraint if we previously reset it.
             var textLayout = TextLayout;
@@ -735,11 +735,11 @@ namespace Avalonia.Controls
             return size;
         }
 
-        protected void UpdateTextRuns()
+        protected void UpdateTextRuns(bool force = false)
         {
             var inlines = Inlines;
 
-            if (HasComplexContent && _textRuns == null)
+            if (HasComplexContent && (force || _textRuns == null))
             {
                 var textRuns = new List<TextRun>();
 

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -665,6 +665,8 @@ namespace Avalonia.Controls
             {
                 LineSpacing = LineSpacing
             };
+            
+            UpdateTextRuns();
 
             ITextSource textSource;
 
@@ -722,10 +724,22 @@ namespace Avalonia.Controls
                 //Force arrange so text will be properly alligned.
                 InvalidateArrange();
             }
-           
+            
+            UpdateTextRuns();
+
+            //This implicitly recreated the TextLayout with a new constraint if we previously reset it.
+            var textLayout = TextLayout;
+
+            var size = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.MinTextWidth, textLayout.Height).Inflate(padding), 1, 1);
+
+            return size;
+        }
+
+        protected void UpdateTextRuns()
+        {
             var inlines = Inlines;
 
-            if (HasComplexContent)
+            if (HasComplexContent && _textRuns == null)
             {
                 var textRuns = new List<TextRun>();
 
@@ -736,13 +750,6 @@ namespace Avalonia.Controls
 
                 _textRuns = textRuns;
             }
-
-            //This implicitly recreated the TextLayout with a new constraint if we previously reset it.
-            var textLayout = TextLayout;
-
-            var size = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.MinTextWidth, textLayout.Height).Inflate(padding), 1, 1);
-
-            return size;
         }
 
         protected override Size ArrangeOverride(Size finalSize)
@@ -882,7 +889,7 @@ namespace Avalonia.Controls
 
         void IInlineHost.Invalidate()
         {
-            InvalidateMeasure();
+            InvalidateTextLayout();
         }
 
         IAvaloniaList<Visual> IInlineHost.VisualChildren => VisualChildren;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes an issue that `TextBlock` with inlines could disappear when it's measure is invalidated.

## What is the current behavior?
Invalidating a `TextBlock` measure with inlines could cause the `TextBlock` to disappear.
This can be reproduced by going into ControlCatalog/TextBlockPage and then changing Avalonia's theme -
![image](https://github.com/user-attachments/assets/7427be0f-dfc3-4876-8492-50ba14b9d70b)

## What is the updated/expected behavior with this PR?
The `TextBlock` should not disappear when it's measure is invalidated.


## How was the solution implemented (if it's not obvious)?
Recalculate `_textRuns` in the next measure/render after it is set to `null` by `OnMeasureInvalidated`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
