### PR TITLE
Fix Window.MeasureOverride measuring with the old ClientSize

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -1057,8 +1057,13 @@ namespace Avalonia.Controls
         {
             var sizeToContent = SizeToContent;
             var clientSize = ClientSize;
-            var constraint = clientSize;
             var maxAutoSize = PlatformImpl?.MaxAutoSizeHint ?? Size.Infinity;
+            var useAutoWidth = sizeToContent.HasAllFlags(SizeToContent.Width);
+            var useAutoHeight = sizeToContent.HasAllFlags(SizeToContent.Height);
+
+            var constraint = new Size(
+                useAutoWidth || double.IsInfinity(availableSize.Width) ? clientSize.Width : availableSize.Width,
+                useAutoHeight || double.IsInfinity(availableSize.Height) ? clientSize.Height : availableSize.Height);
 
             if (MaxWidth > 0 && MaxWidth < maxAutoSize.Width)
             {
@@ -1069,19 +1074,19 @@ namespace Avalonia.Controls
                 maxAutoSize = maxAutoSize.WithHeight(MaxHeight);
             }
 
-            if (sizeToContent.HasAllFlags(SizeToContent.Width))
+            if (useAutoWidth)
             {
                 constraint = constraint.WithWidth(maxAutoSize.Width);
             }
 
-            if (sizeToContent.HasAllFlags(SizeToContent.Height))
+            if (useAutoHeight)
             {
                 constraint = constraint.WithHeight(maxAutoSize.Height);
             }
 
             var result = base.MeasureOverride(constraint);
 
-            if (!sizeToContent.HasAllFlags(SizeToContent.Width))
+            if (!useAutoWidth)
             {
                 if (!double.IsInfinity(availableSize.Width))
                 {
@@ -1093,7 +1098,7 @@ namespace Avalonia.Controls
                 }
             }
 
-            if (!sizeToContent.HasAllFlags(SizeToContent.Height))
+            if (!useAutoHeight)
             {
                 if (!double.IsInfinity(availableSize.Height))
                 {

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
+using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Moq;
 using Xunit;
@@ -686,10 +687,23 @@ namespace Avalonia.Controls.UnitTests
                         Content = child
                     };
 
+                    // Verify that the child is initially measured with our Width/Height.
                     Show(target);
 
                     Assert.Equal(1, child.MeasureSizes.Count);
                     Assert.Equal(new Size(100, 50), child.MeasureSizes[0]);
+
+                    // Now change the bounds: verify that we are using the new Width/Height, and not the old ClientSize.
+                    child.MeasureSizes.Clear();
+                    child.InvalidateMeasure();
+
+                    target.Width = 120;
+                    target.Height = 70;
+
+                    Dispatcher.UIThread.RunJobs();
+
+                    Assert.Equal(1, child.MeasureSizes.Count);
+                    Assert.Equal(new Size(120, 70), child.MeasureSizes[0]);
                 }
             }
 


### PR DESCRIPTION
## What does the pull request do?
This PR fixes `Window.MeasureOverride` incorrectly measuring its child using its old `ClientSize` when the `Width` or `Height` of the window is manually set (and `SizeToContent == Manual`).

An existing unit test `Child_Should_Be_Measured_With_Width_And_Height_If_SizeToContent_Is_Manual` has been amended, making sure that the logic is still properly applied when `Window.Width/Height` changes.

## What is the current behavior?
Setting `Window.Width/Height` triggers a measure pass with the old `ClientSize` instead of the new bounds. The child's measure call is ignored (since the measure bounds haven't changed). However, this still updates the Window's `DesiredSize` to the new bounds, causing an arrange pass to be triggered. Later, the window bounds effectively change, causing another layout pass, this time calling `Measure` with the proper values.

From the child's point of view, `Arrange` (from the first layout pass) is called before `Measure` (from the second layout pass).

## What is the updated/expected behavior with this PR?
The child is properly measured with the new bounds, causing a single normal measure pass.
