### PR TITLE
Allow [AssignBinding] on attached properties

### DIFF
--- a/src/Avalonia.Base/Data/AssignBindingAttribute.cs
+++ b/src/Avalonia.Base/Data/AssignBindingAttribute.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Data
     /// Applying this attribute to a property indicates that the binding should be assigned to 
     /// the property rather than bound.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method)]
     public sealed class AssignBindingAttribute : Attribute
     {
     }

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlAvaloniaPropertyHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlAvaloniaPropertyHelper.cs
@@ -204,12 +204,11 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
         public IXamlField AvaloniaProperty { get; }
         public XamlIlAvaloniaProperty(XamlAstClrProperty original, IXamlField field,
             AvaloniaXamlIlWellKnownTypes types)
-            :base(original, original.Name, original.DeclaringType, original.Getter, original.Setters)
+            :base(original, original.Name, original.DeclaringType, original.Getter, original.Setters, original.CustomAttributes)
         {
             var assignBinding = original.CustomAttributes.Any(ca => ca.Type.Equals(types.AssignBindingAttribute));
 
             AvaloniaProperty = field;
-            CustomAttributes = original.CustomAttributes;
             if (!assignBinding)
                 Setters.Insert(0, new BindingSetter(types, original.DeclaringType, field));
 
@@ -459,7 +458,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
 
         public XamlIlAvaloniaClassProperty(AvaloniaXamlIlWellKnownTypes types,
             string className,
-            IXamlLineInfo lineInfo) : base(lineInfo, className, types.Classes, null, null, null)
+            IXamlLineInfo lineInfo) : base(lineInfo, className, types.Classes, null)
         {
             Parameters = [types.XamlIlTypes.String];
             _method = types.GetClassProperty;

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/AssignBindingTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/AssignBindingTests.cs
@@ -1,0 +1,62 @@
+﻿#nullable enable
+
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Markup.Xaml.UnitTests.Xaml;
+
+public class AssignBindingTests : XamlTestBase
+{
+    [Fact]
+    public void AssignBinding_Works_With_Clr_Property()
+    {
+        using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+        var control = (AssignBindingTestControl)AvaloniaRuntimeXamlLoader.Load(
+            """
+            <local:AssignBindingTestControl
+                xmlns='https://github.com/avaloniaui'
+                xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'
+                ClrBinding='{Binding SomePath}' />
+            """);
+
+        Assert.NotNull(control.ClrBinding);
+    }
+
+    [Fact]
+    public void AssignBinding_Works_With_AttachedProperty()
+    {
+        using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+        var control = (Control)AvaloniaRuntimeXamlLoader.Load(
+            """
+            <Control
+                xmlns='https://github.com/avaloniaui'
+                xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'
+                local:AssignBindingTestControl.AttachedBinding='{Binding SomePath}' />
+            """);
+
+        var binding = AssignBindingTestControl.GetAttachedBinding(control);
+        Assert.NotNull(binding);
+    }
+}
+
+public sealed class AssignBindingTestControl : Control
+{
+    [AssignBinding]
+    public IBinding? ClrBinding { get; set; }
+
+    public static readonly AttachedProperty<IBinding?> AttachedBindingProperty =
+        AvaloniaProperty.RegisterAttached<AssignBindingTestControl, Control, IBinding?>("AttachedBinding");
+
+    [AssignBinding]
+    public static IBinding? GetAttachedBinding(Control obj)
+        => obj.GetValue(AttachedBindingProperty);
+
+    public static void SetAttachedBinding(Control obj, IBinding? value)
+        => obj.SetValue(AttachedBindingProperty, value);
+}


### PR DESCRIPTION
## What does the pull request do?
This PR allows `[AssignBinding]` to be used on attached property setters.
XamlX is updated to include https://github.com/kekekeks/XamlX/pull/126.
Unit tests have been added.

Necessary for #18405
