### PR TITLE
Fix ManagedStorageProvider OverwritePrompt behaviour

### DIFF
--- a/src/Avalonia.Dialogs/ManagedStorageProvider.cs
+++ b/src/Avalonia.Dialogs/ManagedStorageProvider.cs
@@ -116,6 +116,7 @@ internal class ManagedStorageProvider : BclStorageProvider
         {
             if (await ShowOverwritePrompt(filename, window))
             {
+                result = [filename];
                 window.Close();
             }
         };
@@ -165,6 +166,7 @@ internal class ManagedStorageProvider : BclStorageProvider
         {
             if (await ShowOverwritePrompt(filename, root))
             {
+                result = [filename];
                 popup.Close();
             }
         };


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fix issue with **Avalonia.Dialogs.ManagedStorageProvider** where it returns null, instead of the file selected, when the user choose to overwrite an existing file. As reported here: #17959
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

## What is the current behavior?
Discards filename when the OverwritePrompt result is true.
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

## What is the updated/expected behavior with this PR?
Returns filename so that `SaveFilePickerAsync()` result can be built correctly.

To test:
1. Ensure you are using Managed System Dialogs (e.g. `AppBuilder.UseManagedSystemDialogs()` )
2. `var file = await storageProvider.SaveFilePickerAsync(...)` should return the file selected to be overwritten, instead of null

<!--- Describe how to test the PR. -->


## Checklist

- [ ] Added unit tests (if possible)? _The fix is fairly straightforward. I tried to implement tests, but could not quite get it working for the dialog - would appreciate guidance on whether it is necessary and how to do it for this component, if needed._
- [x] Added XML documentation to any related classes? N/A
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation N/A

## Breaking changes
<!--- List any breaking changes here. -->
None

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
None

## Fixed issues
Fixes #17959
