### PR TITLE
Android - Fix segfault crash when native surface is destroyed on vulkan

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
@@ -14,12 +14,13 @@ namespace Avalonia.Android
     {
         bool _invalidateQueued;
         private bool _isDisposed;
+        private bool _isSurfaceValid;
         readonly object _lock = new object();
         private readonly Handler _handler;
 
         internal event EventHandler? SurfaceWindowCreated;
 
-        IntPtr IPlatformHandle.Handle => Holder?.Surface?.Handle is { } handle ?
+        IntPtr IPlatformHandle.Handle => _isSurfaceValid && Holder?.Surface?.Handle is { } handle ?
             AndroidFramebuffer.ANativeWindow_fromSurface(JNIEnv.Handle, handle) :
             default;
 
@@ -63,12 +64,14 @@ namespace Avalonia.Android
 
         public void SurfaceChanged(ISurfaceHolder holder, Format format, int width, int height)
         {
+            _isSurfaceValid = true;
             Log.Info("AVALONIA", "Surface Changed");
             DoDraw();
         }
 
         public void SurfaceCreated(ISurfaceHolder holder)
         {
+            _isSurfaceValid = true;
             Log.Info("AVALONIA", "Surface Created");
             SurfaceWindowCreated?.Invoke(this, EventArgs.Empty);
             DoDraw();
@@ -76,6 +79,7 @@ namespace Avalonia.Android
 
         public void SurfaceDestroyed(ISurfaceHolder holder)
         {
+            _isSurfaceValid = false;
             Log.Info("AVALONIA", "Surface Destroyed");
 
         }

--- a/src/Android/Avalonia.Android/Platform/Vulkan/VulkanSupport.cs
+++ b/src/Android/Avalonia.Android/Platform/Vulkan/VulkanSupport.cs
@@ -53,6 +53,8 @@ namespace Avalonia.Android.Platform.Vulkan
 
         private static ulong CreateAndroidSurface(nint handle, IVulkanInstance instance)
         {
+            if(handle == IntPtr.Zero)
+                throw new ArgumentException("Surface handle can't be 0x0", nameof(handle));
             var vulkanAndroid = new AndroidVulkanInterface(instance);
             var createInfo = new VkAndroidSurfaceCreateInfoKHR()
             {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This pr checks for valid native surface on android when creating a vulkan surface.


## What is the current behavior?
When android suspends an activity, all surfaces owned by that activity is destroyed. We do not do any checks on the validity if the surfaces when we start drawing and we try to create a khr surface using the handle of a destroyed surface, causing a segfault.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
