### PR TITLE
Make sure MacOS uses the cached value for render scaling.

### DIFF
--- a/src/Avalonia.Native/TopLevelImpl.cs
+++ b/src/Avalonia.Native/TopLevelImpl.cs
@@ -95,7 +95,7 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
     {
         _handle = handle;
         _savedLogicalSize = ClientSize;
-        _savedScaling = RenderScaling;
+        _savedScaling = Native?.Scaling ?? 1;;
         _nativeControlHost = new NativeControlHostImpl(Native!.CreateNativeControlHost());
         _platformBehaviorInhibition = new PlatformBehaviorInhibition(Factory.CreatePlatformBehaviorInhibition());
         _surfaces = new object[] { new GlPlatformSurface(Native), new MetalPlatformSurface(Native), this };
@@ -121,7 +121,8 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
 
         }
     }
-    public double RenderScaling => Native?.Scaling ?? 1;
+
+    public double RenderScaling => _savedScaling;
     public IEnumerable<object> Surfaces => _surfaces ?? Array.Empty<object>();
     public Action<RawInputEventArgs>? Input { get; set; }
     public Action<Rect>? Paint { get; set; }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
On MacOS there is a slight hotpath that shows up during profiling.

![telegram-cloud-photo-size-4-5818999620687218226-y](https://github.com/user-attachments/assets/314d9c9d-5ccc-4ae6-a61a-870344de28a3)

Accessing a property shouldn't show up here. 1600ms in ~20 seconds of profiling, is quite large.

there is a cache of this value `_savedScaling` but it is skipped in the layout code...

![telegram-cloud-photo-size-4-5818999620687218267-y](https://github.com/user-attachments/assets/2b2fe64f-b346-493a-9fd4-0f82e2dbd4e0)


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
unreasonable number of managed to native transitions on property that is accessed with high frequency.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Use the cached value like the other apis that need this value.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
