### PR TITLE
feat: Support pressure and tilt on macos

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -290,6 +290,37 @@
         delta.Y = [event deltaY];
     }
 
+    float pressure = 0.0f;
+    float xTilt = 0.0f;
+    float yTilt = 0.0f;
+    AvnPointerDeviceType pointerType = AvnPointerDeviceType::Mouse;
+
+    switch(event.subtype)
+    {
+        case NSEventSubtypeTabletPoint:
+            switch(event.type)
+            {
+                case NSEventTypeLeftMouseDown:
+                case NSEventTypeLeftMouseDragged:
+                case NSEventTypeRightMouseDown:
+                case NSEventTypeRightMouseDragged:
+                case NSEventTypeOtherMouseDown:
+                case NSEventTypeOtherMouseDragged:
+                    pressure = event.pressure;
+                    break;
+                default:
+                    pressure = 0.0f;
+                    break;
+            }
+            xTilt =  event.tilt.x * 90;
+            yTilt = -event.tilt.y * 90;
+        case NSEventSubtypeTabletProximity:
+            pointerType = AvnPointerDeviceType::Pen;
+            break;
+        default:
+            break;
+    }
+
     uint64_t timestamp = static_cast<uint64_t>([event timestamp] * 1000);
     auto modifiers = [self getModifiers:[event modifierFlags]];
 
@@ -322,7 +353,7 @@
     auto parent = _parent.tryGet();
     if(parent != nullptr)
     {
-        parent->TopLevelEvents->RawMouseEvent(type, timestamp, modifiers, point, delta);
+        parent->TopLevelEvents->RawMouseEvent(type, pointerType, timestamp, modifiers, point, delta, pressure, xTilt, yTilt);
     }
 
     [super mouseMoved:event];

--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -290,7 +290,7 @@
         delta.Y = [event deltaY];
     }
 
-    float pressure = 0.0f;
+    float pressure = 0.5f;
     float xTilt = 0.0f;
     float yTilt = 0.0f;
     AvnPointerDeviceType pointerType = AvnPointerDeviceType::Mouse;
@@ -317,6 +317,7 @@
             pointerType = AvnPointerDeviceType::Pen;
             break;
         case NSEventSubtypeTabletProximity:
+            pressure = 0.0f;
             pointerType = AvnPointerDeviceType::Pen;
             break;
         default:

--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -314,6 +314,8 @@
             }
             xTilt =  event.tilt.x * 90;
             yTilt = -event.tilt.y * 90;
+            pointerType = AvnPointerDeviceType::Pen;
+            break;
         case NSEventSubtypeTabletProximity:
             pointerType = AvnPointerDeviceType::Pen;
             break;

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -492,7 +492,7 @@
                     auto point = [self translateLocalPoint:avnPoint];
                     AvnVector delta = { 0, 0 };
 
-                    parent->BaseEvents->RawMouseEvent(NonClientLeftButtonDown, AvnPointerDeviceType::Mouse, static_cast<uint64>([event timestamp] * 1000), AvnInputModifiersNone, point, delta, 1.0f, .0f, .0f);
+                    parent->BaseEvents->RawMouseEvent(NonClientLeftButtonDown, AvnPointerDeviceType::Mouse, static_cast<uint64>([event timestamp] * 1000), AvnInputModifiersNone, point, delta, .5f, .0f, .0f);
                 }
                 
                 if(!_isTransitioningToFullScreen)

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -492,7 +492,7 @@
                     auto point = [self translateLocalPoint:avnPoint];
                     AvnVector delta = { 0, 0 };
 
-                    parent->BaseEvents->RawMouseEvent(NonClientLeftButtonDown, static_cast<uint64>([event timestamp] * 1000), AvnInputModifiersNone, point, delta);
+                    parent->BaseEvents->RawMouseEvent(NonClientLeftButtonDown, AvnPointerDeviceType::Mouse, static_cast<uint64>([event timestamp] * 1000), AvnInputModifiersNone, point, delta, 1.0f, .0f, .0f);
                 }
                 
                 if(!_isTransitioningToFullScreen)

--- a/src/Avalonia.Base/Input/PointerPoint.cs
+++ b/src/Avalonia.Base/Input/PointerPoint.cs
@@ -157,11 +157,6 @@ namespace Avalonia.Input
                 IsXButton2Pressed = true;
             if (kind == PointerUpdateKind.XButton2Released)
                 IsXButton2Pressed = false;
