### PR TITLE
End/close AppKit sheets attached on window when we hide it

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -143,6 +143,19 @@ HRESULT WindowBaseImpl::Hide() {
 
     @autoreleasepool {
         if (Window != nullptr) {
+            
+            // If window is hidden without ending attached sheet first, it will stuck in "order out" state,
+            // and block any new sheets from being attached.
+            // Additionaly, we don't know if user would define any custom panels, so we only end/close file dialog sheets.
+            auto attachedSheet = Window.attachedSheet;
+            if (attachedSheet
+                && ([attachedSheet isKindOfClass: [NSOpenPanel class]]
+                    || [attachedSheet isKindOfClass: [NSSavePanel class]]))
+            {
+                [Window endSheet:attachedSheet];
+                [attachedSheet close];
+            }
+
             auto frame = [Window frame];
 
             AvnPoint point;


### PR DESCRIPTION
## What is the current behavior?

1. Open File/Folder Picker from a window, don't pick anything
2. Hide parent window programmatically
3. Show parent window back
4. File/Folder Picker (NSSavePanel/NSOpenPanel) will stay on the background forever. And async task will never end.

## What is the updated/expected behavior with this PR?

Hiding parent window also completes any opened NSSavePanel/NSOpenPanel that were attached to it.
Async tasks completes, and new dialogs can be opened.
