### PR TITLE
[DockPanel] Add Spacing properties

### DIFF
--- a/src/Avalonia.Controls/DockPanel.cs
+++ b/src/Avalonia.Controls/DockPanel.cs
@@ -38,14 +38,6 @@ namespace Avalonia.Controls
                 defaultValue: true);
 
         /// <summary>
-        /// Identifies the Padding dependency property.
-        /// </summary>
-        /// <returns>The identifier for the <see cref="Padding"/> dependency property.</returns>
-        public static readonly StyledProperty<Thickness> PaddingProperty =
-            AvaloniaProperty.Register<DockPanel, Thickness>(
-                nameof(Padding));
-
-        /// <summary>
         /// Identifies the HorizontalSpacing dependency property.
         /// </summary>
         /// <returns>The identifier for the <see cref="HorizontalSpacing"/> dependency property.</returns>
@@ -67,7 +59,7 @@ namespace Avalonia.Controls
         static DockPanel()
         {
             AffectsParentMeasure<DockPanel>(DockProperty);
-            AffectsMeasure<DockPanel>(LastChildFillProperty, PaddingProperty, HorizontalSpacingProperty, VerticalSpacingProperty);
+            AffectsMeasure<DockPanel>(LastChildFillProperty, HorizontalSpacingProperty, VerticalSpacingProperty);
         }
 
         /// <summary>
@@ -98,19 +90,6 @@ namespace Avalonia.Controls
         {
             get => GetValue(LastChildFillProperty);
             set => SetValue(LastChildFillProperty, value);
-        }
-
-        /// <summary>
-        /// Gets or sets the distance between the border and its child object.
-        /// </summary>
-        /// <returns>
-        /// The dimensions of the space between the border and its child as a Thickness value.
-        /// Thickness is a structure that stores dimension values using pixel measures.
-        /// </returns>
-        public Thickness Padding
-        {
-            get => GetValue(PaddingProperty);
-            set => SetValue(PaddingProperty, value);
         }
 
         /// <summary>
