### PR TITLE
Fix SelectableTextBlock selection

### DIFF
--- a/src/Avalonia.Controls/SelectableTextBlock.cs
+++ b/src/Avalonia.Controls/SelectableTextBlock.cs
@@ -146,7 +146,7 @@ namespace Avalonia.Controls
         /// </summary>
         public void SelectAll()
         {
-            var text = Text;
+            var text = HasComplexContent ? Inlines?.Text : Text;
 
             SetCurrentValue(SelectionStartProperty, 0);
             SetCurrentValue(SelectionEndProperty, text?.Length ?? 0);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Makes `SelectableTextBlock.SelectAll` method to support inlines.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Triple click on `SelectableTextBlock` with inlines does not select all text.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Triple click on `SelectableTextBlock` with inlines will select all text.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
