### PR TITLE
Fix file modified time in storage item properties

### DIFF
--- a/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageItem.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageItem.cs
@@ -83,7 +83,7 @@ internal abstract class BclStorageItem(FileSystemInfo fileSystemInfo) : IStorage
             return new StorageItemProperties(
                 fileSystemInfo is FileInfo fileInfo ? (ulong)fileInfo.Length : 0,
                 fileSystemInfo.CreationTimeUtc,
-                fileSystemInfo.LastAccessTimeUtc);
+                fileSystemInfo.LastWriteTimeUtc);
         }
 
         return new StorageItemProperties();


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Use `LastWriteTimeUtc` instead of `LastAccessTimeUtc` for last modified time in `BclStorageItemProperties`


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/18457