### PR TITLE
Add ability to cancel focus change

### DIFF
--- a/src/Avalonia.Base/Input/FocusChangingEventArgs.cs
+++ b/src/Avalonia.Base/Input/FocusChangingEventArgs.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Input
+{
+    public class FocusChangingEventArgs : RoutedEventArgs
+    {
+        /// <summary>
+        /// Provides data for focus changing.
+        /// </summary>
+        public FocusChangingEventArgs(RoutedEvent routedEvent) : base(routedEvent)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the element that focus has moved to.
+        /// </summary>
+        public IInputElement? NewFocus { get; init; }
+
+        /// <summary>
+        /// Gets or sets the element that previously had focus.
+        /// </summary>
+        public IInputElement? OldFocus { get; init; }
+
+        /// <summary>
+        /// Gets or sets a value indicating how the change in focus occurred.
+        /// </summary>
+        public NavigationMethod NavigationMethod { get; init; }
+
+        /// <summary>
+        /// Gets or sets any key modifiers active at the time of focus.
+        /// </summary>
+        public KeyModifiers KeyModifiers { get; init; }
+    }
+}

--- a/src/Avalonia.Base/Input/FocusChangingEventArgs.cs
+++ b/src/Avalonia.Base/Input/FocusChangingEventArgs.cs
@@ -19,12 +19,12 @@ namespace Avalonia.Input
         /// <summary>
         /// Gets or sets the element that focus has moved to.
         /// </summary>
-        public IInputElement? NewFocus { get; init; }
+        public IInputElement? NewFocusedElement { get; internal set; }
 
         /// <summary>
         /// Gets or sets the element that previously had focus.
         /// </summary>
-        public IInputElement? OldFocus { get; init; }
+        public IInputElement? OldFocusedElement { get; init; }
 
         /// <summary>
         /// Gets or sets a value indicating how the change in focus occurred.
@@ -41,7 +41,7 @@ namespace Avalonia.Input
         /// </summary>
         public bool Cancelled { get; private set; }
 
-        internal bool IsCancellable { get; init; }
+        internal bool CanCancelOrRedirectFocus { get; init; }
 
         /// <summary>
         /// Attempts to cancel the current focus change
@@ -49,9 +49,22 @@ namespace Avalonia.Input
         /// <returns>true if focus change was cancelled; otherwise, false</returns>
         public bool TryCancel()
         {
-            Cancelled = IsCancellable;
+            Cancelled = CanCancelOrRedirectFocus;
 
             return Cancelled;
+        }
+
+        /// <summary>
+        /// Attempts to redirect focus from the targeted element to the specified element.
+        /// </summary>
+        public bool TrySetNewFocusedElement(IInputElement? inputElement)
+        {
+            if(CanCancelOrRedirectFocus)
+            {
+                NewFocusedElement = inputElement;
+            }
+
+            return inputElement == NewFocusedElement;
         }
     }
 }

--- a/src/Avalonia.Base/Input/FocusChangingEventArgs.cs
+++ b/src/Avalonia.Base/Input/FocusChangingEventArgs.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Provides data for focus changing.
         /// </summary>
-        public FocusChangingEventArgs(RoutedEvent routedEvent) : base(routedEvent)
+        internal FocusChangingEventArgs(RoutedEvent routedEvent) : base(routedEvent)
         {
         }
 
@@ -35,5 +35,23 @@ namespace Avalonia.Input
         /// Gets or sets any key modifiers active at the time of focus.
         /// </summary>
         public KeyModifiers KeyModifiers { get; init; }
+
+        /// <summary>
+        /// Gets whether focus change is canceled.
+        /// </summary>
+        public bool Cancelled { get; private set; }
+
+        internal bool IsCancellable { get; init; }
+
+        /// <summary>
+        /// Attempts to cancel the current focus change
+        /// </summary>
+        /// <returns>true if focus change was cancelled; otherwise, false</returns>
+        public bool TryCancel()
+        {
+            Cancelled = IsCancellable;
+
+            return Cancelled;
+        }
     }
 }

--- a/src/Avalonia.Base/Input/FocusChangingEventArgs.cs
+++ b/src/Avalonia.Base/Input/FocusChangingEventArgs.cs
@@ -39,7 +39,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Gets whether focus change is canceled.
         /// </summary>
-        public bool Cancelled { get; private set; }
+        public bool Canceled { get; private set; }
 
         internal bool CanCancelOrRedirectFocus { get; init; }
 