-
-            if(IsLeftButtonPressed || IsMiddleButtonPressed || IsRightButtonPressed || IsXButton1Pressed || IsXButton2Pressed || IsBarrelButtonPressed)
-                Pressure = 1.0f;
-            else
-                Pressure = .0f;
         }
 
         public PointerPointProperties(RawInputModifiers modifiers, PointerUpdateKind kind,

--- a/src/Avalonia.Base/Input/PointerPoint.cs
+++ b/src/Avalonia.Base/Input/PointerPoint.cs
@@ -157,6 +157,11 @@ namespace Avalonia.Input
                 IsXButton2Pressed = true;
             if (kind == PointerUpdateKind.XButton2Released)
                 IsXButton2Pressed = false;
+
+            if(IsLeftButtonPressed || IsMiddleButtonPressed || IsRightButtonPressed || IsXButton1Pressed || IsXButton2Pressed || IsBarrelButtonPressed)
+                Pressure = 1.0f;
+            else
+                Pressure = .0f;
         }
 
         public PointerPointProperties(RawInputModifiers modifiers, PointerUpdateKind kind,

--- a/src/Avalonia.Native/TopLevelImpl.cs
+++ b/src/Avalonia.Native/TopLevelImpl.cs
@@ -68,6 +68,8 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
     private PlatformBehaviorInhibition? _platformBehaviorInhibition;
 
     private readonly MouseDevice? _mouse;
+    private readonly PenDevice? _pen;
+
     private readonly IKeyboardDevice? _keyboard;
     private readonly ICursorFactory? _cursorFactory;
 
@@ -88,6 +90,7 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
 
         _keyboard = AvaloniaLocator.Current.GetService<IKeyboardDevice>();
         _mouse = new MouseDevice();
+        _pen = new PenDevice();
         _cursorFactory = AvaloniaLocator.Current.GetService<ICursorFactory>();
     }
 
@@ -213,7 +216,7 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
         return args.Handled;
     }
 
-    public void RawMouseEvent(AvnRawMouseEventType type, ulong timeStamp, AvnInputModifiers modifiers, AvnPoint point, AvnVector delta)
+    public void RawMouseEvent(AvnRawMouseEventType type, AvnPointerDeviceType deviceType, ulong timeStamp, AvnInputModifiers modifiers, AvnPoint point, AvnVector delta, float pressure, float xTilt, float yTilt)
     {
         if (_inputRoot is null)
             return;
@@ -248,8 +251,15 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
                 break;
 
             default:
-                var e = new RawPointerEventArgs(_mouse, timeStamp, _inputRoot, (RawPointerEventType)type,
-                    point.ToAvaloniaPoint(), (RawInputModifiers)modifiers);
+                IInputDevice device = deviceType == AvnPointerDeviceType.Pen && _pen != null ? _pen : _mouse;
+                var e = new RawPointerEventArgs(device, timeStamp, _inputRoot, (RawPointerEventType)type,
+                    new RawPointerPoint
+                    {
+                        Position = point.ToAvaloniaPoint(),
+                        Pressure = pressure,
+                        XTilt = xTilt,
+                        YTilt = yTilt
+                    }, (RawInputModifiers)modifiers);
 
                 if (!ChromeHitTest(e))
                 {
@@ -435,9 +445,9 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
             _parent.Resized?.Invoke(s, (WindowResizeReason)reason);
         }
 
-        void IAvnTopLevelEvents.RawMouseEvent(AvnRawMouseEventType type, ulong timeStamp, AvnInputModifiers modifiers, AvnPoint point, AvnVector delta)
+        void IAvnTopLevelEvents.RawMouseEvent(AvnRawMouseEventType type, AvnPointerDeviceType pointerDeviceType, ulong timeStamp, AvnInputModifiers modifiers, AvnPoint point, AvnVector delta, float pressure, float xTilt, float yTilt)
         {
-            _parent.RawMouseEvent(type, timeStamp, modifiers, point, delta);
+            _parent.RawMouseEvent(type, pointerDeviceType, timeStamp, modifiers, point, delta, pressure, xTilt, yTilt);
         }
 
         int IAvnTopLevelEvents.RawKeyEvent(AvnRawKeyEventType type, ulong timeStamp, AvnInputModifiers modifiers, AvnKey key, AvnPhysicalKey physicalKey, string keySymbol)

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -667,6 +667,12 @@ enum AvnPlatformThemeVariant
     HighContrastDark,
 }
 
+enum AvnPointerDeviceType
+{
+    Mouse,
+    Pen,
+}
+
 [uuid(809c652e-7396-11d2-9771-00a0c9b4d50c)]
 interface IAvaloniaNativeFactory : IUnknown
 {
@@ -786,10 +792,15 @@ interface IAvnTopLevelEvents : IUnknown
     HRESULT Paint();
     void Resized([const] AvnSize& size, AvnPlatformResizeReason reason);
     void RawMouseEvent(AvnRawMouseEventType type,
+                                    AvnPointerDeviceType deviceType,
                                     u_int64_t timeStamp,
                                     AvnInputModifiers modifiers,
                                     AvnPoint point,
-                                    AvnVector delta);
+                                    AvnVector delta,
+                                    float pressure,
+                                    float xTilt,
+                                    float yTilt
+                                    );
     bool RawKeyEvent(AvnRawKeyEventType type, u_int64_t timeStamp, AvnInputModifiers modifiers,
                           AvnKey key, AvnPhysicalKey physicalKey, [const] char* keySymbol);
     bool RawTextInputEvent(u_int64_t timeStamp, [const] char* text);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adding pen pressure and tilt support on macos


<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Can not receive the pen pressure and tile information on macos



## What is the updated/expected behavior with this PR?

Can receive the pen pressure and tile information on macos

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Tilt has to be inverted on macos.
- see https://github.com/qt/qtbase/blob/0f128fd7c5a9ee721d1e631743f6eb61d927cf3b/src/plugins/platforms/cocoa/qnsview_tablet.mm#L63
- see https://source.chromium.org/chromium/chromium/src/+/main:components/input/web_input_event_builders_mac.mm;drc=0af5ffa1e4cc4cc4f818725f8fee93ec57855e4b;l=421

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
fix #3540
