### PR TITLE
[Grid] Add RowSpacing and ColumnSpacing

### DIFF
--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -34,7 +34,8 @@ namespace Avalonia.Controls
             RowProperty.Changed.AddClassHandler<Control>(OnCellAttachedPropertyChanged);
             RowSpanProperty.Changed.AddClassHandler<Control>(OnCellAttachedPropertyChanged);
 
-            AffectsMeasure<Grid>(ColumnProperty, ColumnSpanProperty, ColumnSpacingProperty, RowProperty, RowSpanProperty, RowSpacingProperty);
+            AffectsMeasure<Grid>(ColumnSpacingProperty, RowSpacingProperty);
+            AffectsParentMeasure<Grid>(ColumnProperty, ColumnSpanProperty, RowProperty, RowSpanProperty);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -3300,6 +3300,14 @@ namespace Avalonia.Controls
                         drawingContext,
                         grid.ColumnDefinitions[i].FinalOffset, 0.0,
                         grid.ColumnDefinitions[i].FinalOffset, _lastArrangeSize.Height);
+
+                    if (grid.ColumnSpacing != 0)
+                    {
+                        DrawGridLine(
+                            drawingContext,
+                            grid.ColumnDefinitions[i].FinalOffset - grid.ColumnSpacing, 0.0,
+                            grid.ColumnDefinitions[i].FinalOffset - grid.ColumnSpacing, _lastArrangeSize.Height);
+                    }
                 }
 
                 for (int i = 1; i < grid.RowDefinitions.Count; ++i)
@@ -3308,6 +3316,14 @@ namespace Avalonia.Controls
                         drawingContext,
                         0.0, grid.RowDefinitions[i].FinalOffset,
                         _lastArrangeSize.Width, grid.RowDefinitions[i].FinalOffset);
+
+                    if (grid.RowSpacing != 0)
+                    {
+                        DrawGridLine(
+                            drawingContext,
+                            0.0, grid.RowDefinitions[i].FinalOffset - grid.RowSpacing,
+                            _lastArrangeSize.Width, grid.RowDefinitions[i].FinalOffset - grid.RowSpacing);
+                    }
                 }
             }
 

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -1780,6 +1780,8 @@ namespace Avalonia.Controls
             double totalStarWeight = 0.0;
             int starCount = 0;      // number of unresolved *-definitions
             double scale = 1.0;   // scale factor applied to each *-weight;  negative means "Infinity is present"
+            double spacing;
+            spacing = columns ? ColumnSpacing : RowSpacing;
 
             // Phase 1.  Determine the maximum *-weight and prepare to adjust *-weights
             double maxStar = 0.0;
@@ -2105,7 +2107,7 @@ namespace Avalonia.Controls
                 // double dpi = columns ? dpiScale.DpiScaleX : dpiScale.DpiScaleY;
                 var dpi = (VisualRoot as ILayoutRoot)?.LayoutScaling ?? 1.0;
                 double[] roundingErrors = RoundingErrors;
-                double roundedTakenSize = 0.0;
+                double roundedTakenSize = spacing * (definitions.Count - 1);
 
                 // round each of the allocated sizes, keeping track of the deltas
                 for (int i = 0; i < definitions.Count; ++i)
@@ -2210,15 +2212,6 @@ namespace Avalonia.Controls
 
             // Phase 6.  Compute final offsets
             definitions[0].FinalOffset = 0.0;
-            double spacing;
-            if (columns)
-            {
-                spacing = ColumnSpacing;
-            }
-            else
-            {
-                spacing = RowSpacing;
-            }
             for (int i = 0; i < definitions.Count; ++i)
             {
                 definitions[(i + 1) % definitions.Count].FinalOffset = definitions[i].FinalOffset + definitions[i].SizeCache + spacing;

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -163,8 +163,9 @@ namespace Avalonia.Controls
             get => GetValue(ShowGridLinesProperty);
             set => SetValue(ShowGridLinesProperty, value);
         }
+
         /// <summary>