@@ -49,9 +49,9 @@ namespace Avalonia.Input
         /// <returns>true if focus change was cancelled; otherwise, false</returns>
         public bool TryCancel()
         {
-            Cancelled = CanCancelOrRedirectFocus;
+            Canceled = CanCancelOrRedirectFocus;
 
-            return Cancelled;
+            return Canceled;
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Input/FocusManager.cs
+++ b/src/Avalonia.Base/Input/FocusManager.cs
@@ -78,7 +78,7 @@ namespace Avalonia.Input
             else
             {
                 _focusRoot = null;
-                keyboardDevice.SetFocusedElement(null, NavigationMethod.Unspecified, KeyModifiers.None);
+                keyboardDevice.SetFocusedElement(null, NavigationMethod.Unspecified, KeyModifiers.None, false);
                 return false;
             }
         }

--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -83,10 +83,22 @@ namespace Avalonia.Input
             RoutedEvent.Register<InputElement, GotFocusEventArgs>(nameof(GotFocus), RoutingStrategies.Bubble);
 
         /// <summary>
+        /// Defines the <see cref="GettingFocus"/> event.
+        /// </summary>
+        public static readonly RoutedEvent<FocusChangingEventArgs> GettingFocusEvent =
+            RoutedEvent.Register<InputElement, FocusChangingEventArgs>(nameof(GettingFocus), RoutingStrategies.Bubble);
+
+        /// <summary>
         /// Defines the <see cref="LostFocus"/> event.
         /// </summary>
         public static readonly RoutedEvent<RoutedEventArgs> LostFocusEvent =
             RoutedEvent.Register<InputElement, RoutedEventArgs>(nameof(LostFocus), RoutingStrategies.Bubble);
+
+        /// <summary>
+        /// Defines the <see cref="LosingFocus"/> event.
+        /// </summary>
+        public static readonly RoutedEvent<FocusChangingEventArgs> LosingFocusEvent =
+            RoutedEvent.Register<InputElement, FocusChangingEventArgs>(nameof(LosingFocus), RoutingStrategies.Bubble);
 
         /// <summary>
         /// Defines the <see cref="KeyDown"/> event.
@@ -213,6 +225,8 @@ namespace Avalonia.Input
 
             GotFocusEvent.AddClassHandler<InputElement>((x, e) => x.OnGotFocusCore(e));
             LostFocusEvent.AddClassHandler<InputElement>((x, e) => x.OnLostFocusCore(e));
+            GettingFocusEvent.AddClassHandler<InputElement>((x, e) => x.OnGettingFocus(e));
+            LosingFocusEvent.AddClassHandler<InputElement>((x, e) => x.OnLosingFocus(e));
             KeyDownEvent.AddClassHandler<InputElement>((x, e) => x.OnKeyDown(e));
             KeyUpEvent.AddClassHandler<InputElement>((x, e) => x.OnKeyUp(e));
             TextInputEvent.AddClassHandler<InputElement>((x, e) => x.OnTextInput(e));
@@ -250,12 +264,30 @@ namespace Avalonia.Input
         }
 
         /// <summary>
+        /// Occurs before the control receives focus.
+        /// </summary>
+        public event EventHandler<FocusChangingEventArgs>? GettingFocus
+        {
+            add { AddHandler(GettingFocusEvent, value); }
+            remove { RemoveHandler(GettingFocusEvent, value); }
+        }
+
+        /// <summary>
         /// Occurs when the control loses focus.
         /// </summary>
         public event EventHandler<RoutedEventArgs>? LostFocus
         {
             add { AddHandler(LostFocusEvent, value); }
             remove { RemoveHandler(LostFocusEvent, value); }
+        }
+
+        /// <summary>
+        /// Occurs before the control loses focus.
+        /// </summary>
+        public event EventHandler<FocusChangingEventArgs>? LosingFocus
+        {
+            add { AddHandler(LosingFocusEvent, value); }
+            remove { RemoveHandler(LosingFocusEvent, value); }
         }
 
         /// <summary>
@@ -541,6 +573,16 @@ namespace Avalonia.Input
             _isFocusVisible = isFocused && (e.NavigationMethod == NavigationMethod.Directional || e.NavigationMethod == NavigationMethod.Tab);
             IsFocused = isFocused;
             OnGotFocus(e);
