### PR TITLE
Changed text trimming to be based on the resolved flow direction

### DIFF
--- a/samples/ControlCatalog/Pages/TextBlockPage.xaml
+++ b/samples/ControlCatalog/Pages/TextBlockPage.xaml
@@ -23,6 +23,22 @@
           <TextBlock Margin="0,0,10,0"
                      Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
                      TextTrimming="WordEllipsis" />
+          <TextBlock Margin="0,0,10,0"
+                     Text="טקסט בשפה עברית אמור להיות מוצג מימין לשמאל"
+                     FontFamily="Arial"
+                     TextTrimming="CharacterEllipsis" />
+          <TextBlock Margin="0,0,10,0"
+                     Text="טקסט בשפה עברית אמור להיות מוצג מימין לשמאל"
+                     FontFamily="Arial"
+                     TextTrimming="WordEllipsis" />
+          <TextBlock Margin="0,0,10,0"
+                     Text="אחד שתיים שלוש Four חמש Six שבע Eight"
+                     FontFamily="Arial"
+                     TextTrimming="CharacterEllipsis" />
+          <TextBlock Margin="0,0,10,0"
+                     Text="אחד שתיים שלוש Four חמש Six שבע Eight"
+                     FontFamily="Arial"
+                     TextTrimming="WordEllipsis" />
           <TextBlock Text="Left aligned text" TextAlignment="Left" />
           <TextBlock Text="Center aligned text" TextAlignment="Center" />
           <TextBlock Text="Right aligned text" TextAlignment="Right" />

--- a/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
@@ -94,17 +94,21 @@ namespace Avalonia.Media.TextFormatting
         /// Measures the number of characters that fit into available width.
         /// </summary>
         /// <param name="availableWidth">The available width.</param>
+        /// <param name="flowDirection">The flow direction of the text.</param>
         /// <param name="length">The count of fitting characters.</param>
         /// <returns>
         /// <c>true</c> if characters fit into the available width; otherwise, <c>false</c>.
         /// </returns>
-        public bool TryMeasureCharacters(double availableWidth, out int length)
+        public bool TryMeasureCharacters(double availableWidth, FlowDirection flowDirection, out int length)
         {
             length = 0;
             var currentWidth = 0.0;
             var charactersSpan = GlyphRun.Characters.Span;
 
-            for (var i = 0; i < ShapedBuffer.Length; i++)
+            int i = flowDirection == FlowDirection.LeftToRight ? 0 : charactersSpan.Length - 1;
+            int end = flowDirection == FlowDirection.LeftToRight ? charactersSpan.Length : -1;
+            int offset = flowDirection == FlowDirection.LeftToRight ? 1 : -1;
+            while (i != end)
             {
                 var advance = ShapedBuffer[i].GlyphAdvance;
                 var currentCluster = ShapedBuffer[i].GlyphCluster;
@@ -114,9 +118,9 @@ namespace Avalonia.Media.TextFormatting
                     break;
                 }
 
-                if(i + 1 < ShapedBuffer.Length)
+                if (i + offset != end)
                 {
-                    var nextCluster = ShapedBuffer[i + 1].GlyphCluster;
+                    var nextCluster = ShapedBuffer[i + offset].GlyphCluster;
 
                     var count = nextCluster - currentCluster;
 
@@ -129,8 +133,9 @@ namespace Avalonia.Media.TextFormatting
                     length += count;
                 }
 
-             
+
                 currentWidth += advance;
+                i += offset;
             }
 
             return length > 0;

--- a/src/Avalonia.Base/Media/TextFormatting/TextCollapsingProperties.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextCollapsingProperties.cs
@@ -26,7 +26,8 @@ namespace Avalonia.Media.TextFormatting
         /// Collapses given text line.
         /// </summary>
         /// <param name="textLine">Text line to collapse.</param>
-        public abstract TextRun[]? Collapse(TextLine textLine);
+        /// <param name="resolvedFlowDirection">The resolved flow direction</param>
+        public abstract TextRun[]? Collapse(TextLine textLine, FlowDirection resolvedFlowDirection);
 
         /// <summary>
         /// Creates a list of runs for given collapsed length which includes specified symbol at the end.