@@ -147,8 +126,8 @@ namespace Avalonia.Controls
         {
             var parentWidth = 0.0;
             var parentHeight = 0.0;
-            var accumulatedWidth = Padding.Left + Padding.Right;
-            var accumulatedHeight = Padding.Top + Padding.Bottom;
+            var accumulatedWidth = 0d;
+            var accumulatedHeight = 0d;
 
             var leftSpacing = false;
             var topSpacing = false;
@@ -239,11 +218,7 @@ namespace Avalonia.Controls
             if (Children.Count is 0)
                 return finalSize;
 
-            var currentBounds = new Rect(
-                Padding.Left,
-                Padding.Top,
-                GetPositiveOrZero(finalSize.Width - Padding.Left - Padding.Right),
-                GetPositiveOrZero(finalSize.Height - Padding.Top - Padding.Bottom));
+            var currentBounds = new Rect(finalSize);
             var childrenCount = LastChildFill ? Children.Count - 1 : Children.Count;
 
             for (var index = 0; index < childrenCount; ++index)

--- a/src/Avalonia.Controls/DockPanel.cs
+++ b/src/Avalonia.Controls/DockPanel.cs
@@ -157,17 +157,23 @@ namespace Avalonia.Controls
                 {
                     case Dock.Left:
                     case Dock.Right:
-                        horizontalSpacing = true;
                         parentHeight = Math.Max(parentHeight, accumulatedHeight + childDesiredSize.Height);
-                        accumulatedWidth += HorizontalSpacing;
+                        if (child.IsVisible)
+                        {
+                            accumulatedWidth += HorizontalSpacing;
+                            horizontalSpacing = true;
+                        }
                         accumulatedWidth += childDesiredSize.Width;
                         break;
 
                     case Dock.Top:
                     case Dock.Bottom:
-                        verticalSpacing = true;
                         parentWidth = Math.Max(parentWidth, accumulatedWidth + childDesiredSize.Width);
-                        accumulatedHeight += VerticalSpacing;
+                        if (child.IsVisible)
+                        {
+                            accumulatedHeight += VerticalSpacing;
+                            verticalSpacing = true;
+                        }
                         accumulatedHeight += childDesiredSize.Height;
                         break;
                 }
@@ -217,6 +223,9 @@ namespace Avalonia.Controls
             for (var index = 0; index < childrenCount; ++index)
             {
                 var child = Children[index];
+                if (!child.IsVisible)
+                    continue;
+
                 var dock = child.GetValue(DockProperty);
                 double width, height;
                 switch (dock)

--- a/src/Avalonia.Controls/DockPanel.cs
+++ b/src/Avalonia.Controls/DockPanel.cs
@@ -124,8 +124,8 @@ namespace Avalonia.Controls
         /// <returns>The Panel's desired size.</returns>
         protected override Size MeasureOverride(Size availableSize)
         {
-            var parentWidth = 0.0;
-            var parentHeight = 0.0;
+            var parentWidth = 0d;
+            var parentHeight = 0d;
             var accumulatedWidth = 0d;
             var accumulatedHeight = 0d;
 
@@ -187,8 +187,9 @@ namespace Avalonia.Controls
                     accumulatedHeight -= VerticalSpacing;
             }
 
-            parentWidth = Math.Min(availableSize.Width, Math.Max(parentWidth, accumulatedWidth));
-            parentHeight = Math.Min(availableSize.Height, Math.Max(parentHeight, accumulatedHeight));
+            // Make sure the final accumulated size is reflected in parentSize.
+            parentWidth = Math.Max(parentWidth, accumulatedWidth);
+            parentHeight = Math.Max(parentHeight, accumulatedHeight);
             return new Size(parentWidth, parentHeight);
         }
 

--- a/src/Avalonia.Controls/DockPanel.cs
+++ b/src/Avalonia.Controls/DockPanel.cs
@@ -139,8 +139,8 @@ namespace Avalonia.Controls
             {
                 var child = Children[index];
                 var childConstraint = new Size(
-                    GetPositiveOrZero(availableSize.Width - accumulatedWidth),
-                    GetPositiveOrZero(availableSize.Height - accumulatedHeight));
+                    Math.Max(0, availableSize.Width - accumulatedWidth),
+                    Math.Max(0, availableSize.Height - accumulatedHeight));
 
                 child.Measure(childConstraint);
                 var childDesiredSize = child.DesiredSize;
@@ -185,8 +185,8 @@ namespace Avalonia.Controls
             {
                 var child = Children[Children.Count - 1];
                 var childConstraint = new Size(
-                    GetPositiveOrZero(availableSize.Width - accumulatedWidth),
-                    GetPositiveOrZero(availableSize.Height - accumulatedHeight));
+                    Math.Max(0, availableSize.Width - accumulatedWidth),
+                    Math.Max(0, availableSize.Height - accumulatedHeight));
 
                 child.Measure(childConstraint);
                 var childDesiredSize = child.DesiredSize;
@@ -233,7 +233,7 @@ namespace Avalonia.Controls
                         width = Math.Min(child.DesiredSize.Width, currentBounds.Width);
                         child.Arrange(currentBounds.WithWidth(width));
                         width += HorizontalSpacing;
-                        currentBounds = new Rect(currentBounds.X + width, currentBounds.Y, GetPositiveOrZero(currentBounds.Width - width), currentBounds.Height);
+                        currentBounds = new Rect(currentBounds.X + width, currentBounds.Y, Math.Max(0, currentBounds.Width - width), currentBounds.Height);
 
                         break;
                     case Dock.Top:
@@ -241,7 +241,7 @@ namespace Avalonia.Controls
                         height = Math.Min(child.DesiredSize.Height, currentBounds.Height);
                         child.Arrange(currentBounds.WithHeight(height));
                         height += VerticalSpacing;
-                        currentBounds = new Rect(currentBounds.X, currentBounds.Y + height, currentBounds.Width, GetPositiveOrZero(currentBounds.Height - height));
+                        currentBounds = new Rect(currentBounds.X, currentBounds.Y + height, currentBounds.Width, Math.Max(0, currentBounds.Height - height));
 
                         break;
                     case Dock.Right:
@@ -249,7 +249,7 @@ namespace Avalonia.Controls
                         width = Math.Min(child.DesiredSize.Width, currentBounds.Width);
                         child.Arrange(new Rect(currentBounds.X + currentBounds.Width - width, currentBounds.Y, width, currentBounds.Height));
                         width += HorizontalSpacing;
-                        currentBounds = currentBounds.WithWidth(GetPositiveOrZero(currentBounds.Width - width));
+                        currentBounds = currentBounds.WithWidth(Math.Max(0, currentBounds.Width - width));
 
                         break;
                     case Dock.Bottom:
@@ -257,7 +257,7 @@ namespace Avalonia.Controls
                         height = Math.Min(child.DesiredSize.Height, currentBounds.Height);
                         child.Arrange(new Rect(currentBounds.X, currentBounds.Y + currentBounds.Height - height, currentBounds.Width, height));
                         height += VerticalSpacing;
-                        currentBounds = currentBounds.WithHeight(GetPositiveOrZero(currentBounds.Height - height));
+                        currentBounds = currentBounds.WithHeight(Math.Max(0, currentBounds.Height - height));
 
                         break;
                 }