+        }
+
+        protected virtual void OnGettingFocus(FocusChangingEventArgs e)
+        {
+
+        }
+
+        protected virtual void OnLosingFocus(FocusChangingEventArgs e)
+        {
+
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Input/KeyboardDevice.cs
+++ b/src/Avalonia.Base/Input/KeyboardDevice.cs
@@ -131,7 +131,8 @@ namespace Avalonia.Input
         public void SetFocusedElement(
             IInputElement? element,
             NavigationMethod method,
-            KeyModifiers keyModifiers)
+            KeyModifiers keyModifiers,
+            bool isFocusChangeCancellable = true)
         {
             if (element != FocusedElement)
             {
@@ -144,12 +145,13 @@ namespace Avalonia.Input
                     OldFocus = FocusedElement,
                     NewFocus = element,
                     NavigationMethod = method,
-                    KeyModifiers = keyModifiers
+                    KeyModifiers = keyModifiers,
+                    IsCancellable = isFocusChangeCancellable
                 };
 
                 interactive?.RaiseEvent(losingFocus);
 
-                if (losingFocus.Handled)
+                if (losingFocus.Cancelled)
                 {
                     changeFocus = false;
                 }
@@ -161,12 +163,13 @@ namespace Avalonia.Input
                         OldFocus = FocusedElement,
                         NewFocus = element,
                         NavigationMethod = method,
-                        KeyModifiers = keyModifiers
+                        KeyModifiers = keyModifiers,
+                        IsCancellable = isFocusChangeCancellable
                     };
 
                     newFocus.RaiseEvent(gettingFocus);
 
-                    if (gettingFocus.Handled)
+                    if (gettingFocus.Cancelled)
                     {
                         changeFocus = false;
                     }

--- a/src/Avalonia.Base/Input/KeyboardDevice.cs
+++ b/src/Avalonia.Base/Input/KeyboardDevice.cs
@@ -131,8 +131,17 @@ namespace Avalonia.Input
         public void SetFocusedElement(
             IInputElement? element,
             NavigationMethod method,
+            KeyModifiers keyModifiers)
+        {
+            SetFocusedElement(element, method, keyModifiers, true);
+        }
+
+
+        public void SetFocusedElement(
+            IInputElement? element,
+            NavigationMethod method,
             KeyModifiers keyModifiers,
-            bool isFocusChangeCancellable = true)
+            bool isFocusChangeCancellable)
         {
             if (element != FocusedElement)
             {

--- a/src/Avalonia.Base/Input/KeyboardDevice.cs
+++ b/src/Avalonia.Base/Input/KeyboardDevice.cs
@@ -151,11 +151,11 @@ namespace Avalonia.Input
 
                 var losingFocus = new FocusChangingEventArgs(InputElement.LosingFocusEvent)
                 {
-                    OldFocus = FocusedElement,
-                    NewFocus = element,
+                    OldFocusedElement = FocusedElement,
+                    NewFocusedElement = element,
                     NavigationMethod = method,
                     KeyModifiers = keyModifiers,
-                    IsCancellable = isFocusChangeCancellable
+                    CanCancelOrRedirectFocus = isFocusChangeCancellable
                 };
 
                 interactive?.RaiseEvent(losingFocus);
@@ -165,15 +165,15 @@ namespace Avalonia.Input
                     changeFocus = false;
                 }
 
-                if (changeFocus && element is Interactive newFocus)
+                if (changeFocus && losingFocus.NewFocusedElement is Interactive newFocus)
                 {
                     var gettingFocus = new FocusChangingEventArgs(InputElement.GettingFocusEvent)
                     {
-                        OldFocus = FocusedElement,
-                        NewFocus = element,
+                        OldFocusedElement = FocusedElement,
+                        NewFocusedElement = losingFocus.NewFocusedElement,
                         NavigationMethod = method,
                         KeyModifiers = keyModifiers,
-                        IsCancellable = isFocusChangeCancellable
+                        CanCancelOrRedirectFocus = isFocusChangeCancellable
                     };
 
                     newFocus.RaiseEvent(gettingFocus);
@@ -182,6 +182,8 @@ namespace Avalonia.Input
                     {
                         changeFocus = false;
                     }
+
+                    element = gettingFocus.NewFocusedElement;
                 }
 
                 if (changeFocus)

--- a/src/Avalonia.Base/Input/KeyboardDevice.cs
+++ b/src/Avalonia.Base/Input/KeyboardDevice.cs
@@ -160,7 +160,7 @@ namespace Avalonia.Input
 
                 interactive?.RaiseEvent(losingFocus);
 
-                if (losingFocus.Cancelled)
+                if (losingFocus.Canceled)
                 {
                     changeFocus = false;
                 }
@@ -178,7 +178,7 @@ namespace Avalonia.Input
 
                     newFocus.RaiseEvent(gettingFocus);
 
-                    if (gettingFocus.Cancelled)
+                    if (gettingFocus.Canceled)
                     {
                         changeFocus = false;
                     }

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -965,7 +965,7 @@ namespace Avalonia.Controls
                 focused = focused.VisualParent;
 
             if (focused == this)
-                KeyboardDevice.Instance?.SetFocusedElement(null, NavigationMethod.Unspecified, KeyModifiers.None);
+                KeyboardDevice.Instance?.SetFocusedElement(null, NavigationMethod.Unspecified, KeyModifiers.None, false);
         }
 
         protected override bool BypassFlowDirectionPolicies => true;