--- a/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
@@ -4,7 +4,8 @@ namespace Avalonia.Media.TextFormatting
 {
     internal static class TextEllipsisHelper
     {
-        public static TextRun[]? Collapse(TextLine textLine, TextCollapsingProperties properties, bool isWordEllipsis)
+        public static TextRun[]? Collapse(TextLine textLine, TextCollapsingProperties properties, bool isWordEllipsis,
+            FlowDirection resolvedFlowDirection)
         {
             var textRuns = textLine.TextRuns;
 
@@ -26,7 +27,7 @@ namespace Avalonia.Media.TextFormatting
 
             var availableWidth = properties.Width - shapedSymbol.Size.Width;
 
-            if(properties.FlowDirection== FlowDirection.LeftToRight)
+            if (resolvedFlowDirection == FlowDirection.LeftToRight)
             {
                 while (runIndex < textRuns.Count)
                 {
@@ -40,7 +41,7 @@ namespace Avalonia.Media.TextFormatting
 
                                 if (currentWidth > availableWidth)
                                 {
-                                    if (shapedRun.TryMeasureCharacters(availableWidth, out var measuredLength))
+                                    if (shapedRun.TryMeasureCharacters(availableWidth, resolvedFlowDirection, out var measuredLength))
                                     {
                                         if (isWordEllipsis && measuredLength < textLine.Length)
                                         {
@@ -71,7 +72,7 @@ namespace Avalonia.Media.TextFormatting
 
                                     collapsedLength += measuredLength;
 
-                                    return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.LeftToRight, shapedSymbol);
+                                    return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, resolvedFlowDirection, shapedSymbol);
                                 }
 
                                 availableWidth -= shapedRun.Size.Width;
@@ -84,7 +85,7 @@ namespace Avalonia.Media.TextFormatting
                                 //The whole run needs to fit into available space
                                 if (currentWidth + drawableRun.Size.Width > availableWidth)
                                 {
-                                    return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.LeftToRight, shapedSymbol);
+                                    return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, resolvedFlowDirection, shapedSymbol);
                                 }
 
                                 availableWidth -= drawableRun.Size.Width;
@@ -114,7 +115,7 @@ namespace Avalonia.Media.TextFormatting
 
                                 if (currentWidth > availableWidth)
                                 {
-                                    if (shapedRun.TryMeasureCharacters(availableWidth, out var measuredLength))
+                                    if (shapedRun.TryMeasureCharacters(availableWidth, resolvedFlowDirection, out var measuredLength))
                                     {
                                         if (isWordEllipsis && measuredLength < textLine.Length)
                                         {
@@ -145,7 +146,7 @@ namespace Avalonia.Media.TextFormatting
 
                                     collapsedLength += measuredLength;
 
-                                    return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.RightToLeft, shapedSymbol);
+                                    return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, resolvedFlowDirection, shapedSymbol);
                                 }
 
                                 availableWidth -= shapedRun.Size.Width;
@@ -158,7 +159,7 @@ namespace Avalonia.Media.TextFormatting
                                 //The whole run needs to fit into available space
                                 if (currentWidth + drawableRun.Size.Width > availableWidth)
                                 {
-                                    return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.RightToLeft, shapedSymbol);
+                                    return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, resolvedFlowDirection, shapedSymbol);
                                 }
 
                                 availableWidth -= drawableRun.Size.Width;

--- a/src/Avalonia.Base/Media/TextFormatting/TextLeadingPrefixCharacterEllipsis.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLeadingPrefixCharacterEllipsis.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Media.TextFormatting
         public override FlowDirection FlowDirection { get; }
 
         /// <inheritdoc />
-        public override TextRun[]? Collapse(TextLine textLine)
+        public override TextRun[]? Collapse(TextLine textLine, FlowDirection resolvedFlowDirection)
         {
             var textRuns = textLine.TextRuns;
 
@@ -81,7 +81,7 @@ namespace Avalonia.Media.TextFormatting
 
                             if (currentWidth > availableWidth)
                             {
-                                shapedRun.TryMeasureCharacters(availableWidth, out var measuredLength);
+                                shapedRun.TryMeasureCharacters(availableWidth, resolvedFlowDirection, out var measuredLength);
 
                                 if (measuredLength > 0)
                                 {

--- a/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
@@ -170,7 +170,7 @@ namespace Avalonia.Media.TextFormatting
                 return this;
             }
 
-            var collapsedRuns = collapsingProperties.Collapse(this);
+            var collapsedRuns = collapsingProperties.Collapse(this, _resolvedFlowDirection);
 
             if (collapsedRuns is null)
             {
@@ -1167,7 +1167,7 @@ namespace Avalonia.Media.TextFormatting
 
         public void FinalizeLine()
         {
-            _indexedTextRuns = BidiReorderer.Instance.BidiReorder(_textRuns, _paragraphProperties.FlowDirection, FirstTextSourceIndex);
+            _indexedTextRuns = BidiReorderer.Instance.BidiReorder(_textRuns, _resolvedFlowDirection, FirstTextSourceIndex);
 
             _textLineMetrics = CreateLineMetrics();
 

--- a/src/Avalonia.Base/Media/TextFormatting/TextTrailingCharacterEllipsis.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextTrailingCharacterEllipsis.cs
@@ -30,9 +30,9 @@
         public override FlowDirection FlowDirection { get; }
 
         /// <inheritdoc />
-        public override TextRun[]? Collapse(TextLine textLine)
+        public override TextRun[]? Collapse(TextLine textLine, FlowDirection resolvedFlowDirection)
         {
-            return TextEllipsisHelper.Collapse(textLine, this, false);
+            return TextEllipsisHelper.Collapse(textLine, this, false, resolvedFlowDirection);
         }
     }
 }

--- a/src/Avalonia.Base/Media/TextFormatting/TextTrailingWordEllipsis.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextTrailingWordEllipsis.cs
@@ -34,9 +34,9 @@
         public override FlowDirection FlowDirection { get; }
 
         /// <inheritdoc />
-        public override TextRun[]? Collapse(TextLine textLine)
+        public override TextRun[]? Collapse(TextLine textLine, FlowDirection resolvedFlowDirection)
         {
-            return TextEllipsisHelper.Collapse(textLine, this, true);
+            return TextEllipsisHelper.Collapse(textLine, this, true, resolvedFlowDirection);
         }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
Tries to fix #17888, although it doesn't feel like this is the right solution.
Also, with text with RTL and LTR mixed we still have issues.


## What is the updated/expected behavior with this PR?
![image](https://github.com/user-attachments/assets/2873f2a1-1e05-469b-bfe0-cbb0a45cc66e)


## How was the solution implemented (if it's not obvious)?
Use resolved flow direction for text trimming.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
