### PR TITLE
iterate over visible columns only when DnD column header

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -578,7 +578,7 @@ namespace Avalonia.Controls
                 mousePositionHeaders = mousePositionHeaders.WithX(rightEdge - 1);
             }
 
-            foreach (DataGridColumn column in OwningGrid.ColumnsInternal.GetDisplayedColumns())
+            foreach (DataGridColumn column in OwningGrid.ColumnsInternal.GetVisibleColumns())
             {
                 Point mousePosition = OwningGrid.ColumnHeaders.Translate(column.HeaderCell, mousePositionHeaders);
                 double columnMiddle = column.HeaderCell.Bounds.Width / 2;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
fixes DnD of column header in datagrid with invisible column(s)


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
in datagrid with invisible column(s), when dragging column header, drop indicator is shown on wrong position


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
drop indicator is shown on position of visible columns

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
