### PR TITLE
Layout performance improvements

### DIFF
--- a/src/Avalonia.Base/Layout/Layoutable.cs
+++ b/src/Avalonia.Base/Layout/Layoutable.cs
@@ -2,6 +2,7 @@ using System;
 using Avalonia.Diagnostics;
 using Avalonia.Logging;
 using Avalonia.Reactive;
+using Avalonia.Utilities;
 using Avalonia.VisualTree;
 
 #nullable enable
@@ -544,53 +545,43 @@ namespace Avalonia.Layout
                 if (useLayoutRounding)
                 {
                     scale = LayoutHelper.GetLayoutScale(this);
-                    margin = LayoutHelper.RoundLayoutThickness(margin, scale, scale);
+                    margin = LayoutHelper.RoundLayoutThickness(margin, scale);
                 }
 
                 ApplyStyling();
                 ApplyTemplate();
 
+                var minMax = new MinMax(this);
+
                 var constrained = LayoutHelper.ApplyLayoutConstraints(
-                    this,
+                    minMax,
                     availableSize.Deflate(margin));
                 var measured = MeasureOverride(constrained);
 
-                var width = measured.Width;
-                var height = measured.Height;
-
-                {
-                    double widthCache = Width;
-
-                    if (!double.IsNaN(widthCache))
-                    {
-                        width = widthCache;
-                    }
-                }
-
-                width = Math.Min(width, MaxWidth);
-                width = Math.Max(width, MinWidth);
-
-                {
-                    double heightCache = Height;
-
-                    if (!double.IsNaN(heightCache))
-                    {
-                        height = heightCache;
-                    }
-                }
-
-                height = Math.Min(height, MaxHeight);
-                height = Math.Max(height, MinHeight);
+                var width = MathUtilities.Clamp(measured.Width, minMax.MinWidth, minMax.MaxWidth);
+                var height = MathUtilities.Clamp(measured.Height, minMax.MinHeight, minMax.MaxHeight);
 
                 if (useLayoutRounding)
                 {
-                    (width, height) = LayoutHelper.RoundLayoutSizeUp(new Size(width, height), scale, scale);
+                    (width, height) = LayoutHelper.RoundLayoutSizeUp(new Size(width, height), scale);
                 }
 
-                width = Math.Min(width, availableSize.Width);
-                height = Math.Min(height, availableSize.Height);
+                if (width > availableSize.Width)
+                    width = availableSize.Width;
 
-                return NonNegative(new Size(width, height).Inflate(margin));
+                if (height > availableSize.Height)
+                    height = availableSize.Height;
+
+                width += margin.Left + margin.Right;
+                height += margin.Top + margin.Bottom;
+
+                if (width < 0)
+                    width = 0;
+
+                if (height < 0)
+                    height = 0;
+
+                return new Size(width, height);
             }
             else
             {
@@ -618,8 +609,13 @@ namespace Avalonia.Layout
                 if (visual is Layoutable layoutable)
                 {
                     layoutable.Measure(availableSize);
-                    width = Math.Max(width, layoutable.DesiredSize.Width);
-                    height = Math.Max(height, layoutable.DesiredSize.Height);
+                    var childSize = layoutable.DesiredSize;
+
+                    if (childSize.Width > width)
+                        width = childSize.Width;
+
+                    if (childSize.Height > height)
+                        height = childSize.Height;
                 }
             }
 
@@ -650,12 +646,19 @@ namespace Avalonia.Layout
                 // If the margin isn't pre-rounded some sizes will be offset by 1 pixel in certain scales.
                 if (useLayoutRounding)
                 {
-                    margin = LayoutHelper.RoundLayoutThickness(margin, scale, scale);
+                    margin = LayoutHelper.RoundLayoutThickness(margin, scale);
                 }
 
-                var availableSizeMinusMargins = new Size(
-                    Math.Max(0, finalRect.Width - margin.Left - margin.Right),
-                    Math.Max(0, finalRect.Height - margin.Top - margin.Bottom));
+
+                var availableWidthMinusMargins = finalRect.Width - margin.Left - margin.Right;
+                if (availableWidthMinusMargins < 0)
+                    availableWidthMinusMargins = 0;
+
+                var availableHeightMinusMargins = finalRect.Height - margin.Top - margin.Bottom;
+                if (availableHeightMinusMargins < 0)
+                    availableHeightMinusMargins = 0;
+
+                var availableSizeMinusMargins = new Size(availableWidthMinusMargins, availableHeightMinusMargins);
                 var horizontalAlignment = HorizontalAlignment;
                 var verticalAlignment = VerticalAlignment;
                 var size = availableSizeMinusMargins;
