### PR TITLE
Prevented setting 0 to ColumnSpan or RowSpan.

### DIFF
--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -2780,7 +2780,7 @@ namespace Avalonia.Controls
             AvaloniaProperty.RegisterAttached<Grid, Control, int>(
                 "ColumnSpan",
                 defaultValue: 1,
-                validate: v => v >= 0);
+                validate: v => v > 0);
 
         /// <summary>
         /// RowSpan property. This is an attached property.
@@ -2796,7 +2796,7 @@ namespace Avalonia.Controls
             AvaloniaProperty.RegisterAttached<Grid, Control, int>(
                 "RowSpan",
                 defaultValue: 1,
-                validate: v => v >= 0);
+                validate: v => v > 0);
 
         /// <summary>
         /// IsSharedSizeScope property marks scoping element for shared size.


### PR DESCRIPTION
The current code allows setting 0 to ColumnSpan or RowSpan. 

But if this is done, for example, by calling `Grid.SetColumSpan(control, 0)`, the following exception is thrown from Avalonia's layout pass:

`ArgumentOutOfRangeException: 'Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')'`

in 

```
>	Avalonia.Base.dll!Avalonia.Collections.AvaloniaList<System.__Canon>.this[int].get(int index) Line 114	C#
 	Avalonia.Controls.dll!Avalonia.Controls.Grid.GetLengthTypeForRange(System.Collections.Generic.IReadOnlyList<Avalonia.Controls.DefinitionBase> definitions = {Avalonia.Controls.ColumnDefinitions}, int start = 0, int count = 0)	Unknown
 	Avalonia.Controls.dll!Avalonia.Controls.Grid.ValidateCellsCore()	Unknown
 	Avalonia.Controls.dll!Avalonia.Controls.Grid.ValidateCells()	Unknown
 	Avalonia.Controls.dll!Avalonia.Controls.Grid.MeasureOverride(Avalonia.Size constraint = {Avalonia.Size})	Unknown
 	Avalonia.Base.dll!Avalonia.Layout.Layoutable.MeasureCore(Avalonia.Size availableSize = {Avalonia.Size}) Line 395	C#
 	Avalonia.Base.dll!Avalonia.Layout.Layoutable.Measure(Avalonia.Size availableSize = {Avalonia.Size}) Line 278	C#
 	Avalonia.Base.dll!Avalonia.Layout.LayoutManager.Measure(Avalonia.Layout.Layoutable control = "Grid (Name = BottomOptionsGrid)") Line 264	C#
 	Avalonia.Base.dll!Avalonia.Layout.LayoutManager.ExecuteMeasurePass() Line 223	C#
 	Avalonia.Base.dll!Avalonia.Layout.LayoutManager.InnerLayoutPass() Line 207	C#
 	Avalonia.Base.dll!Avalonia.Layout.LayoutManager.ExecuteLayoutPass() Line 130	C#

```

In WPF, the ColumnSpan property immediately throws an ArgumentOfOutRange exception when 0 is set to ColumSpan.