-        /// Gets or sets the size of the spacing to place between row definitions.
+        /// Gets or sets the size of the spacing to place between grid rows.
         /// </summary>
         public double RowSpacing
         {
@@ -173,7 +174,7 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Gets or sets the size of the spacing to place between column definitions.
+        /// Gets or sets the size of the spacing to place between grid columns.
         /// </summary>
         public double ColumnSpacing
         {
@@ -1787,8 +1788,6 @@ namespace Avalonia.Controls
             double totalStarWeight = 0.0;
             int starCount = 0;      // number of unresolved *-definitions
             double scale = 1.0;   // scale factor applied to each *-weight;  negative means "Infinity is present"
-            double spacing;
-            spacing = columns ? ColumnSpacing : RowSpacing;
 
             // Phase 1.  Determine the maximum *-weight and prepare to adjust *-weights
             double maxStar = 0.0;
@@ -2221,7 +2220,7 @@ namespace Avalonia.Controls
             definitions[0].FinalOffset = 0.0;
             for (int i = 0; i < definitions.Count; ++i)
             {
-                definitions[(i + 1) % definitions.Count].FinalOffset = definitions[i].FinalOffset + definitions[i].SizeCache ;
+                definitions[(i + 1) % definitions.Count].FinalOffset = definitions[i].FinalOffset + definitions[i].SizeCache;
             }
         }
 

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -506,8 +506,8 @@ namespace Avalonia.Controls
                     MeasureCellsGroup(extData.CellGroup4, constraint, false, false);
 
                     gridDesiredSize = new Size(
-                            CalculateDesiredSize(DefinitionsU),
-                            CalculateDesiredSize(DefinitionsV));
+                            CalculateDesiredSize(DefinitionsU) + ColumnSpacing * (DefinitionsU.Count - 1),
+                            CalculateDesiredSize(DefinitionsV) + RowSpacing * (DefinitionsU.Count - 1));
                 }
             }
             finally

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -2210,9 +2210,18 @@ namespace Avalonia.Controls
 
             // Phase 6.  Compute final offsets
             definitions[0].FinalOffset = 0.0;
+            double spacing;
+            if (columns)
+            {
+                spacing = ColumnSpacing;
+            }
+            else
+            {
+                spacing = RowSpacing;
+            }
             for (int i = 0; i < definitions.Count; ++i)
             {
-                definitions[(i + 1) % definitions.Count].FinalOffset = definitions[i].FinalOffset + definitions[i].SizeCache;
+                definitions[(i + 1) % definitions.Count].FinalOffset = definitions[i].FinalOffset + definitions[i].SizeCache + spacing;
             }
         }
 

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -160,6 +160,23 @@ namespace Avalonia.Controls
             get => GetValue(ShowGridLinesProperty);
             set => SetValue(ShowGridLinesProperty, value);
         }
+        /// <summary>
+        /// Gets or sets the size of the spacing to place between row definitions.
+        /// </summary>
+        public double RowSpacing
+        {
+            get => GetValue(RowSpacingProperty);
+            set => SetValue(RowSpacingProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the size of the spacing to place between column definitions.
+        /// </summary>
+        public double ColumnSpacing
+        {
+            get => GetValue(ColumnSpacingProperty);
+            set => SetValue(ColumnSpacingProperty, value);
+        }
 
         /// <summary>
         /// Returns a ColumnDefinitions of column definitions.
@@ -2673,6 +2690,18 @@ namespace Avalonia.Controls
         /// </summary>
         public static readonly StyledProperty<bool> ShowGridLinesProperty =
             AvaloniaProperty.Register<Grid, bool>(nameof(ShowGridLines));
+
+        /// <summary>
+        /// Defines the <see cref="RowSpacing"/> property.
+        /// </summary>
+        public static readonly StyledProperty<double> RowSpacingProperty =
+            AvaloniaProperty.Register<Grid, double>(nameof(RowSpacing));
+
+        /// <summary>
+        /// Defines the <see cref="ColumnSpacing"/> property.
+        /// </summary>
+        public static readonly StyledProperty<double> ColumnSpacingProperty =
+            AvaloniaProperty.Register<Grid, double>(nameof(ColumnSpacingProperty));
 
         /// <summary>
         /// Column property. This is an attached property.

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -25,6 +25,8 @@ namespace Avalonia.Controls
         static Grid()
         {
             ShowGridLinesProperty.Changed.AddClassHandler<Grid>(OnShowGridLinesPropertyChanged);
+            ColumnSpacingProperty.Changed.AddClassHandler<Control>(OnSpacingPropertyChanged);
+            RowSpacingProperty.Changed.AddClassHandler<Control>(OnSpacingPropertyChanged);
 
             IsSharedSizeScopeProperty.Changed.AddClassHandler<Control>(DefinitionBase.OnIsSharedSizeScopePropertyChanged);
             ColumnProperty.Changed.AddClassHandler<Control>(OnCellAttachedPropertyChanged);
@@ -32,7 +34,7 @@ namespace Avalonia.Controls
             RowProperty.Changed.AddClassHandler<Control>(OnCellAttachedPropertyChanged);
             RowSpanProperty.Changed.AddClassHandler<Control>(OnCellAttachedPropertyChanged);
 
-            AffectsParentMeasure<Grid>(ColumnProperty, ColumnSpanProperty, RowProperty, RowSpanProperty);
+            AffectsParentMeasure<Grid>(ColumnProperty, ColumnSpanProperty, ColumnSpacingProperty, RowProperty, RowSpanProperty, RowSpacingProperty);
         }
 
         /// <summary>
@@ -2380,6 +2382,17 @@ namespace Avalonia.Controls
             }
 
             grid.SetFlags((bool)e.NewValue!, Flags.ShowGridLinesPropertyValue);
+        }
+
+        private static void OnSpacingPropertyChanged(AvaloniaObject d, AvaloniaPropertyChangedEventArgs e)
+        {
+            Grid grid = (Grid)d;
+
+            if (grid._extData != null
+                && grid.ListenToNotifications)
+            {
+                grid.CellsStructureDirty = true;
+            }
         }
 
         private static void OnCellAttachedPropertyChanged(AvaloniaObject d, AvaloniaPropertyChangedEventArgs e)

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -319,7 +319,7 @@ namespace Avalonia.Controls
                     //  the cells belonging to them.
                     //
                     //  However, there are cases when topology of a grid causes cyclical