@@ -271,7 +271,5 @@ namespace Avalonia.Controls
 
             return finalSize;
         }
-
-        private static double GetPositiveOrZero(double value) => Math.Max(value, 0);
     }
 }

--- a/src/Avalonia.Controls/DockPanel.cs
+++ b/src/Avalonia.Controls/DockPanel.cs
@@ -159,8 +159,7 @@ namespace Avalonia.Controls
                     case Dock.Right:
                         horizontalSpacing = true;
                         parentHeight = Math.Max(parentHeight, accumulatedHeight + childDesiredSize.Height);
-                        if (childConstraint.Width is not 0)
-                            accumulatedWidth += HorizontalSpacing;
+                        accumulatedWidth += HorizontalSpacing;
                         accumulatedWidth += childDesiredSize.Width;
                         break;
 
@@ -168,8 +167,7 @@ namespace Avalonia.Controls
                     case Dock.Bottom:
                         verticalSpacing = true;
                         parentWidth = Math.Max(parentWidth, accumulatedWidth + childDesiredSize.Width);
-                        if (childConstraint.Height is not 0)
-                            accumulatedHeight += VerticalSpacing;
+                        accumulatedHeight += VerticalSpacing;
                         accumulatedHeight += childDesiredSize.Height;
                         break;
                 }

--- a/src/Avalonia.Controls/DockPanel.cs
+++ b/src/Avalonia.Controls/DockPanel.cs
@@ -143,6 +143,16 @@ namespace Avalonia.Controls
                 child.Measure(childConstraint);
                 var childDesiredSize = child.DesiredSize;
 
