### PR TITLE
Fix style without selector not finding target type

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -126,6 +126,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType UriKind { get; }
         public IXamlConstructor UriConstructor { get; }
         public IXamlType Style { get; }
+        public IXamlType Styles { get; }
         public IXamlType ControlTheme { get; }
         public IXamlType WindowTransparencyLevel { get; }
         public IXamlType IReadOnlyListOfT { get; }
@@ -325,6 +326,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             UriKind = cfg.TypeSystem.GetType("System.UriKind");
             UriConstructor = Uri.GetConstructor(new List<IXamlType>() { cfg.WellKnownTypes.String, UriKind });
             Style = cfg.TypeSystem.GetType("Avalonia.Styling.Style");
+            Styles = cfg.TypeSystem.GetType("Avalonia.Styling.Styles");
             ControlTheme = cfg.TypeSystem.GetType("Avalonia.Styling.ControlTheme");
             ControlTemplate = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.Templates.ControlTemplate");
             IReadOnlyListOfT = cfg.TypeSystem.GetType("System.Collections.Generic.IReadOnlyList`1");

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -752,13 +752,13 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
                 <Window xmlns="https://github.com/avaloniaui">
                     <Window.Styles>
                         {styleStart}
-                            <Setter Property="WindowStartupLocation" Value="CenterScreen" />
+                            <Setter Property="Title" Value="title set via style!" />
                         {styleEnd}
                     </Window.Styles>
                 </Window>
                 """);
 
-            Assert.Equal(WindowStartupLocation.CenterScreen, window.WindowStartupLocation);
+            Assert.Equal("title set via style!", window.Title);
         }
     }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -760,5 +760,30 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             Assert.Equal("title set via style!", window.Title);
         }
+
+
+        [Theory]
+        [InlineData("<Style>", "</Style>")]
+        [InlineData("<Style Selector=''>", "</Style>")]
+        public void No_Selector_Should_Fail_In_Control_Theme(string styleStart, string styleEnd)
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+            var exception = Assert.ThrowsAny<XmlException>(() => (Window)AvaloniaRuntimeXamlLoader.Load(
+                $$"""
+                  <Window xmlns="https://github.com/avaloniaui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                     <Window.Resources>
+                          <ControlTheme x:Key="{x:Type Window}" TargetType="Window">
+                              {{styleStart}}
+                                  <Setter Property="Title" Value="title set via style!" />
+                              {{styleEnd}}
+                          </ControlTheme>
+                      </Window.Resources>
+                  </Window>
+                  """));
+
+            Assert.Equal("Cannot add a Style without selector to a ControlTheme. Line 5, position 14.", exception.Message);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the XAML compiler not being able to find the target type of a style without selector.
See #18024 for details.
Unit tests have been added.

## Fixed issues
 - Fixes #18024
