### PR TITLE
Make Window.DialogResult a public property.

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -195,13 +195,19 @@ namespace Avalonia.Controls
         /// </summary>
         public static readonly RoutedEvent<RoutedEventArgs> WindowOpenedEvent =
             RoutedEvent.Register<Window, RoutedEventArgs>("WindowOpened", RoutingStrategies.Direct);
-        private object? _dialogResult;
+
         private readonly Size _maxPlatformClientSize;
         private bool _shown;
         private bool _showingAsDialog;
         private bool _positionWasSet;
         private bool _wasShownBefore;
         private IDisposable? _modalSubscription;
+        
+        /// <summary>
+        /// Get or set the dialog result. This is the value that will be returned by the dialog.
+        /// If User call <see cref="Close(object?)"/> to close a dialog, this property will be set to the parameter first.
+        /// </summary>
+        public object? DialogResult { get; set; }
 
         /// <summary>
         /// Initializes static members of the <see cref="Window"/> class.
@@ -477,7 +483,7 @@ namespace Avalonia.Controls
         /// </remarks>
         public void Close(object? dialogResult)
         {
-            _dialogResult = dialogResult;
+            DialogResult = dialogResult;
             CloseCore(WindowCloseReason.WindowClosing, true, false);
         }
 
@@ -807,7 +813,7 @@ namespace Avalonia.Controls
                         {
                             _modalSubscription = null;
                             owner!.Activate();
-                            tcs.SetResult((TResult)(_dialogResult ?? default(TResult)!));
+                            tcs.SetResult((TResult)(DialogResult ?? default(TResult)!));
                         })
                     ]);
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Make Window.DialogResult a public property


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The only way to return a result when closing a dialog is to call `Close(object?)`, which means we don't have any way to return a value when closing from system title bar (or press ALt+F4). 


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
User can set this property in advance if they want to return some value as default DialogResult. If user choose to close with `Close(object?)` method, then this paramter has a higher priority, which is the original behavior. 


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Similar behaviors from other frameworks:
1. Winform: there is a public property, but it is an enum. 
2. WPF: there is a public property, but a nullable boolean.
3. WinUI: no such a behavior. But when close from close button(or press ESC), a ContentDilaogResult.None is returned


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Closes https://github.com/AvaloniaUI/Avalonia/issues/17691
