### PR TITLE
Fix TextLayout overflow

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -634,6 +634,8 @@ namespace Avalonia.Controls.Presenters
 
         protected override Size ArrangeOverride(Size finalSize)
         {
+            var finalWidth = finalSize.Width;
+
             var textWidth = Math.Ceiling(TextLayout.OverhangLeading + TextLayout.WidthIncludingTrailingWhitespace + TextLayout.OverhangTrailing);
 
             if (finalSize.Width < textWidth)
@@ -641,15 +643,13 @@ namespace Avalonia.Controls.Presenters
                 finalSize = finalSize.WithWidth(textWidth);
             }
 
-            if (MathUtilities.AreClose(_constraint.Width, finalSize.Width))
+            if (MathUtilities.AreClose(_constraint.Width, finalWidth) == false)
             {
-                return finalSize;
+                _constraint = new Size(Math.Ceiling(finalWidth), double.PositiveInfinity);
+
+                _textLayout?.Dispose();
+                _textLayout = null;
             }
-
-            _constraint = new Size(Math.Ceiling(finalSize.Width), double.PositiveInfinity);
-
-            _textLayout?.Dispose();
-            _textLayout = null;
 
             return finalSize;
         }

--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -643,6 +643,10 @@ namespace Avalonia.Controls.Presenters
                 finalSize = finalSize.WithWidth(textWidth);
             }
 
+            // Check if the '_constraint' has changed since the last measure,
+            // if so recalculate the TextLayout according to the new size
+            // NOTE: It is important to check this against the actual final size
+            // (excluding the trailing whitespace) to avoid TextLayout overflow.
             if (MathUtilities.AreClose(_constraint.Width, finalWidth) == false)
             {
                 _constraint = new Size(Math.Ceiling(finalWidth), double.PositiveInfinity);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes a bug that causes TextLayout to be larger than the control bounds, resulting in multi-line text sometimes being displayed truncated

## What is the current behavior?
![bug2](https://github.com/user-attachments/assets/92c2d0a3-f3fe-4c4e-be89-2e93d5604711)


## What is the updated/expected behavior with this PR?
![fix2](https://github.com/user-attachments/assets/6ec47031-0c89-4224-a07a-b6f367826eff)


## How was the solution implemented (if it's not obvious)?
Corrected logic in TextPresenter.ArrangeOverride to check the actual finalSize instead of finalSize including trailing whitespace for TextLayout constraint size.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation