### PR TITLE
Support activation with universal links

### DIFF
--- a/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
@@ -89,6 +89,19 @@ namespace Avalonia.iOS
             return false;
         }
 
+        [Export("application:continueUserActivity:restorationHandler:")]
+        public bool ContinueUserActivity(UIApplication application, NSUserActivity userActivity, UIApplicationRestorationHandler completionHandler)
+        {
+            if (userActivity.ActivityType == NSUserActivityType.BrowsingWeb && Uri.TryCreate(userActivity.WebPageUrl?.ToString(), UriKind.RelativeOrAbsolute, out var uri))
+            {
+                // Activation using a univeral link or web browser-to-native app Handoff
+                _onActivated?.Invoke(this, new ProtocolActivatedEventArgs(uri));
+                return true;
+            }
+
+            return false;
+        }
+
         private void OnEnteredBackground(NSNotification notification)
         {
             _onDeactivated?.Invoke(this, new ActivatedEventArgs(ActivationKind.Background));


### PR DESCRIPTION
## What does the pull request do?
Implements #17600

## What is the current behavior?
`IAvaloniaAppDelegate.Activated` is raised with `ActivatedEventArgs`.

## What is the updated/expected behavior with this PR?
`IAvaloniaAppDelegate.Activated` is raised with `ProtocolActivatedEventArgs` containing the URL that activated the application.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
