### PR TITLE
Fix Loaded being incorrectly raised for unloaded controls

### DIFF
--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -103,7 +103,7 @@ namespace Avalonia.Controls
         private static readonly HashSet<Control> _loadedQueue = new HashSet<Control>();
         private static readonly HashSet<Control> _loadedProcessingQueue = new HashSet<Control>();
 
-        private bool _isLoaded = false;
+        private LoadState _loadState = LoadState.Unloaded;
         private DataTemplates? _dataTemplates;
         private Control? _focusAdorner;
         private AutomationPeer? _automationPeer;
@@ -151,7 +151,7 @@ namespace Avalonia.Controls
         /// <remarks>
         /// This is set to true while raising the <see cref="Loaded"/> event.
         /// </remarks>
-        public bool IsLoaded => _isLoaded;
+        public bool IsLoaded => _loadState == LoadState.Loaded;
 
         /// <summary>
         /// Gets or sets a user-defined object attached to the control.
@@ -293,9 +293,10 @@ namespace Avalonia.Controls
         /// </summary>
         internal void ScheduleOnLoadedCore()
         {
-            if (_isLoaded == false)
+            if (_loadState == LoadState.Unloaded)
             {
                 bool isAdded = _loadedQueue.Add(this);
+                _loadState = LoadState.LoadPending;
 
                 if (isAdded &&
                     _isLoadedProcessing == false)
@@ -312,12 +313,17 @@ namespace Avalonia.Controls
         /// </summary>
         internal void OnLoadedCore()
         {
-            if (_isLoaded == false &&
+            if (_loadState == LoadState.LoadPending &&
                 ((ILogical)this).IsAttachedToLogicalTree)
             {
-                _isLoaded = true;
+                _loadState = LoadState.Loaded;
 
                 OnLoaded(new RoutedEventArgs(LoadedEvent, this));
+            }
+            else
+            {
+                // We somehow got here while being detached?
+                _loadState = LoadState.Unloaded;
             }
         }
 
@@ -327,15 +333,21 @@ namespace Avalonia.Controls
         /// </summary>
         internal void OnUnloadedCore()
         {
-            if (_isLoaded)
+            switch (_loadState)
             {
-                // Remove from the loaded event queue here as a failsafe in case the control
-                // is detached before the dispatcher runs the Loaded jobs.
-                _loadedQueue.Remove(this);
+                case LoadState.Loaded:
+                    _loadState = LoadState.Unloaded;
 
-                _isLoaded = false;
+                    OnUnloaded(new RoutedEventArgs(UnloadedEvent, this));
+                    break;
 
-                OnUnloaded(new RoutedEventArgs(UnloadedEvent, this));
+                case LoadState.LoadPending:
+                    // Remove from the loaded event queue here as a failsafe in case the control
+                    // is detached before the dispatcher runs the Loaded jobs.
+                    _loadedQueue.Remove(this);
+
+                    _loadState = LoadState.Unloaded;
+                    break;
             }
         }
 
@@ -560,6 +572,13 @@ namespace Avalonia.Controls
             _loadedQueue.Clear();
             _loadedProcessingQueue.Clear();
             _isLoadedProcessing = false;
+        }
+
+        private enum LoadState : byte
+        {
+            Unloaded,
+            Loaded,
+            LoadPending
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/LoadedTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/LoadedTests.cs
@@ -72,4 +72,38 @@ public class LoadedTests
             Assert.False(target.IsLoaded);
         }
     }
+
+    [Fact]
+    public void Loaded_Should_Not_Be_Raised_If_Detached_From_Visual_Tree()
+    {
+        using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+        var loadedCount = 0;
+        var unloadedCount = 0;
+        var window = new Window();
+        window.Show();
+
+        var target = new Button();
+
+        target.Loaded += (_, _) => loadedCount++;
+        target.Unloaded += (_, _) => unloadedCount++;
+
+        Assert.Equal(0, loadedCount);
+        Assert.Equal(0, unloadedCount);
+
+        // Attach to, then immediately detach from the visual tree.
+        window.Content = target;
+        window.Content = null;
+
+        // Attach to another logical parent (this can actually happen outside tests with overlay popups)
+        ((ISetLogicalParent) target).SetParent(new Window());
+
+        Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
+
+        // At this point, the control shouldn't have been loaded at all.
+        Assert.Null(target.VisualParent);
+        Assert.False(target.IsLoaded);
+        Assert.Equal(0, loadedCount);
+        Assert.Equal(0, unloadedCount);
+    }
 }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes an issue where the `Loaded` event could be raised on effectively unloaded controls.

## What is the current behavior?
When the following series of events occurs for a control:
 - It gets attached to the visual tree
 - It gets immediately detached from the visual tree
 - But it still has a logical parent

`Loaded` is incorrectly raised, and `IsLoaded` becomes true.

This isn't theoretical: this has been observed with overlay popups being immediately closed during a complex sequence of `Loaded` callbacks. After spending hours trying to reproduce this exact scenario in a unit test to no avail, I instead focused on testing the consequence.

## What is the updated/expected behavior with this PR?
`Loaded` isn't incorrectly raised.

## How was the solution implemented (if it's not obvious)?
`OnUnloadedCore` was supposed to remove the pending control from the `_loadedQueue`. However the logic was incorrect: it was only doing this for loaded controls, which were already removed from the queue.

A three state flag is now used instead of the boolean `_isLoaded`.

A unit test has been added.

## Fixes issues
 - May fix #15064
