### PR TITLE
Fix - Complete window dialog task when dialog is hidden

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -648,14 +648,7 @@ namespace Avalonia.Controls
                     }
                     else
                     {
-                        if (_showingAsDialog)
-                        {
-                            Close(false);
-                        }
-                        else
-                        {
-                            Hide();
-                        }
+                        Hide();
                     }
                 }
             }

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -613,13 +613,12 @@ namespace Avalonia.Controls
                     }
                 }
 
+                Owner = null;
                 PlatformImpl?.Hide();
                 IsVisible = false;
 
                 _modalSubscription?.Dispose();
                 _shown = false;
-
-                Owner = null;
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -1060,7 +1060,7 @@ namespace Avalonia.Controls.UnitTests
             }
             
             [Fact]
-            public void IsVisible_Should_Close_DialogWindow()
+            public void Hiding_DialogWindow_Should_Complete_Task()
             {
                 using (UnitTestApplication.Start(TestServices.StyledWindow))
                 {
@@ -1068,18 +1068,12 @@ namespace Avalonia.Controls.UnitTests
                     parent.Show();
                     
                     var target = new Window();
-                    
-                    var raised = false;
 
                     var task = target.ShowDialog<bool>(parent);
-                    
-                    target.Closed += (sender, args) => raised = true;
 
                     target.IsVisible = false;
-
-                    Assert.True(raised);
                     
-                    Assert.False(task.Result);
+                    Assert.True(task.IsCompletedSuccessfully);
                 }
             }
             


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
- When a dialog window is hidden, sets the task returned with `ShowDialog` as complete.
- Fixes an issue where the parent window would be moved down the z-order when a dialog window was hidden


## What is the current behavior?
When a dialog window is shown, a task is return for user to wait on.  This task is set to completed on `Close`, but not on `Hide`, even though the owner is set to null when hidden. This makes any thread waiting on the window to lock up.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
