### PR TITLE
Fix in HeadlessClipboardStub.GetDataAsync where format is not considered

### DIFF
--- a/src/Headless/Avalonia.Headless/HeadlessPlatformStubs.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessPlatformStubs.cs
@@ -66,7 +66,17 @@ namespace Avalonia.Headless
 
         public async Task<object?> GetDataAsync(string format)
         {
-            return await Task.Run(() => _data);
+            return await Task.Run(() =>
+            {
+                if (format == DataFormats.Text)
+                    return _text;
+                if (format == DataFormats.Files && _data is not null)
+                    return _data.GetFiles();
+                if (format == DataFormats.FileNames && _data is not null)
+                    return _data.GetFileNames();
+                else
+                    return (object?)_data;
+            });
         }
     }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixed problem with ClipboardStub.GetDataAsync not taking formatting into account during headless testing.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Ignores the specified format and always returns an IDataObject.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Returns an object of the specified format. If an undefined format is specified, the behavior is the same as before.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
