### PR TITLE
Extend diagnostic TreeNode features to more types

### DIFF
--- a/src/Avalonia.Base/StyledElement.cs
+++ b/src/Avalonia.Base/StyledElement.cs
@@ -180,12 +180,6 @@ namespace Avalonia
         /// Classes can be used to apply user-defined styling to styled elements, or to allow styled elements
         /// that share a common purpose to be easily selected.
         /// </para>
-        /// <para>
-        /// Even though this property can be set, the setter is only intended for use in object
-        /// initializers. Assigning to this property does not change the underlying collection,
-        /// it simply clears the existing collection and adds the contents of the assigned
-        /// collection.
-        /// </para>
         /// </remarks>
         public Classes Classes => _classes ??= new();
 

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/TreeNode.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/TreeNode.cs
@@ -15,26 +15,25 @@ namespace Avalonia.Diagnostics.ViewModels
         private string _classes;
         private bool _isExpanded;
 
-        protected TreeNode(AvaloniaObject avaloniaObject, TreeNode? parent, string? customName = null)
+        protected TreeNode(AvaloniaObject avaloniaObject, TreeNode? parent, string? customTypeName = null)
         {
             _classes = string.Empty;
             Parent = parent;
-            var visual = avaloniaObject ;
-            Type = customName ?? avaloniaObject.GetType().Name;
-            Visual = visual!;
+            Type = customTypeName ?? avaloniaObject.GetType().Name;
+            Visual = avaloniaObject;
             FontWeight = IsRoot ? FontWeight.Bold : FontWeight.Normal;
 
-            if (visual is Control control)
-            {
-                ElementName = control.Name;
+            ElementName = (avaloniaObject as INamed)?.Name;
 
-                _classesSubscription = ((IObservable<object?>)control.Classes.GetWeakCollectionChangedObservable())
+            if (avaloniaObject is StyledElement { Classes: { } classes })
+            {
+                _classesSubscription = ((IObservable<object?>)classes.GetWeakCollectionChangedObservable())
                     .StartWith(null)
                     .Subscribe(_ =>
                     {
-                        if (control.Classes.Count > 0)
+                        if (classes.Count > 0)
                         {
-                            Classes = "(" + string.Join(" ", control.Classes) + ")";
+                            Classes = $"({string.Join(" ", classes)})";
                         }
                         else
                         {


### PR DESCRIPTION
`TreeNode` will now:

- Display the name of any `INamed`
- Display the classes of any `StyledElement`

I also saw and removed stale documentation about a non-existent `StyledElement.Clasess` setter.

## What is the current behavior?
The name and classes of an element are only displayed for `Control` types. But other types can use these features too.

The change to `INamed` should have been made in #14757.

## Breaking changes
None

## Obsoletions / Deprecations
None
