### PR TITLE
In-process dnd should always handle pointermoved for consistency withactual dnd

### DIFF
--- a/src/Avalonia.Controls/Platform/InProcessDragSource.cs
+++ b/src/Avalonia.Controls/Platform/InProcessDragSource.cs
@@ -202,11 +202,11 @@ namespace Avalonia.Platform
                 case RawPointerEventType.RightButtonUp:
                     CheckDraggingAccepted(RawInputModifiers.RightMouseButton); break;
                 case RawPointerEventType.Move:
+                    e.Handled = true;
                     var mods = e.InputModifiers & MOUSE_INPUTMODIFIERS;
                     if (_initialInputModifiers.Value != mods)
                     {
                         CancelDragging();
-                        e.Handled = true;
                         return;
                     }
 


### PR DESCRIPTION
Actual DnD on windows and mac swallows any pointer movement events

Also see https://github.com/AvaloniaUI/Avalonia/pull/18069