### PR TITLE
Fix DBus type in exported menu

### DIFF
--- a/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
+++ b/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
@@ -244,7 +244,7 @@ namespace Avalonia.FreeDesktop
                             return null;
                         if (item.Gesture.KeyModifiers == 0)
                             return null;
-                        var lst = new List<string>();
+                        var lst = new Array<string>();
                         var mod = item.Gesture;
                         if (mod.KeyModifiers.HasAllFlags(KeyModifiers.Control))
                             lst.Add("Control");
@@ -255,7 +255,7 @@ namespace Avalonia.FreeDesktop
                         if (mod.KeyModifiers.HasAllFlags(KeyModifiers.Meta))
                             lst.Add("Super");
                         lst.Add(item.Gesture.Key.ToString());
-                        return VariantValue.ArrayOfVariant((VariantValue[]) [VariantValue.Array(lst)]);
+                        return new Array<Array<string>> { lst }.AsVariantValue();
                     }
 
                     if (name == "toggle-type")
@@ -324,7 +324,7 @@ namespace Avalonia.FreeDesktop
                         var layout = GetLayout(ch, (ch as NativeMenuItem)?.Menu, depth == -1 ? -1 : depth - 1, propertyNames);
                         children[c] = VariantValue.Struct(
                             VariantValue.Int32(layout.Item1),
-                            new Dict<string, VariantValue>(layout.Item2),
+                            new Dict<string, VariantValue>(layout.Item2).AsVariantValue(),
                             VariantValue.ArrayOfVariant(layout.Item3));
                     }
                 }


### PR DESCRIPTION
## What does the pull request do?
Fix the DBus type of shortcuts when exporting a menu (for example for a global menu).

## What is the current behavior?

## What is the updated/expected behavior with this PR?


## How was the solution implemented (if it's not obvious)?

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

## Obsoletions / Deprecations
None

## Fixed issues
