### PR TITLE
Datagrid user Add/Delete rows

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
@@ -57,6 +57,11 @@ namespace Avalonia.Collections
     public sealed class DataGridCollectionView : IDataGridCollectionView, IDataGridEditableCollectionView, IList, INotifyPropertyChanged 
     {
         /// <summary>
+        /// Gets the object that is in the collection to represent a new item.
+        /// </summary>
+        public static object NewItemPlaceholder { get; } = new();
+
+        /// <summary>
         /// Since there's nothing in the un-cancelable event args that is mutable,
         /// just create one instance to be used universally.
         /// </summary>
@@ -378,9 +383,16 @@ namespace Avalonia.Collections
         {
             get
             {
-                return !IsEditingItem &&
-                    (SourceList != null && !SourceList.IsFixedSize && CanConstructItem);
+                return !IsEditingItem && SourceCanAddNew;
             }
+        }
+
+        /// <summary>
+        /// Gets a value indicating if the souce list can add items
+        /// </summary>
+        public bool SourceCanAddNew
+        {
+            get => SourceList != null && !SourceList.IsFixedSize && CanConstructItem;
         }
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/DataGridCheckBoxColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCheckBoxColumn.cs
@@ -3,6 +3,7 @@
 // Please see http://go.microsoft.com/fwlink/?LinkID=131993 for details.
 // All other rights reserved.
 
+using Avalonia.Collections;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
@@ -129,7 +130,7 @@ namespace Avalonia.Controls
             checkBoxElement.IsEnabled = isEnabled;
             checkBoxElement.IsHitTestVisible = false;
             ConfigureCheckBox(checkBoxElement);
-            if (Binding != null)
+            if (Binding != null && dataItem != DataGridCollectionView.NewItemPlaceholder)
             {
                 checkBoxElement.Bind(BindingTarget, Binding);
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridComboBoxColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridComboBoxColumn.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using Avalonia.Collections;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
@@ -177,7 +178,7 @@ public class DataGridComboBoxColumn : DataGridBoundColumn
 
         SyncProperties(comboBox);
 
-        //if (Binding != null && dataItem != DataGridCollectionView.NewItemPlaceholder)
+        if (Binding != null && dataItem != DataGridCollectionView.NewItemPlaceholder)
             comboBox.Bind(BindingTarget, Binding);
 
         return comboBox;

--- a/src/Avalonia.Controls.DataGrid/DataGridComboBoxColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridComboBoxColumn.cs
@@ -1,0 +1,231 @@
+﻿using System;
+using System.Collections;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml.MarkupExtensions;
+using Avalonia.Metadata;
+using Avalonia.Styling;
+
+namespace Avalonia.Controls;
+
+public class DataGridComboBoxColumn : DataGridBoundColumn
+{
+    /// <summary>
+    /// Defines the <see cref="DisplayMemberBinding" /> property
+    /// </summary>
+    public static readonly StyledProperty<IBinding> DisplayMemberBindingProperty =
+        ItemsControl.DisplayMemberBindingProperty.AddOwner<DataGridComboBoxColumn>();
+
+    /// <summary>
+    /// Defines the <see cref="ItemsSource"/> property.
+    /// </summary>
+    public static readonly StyledProperty<IEnumerable> ItemsSourceProperty =
+        ItemsControl.ItemsSourceProperty.AddOwner<DataGridComboBoxColumn>();
+
+    /// <summary>
+    /// Defines the <see cref="ItemTemplate"/> property.
+    /// </summary>
+    public static readonly StyledProperty<IDataTemplate> ItemTemplateProperty =
+        ItemsControl.ItemTemplateProperty.AddOwner<DataGridComboBoxColumn>();
+
+    /// <summary>
+    /// Defines the <see cref="SelectedValue"/> property
+    /// </summary>
+    public static readonly StyledProperty<IBinding> SelectedValueProperty =
+        //we cant use SelectingItemsControl.SelectedValue here because we need the binding to check for readonly status
+        AvaloniaProperty.Register<DataGridComboBoxColumn, IBinding>(nameof(SelectedValue));
+
+    /// <summary>
+    /// Defines the <see cref="SelectedValueBinding"/> property
+    /// </summary>
+    public static readonly StyledProperty<IBinding> SelectedValueBindingProperty =
+        SelectingItemsControl.SelectedValueBindingProperty.AddOwner<DataGridComboBoxColumn>();
+
+    /// <summary>
+    /// Defines the <see cref="SelectionBoxItemTemplate"/> property.
+    /// </summary>
+    public static readonly StyledProperty<IDataTemplate> SelectionBoxItemTemplateProperty =
+        ComboBox.SelectionBoxItemTemplateProperty.AddOwner<DataGridComboBoxColumn>();
+
+    /// <inheritdoc cref="ItemsControl.DisplayMemberBinding"/>
+    [AssignBinding, InheritDataTypeFromItems(nameof(ItemsSource))]
+    public IBinding DisplayMemberBinding
+    {
+        get => GetValue(DisplayMemberBindingProperty);
+        set => SetValue(DisplayMemberBindingProperty, value);
+    }
+
+
+    /// <inheritdoc cref="ItemsControl.ItemsSource"/>
+    public IEnumerable ItemsSource
+    {
+        get => GetValue(ItemsSourceProperty);
+        set => SetValue(ItemsSourceProperty, value);
+    }
+
+    /// <inheritdoc cref="ItemsControl.ItemTemplate"/>
+    [InheritDataTypeFromItems(nameof(DataGrid.ItemsSource), AncestorType = typeof(DataGrid))]
+    public IDataTemplate ItemTemplate
+    {
+        get => GetValue(ItemTemplateProperty);
+        set => SetValue(ItemTemplateProperty, value);
+    }
+
+    /// <summary>
+    /// The binding used to get the value of the selected item
+    /// </summary>
+    [AssignBinding, InheritDataTypeFromItems(nameof(DataGrid.ItemsSource), AncestorType = typeof(DataGrid))]
+    public IBinding SelectedValue
+    {
+        get => GetValue(SelectedValueProperty);
+        set => SetValue(SelectedValueProperty, value);
+    }
+
+    /// <summary>
+    /// A binding used to get the value of an item selected in the combobox
+    /// </summary>
+    [AssignBinding, InheritDataTypeFromItems(nameof(ItemsSource), AncestorType = typeof(DataGridComboBoxColumn))]
+    public IBinding SelectedValueBinding
+    {
+        get => GetValue(SelectedValueBindingProperty);
+        set => SetValue(SelectedValueBindingProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the data template used to display the item in the combo box (not the dropdown) 
+    /// </summary>
+    [InheritDataTypeFromItems(nameof(ItemsSource))]
+    public IDataTemplate SelectionBoxItemTemplate
+    {
+        get => GetValue(SelectionBoxItemTemplateProperty);
+        set => SetValue(SelectionBoxItemTemplateProperty, value);
+    }
+
+    [AssignBinding, InheritDataTypeFromItems(nameof(DataGrid.ItemsSource), AncestorType = typeof(DataGrid))]
+    public virtual IBinding SelectedItemBinding
+    {
+        get => Binding;
+        set => Binding = value;
+    }
+
+
+    private readonly Lazy<ControlTheme> _cellComboBoxTheme;
+
+    public DataGridComboBoxColumn()
+    {
+        BindingTarget = SelectingItemsControl.SelectedItemProperty;
+
+        _cellComboBoxTheme = new Lazy<ControlTheme>(() =>
+                OwningGrid.TryFindResource("DataGridCellComboBoxTheme", out var theme) ? (ControlTheme)theme : null);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == DisplayMemberBindingProperty
+            || change.Property == ItemsSourceProperty
+            || change.Property == ItemTemplateProperty
+            || change.Property == SelectedValueProperty
+            || change.Property == SelectedValueBindingProperty
+            || change.Property == SelectionBoxItemTemplateProperty)
+        {
+            NotifyPropertyChanged(change.Property.Name);
+        }
+
+        //if using the SelectedValue binding then the combobox needs to be bound using the selected value
+        //otherwise use the default SelectedItem
+        if (change.Property == SelectedValueProperty)
+            BindingTarget = change.NewValue == null
+                ? SelectingItemsControl.SelectedItemProperty
+                : SelectingItemsControl.SelectedValueProperty;
+    }
+
+    /// <summary>
+    /// Gets a <see cref="T:Avalonia.Controls.ComboBox" /> control that is bound to the column's <see cref="SelectedItemBinding"/> property value.
+    /// </summary>
+    /// <param name="cell">The cell that will contain the generated element.</param>
+    /// <param name="dataItem">The data item represented by the row that contains the intended cell.</param>
+    /// <returns>A new <see cref="T:Avalonia.Controls.ComboBox" /> control that is bound to the column's <see cref="SelectedItemBinding"/> property value.</returns>
+    protected override Control GenerateEditingElementDirect(DataGridCell cell, object dataItem)
+    {
+        ComboBox comboBox = new ComboBox
+        {
+            Name = "CellComboBox"
+        };
+
+        if (_cellComboBoxTheme.Value is { } theme)
+            comboBox.Theme = theme;
+
+        SyncProperties(comboBox);
+
+        return comboBox;
+    }
+
+    protected override Control GenerateElement(DataGridCell cell, object dataItem)
+    {
+        ComboBox comboBox = new ComboBox
+        {
+            Name = "DisplayValueComboBox",
+            IsHitTestVisible = false
+        };
+
+        if (_cellComboBoxTheme.Value is { } theme)
+            comboBox.Theme = theme;
+
+        SyncProperties(comboBox);
+
+        //if (Binding != null && dataItem != DataGridCollectionView.NewItemPlaceholder)
+            comboBox.Bind(BindingTarget, Binding);
+
+        return comboBox;
+    }
+
+    protected override object PrepareCellForEdit(Control editingElement, RoutedEventArgs editingEventArgs)
+    {
+        if (editingElement is ComboBox comboBox)
+        {
+            comboBox.IsDropDownOpen = true;
+            if (BindingTarget == SelectingItemsControl.SelectedValueProperty)
+                return comboBox.SelectedValue;
+
+            return comboBox.SelectedItem;
+        }
+        return null;
+    }
+
+    private void SyncProperties(ComboBox comboBox)
+    {
+        DataGridHelper.SyncColumnProperty(this, comboBox, DisplayMemberBindingProperty);
+        DataGridHelper.SyncColumnProperty(this, comboBox, ItemsSourceProperty);
+        DataGridHelper.SyncColumnProperty(this, comboBox, ItemTemplateProperty);
+        DataGridHelper.SyncColumnProperty(this, comboBox, SelectedValueBindingProperty);
+        DataGridHelper.SyncColumnProperty(this, comboBox, SelectionBoxItemTemplateProperty);
+
+        //if binding using SelectedItem then the DataGridBoundColumn handles that, otherwise we need to
+        if (BindingTarget == SelectingItemsControl.SelectedValueProperty)
+            comboBox.Bind(SelectingItemsControl.SelectedValueProperty, SelectedValue);
+    }
+
+    public override bool IsReadOnly
+    {
+        get
+        {
+            if (OwningGrid == null)
+                return base.IsReadOnly;
+            if (OwningGrid.IsReadOnly)
+                return true;
+
+            var valueBinding = Binding ?? SelectedValue;
+            string path = (valueBinding as Binding)?.Path
+                        ?? (valueBinding as CompiledBindingExtension)?.Path.ToString();
+            return OwningGrid.DataConnection.GetPropertyIsReadOnly(path, out _);
+        }
+        set
+        {
+            base.IsReadOnly = value;
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/DataGridDataConnection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridDataConnection.cs
@@ -31,6 +31,7 @@ namespace Avalonia.Controls
         private DataGrid _owner;
         private bool _scrollForCurrentChanged;
         private DataGridSelectionAction _selectionActionForCurrentChanged;
+        private bool _onCollectionChangeAddRemoveNewRowPlaceholder;
 
         public DataGridDataConnection(DataGrid owner)
         {
@@ -193,6 +194,32 @@ namespace Avalonia.Controls
             }
         }
 
+        private bool CanAddNew
+        {
+            get
+            {
+                if (!_owner.CanUserAddRows)
+                    return false;
+                if (EditableCollectionView == null)
+                    return false;
+                if (EditableCollectionView is DataGridCollectionView dataGridCollectionView && !dataGridCollectionView.SourceCanAddNew)
+                    return false;
+                if (EditableCollectionView.IsAddingNew)
+                    return false;
+
+                return true;
+            }
+        }
+
+        public bool CanRemove
+        {
+            get => _owner.CanUserDeleteRows
+                && (
+                    (EditableCollectionView?.CanRemove ?? false)
+                    || (!List?.IsReadOnly ?? false)
+                );
+        }
+
         /// <summary>Try get number of DataSource items.</summary>
         /// <param name="allowSlow">When "allowSlow" is false, method will not use Linq.Count() method and will return 0 or 1 instead.</param>
         /// <param name="getAny">If "getAny" is true, method can use Linq.Any() method to speedup.</param>
@@ -208,12 +235,18 @@ namespace Avalonia.Controls
                 IEnumerable enumerable when getAny => (true, enumerable.Cast<object>().Any() ? 1 : 0),
                 _ => (false, 0)
             };
+            if (result && CanAddNew)
+                count++;
+
             return result;
         }
 
         internal bool Any()
         {
-            return TryGetCount(false, true, out var count) && count > 0;
+            bool result = TryGetCount(false, true, out var count);
+            if (result && CanAddNew)
+                count--;
+            return result && count > 0;
         }
 
         /// <summary>
@@ -237,7 +270,14 @@ namespace Avalonia.Controls
                 }
                 else
                 {
-                    editableCollectionView.EditItem(dataItem);
+                    if (dataItem == DataGridCollectionView.NewItemPlaceholder)
+                    {
+                        _onCollectionChangeAddRemoveNewRowPlaceholder = true;
+                        editableCollectionView.AddNew();
+                        _onCollectionChangeAddRemoveNewRowPlaceholder = false;
+                    }
+                    else
+                        editableCollectionView.EditItem(dataItem);
                     return editableCollectionView.IsEditingItem || editableCollectionView.IsAddingNew;
                 }
             }
@@ -264,6 +304,16 @@ namespace Avalonia.Controls
                 if (editableCollectionView.CanCancelEdit)
                 {
                     editableCollectionView.CancelEdit();
+                    return true;
+                }
+                else if (editableCollectionView.IsAddingNew)
+                {
+                    //while we are not techincally committing it supresses relevant changes (row being removed)
+                    CommittingEdit = true;
+                    editableCollectionView.CancelNew();
+                    CommittingEdit = false;
+                    //now add the blank new row back in 
+                    AddNewItemRow(_owner.SlotCount);
                     return true;
                 }
                 return false;
@@ -322,6 +372,7 @@ namespace Avalonia.Controls
                     if (editableCollectionView.IsAddingNew)
                     {
                         editableCollectionView.CommitNew();
+                        AddNewItemRow(_owner.SlotCount);
                     }
                     else
                     {
@@ -351,7 +402,13 @@ namespace Avalonia.Controls
 
             if (DataSource is DataGridCollectionView collectionView)
             {
-                return (index < collectionView.Count) ? collectionView.GetItemAt(index) : null;
+                int count = collectionView.Count;
+                if (index < count)
+                    return collectionView.GetItemAt(index);
+                else if (index == count)
+                    return DataGridCollectionView.NewItemPlaceholder;
+                else
+                    return null;
             }
 
             IList list = List;
@@ -413,10 +470,10 @@ namespace Avalonia.Controls
         {
             propertyType = null;
             if (DataType == null)
-                return true;
+                return !AllowEdit;
 
             if (string.IsNullOrEmpty(propertyName))
-                return true;
+                return DataType.GetIsReadOnly();
 
             propertyType = DataType;
             PropertyInfo propertyInfo = null;
@@ -447,20 +504,30 @@ namespace Avalonia.Controls
 
         public int IndexOf(object dataItem)
         {
+            bool isNewItem = dataItem == DataGridCollectionView.NewItemPlaceholder;
+
             if (DataSource is DataGridCollectionView cv)
             {
-                return cv.IndexOf(dataItem);
+                return isNewItem ? cv.Count : cv.IndexOf(dataItem);
             }
 
             IList list = List;
             if (list != null)
             {
-                return list.IndexOf(dataItem);
+                return isNewItem ? list.Count : list.IndexOf(dataItem);
             }
 
             IEnumerable enumerable = DataSource;
             if (enumerable != null && dataItem != null)
             {
+                if (isNewItem)
+                {
+                    int count = 0;
+                    foreach (object item in enumerable)
+                        count++;
+                    return count;
+                }
+
                 int index = 0;
                 foreach (object dataItemTmp in enumerable)
                 {
@@ -531,7 +598,11 @@ namespace Avalonia.Controls
                 _scrollForCurrentChanged = scrollIntoView;
                 _backupSlotForCurrentChanged = backupSlot;
 
-                CollectionView.MoveCurrentTo(item is DataGridCollectionViewGroup ? null : item);
+                //if its the new item pretend the collection has changed so the selection gets updated
+                if (item == DataGridCollectionView.NewItemPlaceholder)
+                    CollectionView_CurrentChanged(this, EventArgs.Empty);
+                else
+                    CollectionView.MoveCurrentTo(item is DataGridCollectionViewGroup ? null : item);
 
                 _expectingCurrentChanged = false;
             }
@@ -674,6 +745,8 @@ namespace Avalonia.Controls
                         // If we're grouping then we handle this through the CollectionViewGroup notifications
                         // According to WPF, Add is a single item operation
                         Debug.Assert(e.NewItems.Count == 1);
+                        if (_onCollectionChangeAddRemoveNewRowPlaceholder)
+                            _owner.RemoveRowAt(e.NewStartingIndex, IndexOf(DataGridCollectionView.NewItemPlaceholder));
                         _owner.InsertRowAt(e.NewStartingIndex);
                     }
                     break;
@@ -734,5 +807,23 @@ namespace Avalonia.Controls
             }
         }
 
+        private void AddNewItemRow(int slot)
+        {
+            _owner.InsertRowAt(slot);
+        }
+
+        /// <summary>
+        /// Remove an item from the underlying <see cref="DataSource"/>
+        /// </summary>
+        /// <returns></returns>
+        internal void Remove(object item)
+        {
+            if (EditableCollectionView != null)
+                EditableCollectionView.Remove(item);
+            else if (List != null && !List.IsReadOnly)
+                List.Remove(item);
+            else
+                throw new NotSupportedException("Underlaying data source does not support modifications");
+        }
     }
 }

