### PR TITLE
Adding SelectionMode to TabStrip

### DIFF
--- a/samples/ControlCatalog/Pages/TabStripPage.xaml
+++ b/samples/ControlCatalog/Pages/TabStripPage.xaml
@@ -2,14 +2,22 @@
              x:Class="ControlCatalog.Pages.TabStripPage"
              xmlns="https://github.com/avaloniaui"
              xmlns:viewModels="using:ControlCatalog.ViewModels"
-             x:DataType="viewModels:TabControlPageViewModel">
-    <StackPanel Orientation="Vertical" Spacing="4">
+             x:DataType="viewModels:TabStripPageViewModel">
+  <DockPanel>
+    <StackPanel DockPanel.Dock="Top"  Orientation="Vertical" Spacing="4">
         <TextBlock Classes="h2">A control which displays a selectable strip of tabs</TextBlock>
-
         <Separator Margin="0 16"/>
-        
+    </StackPanel>
+    <StackPanel DockPanel.Dock="Right" Margin="16 0">
+      <TextBlock Classes="h2" xml:space="preserve" Margin="0 4">Modifies the SelectionModes of 
+      the XAML defined Tabstrip:</TextBlock>
+      <CheckBox IsChecked="{Binding Multiple}">Multiple</CheckBox>
+      <CheckBox IsChecked="{Binding Toggle}">Toggle</CheckBox>
+      <CheckBox IsChecked="{Binding AlwaysSelected}">AlwaysSelected</CheckBox>
+    </StackPanel>
+    <StackPanel Orientation="Vertical" Spacing="4">
         <TextBlock Classes="h1">Defined in XAML</TextBlock>
-        <TabStrip>
+        <TabStrip SelectionMode="{Binding SelectionMode^}">
             <TabStripItem>Item 1</TabStripItem>
             <TabStripItem>Item 2</TabStripItem>
             <TabStripItem IsEnabled="False">Disabled</TabStripItem>
@@ -31,4 +39,5 @@
             </TabStrip.ItemTemplate>
         </TabStrip>
     </StackPanel>
+  </DockPanel>
 </UserControl>

--- a/samples/ControlCatalog/Pages/TabStripPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/TabStripPage.xaml.cs
@@ -10,7 +10,7 @@ namespace ControlCatalog.Pages
         {
             InitializeComponent();
 
-            DataContext = new TabControlPageViewModel
+            DataContext = new TabStripPageViewModel
             {
                 Tabs = new []
                 {

--- a/samples/ControlCatalog/ViewModels/TabStripPageViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/TabStripPageViewModel.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Avalonia.Controls;
+using MiniMvvm;
+
+namespace ControlCatalog.ViewModels;
+
+public class TabStripPageViewModel : ViewModelBase
+{
+    private bool _multiple;
+    private bool _toggle;
+    private bool _alwaysSelected;
+    private IObservable<SelectionMode> _selectionMode;
+
+    public TabControlPageViewModelItem[]? Tabs { get; set; }
+    public IObservable<SelectionMode> SelectionMode => _selectionMode;
+
+    public TabStripPageViewModel()
+    {
+        _selectionMode = this.WhenAnyValue(
+            x => x.Multiple,
+            x => x.Toggle,
+            x => x.AlwaysSelected,
+            (m, t, a) =>
+                (m ? Avalonia.Controls.SelectionMode.Multiple : 0) |
+                (t ? Avalonia.Controls.SelectionMode.Toggle : 0) |
+                (a ? Avalonia.Controls.SelectionMode.AlwaysSelected : 0));
+    }
+
+    public bool Multiple
+    {
+        get => _multiple;
+        set => this.RaiseAndSetIfChanged(ref _multiple, value);
+    }
+
+    public bool Toggle
+    {
+        get => _toggle;
+        set => this.RaiseAndSetIfChanged(ref _toggle, value);
+    }
+
+    public bool AlwaysSelected
+    {
+        get => _alwaysSelected;
+        set => this.RaiseAndSetIfChanged(ref _alwaysSelected, value);
+    }
+}

--- a/src/Avalonia.Controls/Primitives/TabStrip.cs
+++ b/src/Avalonia.Controls/Primitives/TabStrip.cs
@@ -11,7 +11,6 @@ namespace Avalonia.Controls.Primitives
 
         static TabStrip()
         {
-            SelectionModeProperty.OverrideDefaultValue<TabStrip>(SelectionMode.AlwaysSelected);
             FocusableProperty.OverrideDefaultValue(typeof(TabStrip), false);
             ItemsPanelProperty.OverrideDefaultValue<TabStrip>(DefaultPanel);
         }

--- a/src/Avalonia.Controls/Primitives/TabStrip.cs
+++ b/src/Avalonia.Controls/Primitives/TabStrip.cs
@@ -9,6 +9,29 @@ namespace Avalonia.Controls.Primitives
         private static readonly FuncTemplate<Panel?> DefaultPanel =
             new(() => new WrapPanel { Orientation = Orientation.Horizontal });
 
+        /// <summary>
+        /// Defines the <see cref="SelectionMode"/> property.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("AvaloniaProperty", "AVP1010",
+            Justification = "This property is owned by SelectingItemsControl, but protected there. TabStrip changes its visibility.")]
+        public static readonly new StyledProperty<SelectionMode> SelectionModeProperty =
+            SelectingItemsControl.SelectionModeProperty;
+
+        /// <summary>
+        /// Gets or sets the selection mode.
+        /// </summary>
+        /// <remarks>
+        /// Note that the selection mode only applies to selections made via user interaction.
+        /// Multiple selections can be made programmatically regardless of the value of this property.
+        /// </remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("AvaloniaProperty", "AVP1012",
+            Justification = "This property is owned by SelectingItemsControl, but protected there. TabStrip changes its visibility.")]
+        public new SelectionMode SelectionMode
+        {
+            get => base.SelectionMode;
+            set => base.SelectionMode = value;
+        }
+
         static TabStrip()
         {
             FocusableProperty.OverrideDefaultValue(typeof(TabStrip), false);

--- a/tests/Avalonia.Controls.UnitTests/Primitives/TabStripTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/TabStripTests.cs
@@ -1,10 +1,6 @@
-using System.Collections.ObjectModel;
-using System.Linq;
-using Moq;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
-using Avalonia.LogicalTree;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Primitives
@@ -12,7 +8,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
     public class TabStripTests
     {
         [Fact]
-        public void First_Tab_Should_Be_Selected_By_Default()
+        public void First_Tab_Should_Not_Be_Selected_By_Default()
         {
             var target = new TabStrip
             {
@@ -32,8 +28,8 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
             target.ApplyTemplate();
 
-            Assert.Equal(0, target.SelectedIndex);
-            Assert.Same(target.Items[0], target.SelectedItem);
+            Assert.Equal(-1, target.SelectedIndex);
+            Assert.Same(null, target.SelectedItem);
         }
 
         [Fact]
@@ -60,39 +56,6 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
             Assert.Equal(1, target.SelectedIndex);
             Assert.Same(target.Items[1], target.SelectedItem);
-        }
-
-        [Fact]
-        public void Removing_Selected_Should_Select_First()
-        {
-            var target = new TabStrip
-            {
-                Template = new FuncControlTemplate<TabStrip>(CreateTabStripTemplate),
-                Items =
-                {
-                    new TabItem
-                    {
-                        Name = "first"
-                    },
-                    new TabItem
-                    {
-                        Name = "second"
-                    },
-                    new TabItem
-                    {
-                        Name = "3rd"
-                    },
-                }
-            };
-
-            target.ApplyTemplate();
-            target.SelectedItem = target.Items[1];
-            Assert.Same(target.Items[1], target.SelectedItem);
-            target.Items.RemoveAt(1);
-
-            Assert.Equal(0, target.SelectedIndex);
-            Assert.Same(target.Items[0], target.SelectedItem);
-            Assert.Same("first", ((TabItem)target.SelectedItem).Name);
         }
 
         private Control CreateTabStripTemplate(TabStrip parent, INameScope scope)


### PR DESCRIPTION
## What does the pull request do?

This implements #17969. In essence, it exposes the `SelectionMode` property to make the selection mode configurable and it disables the behavior that the first item is always selected. This mimics the behavior of the `ListBox`.

## What is the current behavior?
First item is always selected and you can't change the SelectionMode.


## What is the updated/expected behavior with this PR?
I updated the ControlCatalog to allow to "play" with the settings:

![image](https://github.com/user-attachments/assets/60a2c3f7-85d0-46b6-bbb7-b1fec33ddc32)

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Implements #17969
