### PR TITLE
Fix - Search for visual parents when hittesting for pointer events

### DIFF
--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -866,7 +866,7 @@ namespace Avalonia.Controls
             var candidate = hitTestElement;
             while (candidate?.IsEffectivelyEnabled == false)
             {
-                candidate = (candidate as Visual)?.Parent as IInputElement;
+                candidate = (candidate as Visual)?.VisualParent as IInputElement;
             }
 
             return candidate;

--- a/tests/Avalonia.Base.UnitTests/Input/PointerOverTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/PointerOverTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
+using Avalonia.Media;
 using Avalonia.Rendering;
 using Avalonia.UnitTests;
 
@@ -492,6 +493,60 @@ namespace Avalonia.Base.UnitTests.Input
                     (root, nameof(InputElement.PointerExited), lastClientPosition),
                 },
                 result);
+        }
+
+        [Fact]
+        public void Disabled_Element_Should_Set_PointerOver_On_Visual_Parent()
+        {
+            using var app = UnitTestApplication.Start(new TestServices(inputManager: new InputManager()));
+
+            var renderer = new Mock<IHitTester>();
+            var deviceMock = CreatePointerDeviceMock();
+            var impl = CreateTopLevelImplMock();
+
+            var disabledChild = new Border
+            {
+                Background = Brushes.Red,
+                Width = 100,
+                Height = 100,
+                IsEnabled = false
+            };
+
+            var visualParent = new Border
+            {
+                Background = Brushes.Black,
+                Width = 100,
+                Height = 100,
+                Child = disabledChild
+            };
+
+            var logicalParent = new Border
+            {
+                Background = Brushes.Blue,
+                Width = 100,
+                Height = 100
+            };
+
+            // Change the logical parent and check that we're correctly hit testing on the visual tree.
+            // This scenario is made up because it's easy to test.
+            // In the real world, this happens with nested Popups from MenuItems (but that's very cumbersome to test).
+            ((ISetLogicalParent) disabledChild).SetParent(null);
+            ((ISetLogicalParent) disabledChild).SetParent(logicalParent);
+
+            var root = CreateInputRoot(
+                impl.Object,
+                new Panel
+                {
+                    Children = { visualParent }
+                },
+                renderer.Object);
+
+            Assert.False(visualParent.IsPointerOver);
+            SetHit(renderer, disabledChild);
+
+            impl.Object.Input!(CreateRawPointerMovedArgs(deviceMock.Object, root, new Point(50, 50)));
+            Assert.True(visualParent.IsPointerOver);
+            Assert.False(logicalParent.IsPointerOver);
         }
 
         private static void AddEnteredExitedHandlers(


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes an issue created by https://github.com/AvaloniaUI/Avalonia/pull/14928 . When pointer events are generated in Toplevel, it uses the logical tree of the hittest elements, i.e. through the `Parent` property. This causes issues with detecting which part of the visual tree a pointer lost event should be sent when pointer moves over disabled elements, because that search uses the visual tree, i.e. through the `VisualParent`


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