--- a/src/Avalonia.Controls.DataGrid/DataGridTextColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridTextColumn.cs
@@ -12,6 +12,7 @@ using Avalonia.Layout;
 using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Controls.Documents;
 using Avalonia.Styling;
+using Avalonia.Collections;
 
 namespace Avalonia.Controls
 {
@@ -197,7 +198,7 @@ namespace Avalonia.Controls
 
             SyncProperties(textBlockElement);
 
-            if (Binding != null)
+            if (Binding != null && dataItem != DataGridCollectionView.NewItemPlaceholder)
             {
                 textBlockElement.Bind(TextBlock.TextProperty, Binding);
             }

--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -80,6 +80,9 @@
         <Setter Property="Theme" Value="{StaticResource TooltipDataValidationErrors}" />
       </Style>
     </ControlTheme>
+     <ControlTheme x:Key="DataGridCellComboBoxTheme" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+       <Setter Property="HorizontalAlignment" Value="Stretch"/>
+     </ControlTheme>
 
     <ControlTheme x:Key="{x:Type DataGridCell}" TargetType="DataGridCell">
       <Setter Property="Background" Value="{DynamicResource DataGridCellBackgroundBrush}" />

--- a/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
@@ -14,6 +14,9 @@
       <Setter Property="VerticalAlignment" Value="Stretch" />
       <Setter Property="Background" Value="Transparent" />
     </ControlTheme>
+    <ControlTheme x:Key="DataGridCellComboBoxTheme" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+      <Setter Property="HorizontalAlignment" Value="Stretch"/>
+    </ControlTheme>
 
     <ControlTheme x:Key="{x:Type DataGridCell}"
                   TargetType="DataGridCell">


### PR DESCRIPTION
## What does the pull request do?
Adds the ability to add/delete rows in datagrid

## What is the current behavior?
None existant

## What is the updated/expected behavior with this PR?
User can add and delete rows


## How was the solution implemented (if it's not obvious)?
Adds as static object in `DataGridCollectionView` called `NewItemPlaceholder` which is set as the datacontext for new rows. 

`DataGridDataConnection` does a lot of the heavy lifting by essentially adding 1 to the row count where needed, then when the edit starts it removes the 'new row' in the grid and replaces it with a row that has the data context of the new item.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

## Obsoletions / Deprecations

## Fixed issues
AvaloniaUI/Avalonia.Controls.DataGrid#59 

## small note
Just realised I've done this branch from pull request AvaloniaUI/Avalonia#18105, if you're happy with both then this can just be merged in, if not then I can remove the combo box column from here
