### PR TITLE
Remove `List<IObserver<T>>.ToArray()` allocations in `LightweightObservableBase`

### DIFF
--- a/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
+++ b/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
@@ -174,7 +174,7 @@ namespace Avalonia.Reactive
                 }
             }
         }
-        
+
         protected void PublishCompleted()
         {
             if (Volatile.Read(ref _observers) != null)

--- a/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
+++ b/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
@@ -131,9 +131,6 @@ namespace Avalonia.Reactive
                         return;
                     }
 
-                    // Uncomment LightweightObservableBaseCounters after this class and the following line to track observer counts
-                    //LightweightObservableBaseCounters.Add(_observers.GetType().FullName!, _observers.Count);
-
                     count = _observers.Count;
                     switch (count)
                     {
@@ -235,59 +232,4 @@ namespace Avalonia.Reactive
         {
         }
     }
-
-    // Uncomment this class to track observer counts
-    // --------------------------------------------------------------------
-    //internal class LightweightObservableBaseCounters
-    //{
-    //    private static readonly List<(string, int)> _allocated = new();
-
-    //    static LightweightObservableBaseCounters()
-    //    {
-    //        AppDomain.CurrentDomain.ProcessExit += PrintStatistics;
-    //    }
-
-    //    private static void PrintStatistics(object? sender, EventArgs e)
-    //    {
-    //        var totalAllocation = _allocated.Count;
-    //        int arraySize = 0;
-    //        foreach (var pair in _allocated)
-    //        {
-    //            arraySize += pair.Item2 * IntPtr.Size + IntPtr.Size * 3; // Array size + object header + sync block index + type handle
-    //        }
-
-    //        // Print statistics per count
-    //        var mapArraySizeToCount = new Dictionary<int, int>();
-    //        foreach (var pair in _allocated)
-    //        {
-    //            var count = pair.Item2;
-    //            if (mapArraySizeToCount.ContainsKey(count))
-    //            {
-    //                mapArraySizeToCount[count]++;
-    //            }
-    //            else
-    //            {
-    //                mapArraySizeToCount[count] = 1;
-    //            }
-    //        }
-
-    //        Console.WriteLine("Array size to count:");
-    //        foreach (var pair in mapArraySizeToCount)
-    //        {
-    //            var size = pair.Key;
-    //            var count = pair.Value;
-    //            Console.WriteLine($"Array size: {size} bytes, Count: {count}");
-    //        }
-    //        Console.WriteLine($"Total array count: {totalAllocation}");
-    //        Console.WriteLine($"Total array size in bytes: {arraySize} bytes");
-    //    }
-
-    //    public static void Add(string name, int count)
-    //    {
-    //        lock (_allocated)
-    //        {
-    //            _allocated.Add((name, count));
-    //        }
-    //    }
-    //}
 }

--- a/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
+++ b/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
@@ -134,7 +134,8 @@ namespace Avalonia.Reactive
                     // Uncomment LightweightObservableBaseCounters after this class and the following line to track observer counts
                     //LightweightObservableBaseCounters.Add(_observers.GetType().FullName!, _observers.Count);
 
-                    switch (_observers.Count)
+                    count = _observers.Count;
+                    switch (count)
                     {
                         case 3:
                             observer0 = _observers[0];
@@ -148,15 +149,12 @@ namespace Avalonia.Reactive
                         case 1:
                             observer0 = _observers[0];
                             break;
+                        case 0:
+                            return;
                         default:
                         {
-                            count = _observers.Count;
-                            if (count != 0)
-                            {
-                                observers = ArrayPool<IObserver<T>>.Shared.Rent(count);
-                                _observers.CopyTo(observers);
-                            }
-
+                            observers = ArrayPool<IObserver<T>>.Shared.Rent(count);
+                            _observers.CopyTo(observers);
                             break;
                         }
                     }


### PR DESCRIPTION
Hello folks, ☺️

## What does the pull request do?

This PR is removing the `List<IObserver<T>>.ToArray()` allocations happening in `LightweightObservableBase` when Routing events are fired (e.g. whenever you move the mouse)

When profiling the memory, I noticed that when generating lots of routing events (e.g. just moving the mouse over a window) several MB of `IObserver<ValueTuple<Object, RoutedEventArgs>>[]` were created.

See for example here with the `ControlDialog` application by just moving the mouse on the Window for a few seconds:

![image](https://github.com/user-attachments/assets/b6a1880c-c565-4f49-983f-5c1ef7d2eed2)

## What is the current behavior?

I noticed 2 problems:

1. The case of array 0 was not covered and always allocating an empty array (at minimum 32 bytes per alloc on x64)
2. Several other smaller allocs could happen for size 2/3
3. Depending on the number of controls, the size of the allocation can grow quickly (several controls having to be notified)

For example, here are some statistics about these array allocations:

Array size to count:
* Array size: 0 bytes, Count: 31926
* Array size: 1 bytes, Count: 29254
* Array size: 2 bytes, Count: 278919
* Array size: 3 bytes, Count: 5567
* Array size: 4 bytes, Count: 2141

Total array count: 347807
Total array size in bytes: 13246224 bytes


## What is the updated/expected behavior with this PR?

This PR is introducing the case for 0/2/3 elements and pooling the array for other cases with ArrayPool.

After this PR, the allocation is removed:

![image](https://github.com/user-attachments/assets/8056751d-a1d2-43ba-921e-dece2f80c966)


A direct side effect is less GC collections:

Before this PR, a trigger of the GC happens after 4.6s

![image](https://github.com/user-attachments/assets/69703cdc-cecb-4c10-a8d0-b08f26bd8e02)

After this PR, a trigger of the GC happens after 7s.

![image](https://github.com/user-attachments/assets/861c3ac2-9929-4138-88cb-d57917a03f0f)

## How was the solution implemented (if it's not obvious)?

Cases of 0/2/3 and ArrayPool.

I have left the code that can print some statistics commented. If it is a problem, I can remove it from the PR.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues

None
