### PR TITLE
fix NumericUpDown Spinned event

### DIFF
--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -630,9 +630,6 @@ namespace Avalonia.Controls
                 throw new ArgumentNullException(nameof(e));
             }
 
-            var handler = Spinned;
-            handler?.Invoke(this, e);
-
             if (e.Direction == SpinDirection.Increase)
             {
                 DoIncrement();
@@ -641,6 +638,9 @@ namespace Avalonia.Controls
             {
                 DoDecrement();
             }
+
+            var handler = Spinned;
+            handler?.Invoke(this, e);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -639,8 +639,7 @@ namespace Avalonia.Controls
                 DoDecrement();
             }
 
-            var handler = Spinned;
-            handler?.Invoke(this, e);
+            Spinned?.Invoke(this, e);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
For NumericUpDown control, raise Spinned event after value change.


## What is the current behavior?
At the time of (NumericUpDown.)Spinned event the value is stale, not incremented / decremented yet.


## What is the updated/expected behavior with this PR?
At the time of (NumericUpDown.)Spinned event the value is already incremented / decremented. So, subscribers will see correct current value.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

## Fixed issues