@@ -670,12 +673,12 @@ namespace Avalonia.Layout
                     size = size.WithHeight(Math.Min(size.Height, DesiredSize.Height - margin.Top - margin.Bottom));
                 }
 
-                size = LayoutHelper.ApplyLayoutConstraints(this, size);
+                size = LayoutHelper.ApplyLayoutConstraints(new MinMax(this), size);
 
                 if (useLayoutRounding)
                 {
-                    size = LayoutHelper.RoundLayoutSizeUp(size, scale, scale);
-                    availableSizeMinusMargins = LayoutHelper.RoundLayoutSizeUp(availableSizeMinusMargins, scale, scale);
+                    size = LayoutHelper.RoundLayoutSizeUp(size, scale);
+                    availableSizeMinusMargins = LayoutHelper.RoundLayoutSizeUp(availableSizeMinusMargins, scale);
                 }
 
                 size = ArrangeOverride(size).Constrain(size);
@@ -702,13 +705,14 @@ namespace Avalonia.Layout
                         break;
                 }
 
+                var origin = new Point(originX, originY);
+
                 if (useLayoutRounding)
                 {
-                    originX = LayoutHelper.RoundLayoutValue(originX, scale);
-                    originY = LayoutHelper.RoundLayoutValue(originY, scale);
+                    origin = LayoutHelper.RoundLayoutPoint(origin, scale);
                 }
 
-                Bounds = new Rect(originX, originY, size.Width, size.Height);
+                Bounds = new Rect(origin, size);
             }
         }
 
@@ -887,11 +891,10 @@ namespace Avalonia.Layout
         /// <returns>True if the rect is invalid; otherwise false.</returns>
         private static bool IsInvalidRect(Rect rect)
         {
-            return rect.Width < 0 || rect.Height < 0 ||
-                double.IsInfinity(rect.X) || double.IsInfinity(rect.Y) ||
-                double.IsInfinity(rect.Width) || double.IsInfinity(rect.Height) ||
-                double.IsNaN(rect.X) || double.IsNaN(rect.Y) ||
-                double.IsNaN(rect.Width) || double.IsNaN(rect.Height);
+            return MathUtilities.IsNegativeOrNonFinite(rect.Width) ||
+                MathUtilities.IsNegativeOrNonFinite(rect.Height) ||
+                !MathUtilities.IsFinite(rect.X) ||
+                !MathUtilities.IsFinite(rect.Y);
         }
 
         /// <summary>
