### PR TITLE
Make mobile TryGetPlatformHandle consistent  

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -78,7 +78,8 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
             _systemNavigationManager = new AndroidSystemNavigationManagerImpl(avaloniaView.Context as IActivityNavigationService);
 
-            Surfaces = new object[] { _gl, _framebuffer, Handle };
+            Surfaces = new object[] { _gl, _framebuffer, _view };
+            Handle = new AndroidViewControlHandle(_view);
         }
 
         public IInputRoot? InputRoot { get; private set; }
@@ -102,7 +103,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         internal InvalidationAwareSurfaceView InternalView => _view;
 
         public double DesktopScaling => RenderScaling;
-        public IPlatformHandle Handle => _view;
+        public IPlatformHandle Handle { get; }
 
         public IEnumerable<object> Surfaces { get; }
 

--- a/src/Browser/Avalonia.Browser/BrowserTopLevelImpl.cs
+++ b/src/Browser/Avalonia.Browser/BrowserTopLevelImpl.cs
@@ -70,6 +70,8 @@ namespace Avalonia.Browser
             _surface.SizeChanged += OnSizeChanged;
             _surface.ScalingChanged += OnScalingChanged;
             Compositor = _surface.Compositor;
+
+            Handle = new JSObjectControlHandle(container);
         }
 
         private void OnScalingChanged()

--- a/src/iOS/Avalonia.iOS/AvaloniaView.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaView.cs
@@ -156,10 +156,9 @@ namespace Avalonia.iOS
             public TopLevelImpl(AvaloniaView view)
             {
                 _view = view;
-                var handle = new UIViewControlHandle(_view);
-                Handle = handle;
+                Handle = new UIViewControlHandle(_view);
 
-                _nativeControlHost = new NativeControlHostImpl(handle);
+                _nativeControlHost = new NativeControlHostImpl(view);
 #if TVOS
                 _storageProvider = null;
                 _clipboard = null;

--- a/src/iOS/Avalonia.iOS/AvaloniaView.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaView.cs
@@ -156,7 +156,10 @@ namespace Avalonia.iOS
             public TopLevelImpl(AvaloniaView view)
             {
                 _view = view;
-                _nativeControlHost = new NativeControlHostImpl(view);
+                var handle = new UIViewControlHandle(_view);
+                Handle = handle;
+
+                _nativeControlHost = new NativeControlHostImpl(handle);
 #if TVOS
                 _storageProvider = null;
                 _clipboard = null;

--- a/src/iOS/Avalonia.iOS/NativeControlHostImpl.cs
+++ b/src/iOS/Avalonia.iOS/NativeControlHostImpl.cs
@@ -11,11 +11,11 @@ namespace Avalonia.iOS
 {
     internal class NativeControlHostImpl : INativeControlHostImpl
     {
-        private readonly AvaloniaView _avaloniaView;
+        private readonly UIViewControlHandle _parent;
 
-        public NativeControlHostImpl(AvaloniaView avaloniaView)
+        public NativeControlHostImpl(UIViewControlHandle parent)
         {
-            _avaloniaView = avaloniaView;
+            _parent = parent;
         }
 
         public INativeControlHostDestroyableControlHandle CreateDefaultChild(IPlatformHandle parent)
@@ -25,11 +25,10 @@ namespace Avalonia.iOS
 
         public INativeControlHostControlTopLevelAttachment CreateNewAttachment(Func<IPlatformHandle, IPlatformHandle> create)
         {
-            var parent = new UIViewControlHandle(_avaloniaView);
             NativeControlAttachment? attachment = null;
             try
             {
-                var child = create(parent);
+                var child = create(_parent);
                 // It has to be assigned to the variable before property setter is called so we dispose it on exception
 #pragma warning disable IDE0017 // Simplify object initialization
                 attachment = new NativeControlAttachment(child);
@@ -106,7 +105,7 @@ namespace Avalonia.iOS
                     }
                     else
                     {
-                        _attachedTo._avaloniaView.AddSubview(_view);
+                        _attachedTo._parent.View.AddSubview(_view);
                     }
                 }
             }

--- a/src/iOS/Avalonia.iOS/NativeControlHostImpl.cs
+++ b/src/iOS/Avalonia.iOS/NativeControlHostImpl.cs
@@ -11,11 +11,11 @@ namespace Avalonia.iOS
 {
     internal class NativeControlHostImpl : INativeControlHostImpl
     {
-        private readonly UIViewControlHandle _parent;
+        private readonly AvaloniaView _avaloniaView;
 
-        public NativeControlHostImpl(UIViewControlHandle parent)
+        public NativeControlHostImpl(AvaloniaView avaloniaView)
         {
-            _parent = parent;
+            _avaloniaView = avaloniaView;
         }
 
         public INativeControlHostDestroyableControlHandle CreateDefaultChild(IPlatformHandle parent)
@@ -25,10 +25,11 @@ namespace Avalonia.iOS
 
         public INativeControlHostControlTopLevelAttachment CreateNewAttachment(Func<IPlatformHandle, IPlatformHandle> create)
         {
+            var parent = new UIViewControlHandle(_avaloniaView);
             NativeControlAttachment? attachment = null;
             try
             {
-                var child = create(_parent);
+                var child = create(parent);
                 // It has to be assigned to the variable before property setter is called so we dispose it on exception
 #pragma warning disable IDE0017 // Simplify object initialization
                 attachment = new NativeControlAttachment(child);
@@ -105,7 +106,7 @@ namespace Avalonia.iOS
                     }
                     else
                     {
-                        _attachedTo._parent.View.AddSubview(_view);
+                        _attachedTo._avaloniaView.AddSubview(_view);
                     }
                 }
             }


### PR DESCRIPTION
## What does the pull request do?

`TopLevel.TryGetPlatformHandle` is expected to return handle of the view/window where top level is hosted. That's how it works on desktop platforms, and is useful for interop integrations.
On mobile, the same API couldn't be utilized to its potential, which this PR solves.

## What is the current behavior?

iOS:
- TryGetPlatformHandle returns null

Browser:
- TryGetPlatformHandle returns null

Android:
- TryGetPlatformHandle returns Surface handle, which is only usable in the internal rendering and is already exposed by `PlatformImpl.Surfaces` (private api).

## What is the updated/expected behavior with this PR?


iOS:
- TryGetPlatformHandle returns UIViewControlHandle with UIKit view reference.

Browser:
- TryGetPlatformHandle returns JSObjectControlHandle with container `<div/>` reference.

Android:
- TryGetPlatformHandle returns AndroidViewControlHandle with Android view reference.

## Breaking changes

`Android.TryGetPlatformHandle` returns different type of handle now. But arguably, previous value wasn't useful.