### PR TITLE
InputMethod should remove handler when remove handler

### DIFF
--- a/src/Avalonia.Base/Input/InputMethod.cs
+++ b/src/Avalonia.Base/Input/InputMethod.cs
@@ -43,7 +43,7 @@ namespace Avalonia.Input
         
         public static void RemoveTextInputMethodClientRequeryRequestedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
         {
-            element.AddHandler(TextInputMethodClientRequeryRequestedEvent, handler);
+            element.RemoveHandler(TextInputMethodClientRequeryRequestedEvent, handler);
         }
         
         private InputMethod()


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix a typo


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Open and close dialog window again and again will retain a lot of InputMethod related event handlers. 
![image](https://github.com/user-attachments/assets/d9105977-d8bc-4fa5-b963-96fb71d14c9f)



## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
handlers are properly removed. 

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
