### PR TITLE
Raise pointer events on captured element

### DIFF
--- a/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
+++ b/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
@@ -79,7 +79,9 @@ namespace Avalonia.Input
                 else if (pointerDevice.TryGetPointer(args) is { } pointer &&
                     pointer.Type != PointerType.Touch)
                 {
-                    var element = pointer.Captured ?? args.InputHitTestResult.firstEnabledAncestor;
+                    var element = GetEffectivePointerOverElement(
+                        args.InputHitTestResult.firstEnabledAncestor,
+                        pointer.Captured);
 
                     SetPointerOver(pointer, args.Root, element, args.Timestamp, args.Position,
                         new PointerPointProperties(args.InputModifiers, args.Type.ToUpdateKind()),
@@ -96,7 +98,10 @@ namespace Avalonia.Input
 
                 if (dirtyRect.Contains(clientPoint))
                 {
-                    var element = pointer.Captured ?? _inputRoot.InputHitTest(clientPoint);
+                    var element = GetEffectivePointerOverElement(
+                        _inputRoot.InputHitTest(clientPoint),
+                        pointer.Captured);
+
                     SetPointerOver(pointer, _inputRoot, element, 0, clientPoint, PointerPointProperties.None, KeyModifiers.None);
                 }
                 else if (!((Visual)_inputRoot).Bounds.Contains(clientPoint))
@@ -105,6 +110,11 @@ namespace Avalonia.Input
                 }
             }
         }
+
+        private static IInputElement? GetEffectivePointerOverElement(IInputElement? hitTestElement, IInputElement? captured)
+            => captured is not null && hitTestElement != captured ?
+                null :
+                hitTestElement;
 
         private void ClearPointerOver()
         {

--- a/tests/Avalonia.Base.UnitTests/Input/PointerOverTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/PointerOverTests.cs
@@ -119,7 +119,7 @@ namespace Avalonia.Base.UnitTests.Input
         }
 
         [Fact]
-        public void HitTest_Should_Be_Ignored_If_Element_Captured()
+        public void HitTest_Should_Ignore_Non_Captured_Elements()
         {
             using var app = UnitTestApplication.Start(new TestServices(inputManager: new InputManager()));
 
@@ -144,8 +144,19 @@ namespace Avalonia.Base.UnitTests.Input
                 }
             }, renderer.Object);
 
-            SetHit(renderer, canvas);
             pointer.SetupGet(p => p.Captured).Returns(decorator);
+
+            // Move the pointer over the canvas: the captured decorator should lose the pointer over state.
+            SetHit(renderer, canvas);
+            impl.Object.Input!(CreateRawPointerMovedArgs(device, root));
+
+            Assert.False(decorator.IsPointerOver);
+            Assert.False(border.IsPointerOver);
+            Assert.False(canvas.IsPointerOver);
+            Assert.False(root.IsPointerOver);
+
+            // Move back the pointer over the decorator: raise events normally for it since it's captured.
+            SetHit(renderer, decorator);
             impl.Object.Input!(CreateRawPointerMovedArgs(device, root));
 
             Assert.True(decorator.IsPointerOver);


### PR DESCRIPTION
## What does the pull request do?
Alternative to #15357 - please read that PR for a better understanding of the underlying issue.

As noticed in https://github.com/AvaloniaUI/Avalonia/pull/15357#issuecomment-2642680189, completely ignoring the capture leads to some unexpected behavior, such as any control reacting to the mouse moving over, even if they aren't really clickable.

This PR changes the logic to better match UWP: pointer events are now raised for the captured element.
Note that contrary to UWP and Win32, `PointerMoved` is still only raised when the pointer is directly over the captured element.
We should consider changing that in another PR if needed.

An existing unit test has been updated.

## Fixed issues
 - Fixes #15293