@@ -902,9 +905,8 @@ namespace Avalonia.Layout
         /// <returns>True if the size is invalid; otherwise false.</returns>
         private static bool IsInvalidSize(Size size)
         {
-            return size.Width < 0 || size.Height < 0 ||
-                double.IsInfinity(size.Width) || double.IsInfinity(size.Height) ||
-                double.IsNaN(size.Width) || double.IsNaN(size.Height);
+            return MathUtilities.IsNegativeOrNonFinite(size.Width) ||
+                MathUtilities.IsNegativeOrNonFinite(size.Height);
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Layout/MinMax.cs
+++ b/src/Avalonia.Base/Layout/MinMax.cs
@@ -1,0 +1,51 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Avalonia.Layout;
+
+internal struct MinMax
+{
+    public double MinWidth;
+    public double MaxWidth;
+    public double MinHeight;
+    public double MaxHeight;
+
+    public MinMax(Layoutable e)
+    {
+        (MinWidth, MaxWidth) = CalcMinMax(e.Width, e.MinWidth, e.MaxWidth);
+        (MinHeight, MaxHeight) = CalcMinMax(e.Height, e.MinHeight, e.MaxHeight);
+    }
+
+    private static (double Min, double Max) CalcMinMax(double value, double min, double max)
+    {
+        double v0, v1;
+
+        if (double.IsNaN(value))
+        {
+            v0 = 0.0;
+            v1 = double.PositiveInfinity;
+        }
+        else
+        {
+            v0 = v1 = value;
+        }
+
+        max = ClampUnchecked(v1, min, max);
+        min = ClampUnchecked(v0, min, max);
+
+        return (min, max);
+    }
+
+    // Don't use Math.Clamp, it's possible for min to be greater than max here
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static double ClampUnchecked(double value, double min, double max)
+    {
+        if (value > max)
+            value = max;
+
+        if (value < min)
+            value = min;
+
+        return value;
+    }
+
+}

--- a/src/Avalonia.Base/Size.cs
+++ b/src/Avalonia.Base/Size.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 #if !BUILDTASK
 using Avalonia.Animation.Animators;
 #endif
@@ -187,11 +188,18 @@ namespace Avalonia
         /// <param name="thickness">The thickness.</param>
         /// <returns>The deflated size.</returns>
         /// <remarks>The deflated size cannot be less than 0.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Size Deflate(Thickness thickness)
         {
-            return new Size(
-                Math.Max(0, _width - thickness.Left - thickness.Right),
-                Math.Max(0, _height - thickness.Top - thickness.Bottom));
+            var width = _width - thickness.Left - thickness.Right;
+            if (width < 0)
+                width = 0;
+
+            var height = _height - thickness.Top - thickness.Bottom;
+            if (height < 0)
+                height = 0;
+
+            return new Size(width, height);
         }
 
         /// <summary>
@@ -247,6 +255,7 @@ namespace Avalonia
         /// </summary>
         /// <param name="thickness">The thickness.</param>
         /// <returns>The inflated size.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Size Inflate(Thickness thickness)
         {
             return new Size(

--- a/src/Avalonia.Base/StyledElement.cs
+++ b/src/Avalonia.Base/StyledElement.cs
@@ -84,7 +84,7 @@ namespace Avalonia
         private string? _name;
         private Classes? _classes;
         private ILogicalRoot? _logicalRoot;
-        private IAvaloniaList<ILogical>? _logicalChildren;
+        private AvaloniaList<ILogical>? _logicalChildren;
         private IResourceDictionary? _resources;
         private Styles? _styles;
         private bool _stylesApplied;

--- a/src/Avalonia.Base/Threading/Dispatcher.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.cs
@@ -44,9 +44,18 @@ public partial class Dispatcher : IDispatcher
         _exceptionFilterEventArgs = new DispatcherUnhandledExceptionFilterEventArgs(this);
     }
     
-    public static Dispatcher UIThread => s_uiThread ??= CreateUIThreadDispatcher();
+    public static Dispatcher UIThread
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            return s_uiThread ??= CreateUIThreadDispatcher();
+        }
+    }
+
     public bool SupportsRunLoops => _controlledImpl != null;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static Dispatcher CreateUIThreadDispatcher()
     {
         var impl = AvaloniaLocator.Current.GetService<IDispatcherImpl>();

--- a/src/Avalonia.Base/Utilities/MathUtilities.cs
+++ b/src/Avalonia.Base/Utilities/MathUtilities.cs
@@ -208,6 +208,7 @@ namespace Avalonia.Utilities
         /// <param name="min">The minimum value.</param>
         /// <param name="max">The maximum value.</param>
         /// <returns>The clamped value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Clamp(double val, double min, double max)
         {
             if (min > max)
@@ -363,6 +364,28 @@ namespace Avalonia.Utilities
         {
             return GetMinMax(initialValue, initialValue + delta);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsNegativeOrNonFinite(double d)
+        {
+#if NET6_0_OR_GREATER
+            ulong bits = BitConverter.DoubleToUInt64Bits(d);
+            return bits >= 0x7FF0_0000_0000_0000;
+#else
+            return d < 0 || !IsFinite(d);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsFinite(double d)
+        {
+#if NET6_0_OR_GREATER
+            return double.IsFinite(d);
+#else
+            long bits = BitConverter.DoubleToInt64Bits(d);
+            return (bits & 0x7FFF_FFFF_FFFF_FFFF) < 0x7FF0_0000_0000_0000;
+#endif
+        }
         
 #if !BUILDTASK
         internal static int WhichPolygonSideIntersects(
@@ -451,7 +474,7 @@ namespace Avalonia.Utilities
             return true;
         }
 #endif
-        
+
         private static void ThrowCannotBeGreaterThanException<T>(T min, T max)
         {
             throw new ArgumentException($"{min} cannot be greater than {max}.");

--- a/src/Avalonia.Base/Visual.cs
+++ b/src/Avalonia.Base/Visual.cs
@@ -148,6 +148,8 @@ namespace Avalonia
         /// </summary>
         public Visual()
         {
+            _visualRoot = this as IRenderRoot;
+
             // Disable transitions until we're added to the visual tree.
             DisableTransitions();
 
@@ -317,16 +319,12 @@ namespace Avalonia
         /// <summary>
         /// Gets the control's child visuals.
         /// </summary>
-        protected internal IAvaloniaList<Visual> VisualChildren
-        {
-            get;
-            private set;
-        }
+        protected internal IAvaloniaList<Visual> VisualChildren { get; }
 
         /// <summary>
         /// Gets the root of the visual tree, if the control is attached to a visual tree.
         /// </summary>
-        protected internal IRenderRoot? VisualRoot => _visualRoot ?? (this as IRenderRoot);
+        protected internal IRenderRoot? VisualRoot => _visualRoot;
 
         internal RenderOptions RenderOptions { get; set; }
 
@@ -544,7 +542,7 @@ namespace Avalonia
         {
             Logger.TryGet(LogEventLevel.Verbose, LogArea.Visual)?.Log(this, "Detached from visual tree");
 
-            _visualRoot = null;
+            _visualRoot = this as IRenderRoot;
             RootedVisualChildrenCount--;
 
             if (RenderTransform is IMutableTransform mutableTransform)
@@ -683,9 +681,9 @@ namespace Avalonia
             var old = _visualParent;
             _visualParent = value;
 
-            if (_visualRoot != null)
+            if (_visualRoot is not null && old is not null)
             {
-                var e = new VisualTreeAttachmentEventArgs(old!, _visualRoot);
+                var e = new VisualTreeAttachmentEventArgs(old, _visualRoot);
                 OnDetachedFromVisualTreeCore(e);
             }
 

--- a/src/Avalonia.Controls/Border.cs
+++ b/src/Avalonia.Controls/Border.cs
@@ -156,7 +156,7 @@ namespace Avalonia.Controls
                     var borderThickness = BorderThickness;
 
                     if (UseLayoutRounding)
-                        borderThickness = LayoutHelper.RoundLayoutThickness(borderThickness, _scale, _scale);
+                        borderThickness = LayoutHelper.RoundLayoutThickness(borderThickness, _scale);
 
                     _layoutThickness = borderThickness;
                 }

--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -525,7 +525,7 @@ namespace Avalonia.Controls.Presenters
                     var borderThickness = BorderThickness;
 
                     if (UseLayoutRounding)
-                        borderThickness = LayoutHelper.RoundLayoutThickness(borderThickness, _scale, _scale);
+                        borderThickness = LayoutHelper.RoundLayoutThickness(borderThickness, _scale);
 
                     _layoutThickness = borderThickness;
                 }
@@ -618,8 +618,8 @@ namespace Avalonia.Controls.Presenters
 
             if (useLayoutRounding)
             {
-                padding = LayoutHelper.RoundLayoutThickness(padding, scale, scale);
-                borderThickness = LayoutHelper.RoundLayoutThickness(borderThickness, scale, scale);
+                padding = LayoutHelper.RoundLayoutThickness(padding, scale);
+                borderThickness = LayoutHelper.RoundLayoutThickness(borderThickness, scale);
             }
 
             padding += borderThickness;
@@ -642,8 +642,8 @@ namespace Avalonia.Controls.Presenters
 
             if (useLayoutRounding)
             {
-                sizeForChild = LayoutHelper.RoundLayoutSizeUp(sizeForChild, scale, scale);
-                availableSize = LayoutHelper.RoundLayoutSizeUp(availableSize, scale, scale);
+                sizeForChild = LayoutHelper.RoundLayoutSizeUp(sizeForChild, scale);
+                availableSize = LayoutHelper.RoundLayoutSizeUp(availableSize, scale);
             }
 
             switch (horizontalContentAlignment)
@@ -666,14 +666,14 @@ namespace Avalonia.Controls.Presenters
                     break;
             }
 
+            var origin = new Point(originX, originY);
+
             if (useLayoutRounding)
             {
-                originX = LayoutHelper.RoundLayoutValue(originX, scale);
-                originY = LayoutHelper.RoundLayoutValue(originY, scale);
+                origin = LayoutHelper.RoundLayoutPoint(origin, scale);
             }
 
-            var boundsForChild =
-                new Rect(originX, originY, sizeForChild.Width, sizeForChild.Height).Deflate(padding);
+            var boundsForChild = new Rect(origin, sizeForChild).Deflate(padding);
 
             Child.Arrange(boundsForChild);
 

--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -511,7 +511,7 @@ namespace Avalonia.Controls.Presenters
             if (Child.UseLayoutRounding)
             {
                 var scale = LayoutHelper.GetLayoutScale(Child);
-                childMargin = LayoutHelper.RoundLayoutThickness(childMargin, scale, scale);
+                childMargin = LayoutHelper.RoundLayoutThickness(childMargin, scale);
             }
 
             var extent = Child!.Bounds.Size.Inflate(childMargin);

--- a/src/Avalonia.Controls/Primitives/TemplatedControl.cs
+++ b/src/Avalonia.Controls/Primitives/TemplatedControl.cs
@@ -291,7 +291,6 @@ namespace Avalonia.Controls.Primitives
         public sealed override void ApplyTemplate()
         {
             var template = Template;
-            var logical = (ILogical)this;
 
             // Apply the template if it is not the same as the template already applied - except
             // for in the case that the template is null and we're not attached to the logical 
@@ -299,7 +298,7 @@ namespace Avalonia.Controls.Primitives
             // the template has been detached, so we want to wait until it's re-attached to the 
             // logical tree as if it's re-attached to the same tree the template will be the same
             // and we don't need to do anything.
-            if (_appliedTemplate != template && (template != null || logical.IsAttachedToLogicalTree))
+            if (_appliedTemplate != template && (template != null || ((ILogical)this).IsAttachedToLogicalTree))
             {
                 if (VisualChildren.Count > 0)
                 {

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -605,7 +605,7 @@ namespace Avalonia.Controls
             }
 
             var scale = LayoutHelper.GetLayoutScale(this);
-            var padding = LayoutHelper.RoundLayoutThickness(Padding, scale, scale);
+            var padding = LayoutHelper.RoundLayoutThickness(Padding, scale);
             var top = padding.Top;
             var textHeight = TextLayout.Height;
 
@@ -709,7 +709,7 @@ namespace Avalonia.Controls
         protected override Size MeasureOverride(Size availableSize)
         {
             var scale = LayoutHelper.GetLayoutScale(this);
-            var padding = LayoutHelper.RoundLayoutThickness(Padding, scale, scale);
+            var padding = LayoutHelper.RoundLayoutThickness(Padding, scale);
             var deflatedSize = availableSize.Deflate(padding);
 
             if (_constraint != deflatedSize)
@@ -740,7 +740,7 @@ namespace Avalonia.Controls
             //This implicitly recreated the TextLayout with a new constraint if we previously reset it.
             var textLayout = TextLayout;
 
-            var size = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.MinTextWidth, textLayout.Height).Inflate(padding), 1, 1);
+            var size = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.MinTextWidth, textLayout.Height).Inflate(padding), 1);
 
             return size;
         }
@@ -748,7 +748,7 @@ namespace Avalonia.Controls
         protected override Size ArrangeOverride(Size finalSize)
         {
             var scale = LayoutHelper.GetLayoutScale(this);
-            var padding = LayoutHelper.RoundLayoutThickness(Padding, scale, scale);
+            var padding = LayoutHelper.RoundLayoutThickness(Padding, scale);
 
             var availableSize = finalSize.Deflate(padding);
 

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -131,6 +131,7 @@ namespace Avalonia.Controls
         private readonly IDisposable? _pointerOverPreProcessorSubscription;
         private readonly IDisposable? _backGestureSubscription;
         private readonly Dictionary<AvaloniaProperty, Action> _platformImplBindings = new();
+        private double _scaling;
         private Size _clientSize;
         private Size? _frameSize;
         private WindowTransparencyLevel _actualTransparencyLevel;
@@ -211,6 +212,7 @@ namespace Avalonia.Controls
             PlatformImpl = impl ?? throw new InvalidOperationException(
                 "Could not create window implementation: maybe no windowing subsystem was initialized?");
 
+            _scaling = ValidateScaling(impl.RenderScaling);
             _actualTransparencyLevel = PlatformImpl.TransparencyLevel;
 
             dependencyResolver ??= AvaloniaLocator.Current;
@@ -536,11 +538,10 @@ namespace Avalonia.Controls
             return control.GetValue(AutoSafeAreaPaddingProperty);
         }
 
-        /// <inheritdoc/>
-        double ILayoutRoot.LayoutScaling => PlatformImpl?.RenderScaling ?? 1;
+        double ILayoutRoot.LayoutScaling => _scaling;
 
         /// <inheritdoc/>
-        public double RenderScaling => PlatformImpl?.RenderScaling ?? 1;
+        public double RenderScaling => _scaling;
 
         IStyleHost IStyleHost.StylingParent => _globalStyles!;
 
@@ -698,6 +699,7 @@ namespace Avalonia.Controls
             Debug.Assert(PlatformImpl != null);
             // The PlatformImpl is completely invalid at this point
             PlatformImpl = null;
+            _scaling = 1.0;
             
             if (_globalStyles is object)
             {
@@ -749,6 +751,7 @@ namespace Avalonia.Controls
         /// <param name="scaling">The window scaling.</param>
         private void HandleScalingChanged(double scaling)
         {
+            _scaling = ValidateScaling(scaling);
             LayoutHelper.InvalidateSelfAndChildrenMeasure(this);
             Dispatcher.UIThread.Send(_ => ScalingChanged?.Invoke(this, EventArgs.Empty));
         }
@@ -951,6 +954,24 @@ namespace Avalonia.Controls
         }
 
         ITextInputMethodImpl? ITextInputMethodRoot.InputMethod => PlatformImpl?.TryGetFeature<ITextInputMethodImpl>();
+
+        private double ValidateScaling(double scaling)
+        {
+            if (MathUtilities.IsNegativeOrNonFinite(scaling) || MathUtilities.IsZero(scaling))
+            {
+                throw new InvalidOperationException(
+                    $"Invalid {nameof(ITopLevelImpl.RenderScaling)} value {scaling} returned from {PlatformImpl?.GetType()}");
+            }
+
+            if (MathUtilities.IsOne(scaling))
+            {
+                // Ensure we've got exactly 1.0 and not an approximation,
+                // so we don't have to use MathUtilities.IsOne in various layout hot paths.
+                return 1.0;
+            }
+
+            return scaling;
+        }
 
         /// <summary>
         /// Provides layout pass timing from the layout manager to the renderer, for diagnostics purposes.

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests.cs
@@ -301,7 +301,10 @@ namespace Avalonia.Controls.UnitTests.Presenters
             target.Measure(new Size(1000, 1000));
             target.Arrange(new Rect(0, 0, 1000, 1000));
 
-            Assert.Equal(new Size(176.00000000000003, 176.00000000000003), target.Child!.DesiredSize);
+            var nonRoundedVieViewport = target.Child!.Bounds.Size.Inflate(
+                LayoutHelper.RoundLayoutThickness(target.Child.Margin, root.LayoutScaling));
+
+            Assert.Equal(new Size(176.00000000000003, 176.00000000000003), nonRoundedVieViewport);
             Assert.Equal(new Size(176, 176), target.Viewport);
             Assert.Equal(new Size(176, 176), target.Extent);
         }

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -66,7 +66,7 @@ namespace Avalonia.Controls.UnitTests
 
                 var textLayout = textBlock.TextLayout;
 
-                var constraint = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.MinTextWidth, textLayout.Height), 1, 1);
+                var constraint = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.MinTextWidth, textLayout.Height), 1);
 
                 Assert.Equal(textBlock.DesiredSize, constraint);
             }
