### PR TITLE
Bring control into view only if control isn't properly visible in viewport

### DIFF
--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -291,10 +291,10 @@ namespace Avalonia.Controls.Presenters
             double childStart,
             double childEnd)
         {
-            // If child is above viewport, i.e. top of child is above viewport top and bottom of child is above viewport bottom.
+            // If child is at least partially above viewport, i.e. top of child is above viewport top and bottom of child is above viewport bottom.
             bool isChildAbove = MathUtilities.LessThan(childStart, viewportStart) && MathUtilities.LessThan(childEnd, viewportEnd);
 
-            // If child is below viewport, i.e. top of child is below viewport top and bottom of child is below viewport bottom.
+            // If child is at least partially below viewport, i.e. top of child is below viewport top and bottom of child is below viewport bottom.
             bool isChildBelow = MathUtilities.GreaterThan(childEnd, viewportEnd) && MathUtilities.GreaterThan(childStart, viewportStart);
             bool isChildLarger = (childEnd - childStart) > (viewportEnd - viewportStart);
 

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.Presenters;
 using Avalonia.Layout;
 using Avalonia.UnitTests;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Avalonia.Controls.UnitTests.Presenters
 {
@@ -397,6 +398,198 @@ namespace Avalonia.Controls.UnitTests.Presenters
             target.BringDescendantIntoView(border, new Rect(200, 200, 0, 0));
 
             Assert.Equal(new Vector(150, 150), target.Offset);
+        }
+
+        [Fact]
+        public void BringDescendantIntoView_Should_Not_Move_Child_If_Completely_In_View()
+        {
+            Border border = new Border
+            {
+                Width = 100,
+                Height = 20
+            };
+            var content = new StackPanel()
+            {
+                Orientation = Orientation.Vertical,
+                Width = 100,
+            };
+
+            for(int i = 0; i < 100; i++)
+            {
+                // border position will be (0,60)
+                var child = i == 3 ? border : new Border
+                {
+                    Width = 100,
+                    Height = 20,
+                };
+                content.Children.Add(child);
+            }
+            var target = new ScrollContentPresenter
+            {
+                CanHorizontallyScroll = true,
+                CanVerticallyScroll = true,
+                Width = 200,
+                Height = 100,
+                Content = new Decorator
+                {
+                    Child = content
+                }
+            };
+
+            target.UpdateChild();
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, 100, 100));
+            target.BringDescendantIntoView(border, new Rect(border.Bounds.Size));
+
+            Assert.Equal(new Vector(0, 0), target.Offset);
+        }
+
+        [Fact]
+        public void BringDescendantIntoView_Should_Move_Child_At_Least_Partially_Above_Viewport()
+        {
+            Border border = new Border
+            {
+                Width = 100,
+                Height = 20
+            };
+            var content = new StackPanel()
+            {
+                Orientation = Orientation.Vertical,
+                Width = 100,
+            };
+
+            for(int i = 0; i < 100; i++)
+            {
+                // border position will be (0,60)
+                var child = i == 3 ? border : new Border
+                {
+                    Width = 100,
+                    Height = 20,
+                };
+                content.Children.Add(child);
+            }
+            var target = new ScrollContentPresenter
+            {
+                CanHorizontallyScroll = true,
+                CanVerticallyScroll = true,
+                Width = 200,
+                Height = 100,
+                Content = new Decorator
+                {
+                    Child = content
+                }
+            };
+
+            target.UpdateChild();
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, 100, 100));
+            // move border to above the view port
+            target.Offset = new Vector(0, 90);
+            target.BringDescendantIntoView(border, new Rect(border.Bounds.Size));
+
+            Assert.Equal(new Vector(0, 60), target.Offset);
+
+            // move border to partially above the view port
+            target.Offset = new Vector(0, 70);
+            target.BringDescendantIntoView(border, new Rect(border.Bounds.Size));
+
+            Assert.Equal(new Vector(0, 60), target.Offset);
+        }
+
+        [Fact]
+        public void BringDescendantIntoView_Should_Not_Move_Child_If_Completely_Covers_Viewport()
+        {
+            Border border = new Border
+            {
+                Width = 100,
+                Height = 200
+            };
+            var content = new StackPanel()
+            {
+                Orientation = Orientation.Vertical,
+                Width = 100,
+            };
+
+            for (int i = 0; i < 100; i++)
+            {
+                // border position will be (0,60)
+                var child = i == 3 ? border : new Border
+                {
+                    Width = 100,
+                    Height = 20,
+                };
+                content.Children.Add(child);
+            }
+            var target = new ScrollContentPresenter
+            {
+                CanHorizontallyScroll = true,
+                CanVerticallyScroll = true,
+                Width = 200,
+                Height = 100,
+                Content = new Decorator
+                {
+                    Child = content
+                }
+            };
+
+            target.UpdateChild();
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, 100, 100));
+            // move border such that it's partially above viewport and partially below viewport
+            target.Offset = new Vector(0, 90);
+            target.BringDescendantIntoView(border, new Rect(border.Bounds.Size));
+
+            Assert.Equal(new Vector(0, 90), target.Offset);
+        }
+
+        [Fact]
+        public void BringDescendantIntoView_Should_Move_Child_At_Least_Partially_Below_Viewport()
+        {
+            Border border = new Border
+            {
+                Width = 100,
+                Height = 20
+            };
+            var content = new StackPanel()
+            {
+                Orientation = Orientation.Vertical,
+                Width = 100,
+            };
+
+            for (int i = 0; i < 100; i++)
+            {
+                // border position will be (0,180)
+                var child = i == 9 ? border : new Border
+                {
+                    Width = 100,
+                    Height = 20,
+                };
+                content.Children.Add(child);
+            }
+            var target = new ScrollContentPresenter
+            {
+                CanHorizontallyScroll = true,
+                CanVerticallyScroll = true,
+                Width = 200,
+                Height = 100,
+                Content = new Decorator
+                {
+                    Child = content
+                }
+            };
+
+            target.UpdateChild();
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, 100, 100));
+
+            // border is at (0, 180) and below the viewport
+            target.BringDescendantIntoView(border, new Rect(border.Bounds.Size));
+
+            Assert.Equal(new Vector(0, 100), target.Offset);
+
+            // move border to partially below the view port
+            target.Offset = new Vector(0, 90);
+            target.BringDescendantIntoView(border, new Rect(border.Bounds.Size));
         }
 
         [Fact]


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Brings a control into view when request only if the control is currently not in the scrollviewer's viewport, or such that most of the child is visible in the viewport. Behavior was adapted from WPF's implementation. If the child is completely visible or contains the full viewport, no offset change is done.


## What is the current behavior?
Requesting a child be brought into view will always align the top of the child to the top of the viewport, even if the child is fully visible.  This forces the scroll offset to change reset even if the child is slightly moved into the viewport manually. This creates problems with focus, as for most focusable controls, they are brought into view on gaining focus. Focus is gained in multiple ways, most common of which is a toplevel activating after being deactivated.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #18252
