### PR TITLE
Fix DockPanel index out of range

### DIFF
--- a/src/Avalonia.Controls/DockPanel.cs
+++ b/src/Avalonia.Controls/DockPanel.cs
@@ -179,7 +179,7 @@ namespace Avalonia.Controls
                 }
             }
 
-            if (LastChildFill)
+            if (LastChildFill && Children.Count > 0)
             {
                 var child = Children[Children.Count - 1];
                 var childConstraint = new Size(
@@ -265,7 +265,7 @@ namespace Avalonia.Controls
                 }
             }
 
-            if (LastChildFill)
+            if (LastChildFill && Children.Count > 0)
             {
                 var child = Children[Children.Count - 1];
                 child.Arrange(new Rect(currentBounds.X, currentBounds.Y, currentBounds.Width, currentBounds.Height));

--- a/tests/Avalonia.Controls.UnitTests/DockPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DockPanelTests.cs
@@ -5,6 +5,21 @@ namespace Avalonia.Controls.UnitTests
     public class DockPanelTests
     {
         [Fact]
+        public void DockPanel_Without_Child()
+        {
+            var target = new DockPanel
+            {
+                Width = 10,
+                Height = 10
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+
+            Assert.Equal(new Rect(0, 0, 10, 10), target.Bounds);
+        }
+        
+        [Fact]
         public void Should_Dock_Controls_Horizontal_First()
         {
             var target = new DockPanel


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Fix issue that DockPanel would throw IndexOutOfRangeException when there's no child in it.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

DockPanel would throw IndexOutOfRangeException when there's no child in it.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

DockPanel would not throw IndexOutOfRangeException when there's no child in it.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues

fix #18260 
