### PR TITLE
Default button should not fire Click event when button is not effectively visible

### DIFF
--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -678,7 +678,7 @@ namespace Avalonia.Controls
         /// <param name="e">The event args.</param>
         private void RootDefaultKeyDown(object? sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Enter && IsVisible && IsEnabled)
+            if (e.Key == Key.Enter && IsEffectivelyVisible && IsEffectivelyEnabled)
             {
                 OnClick();
                 e.Handled = true;
@@ -692,7 +692,7 @@ namespace Avalonia.Controls
         /// <param name="e">The event args.</param>
         private void RootCancelKeyDown(object? sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Escape && IsVisible && IsEnabled)
+            if (e.Key == Key.Escape && IsEffectivelyVisible && IsEffectivelyEnabled)
             {
                 OnClick();
                 e.Handled = true;

--- a/tests/Avalonia.Controls.UnitTests/ButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ButtonTests.cs
@@ -455,6 +455,27 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(2, raised);
             }
         }
+        
+        [Fact]
+        public void Button_IsDefault_Should_Not_Work_When_Button_Is_Not_Effectively_Visible()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var raised = 0;
+                var panel = new Panel();
+                var target = new Button();
+                panel.Children.Add(target);
+                var window = new Window { Content = panel };
+                window.Show();
+
+                target.Click += (s, e) => ++raised;
+                
+                target.IsDefault = true;
+                panel.IsVisible = false;
+                window.RaiseEvent(CreateKeyDownEvent(Key.Enter));
+                Assert.Equal(0, raised);
+            }
+        }
 
         [Fact]
         public void Button_IsCancel_Works()
@@ -487,6 +508,27 @@ namespace Avalonia.Controls.UnitTests
                 window.Content = null;
                 window.RaiseEvent(CreateKeyDownEvent(Key.Escape, target));
                 Assert.Equal(2, raised);
+            }
+        }
+        
+        [Fact]
+        public void Button_IsCancel_Should_Not_Work_When_Button_Is_Not_Effectively_Visible()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var raised = 0;
+                var panel = new Panel();
+                var target = new Button();
+                panel.Children.Add(target);
+                var window = new Window { Content = panel };
+                window.Show();
+
+                target.Click += (s, e) => ++raised;
+                
+                target.IsCancel = true;
+                panel.IsVisible = false;
+                window.RaiseEvent(CreateKeyDownEvent(Key.Escape));
+                Assert.Equal(0, raised);
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR fixes an issue where the Default button could fire the Click event even if the button is not effectively visible

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The Default button fires the Click event even if it is not effectively visible

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The Default button should not fire the Click event if the button is not effectively visible

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 

Fixes #456
-->
Fixes #18479 
