### PR TITLE
Extend dirty rect when UseLayoutRounding=false

### DIFF
--- a/src/Avalonia.Base/Layout/Layoutable.cs
+++ b/src/Avalonia.Base/Layout/Layoutable.cs
@@ -916,5 +916,17 @@ namespace Avalonia.Layout
         {
             return new Size(Math.Max(size.Width, 0), Math.Max(size.Height, 0));
         }
+
+        internal override void SynchronizeCompositionProperties()
+        {
+            base.SynchronizeCompositionProperties();
+
+            if (CompositionVisual is { } visual)
+            {
+                // If the visual isn't using layout rounding, it's possible that antialiasing renders to pixels
+                // outside the current bounds. Extend the dirty rect by 1px in all directions in this case.
+                visual.ShouldExtendDirtyRect = !UseLayoutRounding;
+            }
+        }
     }
 }

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
@@ -254,6 +254,12 @@ namespace Avalonia.Rendering.Composition.Server
         {
             if (rc == default)
                 return;
+
+            // If the visual isn't using layout rounding, it's possible that antialiasing renders to pixels
+            // outside the current bounds. Extend the dirty rect by 1px in all directions in this case.
+            if (ShouldExtendDirtyRect && RenderOptions.EdgeMode != EdgeMode.Aliased)
+                rc = rc.Inflate(new Thickness(1));
+
             Root?.AddDirtyRect(rc);
         }
 

--- a/src/Avalonia.Base/composition-schema.xml
+++ b/src/Avalonia.Base/composition-schema.xml
@@ -34,6 +34,7 @@
         <Property Name="OpacityMaskBrush" ClientName="OpacityMaskBrushTransportField" Type="Avalonia.Media.IBrush?" Private="true"  />
         <Property Name="Effect" Type="Avalonia.Media.IImmutableEffect?" Internal="true" />
         <Property Name="RenderOptions" Type="Avalonia.Media.RenderOptions" />
+        <Property Name="ShouldExtendDirtyRect" Type="bool" Internal="true" />
     </Object>
     <Object Name="CompositionContainerVisual" Inherits="CompositionVisual"/>
     <Object Name="CompositionSolidColorVisual" Inherits="CompositionContainerVisual">


### PR DESCRIPTION
## What does the pull request do?
When `UseLayoutRounding == false` (which isn't the default), it's possible that anti-aliasing causes some borders to be rendered one pixel out of their bounds by Skia. Being out of bounds, the extra pixels aren't cleared when the visual moves or disappears.

This PR extends the dirty rectangle by 1px in this case.
It does _not_ change the visual bounds.

The new behavior is triggered as long as `UseLayoutRounding` is disabled and anti-aliasing is enabled. This PR does _not_ try to apply advanced heuristics to minimize the dirty rects. The exact situation when the out-of-bounds draw is triggered could be quite complex to figure out. Blitting two extra rows and columns of pixels instead should be acceptable.

## Fixed issues
 - Fixes #12157
