### PR TITLE
Add Analyzer and CodeFixProvider for Initializing Bitmap with a "avares" scheme argument. 

### DIFF
--- a/src/tools/Avalonia.Analyzers/Avalonia.Analyzers.csproj
+++ b/src/tools/Avalonia.Analyzers/Avalonia.Analyzers.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all"/>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tools/Avalonia.Analyzers/BitmapAnalyzer.cs
+++ b/src/tools/Avalonia.Analyzers/BitmapAnalyzer.cs
@@ -7,6 +7,11 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Avalonia.Analyzers;
 
+/// <summary>
+/// Analyzes object creation expressions to detect instances where a Bitmap is initialized
+/// from the "avares" scheme directly, which is not allowed. Instead, the AssetLoader should be used
+/// to open assets as a stream first.
+/// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class BitmapAnalyzer: DiagnosticAnalyzer
 {
@@ -25,13 +30,15 @@ public class BitmapAnalyzer: DiagnosticAnalyzer
         isEnabledByDefault: true, 
         description: Description);
     
+    /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.ObjectCreationExpression);
     }
-
+    
+    /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(_rule); } }
 
     private static void AnalyzeNode(SyntaxNodeAnalysisContext context)

--- a/src/tools/Avalonia.Analyzers/BitmapAnalyzer.cs
+++ b/src/tools/Avalonia.Analyzers/BitmapAnalyzer.cs
@@ -1,0 +1,61 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Avalonia.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class BitmapAnalyzer: DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "AVA2002";
+    private const string Title = "Cannot initialize Bitmap from \"avares\" scheme";
+    private const string MessageFormat = "Cannot initialize Bitmap from \"avares\" scheme directly";
+    private const string Description = "Cannot initialize Bitmap from \"avares\" scheme, use AssetLoader to open assets as stream first.";
+    private const string Category = "Usage";
+
+    private static readonly DiagnosticDescriptor _rule = new(
+        DiagnosticId, 
+        Title, 
+        MessageFormat, 
+        Category,
+        DiagnosticSeverity.Warning, 
+        isEnabledByDefault: true, 
+        description: Description);
+    
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.ObjectCreationExpression);
+    }
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(_rule); } }
+
+    private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
+    {
+        var objectCreation = (ObjectCreationExpressionSyntax)context.Node;
+        var semanticModel = context.SemanticModel;
+
+        // Check if the object creation is creating an instance of Avalonia.Media.Imaging.Bitmap
+        var symbol = semanticModel.GetSymbolInfo(objectCreation).Symbol as IMethodSymbol;
+        if (symbol == null || symbol.ContainingType.ToString() != "Avalonia.Media.Imaging.Bitmap")
+        {
+            return;
+        }
+
+        // Check if any argument starts with "avares://"
+        foreach (var argument in objectCreation.ArgumentList.Arguments)
+        {
+            var constantValue = semanticModel.GetConstantValue(argument.Expression);
+            if (constantValue.HasValue && constantValue.Value is string stringValue && stringValue.StartsWith("avares://"))
+            {
+                var diagnostic = Diagnostic.Create(_rule, objectCreation.GetLocation());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+    
+}

--- a/src/tools/Avalonia.Analyzers/BitmapAnalyzerCSCodeFixProvider.cs
+++ b/src/tools/Avalonia.Analyzers/BitmapAnalyzerCSCodeFixProvider.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Avalonia.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(BitmapAnalyzerCSCodeFixProvider))]
+[Shared]
+public class BitmapAnalyzerCSCodeFixProvider : CodeFixProvider
+{
+    private const string _title = "Use AssetLoader to open assets as stream first";
+
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+        ImmutableArray.Create(BitmapAnalyzer.DiagnosticId);
+
+    public override FixAllProvider? GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        var diagnostic = context.Diagnostics.First();
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        // Find the type declaration identified by the diagnostic.
+        var declaration = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf()
+                              .OfType<LocalDeclarationStatementSyntax>().First();
+
+        // Register a code action that will invoke the fix.
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                _title,
+                c => MakeConstAsync(context.Document, declaration, c),
+                _title),
+            diagnostic);
+    }
+
+    private async Task<Document> MakeConstAsync(Document contextDocument, LocalDeclarationStatementSyntax declaration,
+        CancellationToken cancellationToken)
+    {
+        var root = await contextDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var semanticModel = await contextDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+        var objectCreation = declaration.DescendantNodes().OfType<ObjectCreationExpressionSyntax>().First();
+        var argumentList = objectCreation.ArgumentList;
+        var newArguments = argumentList.Arguments.Select(arg =>
+        {
+            var constantValue = semanticModel.GetConstantValue(arg.Expression);
+            if (constantValue.HasValue && constantValue.Value is string stringValue &&
+                stringValue.StartsWith("avares://"))
+            {
+                var newArgument = SyntaxFactory.Argument(
+                    SyntaxFactory.InvocationExpression(
+                                     SyntaxFactory.MemberAccessExpression(
+                                         SyntaxKind.SimpleMemberAccessExpression,
+                                         SyntaxFactory.IdentifierName("AssetLoader"),
+                                         SyntaxFactory.IdentifierName("Open")))
+                                 .WithArgumentList(
+                                     SyntaxFactory.ArgumentList(
+                                         SyntaxFactory.SingletonSeparatedList(
+                                             SyntaxFactory.Argument(
+                                                 SyntaxFactory.ObjectCreationExpression(
+                                                                  SyntaxFactory.IdentifierName("Uri"))
+                                                              .WithArgumentList(
+                                                                  SyntaxFactory.ArgumentList(
+                                                                      SyntaxFactory.SingletonSeparatedList(
+                                                                          SyntaxFactory.Argument(
+                                                                              SyntaxFactory.LiteralExpression(
+                                                                                  SyntaxKind.StringLiteralExpression,
+                                                                                  SyntaxFactory
+                                                                                      .Literal(stringValue)))))))))));
+                return newArgument;
+            }
+
+            return arg;
+        }).ToArray();
+
+        var newArgumentList = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(newArguments));
+        var newObjectCreation = objectCreation.WithArgumentList(newArgumentList);
+        var newRoot = root.ReplaceNode(objectCreation, newObjectCreation);
+
+        var usingDirective = ((CompilationUnitSyntax)newRoot).Usings;
+        var newUsings = new List<UsingDirectiveSyntax>();
+        if(!usingDirective.Any(a=>a.Name.ToString().Contains("Avalonia.Platform")))
+        {
+            newUsings.Add(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("Avalonia.Platform")));
+        }
+        if(!usingDirective.Any(a=>a.Name.ToString().Contains("System")))
+        {
+            newUsings.Add(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("System")));
+        }
+        // Add the new using directives to the root
+        newRoot = ((CompilationUnitSyntax)newRoot).AddUsings(newUsings.ToArray());
+
+        return contextDocument.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/tools/Avalonia.Analyzers/BitmapAnalyzerCSCodeFixProvider.cs
+++ b/src/tools/Avalonia.Analyzers/BitmapAnalyzerCSCodeFixProvider.cs
@@ -12,20 +12,27 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Avalonia.Analyzers;
 
