### PR TITLE
Fix SlicedStream.Seek(offset, SeekOrigin.End)

### DIFF
--- a/src/Avalonia.Base/Platform/Internal/SlicedStream.cs
+++ b/src/Avalonia.Base/Platform/Internal/SlicedStream.cs
@@ -29,7 +29,7 @@ internal class SlicedStream : Stream
         if (origin == SeekOrigin.Begin)
             Position = offset;
         if (origin == SeekOrigin.End)
-            Position = _from + Length + offset;
+            Position = Length + offset;
         if (origin == SeekOrigin.Current)
             Position = Position + offset;
         return Position;

--- a/tests/Avalonia.Base.UnitTests/Platform/SlicedStreamTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Platform/SlicedStreamTests.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+using Avalonia.Platform.Internal;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests;
+
+public class SlicedStreamTests
+{
+    [Theory]
+    [InlineData(2, SeekOrigin.Begin, 22, 2, 9)]
+    [InlineData(2, SeekOrigin.Current, 22, 17, 24)]
+    [InlineData(-2, SeekOrigin.End, 22, 40, 47)]
+    public void Seek_Works(
+        long offset,
+        SeekOrigin origin,
+        long startingUnderlyingPosition,
+        long expectedPosition,
+        long expectedUnderlyingPosition)
+    {
+        var memoryStream = new MemoryStream(new byte[1024]);
+        var slicedStream = new SlicedStream(memoryStream, 7, 42);
+        memoryStream.Position = startingUnderlyingPosition;
+
+        slicedStream.Seek(offset, origin);
+
+        Assert.Equal(expectedPosition, slicedStream.Position);
+        Assert.Equal(expectedUnderlyingPosition, memoryStream.Position);
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/AvaloniaUI/Avalonia/issues/13604

The offset `_from` is applied in `set_Position`, so applying it also in `Seek` mispositions the stream. `ZipArchive` exposes the problem by seeking to the end to read the table of contents.

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes a double-offset in `SlicedStream` which should only be a single offset. Resolves https://github.com/AvaloniaUI/Avalonia/issues/13604

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`SlicedStream.Seek(offset, SeekOrigin.End)` will almost always seek to an incorrect position.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
After calling `stream.Seek(offset, SeekOrigin.End)` it will be the case that `stream.Position == stream.Length + offset)`.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Remove an offset in `Seek` which is also applied when `Seek` calls `set_Position`. Note that this was only incorrect for `SeekOrigin.End`: for `SeekOrigin.Begin` and `SeekOrigin.Current` the offset was (correctly) not applied.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #13604