### PR TITLE
Update compat dispatcher priorities

### DIFF
--- a/src/Avalonia.Base/Threading/DispatcherPriority.cs
+++ b/src/Avalonia.Base/Threading/DispatcherPriority.cs
@@ -112,7 +112,7 @@ namespace Avalonia.Threading
         /// <summary>
         /// The job will be processed with the same priority as data binding.
         /// </summary>
-        [Obsolete("WPF compatibility"), EditorBrowsable(EditorBrowsableState.Never)] public static readonly DispatcherPriority DataBind = new(Render);
+        [Obsolete("WPF compatibility"), EditorBrowsable(EditorBrowsableState.Never)] public static readonly DispatcherPriority DataBind = new(AsyncRenderTargetResize + 1);
         
         /// <summary>
         /// The job will be processed with normal priority.


### PR DESCRIPTION
Due to a typo we had aliases instead of separate priorities:

- AsyncRenderTargetResize was the same as Send (it's a private priority used by X11 platform to queue resize operation ahead of input and rendering)
- compat priority Normal was the same as BeforeRender (private priority)


Also for some reason the compat DataBind priority was the same as Render while it's supposed to be a separate one.


The effect of this change is X11 window resize being executed after Normal/DataBind jobs and compat DataBind priority actually having its own value that's higher than Render.

This _should_ be a safe change to backport.