+/// <summary>
+/// Provides a code fix for the BitmapAnalyzer diagnostic, which replaces "avares://" string arguments
+/// with a call to AssetLoader.Open(new Uri("avares://...")).
+/// </summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(BitmapAnalyzerCSCodeFixProvider))]
 [Shared]
 public class BitmapAnalyzerCSCodeFixProvider : CodeFixProvider
 {
     private const string _title = "Use AssetLoader to open assets as stream first";
 
+    /// <inheritdoc />
     public override ImmutableArray<string> FixableDiagnosticIds { get; } =
         ImmutableArray.Create(BitmapAnalyzer.DiagnosticId);
 
+    /// <inheritdoc />
     public override FixAllProvider? GetFixAllProvider()
     {
         return WellKnownFixAllProviders.BatchFixer;
     }
-
+    
+    /// <inheritdoc />
     public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
@@ -41,12 +48,12 @@ public class BitmapAnalyzerCSCodeFixProvider : CodeFixProvider
         context.RegisterCodeFix(
             CodeAction.Create(
                 _title,
-                c => MakeConstAsync(context.Document, declaration, c),
+                c => ReplaceArgumentAsync(context.Document, declaration, c),
                 _title),
             diagnostic);
     }
 
-    private async Task<Document> MakeConstAsync(Document contextDocument, LocalDeclarationStatementSyntax declaration,
+    private async Task<Document> ReplaceArgumentAsync(Document contextDocument, LocalDeclarationStatementSyntax declaration,
         CancellationToken cancellationToken)
     {
         var root = await contextDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
It is a common mistake (at least for beginners) to initialize a bitmap from Avalonia Asset directly like 
```csharp
var bitmap = new Bitmap("avares://Assembly/Directory/Name.jpg");
```
This PR introduce a code analyzer and a corresponding CodeFixProvider to help address this issue, and replace with correct usage: Use `AssetLoader` to open as a stream first. 

**Notice:**  All Diagnostic Id and descriptions can be updated according to team feadback. 


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Nothing is reported. 


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
warning:
![image](https://github.com/user-attachments/assets/ba979822-3726-4727-9f0c-f5017eb46e50)
fix action:
![image](https://github.com/user-attachments/assets/e811370b-37ff-4abe-8847-54f4b07cefe7)
after fix:
![image](https://github.com/user-attachments/assets/69b11c0a-260b-4231-9651-feae8c3b65df)




## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
