### PR TITLE
Fix Win32 MonitorFromRect

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1631,7 +1631,7 @@ namespace Avalonia.Win32.Interop
         public static extern IntPtr MonitorFromPoint(POINT pt, MONITOR dwFlags);
 
         [DllImport("user32.dll")]
-        public static extern IntPtr MonitorFromRect(RECT rect, MONITOR dwFlags);
+        public static extern IntPtr MonitorFromRect(RECT* rect, MONITOR dwFlags);
 
         [DllImport("user32.dll")]
         public static extern IntPtr MonitorFromWindow(IntPtr hwnd, MONITOR dwFlags);

--- a/src/Windows/Avalonia.Win32/ScreenImpl.cs
+++ b/src/Windows/Avalonia.Win32/ScreenImpl.cs
@@ -70,13 +70,14 @@ internal unsafe class ScreenImpl : ScreensBase<nint, WinScreen>
 
     protected override Screen? ScreenFromRectCore(PixelRect rect)
     {
-        var monitor = MonitorFromRect(new RECT
+        var r = new RECT
         {
-            left = rect.TopLeft.X,
-            top = rect.TopLeft.Y,
-            right = rect.TopRight.X,
-            bottom = rect.BottomRight.Y
-        }, UnmanagedMethods.MONITOR.MONITOR_DEFAULTTONULL);
+            left = rect.X,
+            top = rect.Y,
+            right = rect.Right,
+            bottom = rect.Bottom
+        };
+        var monitor = MonitorFromRect(&r, MONITOR.MONITOR_DEFAULTTONULL);
 
         return ScreenFromHMonitor(monitor);
     }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes our Win32 [`MonitorFromRect`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-monitorfromrect) interop signature being incorrect.
Somehow, it doesn't cause a crash for 64 bits processes, but does for 32 bits ones.