@@ -83,7 +83,7 @@ namespace Avalonia.Controls.UnitTests
 
                 var textLayout = textBlock.TextLayout;
 
-                var constraint = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.WidthIncludingTrailingWhitespace, textLayout.Height), 1, 1);
+                var constraint = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.WidthIncludingTrailingWhitespace, textLayout.Height), 1);
 
                 textBlock.Arrange(new Rect(constraint));
 
@@ -118,7 +118,7 @@ namespace Avalonia.Controls.UnitTests
 
                 var textLayout = textBlock.TextLayout;
 
-                var constraint = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.WidthIncludingTrailingWhitespace, textLayout.Height), 1, 1);
+                var constraint = LayoutHelper.RoundLayoutSizeUp(new Size(textLayout.WidthIncludingTrailingWhitespace, textLayout.Height), 1);
 
                 Assert.Equal(constraint, textBlock.DesiredSize);
             }

--- a/tests/Avalonia.Controls.UnitTests/WindowBaseTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowBaseTests.cs
@@ -239,6 +239,7 @@ namespace Avalonia.Controls.UnitTests
             var renderer = new Mock<IWindowBaseImpl>();
             if (setupAllProperties)
                 renderer.SetupAllProperties();
+            renderer.Setup(x => x.RenderScaling).Returns(1.0);
             renderer.Setup(x => x.Compositor).Returns(RendererMocks.CreateDummyCompositor());
             return renderer;
         }