-                    //  size dependences. For example:
+                    //  size dependencies. For example:
                     //
                     //
                     //                         column width="Auto"      column width="*"
@@ -572,7 +572,6 @@ namespace Avalonia.Controls
 
 
                         cell.Arrange(cellRect);
-
                     }
 
                     //  update render bound on grid lines renderer visual

--- a/tests/Avalonia.Controls.UnitTests/GridTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/GridTests.cs
@@ -1665,19 +1665,14 @@ namespace Avalonia.Controls.UnitTests
                 ColumnSpacing = 10,
                 RowDefinitions = RowDefinitions.Parse("100,100"),
                 ColumnDefinitions = ColumnDefinitions.Parse("100,100"),
+                Children =
+                {
+                    new Border(),
+                    new Border { [Grid.ColumnProperty] = 1 },
+                    new Border { [Grid.RowProperty] = 1 },
+                    new Border { [Grid.RowProperty] = 1, [Grid.ColumnProperty] = 1 }
+                }
             };
-            var child1 = new Border();
-            var child2 = new Border();
-            var child3 = new Border();
-            var child4 = new Border();
-            target.Children.Add(child1);
-            target.Children.Add(child2);
-            target.Children.Add(child3);
-            target.Children.Add(child4);
-            Grid.SetColumn(child2, 1);
-            Grid.SetRow(child3, 1);
-            Grid.SetColumn(child4, 1);
-            Grid.SetRow(child4, 1);
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(target.DesiredSize));
 
@@ -1686,6 +1681,35 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Rect(110, 0, 100, 100), target.Children[1].Bounds);
             Assert.Equal(new Rect(0, 110, 100, 100), target.Children[2].Bounds);
             Assert.Equal(new Rect(110, 110, 100, 100), target.Children[3].Bounds);
+        }
+
+        [Fact]
+        public void Should_Grid_Controls_With_Spacing_Complicated()
+        {
+            var target = new Grid
+            {
+                Width = 200,
+                Height = 200,
+                RowSpacing = 10,
+                ColumnSpacing = 10,
+                RowDefinitions = RowDefinitions.Parse("50,*,2*,Auto"),
+                ColumnDefinitions = ColumnDefinitions.Parse("50,*,2*,Auto"),
+                Children =
+                {
+                    new Border(),
+                    new Border { [Grid.RowProperty] = 1, [Grid.ColumnProperty] = 1 },
+                    new Border { [Grid.RowProperty] = 2, [Grid.ColumnProperty] = 2 },
+                    new Border { [Grid.RowProperty] = 3, [Grid.ColumnProperty] = 3, Width = 30, Height = 30 },
+                },
+            };
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+
+            Assert.Equal(new Rect(0, 0, 200, 200), target.Bounds);
+            Assert.Equal(new Rect(0, 0, 50, 50), target.Children[0].Bounds);
+            Assert.Equal(new Rect(60, 60, 30, 30), target.Children[1].Bounds);
+            Assert.Equal(new Rect(100, 100, 60, 60), target.Children[2].Bounds);
+            Assert.Equal(new Rect(170, 170, 30, 30), target.Children[3].Bounds);
         }
 
         private class TestControl : Control

