### PR TITLE
Enable light dismiss on CalendarDatePicker popup in simple theme

### DIFF
--- a/src/Avalonia.Themes.Simple/Controls/CalendarDatePicker.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/CalendarDatePicker.xaml
@@ -118,7 +118,7 @@
 
           <Popup Name="PART_Popup"
                  PlacementTarget="{TemplateBinding}"
-                 IsLightDismissEnabled="False">
+                 IsLightDismissEnabled="True">
             <Calendar Name="PART_Calendar"
                       DisplayDate="{TemplateBinding DisplayDate}"
                       DisplayDateEnd="{TemplateBinding DisplayDateEnd}"


### PR DESCRIPTION
## What does the pull request do?
This sets `IsLightDismissEnabled` to `True` on the popup of the `CalendarDatePicker` control when using the simple theme. This was likely caused by the replacement of the `StaysOpen` property which was set to false. Link to the issue: #18066

## What is the current behavior?
`IsLightDismissEnabled` is set to `False` which in turn does not allow to auto close the popup when clicking outside of its bounds.


## What is the updated/expected behavior with this PR?
The popup now closes when using the `simple` theme and clicking outside of its bounds. This was the behavior bevor the commit that introduced this bug.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Fixes #18066