### PR TITLE
TextBox: clear selection when moving the caret horizontally

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1983,17 +1983,13 @@ namespace Avalonia.Controls
                 {
                     if (selectionStart != selectionEnd)
                     {
-                        if (CaretIndex == SelectionStart)
-                        {
-                            // setting same value of SelectionEnd and SelectionStart will clear the selection first
-                            // allowing to move the caret horizontally also in direction "away" from selection
-                            SetCurrentValue(SelectionEndProperty, SelectionStart);
-                            selectionEnd = SelectionEnd;
-                        }
-
-                        _presenter.MoveCaretToTextPosition(direction > 0 ?
+                        // clear the selection and move to the appropriate side of previous selection
+                        var newPosition = direction > 0 ?
                             Math.Max(selectionStart, selectionEnd) :
-                            Math.Min(selectionStart, selectionEnd));
+                            Math.Min(selectionStart, selectionEnd);
+                        SetCurrentValue(SelectionStartProperty, newPosition);
+                        SetCurrentValue(SelectionEndProperty, newPosition);
+                        _presenter.MoveCaretToTextPosition(newPosition);
                     }
                     else
                     {

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1983,6 +1983,14 @@ namespace Avalonia.Controls
                 {
                     if (selectionStart != selectionEnd)
                     {
+                        if (CaretIndex == SelectionStart)
+                        {
+                            // setting same value of SelectionEnd and SelectionStart will clear the selection first
+                            // allowing to move the caret horizontally also in direction "away" from selection
+                            SetCurrentValue(SelectionEndProperty, SelectionStart);
+                            selectionEnd = SelectionEnd;
+                        }
+
                         _presenter.MoveCaretToTextPosition(direction > 0 ?
                             Math.Max(selectionStart, selectionEnd) :
                             Math.Min(selectionStart, selectionEnd));

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -1535,6 +1535,172 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        [Theory]
+        [InlineData(2,4)]
+        [InlineData(0,4)]
+        [InlineData(2,6)]
+        [InlineData(0,6)]
+        public void When_Selection_From_Left_To_Right_Pressing_Right_Should_Remove_Selection_Moving_Caret_To_End_Of_Previous_Selection(int selectionStart, int selectionEnd)
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "ABCDEF"
+                };
+
+                tb.Measure(Size.Infinity);
+                tb.CaretIndex = selectionStart;
+                tb.SelectionStart = selectionStart;
+                tb.SelectionEnd = selectionEnd;
+
+                RaiseKeyEvent(tb, Key.Right, KeyModifiers.None);
+
+                Assert.Equal(selectionEnd, tb.SelectionStart);
+                Assert.Equal(selectionEnd, tb.SelectionEnd);
+                Assert.Equal(selectionEnd, tb.CaretIndex);
+            }
+        }
+
+        [Theory]
+        [InlineData(2,4)]
+        [InlineData(0,4)]
+        [InlineData(2,6)]
+        [InlineData(0,6)]
+        public void When_Selection_From_Left_To_Right_Pressing_Left_Should_Remove_Selection_Moving_Caret_To_Start_Of_Previous_Selection(int selectionStart, int selectionEnd)
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "ABCDEF"
+                };
+
+                tb.Measure(Size.Infinity);
+                tb.CaretIndex = selectionStart;
+                tb.SelectionStart = selectionStart;
+                tb.SelectionEnd = selectionEnd;
+
+                RaiseKeyEvent(tb, Key.Left, KeyModifiers.None);
+
+                Assert.Equal(selectionStart, tb.SelectionStart);
+                Assert.Equal(selectionStart, tb.SelectionEnd);
+                Assert.Equal(selectionStart, tb.CaretIndex);
+            }
+        }
+
+        [Theory]
+        [InlineData(4,2)]
+        [InlineData(4,0)]
+        [InlineData(6,2)]
+        [InlineData(6,0)]
+        public void When_Selection_From_Right_To_Left_Pressing_Right_Should_Remove_Selection_Moving_Caret_To_Start_Of_Previous_Selection(int selectionStart, int selectionEnd)
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "ABCDEF"
+                };
+
+                tb.Measure(Size.Infinity);
+                tb.CaretIndex = selectionStart;
+                tb.SelectionStart = selectionStart;
+                tb.SelectionEnd = selectionEnd;
+
+                RaiseKeyEvent(tb, Key.Right, KeyModifiers.None);
+
+                Assert.Equal(selectionStart, tb.SelectionStart);
+                Assert.Equal(selectionStart, tb.SelectionEnd);
+                Assert.Equal(selectionStart, tb.CaretIndex);
+            }
+        }
+
+        [Theory]
+        [InlineData(4,2)]
+        [InlineData(4,0)]
+        [InlineData(6,2)]
+        [InlineData(6,0)]
+        public void When_Selection_From_Right_To_Left_Pressing_Left_Should_Remove_Selection_Moving_Caret_To_End_Of_Previous_Selection(int selectionStart, int selectionEnd)
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "ABCDEF"
+                };
+
+                tb.Measure(Size.Infinity);
+                tb.CaretIndex = selectionStart;
+                tb.SelectionStart = selectionStart;
+                tb.SelectionEnd = selectionEnd;
+
+                RaiseKeyEvent(tb, Key.Left, KeyModifiers.None);
+
+                Assert.Equal(selectionEnd, tb.SelectionStart);
+                Assert.Equal(selectionEnd, tb.SelectionEnd);
+                Assert.Equal(selectionEnd, tb.CaretIndex);
+            }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(2)]
+        [InlineData(4)]
+        [InlineData(6)]
+        public void When_Select_All_From_Position_Left_Should_Remove_Selection_Moving_Caret_To_Start(int caretIndex)
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "ABCDEF"
+                };
+
+                tb.Measure(Size.Infinity);
+                tb.CaretIndex = caretIndex;
+
+                RaiseKeyEvent(tb, Key.A, KeyModifiers.Control);
+                RaiseKeyEvent(tb, Key.Left, KeyModifiers.None);
+
+                Assert.Equal(0, tb.SelectionStart);
+                Assert.Equal(0, tb.SelectionEnd);
+                Assert.Equal(0, tb.CaretIndex);
+            }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(2)]
+        [InlineData(4)]
+        [InlineData(6)]
+        public void When_Select_All_From_Position_Right_Should_Remove_Selection_Moving_Caret_To_End(int caretIndex)
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "ABCDEF"
+                };
+
+                tb.Measure(Size.Infinity);
+                tb.CaretIndex = caretIndex;
+
+                RaiseKeyEvent(tb, Key.A, KeyModifiers.Control);
+                RaiseKeyEvent(tb, Key.Right, KeyModifiers.None);
+
+                Assert.Equal(tb.Text.Length, tb.SelectionStart);
+                Assert.Equal(tb.Text.Length, tb.SelectionEnd);
+                Assert.Equal(tb.Text.Length, tb.CaretIndex);
+            }
+        }
+
         [Fact]
         public void TextBox_In_AdornerLayer_Will_Not_Cause_Collection_Modified_In_VisualLayerManager_Measure()
         {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
fix clearing selection on TextBox when left/right arrow key is pressed


## What is the current behavior?
when there is selection in TextBox, and
selection starts on left, pressing left arrow key does not clear selection
selection starts on right, pressing right arrow key does not clear selection

## What is the updated/expected behavior with this PR?
pressing left/right arrow key clears the selection, moving caret to appropriate side of the previous selection


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