--- a/tests/Avalonia.Controls.UnitTests/GridTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/GridTests.cs
@@ -1712,6 +1712,35 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Rect(170, 170, 30, 30), target.Children[3].Bounds);
         }
 
+        [Fact]
+        public void Should_Grid_Controls_With_Spacing_Overflow()
+        {
+            var target = new Grid
+            {
+                Width = 100,
+                Height = 100,
+                ColumnSpacing = 20,
+                RowSpacing = 20,
+                ColumnDefinitions = ColumnDefinitions.Parse("30,*,*,Auto"),
+                RowDefinitions = RowDefinitions.Parse("30,*,*,Auto"),
+                Children =
+                {
+                    new Border(),
+                    new Border { [Grid.RowProperty] = 1, [Grid.ColumnProperty] = 1 },
+                    new Border { [Grid.RowProperty] = 2, [Grid.ColumnProperty] = 2 },
+                    new Border { [Grid.RowProperty] = 3, [Grid.ColumnProperty] = 3, Width = 30, Height = 30 },
+                },
+            };
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+
+            Assert.Equal(new Rect(0, 0, 100, 100), target.Bounds);
+            Assert.Equal(new Rect(0, 0, 30, 30), target.Children[0].Bounds);
+            Assert.Equal(new Rect(50, 50, 0, 0), target.Children[1].Bounds);
+            Assert.Equal(new Rect(70, 70, 0, 0), target.Children[2].Bounds);
+            Assert.Equal(new Rect(90, 90, 30, 30), target.Children[3].Bounds);
+        }
+
         private class TestControl : Control
         {
             public Size MeasureSize { get; set; }

--- a/tests/Avalonia.Controls.UnitTests/GridTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/GridTests.cs
@@ -1656,6 +1656,38 @@ namespace Avalonia.Controls.UnitTests
             Assert.False(grid.IsArrangeValid);
         }
 
+        [Fact]
+        public void Should_Grid_Controls_With_Spacing()
+        {
+            var target = new Grid
+            {
+                RowSpacing = 10,
+                ColumnSpacing = 10,
+                RowDefinitions = RowDefinitions.Parse("100,100"),
+                ColumnDefinitions = ColumnDefinitions.Parse("100,100"),
+            };
+            var child1 = new Border();
+            var child2 = new Border();
+            var child3 = new Border();
+            var child4 = new Border();
+            target.Children.Add(child1);
+            target.Children.Add(child2);
+            target.Children.Add(child3);
+            target.Children.Add(child4);
+            Grid.SetColumn(child2, 1);
+            Grid.SetRow(child3, 1);
+            Grid.SetColumn(child4, 1);
+            Grid.SetRow(child4, 1);
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+
+            Assert.Equal(new Rect(0, 0, 210, 210), target.Bounds);
+            Assert.Equal(new Rect(0, 0, 100, 100), target.Children[0].Bounds);
+            Assert.Equal(new Rect(110, 0, 100, 100), target.Children[1].Bounds);
+            Assert.Equal(new Rect(0, 110, 100, 100), target.Children[2].Bounds);
+            Assert.Equal(new Rect(110, 110, 100, 100), target.Children[3].Bounds);
+        }
+
         private class TestControl : Control
         {
             public Size MeasureSize { get; set; }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Add `RowSpacing` and `ColumnSpacing` properties for `Grid`, just like in UWP and WinUI 3.
![image](https://github.com/user-attachments/assets/836bf6e8-e3e9-41da-befa-033671ba827f)


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
1. Add a `Grid` with various children.
2. Arrange children in different row and columns.
3. Set `RowSpacing` and `ColumnSpacing` to non-zero values.

## How was the solution implemented (if it's not obvious)?
Add the corresponding spacing before calculating the position of each `RowDefinition` or `ColumnDefinition`.
Subtract spacing before calculating stars when `GridUnitType=star`.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #5152