### PR TITLE
Add FontSize property validation

### DIFF
--- a/src/Avalonia.Controls/Documents/TextElement.cs
+++ b/src/Avalonia.Controls/Documents/TextElement.cs
@@ -39,11 +39,7 @@ namespace Avalonia.Controls.Documents
                 nameof(FontSize),
                 defaultValue: 12,
                 inherits: true,
-                validate: fontSize => fontSize switch
-                {
-                    double.NaN or <= 0 => false,
-                    _ => true
-                });
+                validate: fontSize => fontSize > 0 && !double.IsNaN(fontSize) && !double.IsInfinity(fontSize));
 
         /// <summary>
         /// Defines the <see cref="FontStyle"/> property.

--- a/src/Avalonia.Controls/Documents/TextElement.cs
+++ b/src/Avalonia.Controls/Documents/TextElement.cs
@@ -41,7 +41,7 @@ namespace Avalonia.Controls.Documents
                 inherits: true,
                 validate: fontSize => fontSize switch
                 {
-                    double.NaN or < 0 => false,
+                    double.NaN or <= 0 => false,
                     _ => true
                 });
 

--- a/src/Avalonia.Controls/Documents/TextElement.cs
+++ b/src/Avalonia.Controls/Documents/TextElement.cs
@@ -38,7 +38,12 @@ namespace Avalonia.Controls.Documents
             AvaloniaProperty.RegisterAttached<TextElement, TextElement, double>(
                 nameof(FontSize),
                 defaultValue: 12,
-                inherits: true);
+                inherits: true,
+                validate: fontSize => fontSize switch
+                {
+                    double.NaN or < 0 => false,
+                    _ => true
+                });
 
         /// <summary>
         /// Defines the <see cref="FontStyle"/> property.


### PR DESCRIPTION
A small improvement with more user-friendly validation.

## What is the current behavior?

Before this PR it was possible to break the layout by passing invalid property value, by passing negative font size.
It is somewhat important, since user can now handle unhandled dispatcher exception and continue app running, with broken layout.

## What is the updated/expected behavior with this PR?

With this PR, FontSize property will validate input values itself, and throw validation exception, discarding any invalid input from being actually set.
It's also consistent with [WPF behavior](https://github.com/dotnet/wpf/blob/9dea6632396b8fdcafefc31a6dd0dbd71c7081fd/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElement.cs#L637). Although there is a difference in which values are allowed, as WPF only allows range `0.003...16000`. But Avalonia [doesn't enforce these limitations](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs#L30).

