### PR TITLE
make _lastKnownPosition trackable at dragging

### DIFF
--- a/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
+++ b/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
@@ -29,9 +29,21 @@ namespace Avalonia.Input
 
         public void OnNext(RawInputEventArgs value)
         {
-            if (value is RawPointerEventArgs args
-                && args.Root == _inputRoot
-                && value.Device is IPointerDevice pointerDevice)
+            if (value is RawDragEvent dragArgs)
+            {
+                // When a platform drag operation is in progress, the application does not receive
+                // pointer move events until after the drop event. This is a problem because if a
+                // popup is shown at the pointer position in the drop event, it will be shown at
+                // the position at which the drag was initiated, not the position at which the drop
+                // occurred.
+                //
+                // Solve this by updating the last known pointer position when a drag event occurs.
+                _lastKnownPosition = ((Visual)_inputRoot).PointToScreen(dragArgs.Location);
+            }
+
+            else if (value is RawPointerEventArgs args
+                     && args.Root == _inputRoot
+                     && value.Device is IPointerDevice pointerDevice)
             {
                 if (pointerDevice != _lastActivePointerDevice)
                 {


### PR DESCRIPTION
## What does the pull request do?
Makes pointer over to track last pointer position while dragging an item


## What is the current behavior?
If you want to open flyout menu at the position where item was dropped after dragging using  menuFlyout.Placement = PlacementMode.Pointer, currently, it opens it on a position where item was taken, not dropped, because last pointer position was not updated while dragging


## What is the updated/expected behavior with this PR?
Now RawDragEvent is listened to update last pointer position too 



## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation


## Fixed issues

Fixes #18104