### PR TITLE
Fix: Multi-line text rendered outside control boundaries

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -958,7 +958,9 @@ namespace Avalonia.Media.TextFormatting
 
             for (var i = textSpan.Length - 1; i >= 0; i--)
             {
-                if (char.IsWhiteSpace(textSpan[i]))
+                var isWhitespace = Codepoint.ReadAt(textSpan, i, out _).IsWhiteSpace;
+
+                if (isWhitespace)
                 {
                     whitespaceCharactersCount++;
                 }

--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -634,6 +634,8 @@ namespace Avalonia.Controls.Presenters
 
         protected override Size ArrangeOverride(Size finalSize)
         {
+            var finalWidth = finalSize.Width;
+
             var textWidth = Math.Ceiling(TextLayout.OverhangLeading + TextLayout.WidthIncludingTrailingWhitespace + TextLayout.OverhangTrailing);
 
             if (finalSize.Width < textWidth)
@@ -641,12 +643,12 @@ namespace Avalonia.Controls.Presenters
                 finalSize = finalSize.WithWidth(textWidth);
             }
 
-            if (MathUtilities.AreClose(_constraint.Width, finalSize.Width))
+            if (MathUtilities.AreClose(_constraint.Width, finalWidth))
             {
                 return finalSize;
             }
 
-            _constraint = new Size(Math.Ceiling(finalSize.Width), double.PositiveInfinity);
+            _constraint = new Size(Math.Ceiling(finalWidth), double.PositiveInfinity);
 
             _textLayout?.Dispose();
             _textLayout = null;

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
@@ -169,6 +169,60 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
         }
 
         [Fact]
+        public void Should_Compress_Reversed_Trailing_Whitespace()
+        {
+            using (Start())
+            {
+                const string text = "אאאאא בבבבב";
+
+                var defaultProperties = new GenericTextRunProperties(Typeface.Default, 12, foregroundBrush: Brushes.Black);
+
+                var paragraphProperties = new GenericTextParagraphProperties(defaultProperties, textWrap: TextWrapping.Wrap);
+
+                var textSource = new SingleBufferTextSource(text, defaultProperties);
+
+                var formatter = new TextFormatterImpl();
+
+                var textLine = formatter.FormatLine(textSource, 0, 50, paragraphProperties);
+
+                var textRun = textLine?.TextRuns[0] as ShapedTextRun;
+
+                Assert.NotNull(textRun);
+
+                var whitespaceGlyphInfo = textRun.ShapedBuffer[0];
+
+                Assert.Equal(0, whitespaceGlyphInfo.GlyphAdvance);
+            }
+        }
+
+        [Fact]
+        public void Should_Compress_Reversed_Trailing_Whitespace_2()
+        {
+            using (Start())
+            {
+                const string text = "aaaaa bbbbb";
+
+                var defaultProperties = new GenericTextRunProperties(Typeface.Default, 12, foregroundBrush: Brushes.Black);
+
+                var paragraphProperties = new GenericTextParagraphProperties(FlowDirection.RightToLeft, TextAlignment.Start, true, 
+                                                                             true, defaultProperties, TextWrapping.Wrap, 0, 0, 0);
+                var textSource = new SingleBufferTextSource(text, defaultProperties);
+
+                var formatter = new TextFormatterImpl();
+
+                var textLine = formatter.FormatLine(textSource, 0, 50, paragraphProperties);
+
+                var textRun = textLine?.TextRuns[0] as ShapedTextRun;
+
+                Assert.NotNull(textRun);
+
+                var whitespaceGlyphInfo = textRun.ShapedBuffer[5];
+
+                Assert.Equal(0, whitespaceGlyphInfo.GlyphAdvance);
+            }
+        }
+
+        [Fact]
         public void Should_Format_TextRuns_With_TextRunStyles()
         {
             using (Start())


### PR DESCRIPTION
## What does the pull request do?
It fixes a bug that causes multi-line text to render outside the control's boundaries, resulting in truncated or completely hidden text.

## What is the current behavior?
Multi-line text sometimes truncated at the control's boundaries or is not displayed at all. This can happen due to two reasons:
1. Bidi text processing causes trailing whitespace to reverse and appear before the text, and pushing part of the text out.
2. Trailing whitespace increases the `TextLayout` constraint size (stored in `TextPresenter._constraint` field) during `ArrangeOverride`, causing text to render outside the control's boundaries.

Example gif:
![bug1](https://github.com/user-attachments/assets/54bdf6a4-b4c7-488f-9ba5-c54b48f9ac66)
![bug2](https://github.com/user-attachments/assets/120b929e-2374-4399-a193-26ed3b95befd)

<details>
  <summary>Xaml Code</summary>

## Gif 1
```xaml
<StackPanel Margin="6" Spacing="6">
    
  <TextBox Width="100"
            Padding="0"
            CornerRadius="0"
            Text="aaaaaa  b"
            FontSize="30"
            TextWrapping="Wrap"
            FlowDirection="RightToLeft" />
    
  <TextBox Width="100"
            Padding="0"
            CornerRadius="0"
            Text="אאאאא  ב"
            FontSize="30"
            TextWrapping="Wrap" />
    
</StackPanel>
```

## Gif 2
```xaml
<TextBox Width="100"
          Padding="0"
          CornerRadius="0"
          Text="aaaa bbbb         c"
          FontSize="30"
          TextWrapping="Wrap" />
```

</details>

## What is the updated/expected behavior with this PR?
Text is displayed accurately and without truncation.

Example gif:
![fix1](https://github.com/user-attachments/assets/1c43ebe9-cd5a-4a06-9f06-7b8bd1d24eec)
![fix2](https://github.com/user-attachments/assets/436cd375-6196-40b1-902b-4ca46038c14c)



## How was the solution implemented (if it's not obvious)?
1. Added `CompressReversedTrailingWhitespace` method to check for reversed trailing whitespace due to bidi processing, and if found, sets the `GlyphAdvance` of whitespace glyphs to 0.
2. Corrected logic in `TextPresenter.ArrangeOverride` to check the actual `finalSize` instead of `finalSize` including trailing whitespace for TextLayout constraint size.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation