### PR TITLE
Fix Korean IME on Android

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
@@ -122,7 +122,7 @@ namespace Avalonia.Android.Platform.Input
 
         private void _client_SurroundingTextChanged(object? sender, EventArgs e)
         {
-            if (_inputConnection is null || _inputConnection.IsInBatchEdit)
+            if (_inputConnection is null || _inputConnection.IsInBatchEdit || _inputConnection.IsInUpdate)
                 return;
             OnSurroundingTextChanged();
         }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes https://github.com/AvaloniaUI/Avalonia/issues/16956 on Android.

## What is the current behavior?
`AndroidInputMethod` subscribes to `TextInputMethodClient`'s `SurroundingTextChanged`, which ends up calling `AvaloniaInputConnection.UpdateState` several times on each key press. `AvaloniaInputConnection` also calls this method internally as part of its implementation of Android's `IInputConnection`, just after raising the previously mentioned `SurroundingTextChanged`.

![devenv_dpl3dy4t3e](https://github.com/user-attachments/assets/f246e32e-7c26-48da-a802-b7ca13b1e006)

I am not exactly sure what the relationship between `AndroidInputMethod` and `AvaloniaInputConnection` is, but this behavior does not seem right. These `UpdateState` calls are interfering with one another, messing up composition state when typing Korean. As soon as a 2-letter block is created, `FinishComposingText` is called by the OS, making it impossible to create 3- and 4-letter blocks.

## What is the updated/expected behavior with this PR?
`FinishComposingText` is not called when typing Korean. The user can keep typing without breaking composition, ultimately being able to create any syllable block. Deletes also work as expected - only the final letter part is removed, not the entire block.

https://github.com/user-attachments/assets/c5edbbfe-5d99-4e74-9531-dd11ac5c743c

## How was the solution implemented (if it's not obvious)?
`AndroidInputMethod` does not react to `SurroundingTextChanged`, letting `AvaloniaInputConnection` handle its state. No idea whether anything else breaks as a result though.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
Don't know.

