### PR TITLE
Correct which types receive `CompilerGeneratedAttribute`

### DIFF
--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
@@ -265,6 +265,7 @@ namespace Avalonia.Build.Tasks
             };
             loaderDispatcherDef.Methods.Add(loaderDispatcherMethod);
             loaderDispatcherDef.Methods.Add(loaderDispatcherMethodOld);
+            typeSystem.AddCompilerGeneratedAttribute(loaderDispatcherDef);
 
 
             var stringEquals = asm.MainModule.ImportReference(asm.MainModule.TypeSystem.String.Resolve().Methods.First(
@@ -371,7 +372,7 @@ namespace Avalonia.Build.Tasks
 
                         var populateBuilder = classTypeDefinition == null ?
                             builder :
-                            typeSystem.CreateTypeBuilder(classTypeDefinition);
+                            typeSystem.CreateTypeBuilder(classTypeDefinition, compilerGeneratedType: false); // don't add CompilerGeneratedAttribute to the user's type
 
                         ((List<XamlDocumentResource>)parsedXamlDocuments).Add(new XamlDocumentResource(
                             parsed, res.Uri, res, classType,
@@ -474,6 +475,7 @@ namespace Avalonia.Build.Tasks
                             var designLoaderField = new FieldDefinition("!XamlIlPopulateOverride",
                                 FieldAttributes.Static | FieldAttributes.Private, designLoaderFieldTypeReference);
                             classTypeDefinition.Fields.Add(designLoaderField);
+                            typeSystem.AddCompilerGeneratedAttribute(designLoaderField);
 
                             const string TrampolineName = "!XamlIlPopulateTrampoline";
                             var trampolineMethodWithoutSP = new Lazy<MethodDefinition>(() => CreateTrampolineMethod(false));
@@ -489,6 +491,7 @@ namespace Avalonia.Build.Tasks
                                 trampoline.Parameters.Add(new ParameterDefinition(classTypeDefinition));
 
                                 classTypeDefinition.Methods.Add(trampoline);
+                                typeSystem.AddCompilerGeneratedAttribute(trampoline);
 
                                 var regularStart = Instruction.Create(OpCodes.Nop);
                             


### PR DESCRIPTION
Following kekekeks/XamlX#104, some additional changes were needed on the Avalonia side. Unfortunately it took so long to get that PR approved that I forgot all about them.

* Remove `CompilerGeneratedAttribute` from user types containing compiled XAML (e.g. user controls, applications).
* Add the attribute to various types which actually are compiler generated, but not with `CreateTypeBuilder`.

This PR is best tested by using a decompiler to examine the build output.

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #9026