### PR TITLE
Added surface dispose to DrawingSurfaceDemoBase

### DIFF
--- a/samples/GpuInterop/DrawingSurfaceDemoBase.cs
+++ b/samples/GpuInterop/DrawingSurfaceDemoBase.cs
@@ -33,7 +33,11 @@ public abstract class DrawingSurfaceDemoBase : Control, IGpuDemo
     protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
     {
         if (_initialized)
+        {
+            Surface?.Dispose();
             FreeGraphicsResources();
+        }
+
         _initialized = false;
         base.OnDetachedFromLogicalTree(e);
     }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Fixes #18406 - While this bug didn't appear when using single interop control (which is in samples), it was a silent killer for apps that used GpuInterop demo code as a template. 


## What is the current behavior?
Avalonia doesn't randomly hard-crash when creating and destroying demo controls.


## What is the updated/expected behavior with this PR?
Easiest way to test this fix is to run the sample from #18406 and add `surface.Dispose()` to `DrawingSurfaceDemoBase` as in this PR.


## Checklist

- [ ] Added unit tests (if possible)? - not relevant
- [ ] Added XML documentation to any related classes?  - not relevant
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation  - not relevant

## Fixed issues
Fixes #18406
