### PR TITLE
Reset bidi levels of trailing whitespace after text wrapping (According to TR9 guidelines)

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/ShapedBuffer.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/ShapedBuffer.cs
@@ -49,7 +49,7 @@ namespace Avalonia.Media.TextFormatting
         /// <summary>
         /// The buffer's bidi level.
         /// </summary>
-        public sbyte BidiLevel { get; }
+        public sbyte BidiLevel { get; private set; }
 
         /// <summary>
         /// The buffer's reading direction.
@@ -168,6 +168,8 @@ namespace Avalonia.Media.TextFormatting
 
             return new SplitResult<ShapedBuffer>(first, second);
         }
+
+        internal void ResetBidiLevel(sbyte paragraphEmbeddingLevel) => BidiLevel = paragraphEmbeddingLevel;
 
         int IReadOnlyCollection<GlyphInfo>.Count => _glyphInfos.Length;
 

--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -908,6 +908,11 @@ namespace Avalonia.Media.TextFormatting
                     textLineBreak = null;
                 }
 
+                if (postSplitRuns?.Count > 0)
+                {
+                    ResetTrailingWhitespaceBidiLevels(preSplitRuns, paragraphProperties.FlowDirection, objectPool);
+                }
+
                 var textLine = new TextLineImpl(preSplitRuns.ToArray(), firstTextSourceIndex, measuredLength,
                     paragraphWidth, paragraphProperties, resolvedFlowDirection,
                     textLineBreak);
@@ -920,6 +925,86 @@ namespace Avalonia.Media.TextFormatting
             {
                 objectPool.TextRunLists.Return(ref preSplitRuns);
                 objectPool.TextRunLists.Return(ref postSplitRuns);
+            }
+        }
+
+        private static void ResetTrailingWhitespaceBidiLevels(RentedList<TextRun> lineTextRuns, FlowDirection paragraphFlowDirection, FormattingObjectPool objectPool)
+        {
+            if (lineTextRuns.Count == 0)
+            {
+                return;
+            }
+
+            var lastTextRunIndex = lineTextRuns.Count - 1;
+
+            var lastTextRun = lineTextRuns[lastTextRunIndex];
+
+            if (lastTextRun is not ShapedTextRun shapedText)
+            {
+                return;
+            }
+
+            var paragraphEmbeddingLevel = (sbyte)paragraphFlowDirection;
+
+            if (shapedText.BidiLevel == paragraphEmbeddingLevel)
+            {
+                return;
+            }
+
+            var textSpan = shapedText.Text.Span;
+
+            if (textSpan.IsEmpty)
+            {
+                return;
+            }
+
+            var whitespaceCharactersCount = 0;
+
+            for (var i = textSpan.Length - 1; i >= 0; i--)
+            {
+                var isWhitespace = Codepoint.ReadAt(textSpan, i, out _).IsWhiteSpace;
+
+                if (isWhitespace)
+                {
+                    whitespaceCharactersCount++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (whitespaceCharactersCount == 0)
+            {
+                return;
+            }
+
+            var splitIndex = shapedText.Length - whitespaceCharactersCount;
+
+            var (textRuns, trailingWhitespaceRuns) = SplitTextRuns([shapedText], splitIndex, objectPool);
+
+            try
+            {
+                if (trailingWhitespaceRuns != null)
+                {
+                    for (var i = 0; i < trailingWhitespaceRuns.Count; i++)
+                    {
+                        if (trailingWhitespaceRuns[i] is ShapedTextRun shapedTextRun)
+                        {
+                            shapedTextRun.ShapedBuffer.ResetBidiLevel(paragraphEmbeddingLevel);
+                        }
+                    }
+
+                    lineTextRuns.RemoveAt(lastTextRunIndex);
+
+                    lineTextRuns.AddRange(textRuns);
+                    lineTextRuns.AddRange(trailingWhitespaceRuns);
+                }
+            }
+            finally
+            {
+                objectPool.TextRunLists.Return(ref textRuns);
+                objectPool.TextRunLists.Return(ref trailingWhitespaceRuns);
             }
         }
 

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
@@ -169,6 +169,87 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
         }
 
         [Fact]
+        public void Should_Reset_Bidi_Levels_Of_Trailing_Whitespaces_After_TextWrapping()
+        {
+            using (Start())
+            {
+                const string text = "aaa bbb";
+
+                var defaultProperties = new GenericTextRunProperties(Typeface.Default);
+
+                var paragraphProperties = new GenericTextParagraphProperties(FlowDirection.RightToLeft, TextAlignment.Right, true,
+                                                                             true, defaultProperties, TextWrapping.Wrap, 0, 0, 0);
+
+                var textSource = new SimpleTextSource(text, defaultProperties);
+
+                var formatter = new TextFormatterImpl();
+
+                var firstLine = formatter.FormatLine(textSource, 0, 50, paragraphProperties);
+
+                Assert.NotNull(firstLine);
+
+                Assert.Equal(2, firstLine.TextRuns.Count);
+
+                var first = firstLine.TextRuns[0] as ShapedTextRun;
+
+                var second = firstLine.TextRuns[1] as ShapedTextRun;
+
+                Assert.NotNull(first);
+
+                Assert.NotNull(second);
+
+                Assert.Equal(" ", first.Text.ToString());
+
+                Assert.Equal("aaa", second.Text.ToString());
+
+                Assert.Equal(1, first.BidiLevel);
+
+                Assert.Equal(2, second.BidiLevel);
+            }
+        }
+
+
+        [Fact]
+        public void Should_Reset_Bidi_Levels_Of_Trailing_Whitespaces_After_TextWrapping_2()
+        {
+            using (Start())
+            {
+                const string text = "אאא בבב";
+
+                var defaultProperties = new GenericTextRunProperties(Typeface.Default);
+
+                var paragraphProperties = new GenericTextParagraphProperties(FlowDirection.LeftToRight, TextAlignment.Left, true,
+                                                                             true, defaultProperties, TextWrapping.Wrap, 0, 0, 0);
+
+                var textSource = new SimpleTextSource(text, defaultProperties);
+
+                var formatter = new TextFormatterImpl();
+
+                var firstLine = formatter.FormatLine(textSource, 0, 40, paragraphProperties);
+
+                Assert.NotNull(firstLine);
+
+                Assert.Equal(2, firstLine.TextRuns.Count);
+
+                var first = firstLine.TextRuns[0] as ShapedTextRun;
+
+                var second = firstLine.TextRuns[1] as ShapedTextRun;
+
+                Assert.NotNull(first);
+
+                Assert.NotNull(second);
+
+                Assert.Equal("אאא", first.Text.ToString());
+
+                Assert.Equal(" ", second.Text.ToString());
+
+                Assert.Equal(1, first.BidiLevel);
+
+                Assert.Equal(0, second.BidiLevel);
+            }
+        }
+
+        [Fact]
         public void Should_Format_TextRuns_With_TextRunStyles()
         {
             using (Start())


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
In some situations it is necessary to reset the levels of trailing whitespace to the paragraph embedding level after text wrapping,  this PR does this according to TR9 docs.

https://www.unicode.org/reports/tr9/#L1


## What is the current behavior?
Currently it does not work according to TR9, and sometimes white spaces jump to the beginning of the text.
![before](https://github.com/user-attachments/assets/25784208-aad2-4acb-867f-1f89f846ab70)


## What is the updated/expected behavior with this PR?
Alignment with TR9 guidelines
![after](https://github.com/user-attachments/assets/534846e4-cd26-4095-af3e-7d638ddb16aa)


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation