### PR TITLE
Warning AVLN2208: Item container in the data template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -220,6 +220,8 @@ avalonia_xaml_diagnostic.AVLN2205.severity = error
 avalonia_xaml_diagnostic.AVLN2206.severity = info
 # TemplatePartWrongType
 avalonia_xaml_diagnostic.AVLN2207.severity = error
+# ItemContainerInsideTemplate
+avalonia_xaml_diagnostic.AVLN2208.severity = error
 # Obsolete
 avalonia_xaml_diagnostic.AVLN5001.severity = error
 

--- a/build/WarnAsErrors.props
+++ b/build/WarnAsErrors.props
@@ -17,5 +17,7 @@
     <WarningsNotAsErrors>$(WarningsNotAsErrors);AVLN2205</WarningsNotAsErrors>
     <!-- AVLN2207: TemplatePartWrongType -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);AVLN2207</WarningsNotAsErrors>
+    <!-- AVLN2208: ItemContainerInsideTemplate -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);AVLN2208</WarningsNotAsErrors>
   </PropertyGroup>
 </Project>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/EventsPageView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/EventsPageView.xaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:Avalonia.Diagnostics.ViewModels"
              xmlns:controls="using:Avalonia.Diagnostics.Controls"
+             xmlns:models="using:Avalonia.Diagnostics.Models"
              x:Class="Avalonia.Diagnostics.Views.EventsPageView"
              Margin="2"
              x:DataType="vm:EventsPageViewModel">
@@ -73,34 +74,37 @@
 
       <ListBox Name="EventsList" ItemsSource="{Binding RecordedEvents}"
                SelectedItem="{Binding SelectedEvent, Mode=TwoWay}">
+        <ListBox.Styles>
+          <Style Selector="ListBoxItem">
+            <Setter Property="Classes.handled" Value="{Binding IsHandled, DataType=vm:FiredEvent}" />
+          </Style>
+        </ListBox.Styles>
 
         <ListBox.ItemTemplate>
           <DataTemplate>
-            <ListBoxItem Classes.handled="{Binding IsHandled}">
-              <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto">
+            <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto">
 
-                <TextBlock Grid.Column="0"  Text="{Binding TriggerTime, StringFormat={}{0:HH:mm:ss.fff}}"/>
+              <TextBlock Grid.Column="0"  Text="{Binding TriggerTime, StringFormat={}{0:HH:mm:ss.fff}}"/>
 
-                <StackPanel Margin="10,0,0,0" Grid.Column="1" Spacing="2" Orientation="Horizontal" >
-                  <TextBlock Tag="{Binding Event}" DoubleTapped="NavigateTo" Text="{Binding Event.Name}" FontWeight="Bold" Classes="nav" />
-                  <TextBlock Text="on" />
-                  <TextBlock Tag="{Binding Originator}" DoubleTapped="NavigateTo" Text="{Binding Originator.HandlerName}" Classes="nav" />
-                </StackPanel>
+              <StackPanel Margin="10,0,0,0" Grid.Column="1" Spacing="2" Orientation="Horizontal" >
+                <TextBlock Tag="{Binding Event}" DoubleTapped="NavigateTo" Text="{Binding Event.Name}" FontWeight="Bold" Classes="nav" />
+                <TextBlock Text="on" />
+                <TextBlock Tag="{Binding Originator}" DoubleTapped="NavigateTo" Text="{Binding Originator.HandlerName}" Classes="nav" />
+              </StackPanel>
 
-                <StackPanel Margin="2,0,0,0" Grid.Column="2" Spacing="2" Orientation="Horizontal" IsVisible="{Binding IsHandled}" >
-                  <TextBlock Text="::" />
-                  <TextBlock Text="Handled by" />
-                  <TextBlock Tag="{Binding HandledBy}" DoubleTapped="NavigateTo" Text="{Binding HandledBy.HandlerName}" Classes="nav" />
-                </StackPanel>
+              <StackPanel Margin="2,0,0,0" Grid.Column="2" Spacing="2" Orientation="Horizontal" IsVisible="{Binding IsHandled}" >
+                <TextBlock Text="::" />
+                <TextBlock Text="Handled by" />
+                <TextBlock Tag="{Binding HandledBy}" DoubleTapped="NavigateTo" Text="{Binding HandledBy.HandlerName}" Classes="nav" />
+              </StackPanel>
 
-                <StackPanel Grid.Column="4" Orientation="Horizontal" HorizontalAlignment="Right">
-                  <TextBlock Text="Routing (" />
-                  <TextBlock Text="{Binding Event.RoutingStrategies}"/>
-                  <TextBlock Text=")"/>
-                </StackPanel>
+              <StackPanel Grid.Column="4" Orientation="Horizontal" HorizontalAlignment="Right">
+                <TextBlock Text="Routing (" />
+                <TextBlock Text="{Binding Event.RoutingStrategies}"/>
+                <TextBlock Text=")"/>
+              </StackPanel>
 
-              </Grid>
-            </ListBoxItem>
+            </Grid>
           </DataTemplate>
         </ListBox.ItemTemplate>
       </ListBox>
@@ -111,26 +115,29 @@
         <TextBlock DockPanel.Dock="Top" FontSize="16" Text="Event chain:" />
 
         <ListBox ItemsSource="{Binding SelectedEvent.EventChain}">
+          <ListBox.Styles>
+            <Style Selector="ListBoxItem">
+              <Setter Property="Classes.handled" Value="{Binding Handled, DataType=models:EventChainLink}" />
+            </Style>
+          </ListBox.Styles>
           <ListBox.ItemTemplate>
             <DataTemplate>
-              <ListBoxItem Classes.handled="{Binding Handled}"
-                           PointerEntered="ListBoxItem_PointerEntered"
-                           PointerExited="ListBoxItem_PointerExited"
-                           >
-                <StackPanel Orientation="Vertical">
+              <StackPanel Orientation="Vertical"
+                          Background="Transparent"
+                          PointerEntered="ListBoxItem_PointerEntered"
+                          PointerExited="ListBoxItem_PointerExited">
 
-                  <Rectangle IsVisible="{Binding BeginsNewRoute}" StrokeDashArray="2,2" StrokeThickness="1" Stroke="Gray" />
+                <Rectangle IsVisible="{Binding BeginsNewRoute}" StrokeDashArray="2,2" StrokeThickness="1" Stroke="Gray" />
 
-                  <StackPanel Orientation="Horizontal" Spacing="2">
-                    <TextBlock Text="{Binding Route}" FontWeight="Bold" />
-                    <TextBlock Tag="{Binding}"
-                               DoubleTapped="NavigateTo"
-                               Text="{Binding HandlerName}"
-                               Classes="nav" />
-                  </StackPanel>
-
+                <StackPanel Orientation="Horizontal" Spacing="2">
+                  <TextBlock Text="{Binding Route}" FontWeight="Bold" />
+                  <TextBlock Tag="{Binding}"
+                             DoubleTapped="NavigateTo"
+                             Text="{Binding HandlerName}"
+                             Classes="nav" />
                 </StackPanel>
-              </ListBoxItem>
+
+              </StackPanel>
             </DataTemplate>
           </ListBox.ItemTemplate>
         </ListBox>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/EventsPageView.xaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/EventsPageView.xaml.cs
