### PR TITLE
Clear `Imm32InputMethod.Composition` after receiving `cancel` message (`WM_IME_COMPOSITION` with `lParam` set to `0`)

### DIFF
--- a/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
+++ b/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
@@ -372,6 +372,11 @@ namespace Avalonia.Win32.Input
             }
 
             var flags = (GCS)ToInt32(lParam);
+            
+            if (flags == 0)
+            {
+                CompositionChanged("");
+            }
 
             if ((flags & GCS.GCS_RESULTSTR) != 0)
             {


### PR DESCRIPTION
## What does the pull request do?

This PR clears `Imm32InputMethod.Composition` when `AppWndProc` receives `WM_IME_COMPOSITION` message with `lParam` set to `0`, which apparently means that the IME canceled the composition entirely.

## What is the current behavior?

`HandleComposition` does nothing if `lParam` were `0`, which causes #18021 by `HandleCompositionEnd` erroneously executes `_parent.Input(e);` with uncleared `Composition`.

## What is the updated/expected behavior with this PR?

`HandleComposition` now clears `Composition` if `lParam` were `0`. `HandleCompositionEnd` now sees the empty `Composition` after IME cancelling the composition.

## How was the solution implemented (if it's not obvious)?

```csharp
if (flags == 0)
{
    CompositionChanged("");
}
```

## Checklist

- [ ] Added unit tests (I don't think it's possible since it needs IME installed in testing environment)
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

## Obsoletions / Deprecations

## Fixed issues

Fixes #18021 