### PR TITLE
Fix TextWrapping in combination with TextEndOfLine runs

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -574,10 +574,11 @@ namespace Avalonia.Media.TextFormatting
         {
             var measuredLength = 0;
             var currentWidth = 0.0;
+            var runIndex = 0;
 
-            for (var i = 0; i < textRuns.Count; ++i)
+            for (; runIndex < textRuns.Count; ++runIndex)
             {
-                var currentRun = textRuns[i];
+                var currentRun = textRuns[runIndex];
 
                 switch (currentRun)
                 {
@@ -630,7 +631,14 @@ namespace Avalonia.Media.TextFormatting
                                             runLength = clusterLength;
                                         }
 
-                                        return measuredLength + runLength;
+                                        measuredLength += runLength;
+
+                                        if (runIndex < textRuns.Count - 1 && runLength == currentRun.Length && textRuns[runIndex + 1] is TextEndOfLine endOfLine)
+                                        {
+                                            measuredLength += endOfLine.Length;
+                                        }
+
+                                        return measuredLength;
                                     }
 
                                     currentWidth += clusterWidth;

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
@@ -1160,6 +1160,30 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
             }
         }
 
+        [Fact]
+        public void Should_Wrap_With_LineEnd()
+        {
+            using (Start())
+            {
+                var defaultProperties =
+                   new GenericTextRunProperties(Typeface.Default, 72, foregroundBrush: Brushes.Black);
+
+                var paragraphProperties = new GenericTextParagraphProperties(defaultProperties, textWrap: TextWrapping.Wrap);
+
+                var textLayout = new TextLayout(new SingleBufferTextSource("01", defaultProperties, true), paragraphProperties, maxWidth: 36);
+
+                Assert.Equal(2, textLayout.TextLines.Count);
+
+                var lastLine = textLayout.TextLines.Last();
+
+                Assert.Equal(2, lastLine.TextRuns.Count);
+
+                var lastRun = lastLine.TextRuns.Last();
+
+                Assert.IsAssignableFrom<TextEndOfLine>(lastRun);
+            }
+        }
+
         private static IDisposable Start()
         {
             var disposable = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR makes sure the text wrapping algorithm isn't pushing EOL runs to a new line if we break right before the EOL run. Otherwise we end up getting an additional unwanted line.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
