### PR TITLE
DataGrd: Use VisualBrush to generate DragIndicator if Header is a Control.

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -12,6 +12,8 @@ using Avalonia.Collections;
 using Avalonia.Controls.Automation.Peers;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Mixins;
+using Avalonia.Controls.Shapes;
+using Avalonia.Controls.Templates;
 using Avalonia.Controls.Utils;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -678,8 +680,7 @@ namespace Avalonia.Controls
             {
                 OwningColumn = OwningColumn,
                 IsEnabled = false,
-                Content = Content,
-                ContentTemplate = ContentTemplate
+                Content = GetDragIndicatorContent(Content, ContentTemplate)
             };
             if (OwningGrid.ColumnHeaderTheme is { } columnHeaderTheme)
             {
@@ -723,6 +724,36 @@ namespace Avalonia.Controls
             {
                 dragIndicator.Width = Bounds.Width;
             }
+        }
+
+        private object GetDragIndicatorContent(object content, IDataTemplate? dataTemplate)
+        {
+            if (content is ContentControl icc)
+            {
+                content = icc.Content;
+            }
+
+            if (content is Control control)
+            {
+                if (VisualRoot == null) return content;
+                control.Measure(Size.Infinity);
+                var rect = new Rectangle()
+                {
+                    Width = control.DesiredSize.Width,
+                    Height = control.DesiredSize.Height,
+                    Fill = new VisualBrush
+                    {
+                        Visual = control, Stretch = Stretch.None, AlignmentX = AlignmentX.Left,
+                    }
+                };
+                return rect;
+            }
+
+            if (dataTemplate is not null)
+            {
+                return dataTemplate.Build(content);
+            }
+            return content;
         }
 
         //TODO DragEvents


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Reusing DataGridColumnHeader content to generate indicator will trigger visual tree exception if content is a control. This PR use similar approach as ComboBox to generate a rectangle with visual brush to avoid this issue. 


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When column header is a control, reordering the column will crash app with exception `Control XX already has a visual parent`


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Can drag as expected. 


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Same as how ComboBox generates SelectionBoxItem. 


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
