### PR TITLE
Fix Border invisible issue when thickness set to 0.5 under 100% DPIScale

### DIFF
--- a/src/Avalonia.Base/Layout/LayoutHelper.cs
+++ b/src/Avalonia.Base/Layout/LayoutHelper.cs
@@ -189,10 +189,10 @@ namespace Avalonia.Layout
         public static Thickness RoundLayoutThickness(Thickness thickness, double dpiScaleX, double dpiScaleY)
         {
             return new Thickness(
-                RoundLayoutValue(thickness.Left, dpiScaleX),
-                RoundLayoutValue(thickness.Top, dpiScaleY),
-                RoundLayoutValue(thickness.Right, dpiScaleX),
-                RoundLayoutValue(thickness.Bottom, dpiScaleY)
+                RoundLayoutValueUp(thickness.Left, dpiScaleX),
+                RoundLayoutValueUp(thickness.Top, dpiScaleY),
+                RoundLayoutValueUp(thickness.Right, dpiScaleX),
+                RoundLayoutValueUp(thickness.Bottom, dpiScaleY)
             );
         }
 

--- a/src/Avalonia.Base/Layout/LayoutHelper.cs
+++ b/src/Avalonia.Base/Layout/LayoutHelper.cs
@@ -189,10 +189,10 @@ namespace Avalonia.Layout
         public static Thickness RoundLayoutThickness(Thickness thickness, double dpiScaleX, double dpiScaleY)
         {
             return new Thickness(
-                RoundLayoutValueUp(thickness.Left, dpiScaleX),
-                RoundLayoutValueUp(thickness.Top, dpiScaleY),
-                RoundLayoutValueUp(thickness.Right, dpiScaleX),
-                RoundLayoutValueUp(thickness.Bottom, dpiScaleY)
+                RoundLayoutValue(thickness.Left, dpiScaleX),
+                RoundLayoutValue(thickness.Top, dpiScaleY),
+                RoundLayoutValue(thickness.Right, dpiScaleX),
+                RoundLayoutValue(thickness.Bottom, dpiScaleY)
             );
         }
 

--- a/src/Avalonia.Base/Layout/LayoutHelper.cs
+++ b/src/Avalonia.Base/Layout/LayoutHelper.cs
@@ -229,7 +229,7 @@ namespace Avalonia.Layout
             }
             else
             {
-                newValue = Math.Round(value);
+                newValue = Math.Ceiling(value);
             }
 
             return newValue;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix Border invisible issue when thickness set to 0.5 under 100% DPIScale, See Details at https://github.com/AvaloniaUI/Avalonia/issues/12500 and https://github.com/AvaloniaUI/Avalonia/issues/18364

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Change RoundLayoutValue method  to Math.Ceiling when DPIScale is 100%

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