+                // Now, we adjust:
+                // 1. Size consumed by children (accumulatedSize).  This will be used when computing subsequent
+                //    children to determine how much space is remaining for them.
+                // 2. Parent size implied by this child (parentSize) when added to the current children (accumulatedSize).
+                //    This is different from the size above in one respect: A Dock.Left child implies a height, but does
+                //    not actually consume any height for subsequent children.
+                // If we accumulate size in a given dimension, the next child (or the end conditions after the child loop)
+                // will deal with computing our minimum size (parentSize) due to that accumulation.
+                // Therefore, we only need to compute our minimum size (parentSize) in dimensions that this child does
+                //   not accumulate: Width for Top/Bottom, Height for Left/Right.
                 switch (child.GetValue(DockProperty))
                 {
                     case Dock.Left:

--- a/src/Avalonia.Controls/DockPanel.cs
+++ b/src/Avalonia.Controls/DockPanel.cs
@@ -129,10 +129,8 @@ namespace Avalonia.Controls
             var accumulatedWidth = 0d;
             var accumulatedHeight = 0d;
 
-            var leftSpacing = false;
-            var topSpacing = false;
-            var rightSpacing = false;
-            var bottomSpacing = false;
+            var horizontalSpacing = false;
+            var verticalSpacing = false;
             var childrenCount = LastChildFill ? Children.Count - 1 : Children.Count;
 
             for (var index = 0; index < childrenCount; ++index)
@@ -148,15 +146,8 @@ namespace Avalonia.Controls
                 switch (child.GetValue(DockProperty))
                 {
                     case Dock.Left:
-                        leftSpacing = true;
-                        parentHeight = Math.Max(parentHeight, accumulatedHeight + childDesiredSize.Height);
-                        if (childConstraint.Width is not 0)
-                            accumulatedWidth += HorizontalSpacing;
-                        accumulatedWidth += childDesiredSize.Width;
-                        break;
-
                     case Dock.Right:
-                        rightSpacing = true;
+                        horizontalSpacing = true;
                         parentHeight = Math.Max(parentHeight, accumulatedHeight + childDesiredSize.Height);
                         if (childConstraint.Width is not 0)
                             accumulatedWidth += HorizontalSpacing;
@@ -164,15 +155,8 @@ namespace Avalonia.Controls
                         break;
 
                     case Dock.Top:
-                        topSpacing = true;
-                        parentWidth = Math.Max(parentWidth, accumulatedWidth + childDesiredSize.Width);
-                        if (childConstraint.Height is not 0)
-                            accumulatedHeight += VerticalSpacing;
-                        accumulatedHeight += childDesiredSize.Height;
-                        break;
-
                     case Dock.Bottom:
-                        bottomSpacing = true;
+                        verticalSpacing = true;
                         parentWidth = Math.Max(parentWidth, accumulatedWidth + childDesiredSize.Width);
                         if (childConstraint.Height is not 0)
                             accumulatedHeight += VerticalSpacing;
@@ -197,9 +181,9 @@ namespace Avalonia.Controls
             }
             else
             {
-                if (leftSpacing || rightSpacing)
+                if (horizontalSpacing)
                     accumulatedWidth -= HorizontalSpacing;
-                if (bottomSpacing || topSpacing)
+                if (verticalSpacing)
                     accumulatedHeight -= VerticalSpacing;
             }
 

--- a/tests/Avalonia.Controls.UnitTests/DockPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DockPanelTests.cs
@@ -57,6 +57,34 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Should_Dock_Controls_With_Spacing()
+        {
+            var target = new DockPanel
+            {
+                HorizontalSpacing = 10,
+                VerticalSpacing = 10,
+                Children =
+                {
+                    new Border { Width = 500, Height = 50, [DockPanel.DockProperty] = Dock.Top },
+                    new Border { Width = 500, Height = 50, [DockPanel.DockProperty] = Dock.Bottom },
+                    new Border { Width = 50, Height = 400, [DockPanel.DockProperty] = Dock.Left },
+                    new Border { Width = 50, Height = 400, [DockPanel.DockProperty] = Dock.Right },
+                    new Border { },
+                }
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+
+            Assert.Equal(new Rect(0, 0, 500, 520), target.Bounds);
+            Assert.Equal(new Rect(0, 0, 500, 50), target.Children[0].Bounds);
+            Assert.Equal(new Rect(0, 470, 500, 50), target.Children[1].Bounds);
+            Assert.Equal(new Rect(0, 60, 50, 400), target.Children[2].Bounds);
+            Assert.Equal(new Rect(450, 60, 50, 400), target.Children[3].Bounds);
+            Assert.Equal(new Rect(60, 60, 380, 400), target.Children[4].Bounds);
+        }
+
+        [Fact]
         public void Changing_Child_Dock_Invalidates_Measure()
         {
             Border child;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Add HorizontalSpacing, VerticalSpacing properties for DockPanel

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
DockPanel only has `LastChildFill` property

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Add HorizontalSpacing, VerticalSpacing Property
![image](https://github.com/user-attachments/assets/8fc19504-f8b1-4850-a34c-713b7c1472d8)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
None

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
None

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
