### PR TITLE
Improve KeyGesture.ToString() output in case when Key is set to Key.None

### DIFF
--- a/src/Avalonia.Base/Input/KeyGesture.cs
+++ b/src/Avalonia.Base/Input/KeyGesture.cs
@@ -79,15 +79,10 @@ namespace Avalonia.Input
                 {
                     var partSpan = gesture.AsSpan(cstart, c - cstart).Trim();
 
-                    if (isLast)
-                    {
-                        key = ParseKey(partSpan.ToString());
-                    }
-                    else
+                    if (!TryParseKey(partSpan.ToString(), out key))
                     {
                         keyModifiers |= ParseModifier(partSpan);
                     }
-
                     cstart = c + 1;
                 }
             }
@@ -166,12 +161,16 @@ namespace Avalonia.Input
             ResolveNumPadOperationKey(keyEvent.Key) == ResolveNumPadOperationKey(Key);
 
         // TODO: Move that to external key parser
-        private static Key ParseKey(string key)
+        private static bool TryParseKey(string keyStr, out Key key)
         {
-            if (s_keySynonyms.TryGetValue(key.ToLower(CultureInfo.InvariantCulture), out Key rv))
-                return rv;
+            key = Key.None;
+            if (s_keySynonyms.TryGetValue(keyStr.ToLower(CultureInfo.InvariantCulture), out key))
+                return true;
 
-            return EnumHelper.Parse<Key>(key, true);
+            if (EnumHelper.TryParse(keyStr, true, out key))
+                return true;
+
+            return false;
         }
 
         private static KeyModifiers ParseModifier(ReadOnlySpan<char> modifier)

--- a/src/Avalonia.Base/Input/KeyGesture.cs
+++ b/src/Avalonia.Base/Input/KeyGesture.cs
@@ -151,8 +151,11 @@ namespace Avalonia.Input
                 s.Append(formatInfo.Meta);
             }
 
-            Plus(s);
-            s.Append(formatInfo.FormatKey(Key));
+            if ((Key != Key.None) || (KeyModifiers == KeyModifiers.None))
+            {
+                Plus(s);
+                s.Append(formatInfo.FormatKey(Key));
+            }
 
             return StringBuilderCache.GetStringAndRelease(s);
         }

--- a/tests/Avalonia.Base.UnitTests/Input/KeyGestureTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/KeyGestureTests.cs
@@ -13,6 +13,9 @@ namespace Avalonia.Base.UnitTests.Input
             new object[]{"Control++", new KeyGesture(Key.OemPlus, KeyModifiers.Control) },
             new object[]{ "Shift+⌘+A", new KeyGesture(Key.A, KeyModifiers.Meta | KeyModifiers.Shift) },
             new object[]{ "Shift+Cmd+A", new KeyGesture(Key.A, KeyModifiers.Meta | KeyModifiers.Shift) },
+            new object[]{"None", new KeyGesture(Key.None)},
+            new object[]{"Alt+Shift", new KeyGesture(Key.None, KeyModifiers.Alt | KeyModifiers.Shift)},
+
         };
 
         public static readonly IEnumerable<object[]> ToStringData = new object[][]
@@ -23,6 +26,8 @@ namespace Avalonia.Base.UnitTests.Input
             new object[]{new KeyGesture(Key.A, KeyModifiers.Alt | KeyModifiers.Shift), "Shift+Alt+A"},
             new object[]{new KeyGesture(Key.A, KeyModifiers.Control | KeyModifiers.Alt | KeyModifiers.Shift), "Ctrl+Shift+Alt+A"},
             new object[]{new KeyGesture(Key.A, KeyModifiers.Meta | KeyModifiers.Shift), "Shift+Cmd+A"},
+            new object[]{new KeyGesture(Key.None), "None"},
+            new object[]{new KeyGesture(Key.None, KeyModifiers.Alt | KeyModifiers.Shift), "Shift+Alt"},
         };
 
         [Theory]


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Improve KeyGesture.ToString() output in case when Key is set to Key.None


## What is the current behavior?
When create a new KeyGesure like :
```csharp
new KeyGesture(Key.None, KeyModifiers.Alt | KeyModifiers.Shift)
```
`ToString()` output string contains `Shift+Alt+None`


## What is the updated/expected behavior with this PR?
Output string contains only modifiers (like `Shift+Alt`)

In case, if KeyGesture creates as 
```csharp 
new KeyGesture(Key.None, KeyModifiers.None)
```
output string is `None`

