### PR TITLE
Added LogToDelegate and LogToTextWriter APIs

### DIFF
--- a/src/Avalonia.Base/Logging/StringLogSink.cs
+++ b/src/Avalonia.Base/Logging/StringLogSink.cs
@@ -6,15 +6,18 @@ using Avalonia.Utilities;
 
 namespace Avalonia.Logging
 {
-    internal class TraceLogSink : ILogSink
+    internal class StringLogSink : ILogSink
     {
+        private readonly Action<string> _logger;
         private readonly LogEventLevel _level;
         private readonly IList<string>? _areas;
 
-        public TraceLogSink(
+        public StringLogSink(
+            Action<string> logger,
             LogEventLevel minimumLevel,
             IList<string>? areas = null)
         {
+            _logger = logger;
             _level = minimumLevel;
             _areas = areas?.Count > 0 ? areas : null;
         }
@@ -28,7 +31,7 @@ namespace Avalonia.Logging
         {
             if (IsEnabled(level, area))
             {
-                Trace.WriteLine(Format<object, object, object>(area, messageTemplate, source, null));
+                _logger(Format<object, object, object>(area, messageTemplate, source, null));
             }
         }
 
@@ -36,7 +39,7 @@ namespace Avalonia.Logging
         {
             if (IsEnabled(level, area))
             {
-                Trace.WriteLine(Format(area, messageTemplate, source, propertyValues));
+                _logger(Format(area, messageTemplate, source, propertyValues));
             }
         }
 

--- a/src/Avalonia.Controls/LoggingExtensions.cs
+++ b/src/Avalonia.Controls/LoggingExtensions.cs
@@ -21,7 +21,7 @@ namespace Avalonia
 
 
         /// <summary>
-        /// Logs Avalonia events a custom delegate
+        /// Logs Avalonia events to a TextWriter
         /// </summary>
         /// <param name="builder">The app builder instance.</param>
         /// <param name="writer">The TextWriter that's used for log events.</param>
@@ -34,7 +34,7 @@ namespace Avalonia
         
         
         /// <summary>
-        /// Logs Avalonia events a custom delegate
+        /// Logs Avalonia events to a custom delegate
         /// </summary>
         /// <param name="builder">The app builder instance.</param>
         /// <param name="logCallback">The callback that's used for log events.</param>

--- a/src/Avalonia.Controls/LoggingExtensions.cs
+++ b/src/Avalonia.Controls/LoggingExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Avalonia.Controls;
+﻿#define TRACE
+using System;
+using System.Diagnostics;
+using System.IO;
 using Avalonia.Logging;
 
 namespace Avalonia
@@ -12,12 +15,39 @@ namespace Avalonia
         /// <param name="level">The minimum level to log.</param>
         /// <param name="areas">The areas to log. Valid values are listed in <see cref="LogArea"/>.</param>
         /// <returns>The app builder instance.</returns>
-        public static AppBuilder LogToTrace(
+        public static AppBuilder LogToTrace(this AppBuilder builder,
+            LogEventLevel level = LogEventLevel.Warning, params string[] areas) =>
+            LogToDelegate(builder, s => Trace.WriteLine(s), level, areas);
+
+
+        /// <summary>
+        /// Logs Avalonia events a custom delegate
+        /// </summary>
+        /// <param name="builder">The app builder instance.</param>
+        /// <param name="writer">The TextWriter that's used for log events.</param>
+        /// <param name="level">The minimum level to log.</param>
+        /// <param name="areas">The areas to log. Valid values are listed in <see cref="LogArea"/>.</param>
+        /// <returns>The app builder instance.</returns>
+        public static AppBuilder LogToTextWriter(this AppBuilder builder, TextWriter writer,
+            LogEventLevel level = LogEventLevel.Warning, params string[] areas) =>
+            LogToDelegate(builder, TextWriter.Synchronized(writer).WriteLine, level, areas);
+        
+        
+        /// <summary>
+        /// Logs Avalonia events a custom delegate
+        /// </summary>
+        /// <param name="builder">The app builder instance.</param>
+        /// <param name="logCallback">The callback that's used for log events.</param>
+        /// <param name="level">The minimum level to log.</param>
+        /// <param name="areas">The areas to log. Valid values are listed in <see cref="LogArea"/>.</param>
+        /// <returns>The app builder instance.</returns>
+        public static AppBuilder LogToDelegate(
             this AppBuilder builder,
+            Action<string> logCallback,
             LogEventLevel level = LogEventLevel.Warning,
             params string[] areas)
         {
-            Logger.Sink = new TraceLogSink(level, areas);
+            Logger.Sink = new StringLogSink(logCallback, level, areas);
             return builder;
         }
     }


### PR DESCRIPTION
The intended use case is something like:

```cs
.LogToTextWriter(File.CreateText("/path/to/log.txt);
```

Right now we don't have any ILogSink implementations aside from the trace one and implementing log formatting manually is a menial task.

Which makes it more difficult to collect Avalonia logs from environments without easy access to an attached debugger.

This PR repurposes TraceLogSink into a general-purpose StringLogSink by replacing Trace.WriteLine with a delegate and adds 2 convenience methods to LoggingExtensions.