@@ -77,7 +77,7 @@ namespace Avalonia.Diagnostics.Views
         private void ListBoxItem_PointerEntered(object? sender, PointerEventArgs e)
         {
             if (DataContext is EventsPageViewModel vm 
-                && sender is ListBoxItem control 
+                && sender is Control control 
                 && control.DataContext is EventChainLink chainLink
                 && chainLink.Handler is Visual visual)
             {

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlDiagnosticCodes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlDiagnosticCodes.cs
@@ -28,6 +28,7 @@ internal static class AvaloniaXamlDiagnosticCodes
     public const string RequiredTemplatePartMissing = "AVLN2205";
     public const string OptionalTemplatePartMissing = "AVLN2206";
     public const string TemplatePartWrongType = "AVLN2207";
+    public const string ItemContainerInsideTemplate = "AVLN2208";
 
     // XAML emit errors 3000-3999.
     public const string EmitError = "AVLN3000";

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlCompiler.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlCompiler.cs
@@ -66,7 +66,8 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 new AvaloniaXamlIlConstructorServiceProviderTransformer(),
                 new AvaloniaXamlIlTransitionsTypeMetadataTransformer(),
                 new AvaloniaXamlIlResolveByNameMarkupExtensionReplacer(),
-                new AvaloniaXamlIlThemeVariantProviderTransformer()
+                new AvaloniaXamlIlThemeVariantProviderTransformer(),
+                new AvaloniaXamlIlDataTemplateWarningsTransformer()
             );
             InsertBefore<ConvertPropertyValuesToAssignmentsTransformer>(
                 new AvaloniaXamlIlOptionMarkupExtensionTransformer());

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlDataTemplateWarningsTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlDataTemplateWarningsTransformer.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers;
+using XamlX;
+using XamlX.Ast;
+using XamlX.Transform;
+using XamlX.TypeSystem;
+
+namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers;
+
+#if !XAMLX_INTERNAL
+public
+#endif
+    class AvaloniaXamlIlDataTemplateWarningsTransformer : IXamlAstTransformer
+{
+    public IXamlAstNode Transform(AstTransformationContext context, IXamlAstNode node)
+    {
+        var avaloniaTypes = context.GetAvaloniaTypes();
+        var contentControl = context.GetAvaloniaTypes().ContentControl;
+
+        // This transformers only looks for ContentControl delivered objects inside of DataTemplate
+        if ((node is not XamlAstObjectNode objectNode)
+            || !contentControl.IsAssignableFrom(objectNode.Type.GetClrType())
+            || context.ParentNodes().FirstOrDefault() is not XamlAstObjectNode parentNode
+            || !avaloniaTypes.IDataTemplate.IsAssignableFrom(parentNode.Type.GetClrType()))
+        {
+            return node;
+        }
+
+        // And only inside of ItemTemplate or DataTemplates property value.
+        if (context.ParentNodes().OfType<XamlAstXamlPropertyValueNode>().FirstOrDefault() is not { } valueNode
+            || valueNode.Property.GetClrProperty() is not { } clrProperty
+            || !((clrProperty.Name == "ItemTemplate" && clrProperty.DeclaringType == avaloniaTypes.ItemsControl)
+                || (clrProperty.Name == "DataTemplates" && clrProperty.DeclaringType == avaloniaTypes.Control)))
+        {
+            return node;
+        }
+
+        // And only inside of ItemsControl
+        if (context.ParentNodes().SkipWhile(p => p != valueNode)
+                .OfType<XamlAstObjectNode>().FirstOrDefault() is not { } itemsControlNode
+            || !avaloniaTypes.ItemsControl.IsAssignableFrom(itemsControlNode.Type.GetClrType()))
+        {
+            return node;
+        }
+
+        // Avalonia doesn't have any reliable way to determine container type from the API.
+        if (GetKnownItemContainerTypeFullName(itemsControlNode.Type.GetClrType()) is not { } knownItemContainerTypeName
+            || itemsControlNode.Type.GetClrType().Assembly?.FindType(knownItemContainerTypeName) is not { } knownItemContainerType)
+        {
+            return node;
+        }
+
+        if (knownItemContainerType.IsAssignableFrom(objectNode.Type.GetClrType()))
+        {
+            context.ReportDiagnostic(new XamlDiagnostic(
+                AvaloniaXamlDiagnosticCodes.ItemContainerInsideTemplate,
+                XamlDiagnosticSeverity.Warning,
+                $"Unexpected '{knownItemContainerType.Name}' inside of '{itemsControlNode.Type.GetClrType().Name}.{clrProperty.Name}'. "
+                + $"'{itemsControlNode.Type.GetClrType().Name}.{clrProperty.Name}' defines template of the container content, not the container itself.", node));
+        }
+
+        return node;
+    }
+
+    private static string? GetKnownItemContainerTypeFullName(IXamlType itemsControlType) => itemsControlType.FullName switch
+    {
+        "Avalonia.Controls.ListBox" => "Avalonia.Controls.ListBoxItem",
+        "Avalonia.Controls.ComboBox" => "Avalonia.Controls.ComboBoxItem",
+        "Avalonia.Controls.Menu" => "Avalonia.Controls.MenuItem",
+        "Avalonia.Controls.MenuItem" => "Avalonia.Controls.MenuItem",
+        "Avalonia.Controls.Primitives.TabStrip" => "Avalonia.Controls.Primitives.TabStripItem",
+        "Avalonia.Controls.TabControl" => "Avalonia.Controls.TabItem",
+        "Avalonia.Controls.TreeView" => "Avalonia.Controls.TreeViewItem",
+        _ => null
+    };
+}

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -63,6 +63,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType IDataTemplate { get; }
         public IXamlType ITemplateOfControl { get; }
         public IXamlType Control { get; }
+        public IXamlType ContentControl { get; }
         public IXamlType ItemsControl { get; }
         public IXamlType ReflectionBindingExtension { get; }
 
@@ -249,6 +250,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             DataTemplate = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.Templates.DataTemplate");
             IDataTemplate = cfg.TypeSystem.GetType("Avalonia.Controls.Templates.IDataTemplate");
             Control = cfg.TypeSystem.GetType("Avalonia.Controls.Control");
+            ContentControl = cfg.TypeSystem.GetType("Avalonia.Controls.ContentControl");
             ITemplateOfControl = cfg.TypeSystem.GetType("Avalonia.Controls.ITemplate`1").MakeGenericType(Control);
             ItemsControl = cfg.TypeSystem.GetType("Avalonia.Controls.ItemsControl");
             ReflectionBindingExtension = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.MarkupExtensions.ReflectionBindingExtension");


### PR DESCRIPTION
## What does the pull request do?

It's a fairly common mistake to put item container inside of data template.
Typical example can be found even in this repository:
https://github.com/AvaloniaUI/Avalonia/blob/151d97a508a0cd6c4ee5f30e1a9fa954df1e6302/src/Avalonia.Diagnostics/Diagnostics/Views/EventsPageView.xaml#L74-L80

The problem with this code is that DataTemplate does not affect how container itself is defined. Instead, it will create a dumb ListBoxItem inside of the proper ListBoxItem. Making it worse, styles are active for both ListBoxItems, but only outer one can be actually selected.

Example of how this code looks in the elements tree:
![image](https://github.com/user-attachments/assets/96ac2771-9279-4aa9-ae36-1cf80e09eb77)

This problem is not limited by ListBoxItem, but by any items control. I often see this mistake with MenuItem and TabControl.

## What is the updated/expected behavior with this PR?

New XAML analyzer is added to XamlX compiler.
Code: "AVLN2208" (can be configured as an error via project settings or editorconfig, or disabled).
Message example (actual text depends on the context):
```
Unexpected 'TabItem' inside of 'TabControl.DataTemplates'. 'TabControl.DataTemplates' defines template of the container content, not the container itself.
```

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

By default, this is a warning. No user code will have these errors, _unless_ these projects have all warnings enabled as errors - but these projects typically expect new errors to be found early.

## Fixed issues

Contributes towards https://github.com/AvaloniaUI/Avalonia/issues/13707