### PR TITLE
DataGrid - preserve groups collapsed state

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridGroupDescription.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridGroupDescription.cs
@@ -136,6 +136,9 @@ namespace Avalonia.Collections
             }
         }
 
+        internal abstract DataGridCollectionViewGroupInternal Parent { get; }
+        internal abstract DataGridGroupDescription GroupBy { get; set; }
+
         protected DataGridCollectionViewGroup(object key)
         {
             Key = key;
@@ -189,7 +192,7 @@ namespace Avalonia.Collections
 
         internal int FullCount { get; set; }
 
-        internal DataGridGroupDescription GroupBy
+        internal override DataGridGroupDescription GroupBy
         {
             get { return _groupBy; }
             set
@@ -269,7 +272,7 @@ namespace Avalonia.Collections
             }
         }
 
-        private DataGridCollectionViewGroupInternal Parent => _parentGroup;
+        internal override DataGridCollectionViewGroupInternal Parent => _parentGroup;
 
         /// <summary>
         /// Adds the specified item to the collection

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -2644,6 +2644,11 @@ namespace Avalonia.Controls
                 // We want to persist selection throughout a reset, so store away the selected items
                 List<object> selectedItemsCache = new List<object>(_selectedItems.SelectedItemsCache);
 
+                var collapsedGroupsCache = RowGroupHeadersTable
+                    .Where(g => !g.Value.IsVisible)
+                    .Select(g => g.Value.CollectionViewGroup.Key)
+                    .ToArray();
+
                 if (recycleRows)
                 {
                     RefreshRows(recycleRows, clearRows: true);
@@ -2651,6 +2656,16 @@ namespace Avalonia.Controls
                 else
                 {
                     RefreshRowsAndColumns(clearRows: true);
+                }
+
+                // collapse previously collapsed groups
+                foreach (var g in collapsedGroupsCache)
+                {
+                    var item = RowGroupHeadersTable.FirstOrDefault(t => t.Value.CollectionViewGroup.Parent.GroupBy.KeysMatch(t.Value.CollectionViewGroup.Key, g));
+                    if (item != null)
+                    {
+                        EnsureRowGroupVisibility(item.Value, false, false);
+                    }
                 }
 
                 // Re-select the old items


### PR DESCRIPTION
## What does the pull request do?
DataGrid has a Grouping behavior. It has a major flaw: when the collection is Reset or just when the DataGrid control is removed and re-attached to the visual tree, it **forgets the collapsed state of groups.**


## What is the current behavior?
Open the Control catalog DataGrid page.
On the Grouping tab collapse some groups.
Switch tabs back and forth.
Groups are expanded again.

## What is the updated/expected behavior with this PR?
The state is saved and restored

## How was the solution implemented (if it's not obvious)?
I tried to mimick the selection state cache on the same spot.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
none

## Obsoletions / Deprecations

## Fixed issues
