### PR TITLE
[Avalonia.Headless.NUnit] Make `SetUp` and `TearDown` methods work when async

### DIFF
--- a/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
+++ b/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
@@ -89,7 +89,7 @@ internal class AvaloniaTestMethodCommand : TestCommand
             }
             
             // Experimentally, after test methods are called after the ExecuteTestMethod has run
-            // So rather than add them to a list of actions to execute, we just have the commands execute them
+            // So we handle them differently than the before methods
             if (s_afterTest.GetValue(beforeAndAfterTestCommand) is Action<TestExecutionContext> afterTest)
             {
                 var setUpTearDownInfo = afterTest.Target?.GetType()

--- a/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
+++ b/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
@@ -59,9 +59,9 @@ internal class AvaloniaTestMethodCommand : TestCommand
         {
             if (s_beforeTest.GetValue(beforeAndAfterTestCommand) is Action<TestExecutionContext> beforeTest)
             {
-                var setUpTearDownInfo = beforeTest.Target!.GetType()
-                    .GetField("setUpTearDown", BindingFlags.Instance | BindingFlags.Public)!;
-                if (setUpTearDownInfo.GetValue(beforeTest.Target) is SetUpTearDownItem setUpTearDown
+                var setUpTearDownInfo = beforeTest.Target?.GetType()
+                    .GetField("setUpTearDown", BindingFlags.Instance | BindingFlags.Public);
+                if (setUpTearDownInfo != null && setUpTearDownInfo.GetValue(beforeTest.Target) is SetUpTearDownItem setUpTearDown
                     && s_setUpMethods.GetValue(setUpTearDown) is List<IMethodInfo> setUpMethods)
                 {
                     Action<TestExecutionContext> beforeAction = c =>
@@ -92,9 +92,9 @@ internal class AvaloniaTestMethodCommand : TestCommand
             // So rather than add them to a list of actions to execute, we just have the commands execute them
             if (s_afterTest.GetValue(beforeAndAfterTestCommand) is Action<TestExecutionContext> afterTest)
             {
-                var setUpTearDownInfo = afterTest.Target!.GetType()
-                    .GetField("setUpTearDown", BindingFlags.Instance | BindingFlags.Public)!;
-                if (setUpTearDownInfo.GetValue(afterTest.Target) is SetUpTearDownItem setUpTearDown
+                var setUpTearDownInfo = afterTest.Target?.GetType()
+                    .GetField("setUpTearDown", BindingFlags.Instance | BindingFlags.Public);
+                if (setUpTearDownInfo != null && setUpTearDownInfo.GetValue(afterTest.Target) is SetUpTearDownItem setUpTearDown
                     && s_tearDownMethods.GetValue(setUpTearDown) is List<IMethodInfo> tearDownMethods)
                 {
                     after.Add(c =>

--- a/tests/Avalonia.Headless.UnitTests/ThreadingTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/ThreadingTests.cs
@@ -10,6 +10,24 @@ namespace Avalonia.Headless.UnitTests;
 public class ThreadingTests
 {
 #if NUNIT
+    [SetUp]
+    public async Task SetUp()
+    {
+        Console.WriteLine(nameof(SetUp));
+        await Task.Delay(500);
+    }
+#endif
+    
+#if NUNIT
+    [TearDown]
+    public async Task TearDown()
+    {
+        Console.WriteLine(nameof(TearDown));
+        await Task.Delay(500);
+    }
+#endif
+    
+#if NUNIT
     [AvaloniaTest, Timeout(10000)]
 #elif XUNIT
     [AvaloniaFact]


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Makes the `SetUp` and `TearDown` methods in NUnit work within Avalonia test fixtures.


## What is the current behavior?
When attempting to use `[SetUp]` or `[TearDown]` attributes within an `Avalonia.Headless.NUnit` project, the tests will run forever/until timeout due to improper handling of the async methods (blocking forever since they're not properly awaited). Furthermore, as I was testing I discovered that `TearDown` methods were never executed in the old setup as the after-test commands were called after `ExecuteTestMethod` had completed (meaning the `_afterTest` list was always empty when called).


## What is the updated/expected behavior with this PR?
`SetUp` and `TearDown` do not block threads and `TearDown` actually runs.


## How was the solution implemented (if it's not obvious)?
We now reflect into the before/after commands and obtain the list of setup methods (assuming the command target is of type `SetUpTearDownItem`). We then get the list of setup methods and then add them to the `_beforeTest` list, appropriately awaiting the ones that return `Task` or `ValueTask` (same behavior as currently exists for tests). If the command target is not of type `SetUpTearDownItem`, we execute the old behavior. For after tasks, we do the same thing except ~rather than adding to the `_afterTest` list, we simply have the command execute the after task directly. The `after` parameters and `_afterList` fields have been removed~ we add the Actions with test context directly to a list of `Action<TestExecutionContext>` and then execute the tests inside the `ExecuteTestMethod` as before.


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes? (N/A)
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation (N/A)

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #18304 