@@ -248,16 +249,8 @@ namespace Avalonia.Controls.UnitTests
             public bool IsClosed { get; private set; }
 
             public TestWindowBase()
-                : base(CreateWindowsBaseImplMock())
+                : base(CreateMockWindowBaseImpl().Object)
             {
-            }
-
-            private static IWindowBaseImpl CreateWindowsBaseImplMock()
-            {
-                var compositor = RendererMocks.CreateDummyCompositor();
-                return Mock.Of<IWindowBaseImpl>(x =>
-                    x.RenderScaling == 1 &&
-                    x.Compositor == compositor);
             }
 
             public TestWindowBase(IWindowBaseImpl impl)

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -18,6 +18,7 @@ namespace Avalonia.Controls.UnitTests
         public void Setting_Title_Should_Set_Impl_Title()
         {
             var windowImpl = new Mock<IWindowImpl>();
+            windowImpl.Setup(r => r.RenderScaling).Returns(1.0);
             windowImpl.Setup(r => r.Compositor).Returns(RendererMocks.CreateDummyCompositor());
             var windowingPlatform = new MockWindowingPlatform(() => windowImpl.Object);
 


### PR DESCRIPTION
## What does the pull request do?

This PR consists of a series of micro optimizations to `Measure()` and `Arrange()`, reducing the number of branches and operations.
These changes result in a measurable reduction in layout times.

For example, our `Measure` micro-benchmark, which measures and arranges a few thousands `StackPanel`s and `Button`s, goes from 1.847 ms before this PR to 1.421 ms after (.NET 8, Windows, x64), nearly a 30% increase in this specific case.

This doesn't mean that users should expect a 30% increase overall. In practice, this depends on the visual tree complexity and controls used. For example, `TextBlock` is usually bottlenecked by text layouting. Also, it's important to keep in mind that layouting is only a _part_ of the whole process of rendering controls to the screen.

## Changes

### `Layoutable.MeasureCore`

- The internal `MinMax` struct computes the expected min/max of a dimension (`Width` or `Height`), but the result weren't reused in `MeasureCore` like in WPF, effectively doing the work twice. This has been changed.
- `Math.Min/Max` calls have been replaced with single comparisons. In `MeasureCore`, one of the two operands is always the result and we don't care about `NaN` or `+0`/`-0` ordering here.

### `LayoutHelper.GetLayoutScale`

- This method was validating the returned scaling from the `TopLevel` for each measured visual. The validation has been moved to `TopLevel`, once, instead.
- If the layout scaling is close to `1.0`, it's normalized to exactly `1.0` in the `TopLevel` implementation. Thanks to that, we can easily check for `scaling == 1.0` directly later instead of using the more expensive `Math.IsOne()` everywhere.

### `LayoutHelper.RoundLayoutSize/Thickness`

 The complexity of these methods – used when `UseLayoutRounding` is enabled (the default) –  has been reduced:

- Internal overloads taking a single DPI scale have been added since all callers were always passing the same value for `scaleX` and `scaleY`.
- A single branch is now used to check the scale for all values instead of one branch per value.
- The scale is now checked for `1.0` exactly instead of using `MathUtilities.IsOne()`, since it's guaranteed to have been normalized by the `TopLevel` (see above).
- `NaN`, `∞` and `Double.MaxValue` aren't checked anymore. The DPI scale is guaranteed to be valid. The only way to get to infinity is to have an invalid value in the first place (or a scale so large that nothing would render correctly anyways).

### `Visual.VisualRoot`

This property is accessed for each measure, arrange, bounds invalidation, visibility change and more...
It's been simplified to a single unconditional field access, set on appropriate paths, instead of always checking for a self implementation of `IRenderRoot`.
