### PR TITLE
Fixed unnecessary window displacement on resize

### DIFF
--- a/samples/IntegrationTestApp/ShowWindowTest.axaml
+++ b/samples/IntegrationTestApp/ShowWindowTest.axaml
@@ -6,7 +6,7 @@
         x:DataType="Window"
         Title="Show Window Test">
   <integrationTestApp:MeasureBorder Name="MyBorder" Background="{DynamicResource SystemRegionBrush}">
-    <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+    <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
       <Label Grid.Column="0" Grid.Row="1">Client Size</Label>
       <TextBox Name="CurrentClientSize" Grid.Column="1" Grid.Row="1" IsReadOnly="True"
                Text="{Binding ClientSize, Mode=OneWay}" />
@@ -54,6 +54,9 @@
       <TextBlock Grid.Column="1" Grid.Row="11" Name="CurrentMeasuredWithText" Text="{Binding #MyBorder.MeasuredWith}" />
 
       <Button Name="HideButton" Grid.Row="12" Command="{Binding $parent[Window].Hide}">Hide</Button>
+
+      <Button Name="AddToWidth" Grid.Row="13" Click="AddToWidth_Click">Add to Width</Button>
+      <Button Name="AddToHeight" Grid.Row="14" Click="AddToHeight_Click">Add to Height</Button>
       
     </Grid>
   </integrationTestApp:MeasureBorder>

--- a/samples/IntegrationTestApp/ShowWindowTest.axaml
+++ b/samples/IntegrationTestApp/ShowWindowTest.axaml
@@ -6,7 +6,7 @@
         x:DataType="Window"
         Title="Show Window Test">
   <integrationTestApp:MeasureBorder Name="MyBorder" Background="{DynamicResource SystemRegionBrush}">
-    <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+    <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
       <Label Grid.Column="0" Grid.Row="1">Client Size</Label>
       <TextBox Name="CurrentClientSize" Grid.Column="1" Grid.Row="1" IsReadOnly="True"
                Text="{Binding ClientSize, Mode=OneWay}" />
@@ -53,10 +53,11 @@
       <Label Grid.Row="11" Content="MeasuredWith:" />
       <TextBlock Grid.Column="1" Grid.Row="11" Name="CurrentMeasuredWithText" Text="{Binding #MyBorder.MeasuredWith}" />
 
-      <Button Name="HideButton" Grid.Row="12" Command="{Binding $parent[Window].Hide}">Hide</Button>
-
-      <Button Name="AddToWidth" Grid.Row="13" Click="AddToWidth_Click">Add to Width</Button>
-      <Button Name="AddToHeight" Grid.Row="14" Click="AddToHeight_Click">Add to Height</Button>
+      <StackPanel Orientation="Horizontal" Grid.Row="12">
+        <Button Name="HideButton" Command="{Binding $parent[Window].Hide}">Hide</Button>
+        <Button Name="AddToWidth" Click="AddToWidth_Click">Add to Width</Button>
+        <Button Name="AddToHeight" Click="AddToHeight_Click">Add to Height</Button>
+      </StackPanel>
       
     </Grid>
   </integrationTestApp:MeasureBorder>

--- a/samples/IntegrationTestApp/ShowWindowTest.axaml.cs
+++ b/samples/IntegrationTestApp/ShowWindowTest.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
 
 namespace IntegrationTestApp
@@ -70,5 +71,8 @@ namespace IntegrationTestApp
         {
             _orderTextBox!.Text = MacOSIntegration.GetOrderedIndex(this).ToString();
         }
+
+        private void AddToWidth_Click(object? sender, RoutedEventArgs e) => Width += 10;
+        private void AddToHeight_Click(object? sender, RoutedEventArgs e) => Height += 10;
     }
 }

--- a/samples/IntegrationTestApp/ShowWindowTest.axaml.cs
+++ b/samples/IntegrationTestApp/ShowWindowTest.axaml.cs
@@ -72,7 +72,7 @@ namespace IntegrationTestApp
             _orderTextBox!.Text = MacOSIntegration.GetOrderedIndex(this).ToString();
         }
 
-        private void AddToWidth_Click(object? sender, RoutedEventArgs e) => Width += 10;
-        private void AddToHeight_Click(object? sender, RoutedEventArgs e) => Height += 10;
+        private void AddToWidth_Click(object? sender, RoutedEventArgs e) => Width = Bounds.Width + 10;
+        private void AddToHeight_Click(object? sender, RoutedEventArgs e) => Height = Bounds.Height + 10;
     }
 }

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -608,12 +608,6 @@ namespace Avalonia.Win32
                     return;
                 }
             }
-            else
-            {
-                var position = Position;
-                windowPlacement.NormalPosition.left = position.X;
-                windowPlacement.NormalPosition.top = position.Y;
-            }
 
             windowPlacement.NormalPosition.right = windowPlacement.NormalPosition.left + windowWidth;
             windowPlacement.NormalPosition.bottom = windowPlacement.NormalPosition.top + windowHeight;

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -349,7 +349,7 @@ namespace Avalonia.IntegrationTests.Appium
             }
         }
 
-        [Fact]
+        [PlatformFact(TestPlatforms.Windows)]
         public void Changing_Size_Should_Not_Change_Position()
         {
             using (OpenWindow())

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -349,6 +349,24 @@ namespace Avalonia.IntegrationTests.Appium
             }
         }
 
+        [Fact]
+        public void Changing_Size_Should_Not_Change_Position()
+        {
+            using (OpenWindow())
+            {
+                var info = GetWindowInfo();
+
+                Session.FindElementByAccessibilityId("AddToWidth").SendClick();
+                Session.FindElementByAccessibilityId("AddToHeight").SendClick();
+
+                var updatedInfo = GetWindowInfo();
+                Assert.Equal(info.Position, updatedInfo.Position);
+                Assert.Equal(info.FrameSize
+                    .WithWidth(info.FrameSize.Width + 10)
+                    .WithHeight(info.FrameSize.Height + 10), updatedInfo.FrameSize);
+            }
+        }
+
         public static TheoryData<Size?, ShowWindowMode, WindowStartupLocation, bool> StartupLocationData()
         {
             var sizes = new Size?[] { null, new Size(400, 300) };


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This fixes unnecessary window displacement on resize ~~introduced by #16608~~. Also related: #17559. (Edit: It was introduced sometime earlier even, probably..)


## What is the current behavior?
When a window on Windows programmatically resizes, it also sets the position for the window placement in workspace coordinates. The coordinates are however fetched from screen coordinates, which causes the window to shift every time the window resizes when the user's taskbar is located on the left or top side of the screen.

https://github.com/user-attachments/assets/ace08127-9f01-404d-ae8f-c389bf9d44c1

For this video, I added a timer to the application that adds 10px to the window height every second using `Height += 10`.


## What is the updated/expected behavior with this PR?
The window should not be moving, and/or be using workspace coordinates instead of screen space coordinates when using `SetWindowPlacement`.


## How was the solution implemented (if it's not obvious)?
The struct that's passed into `SetWindowPlacement` is already fetched from [`GetWindowPlacement`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowplacement) which returns workspace coordinates. We don't need to assign this at all, as it should already be assigned.

Simply removing the code for left & top assignment is enough to fix this.


## Checklist

- [x] Added unit tests (if possible)?
- [x] ~~Added XML documentation to any related classes?~~ Doesn't seem relevant here.
- [x] ~~Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation~~

## Fixed issues
This fixes #16217 