### PR TITLE
Implement SetItems method in ResourceDictionary

### DIFF
--- a/src/Avalonia.Base/Controls/ResourceDictionary.cs
+++ b/src/Avalonia.Base/Controls/ResourceDictionary.cs
@@ -13,6 +13,7 @@ namespace Avalonia.Controls
     /// </summary>
     public class ResourceDictionary : ResourceProvider, IResourceDictionary, IThemeVariantProvider
     {
+        private bool _suspendNotifications;
         private object? _lastDeferredItemKey;
         private Dictionary<object, object?>? _inner;
         private AvaloniaList<IResourceProvider>? _mergedDictionaries;
@@ -40,7 +41,7 @@ namespace Avalonia.Controls
             set
             {
                 Inner[key] = value;
-                Owner?.NotifyHostedResourcesChanged(ResourcesChangedEventArgs.Empty);
+                NotifyHostedResourcesChanged(Owner);
             }
         }
 
@@ -150,6 +151,21 @@ namespace Avalonia.Controls
         public void AddNotSharedDeferred(object key, IDeferredContent deferredContent)
             => Add(key, new NotSharedDeferredItem(deferredContent));
 
+        public void AddOrUpdateRange(IEnumerable<KeyValuePair<object, object?>> values)
+        {
+            _suspendNotifications = true;
+            try
+            {
+                foreach (var value in values)
+                    Inner[value.Key] = value.Value;
+            }
+            finally
+            {
+                _suspendNotifications = false;
+                NotifyHostedResourcesChanged(Owner);
+            }
+        }
+        
         public void Clear()
         {
             if (_inner?.Count > 0)
@@ -376,6 +392,13 @@ namespace Avalonia.Controls
             }
         }
 
+        private void NotifyHostedResourcesChanged(IResourceHost? owner)
+        {
+            if (_suspendNotifications)
+                return;
+            owner?.NotifyHostedResourcesChanged(ResourcesChangedEventArgs.Empty);            
+        }
+        
         private sealed class DeferredItem : IDeferredContent
         {
             private readonly Func<IServiceProvider?,object?> _factory;

--- a/src/Avalonia.Base/Controls/ResourceDictionary.cs
+++ b/src/Avalonia.Base/Controls/ResourceDictionary.cs
@@ -13,7 +13,6 @@ namespace Avalonia.Controls
     /// </summary>
     public class ResourceDictionary : ResourceProvider, IResourceDictionary, IThemeVariantProvider
     {
-        private bool _suspendNotifications;
         private object? _lastDeferredItemKey;
         private Dictionary<object, object?>? _inner;
         private AvaloniaList<IResourceProvider>? _mergedDictionaries;
@@ -41,7 +40,8 @@ namespace Avalonia.Controls
             set
             {
                 Inner[key] = value;
-                NotifyHostedResourcesChanged(Owner);
+                Owner?.NotifyHostedResourcesChanged(ResourcesChangedEventArgs.Empty);            
+
             }
         }
 
@@ -151,9 +151,8 @@ namespace Avalonia.Controls
         public void AddNotSharedDeferred(object key, IDeferredContent deferredContent)
             => Add(key, new NotSharedDeferredItem(deferredContent));
 
-        public void AddOrUpdateRange(IEnumerable<KeyValuePair<object, object?>> values)
+        public void SetItems(IEnumerable<KeyValuePair<object, object?>> values)
         {
-            _suspendNotifications = true;
             try
             {
                 foreach (var value in values)
@@ -161,8 +160,7 @@ namespace Avalonia.Controls
             }
             finally
             {
-                _suspendNotifications = false;
-                NotifyHostedResourcesChanged(Owner);
+                Owner?.NotifyHostedResourcesChanged(ResourcesChangedEventArgs.Empty);            
             }
         }
         
@@ -392,13 +390,6 @@ namespace Avalonia.Controls
             }
         }
 
-        private void NotifyHostedResourcesChanged(IResourceHost? owner)
-        {
-            if (_suspendNotifications)
-                return;
-            owner?.NotifyHostedResourcesChanged(ResourcesChangedEventArgs.Empty);            
-        }
-        
         private sealed class DeferredItem : IDeferredContent
         {
             private readonly Func<IServiceProvider?,object?> _factory;


### PR DESCRIPTION
## What does the pull request do?
This PR provides a new method to the ResourceDictionary called `AddOrUpdateRange` which allows to batch multiple updates in one go and notify all subscribers about the change at the very end once the resources have been updated.

See discussion: https://github.com/AvaloniaUI/Avalonia/discussions/18346

## What is the current behavior?
At the moment, adding or updating existing resources are immediately notifying all subscribers about resource changes. In complex application this can become quite expensive and slow when your updating multiple (tens or hundreds) resources by code.

## What is the updated/expected behavior with this PR?
When using the `AddOrUpdateRange` methods, the notification of all subscribers happens only once at the end of the method, regardless of the number of updates performed.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
https://github.com/AvaloniaUI/Avalonia/discussions/18346