--- a/tests/Avalonia.Base.UnitTests/Input/KeyboardDeviceTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/KeyboardDeviceTests.cs
@@ -159,5 +159,31 @@ namespace Avalonia.Base.UnitTests.Input
 
             Assert.Equal(1, propertyChangedRaised);
         }
+
+        [Fact]
+        public void Cancelled_Focus_Change_Should_Not_Send_Got_Focus_Event()
+        {
+            var target = new KeyboardDevice();
+            var focused = new Control();
+            var root = new TestRoot();
+            bool focusCancelled = false;
+
+            focused.GettingFocus += (s, e) =>
+            {
+                focusCancelled = e.TryCancel();
+            };
+
+            focused.GotFocus += (s, e) =>
+            {
+                focusCancelled = false;
+            };
+
+            target.SetFocusedElement(
+                focused,
+                NavigationMethod.Unspecified,
+                KeyModifiers.None);
+
+            Assert.True(focusCancelled);
+        }
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Input/KeyboardDeviceTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/KeyboardDeviceTests.cs
@@ -185,5 +185,28 @@ namespace Avalonia.Base.UnitTests.Input
 
             Assert.True(focusCancelled);
         }
+
+        [Fact]
+        public void Redirected_Focus_Should_Change_Focused_Element()
+        {
+            var target = new KeyboardDevice();
+            var first = new Control();
+            var second = new Control();
+            var stack = new StackPanel();
+            stack.Children.AddRange(new[] { first, second });
+            var root = new TestRoot(stack);
+
+            first.GettingFocus += (s, e) =>
+            {
+                e.TrySetNewFocusedElement(second);
+            };
+
+            target.SetFocusedElement(
+                first,
+                NavigationMethod.Unspecified,
+                KeyModifiers.None);
+
+            Assert.True(second.IsFocused);
+        }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds the following api;
```c#
public class FocusChangingEventArgs : RoutedEventArgs
    {
        /// <summary>
        /// Gets or sets the element that focus has moved to.
        /// </summary>
        public IInputElement? NewFocusedElement { get;  }

        /// <summary>
        /// Gets or sets the element that previously had focus.
        /// </summary>
        public IInputElement? OldFocusedElement { get; }

        /// <summary>
        /// Gets or sets a value indicating how the change in focus occurred.
        /// </summary>
        public NavigationMethod NavigationMethod { get; }

        /// <summary>
        /// Gets or sets any key modifiers active at the time of focus.
        /// </summary>
        public KeyModifiers KeyModifiers { get; }

        /// <summary>
        /// Gets whether focus change is canceled.
        /// </summary>
        public bool Cancelled { get; }

        /// <summary>
        /// Attempts to cancel the current focus change
        /// </summary>
        /// <returns>true if focus change was cancelled; otherwise, false</returns>
        public bool TryCancel();

        /// <summary>
        /// Attempts to redirect focus from the targeted element to the specified element.
        /// </summary>
        public bool TrySetNewFocusedElement(IInputElement? inputElement);
    }
```

Adds the following events and callbacks to `InputElement`
```c#
public static readonly RoutedEvent<FocusChangingEventArgs> GettingFocusEvent;
public static readonly RoutedEvent<FocusChangingEventArgs> LosingFocusEvent;
protected virtual void OnGettingFocus(FocusChangingEventArgs e);
protected virtual void OnLosingFocus(FocusChangingEventArgs e);

```
These api allow controls to cancel any focus change that affects them, as long as the toplevel allows. There are situations where cancelling is not allowed, like when the toplevel loses focus.

## What is the current behavior?
Focus change can't be cancelled currently. There's no api to lock focus on a control. There are cases where you want to keep keyboard focus on a control while still being able to interact with other controls, like the case of a textbox in a chat app.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
