### PR TITLE
Dismiss popups when toplevel deactivates in embedded scenarios

### DIFF
--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -15,6 +15,7 @@ using Avalonia.Metadata;
 using Avalonia.Platform;
 using Avalonia.VisualTree;
 using Avalonia.Media;
+using Avalonia.Interactivity;
 
 namespace Avalonia.Controls.Primitives
 {
@@ -495,13 +496,13 @@ namespace Avalonia.Controls.Primitives
             SubscribeToEventHandler<Control, EventHandler<VisualTreeAttachmentEventArgs>>(placementTarget, TargetDetached,
                 (x, handler) => x.DetachedFromVisualTree += handler,
                 (x, handler) => x.DetachedFromVisualTree -= handler).DisposeWith(handlerCleanup);
-            
+
             if (topLevel is Window window && window.PlatformImpl != null)
             {
                 SubscribeToEventHandler<Window, EventHandler>(window, WindowDeactivated,
                     (x, handler) => x.Deactivated += handler,
                     (x, handler) => x.Deactivated -= handler).DisposeWith(handlerCleanup);
-                
+
                 SubscribeToEventHandler<IWindowImpl, Action>(window.PlatformImpl, WindowLostFocus,
                     (x, handler) => x.LostFocus += handler,
                     (x, handler) => x.LostFocus -= handler).DisposeWith(handlerCleanup);
@@ -534,6 +535,12 @@ namespace Avalonia.Controls.Primitives
                         (x, handler) => x.Closed += handler,
                         (x, handler) => x.Closed -= handler).DisposeWith(handlerCleanup);
                 }
+            }
+            else if (topLevel is { } tl && tl.PlatformImpl is ITopLevelImpl pimpl)
+            {
+                SubscribeToEventHandler<ITopLevelImpl, Action>(pimpl, TopLevelLostPlatformFocus,
+                    (x, handler) => x.LostFocus += handler,
+                    (x, handler) => x.LostFocus -= handler).DisposeWith(handlerCleanup);
             }
 
             InputManager.Instance?.Process.Subscribe(ListenForNonClientClick).DisposeWith(handlerCleanup);
@@ -981,6 +988,14 @@ namespace Avalonia.Controls.Primitives
         }
 
         private void ParentClosed(object? sender, EventArgs e)
+        {
+            if (IsLightDismissEnabled)
+            {
+                Close();
+            }
+        }
+
+        private void TopLevelLostPlatformFocus()
         {
             if (IsLightDismissEnabled)
             {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
If a context menu is shown from an avalonia control embedded in a native window, like in winforms or wpf, dismiss it if the popup deactivates. This mirrors the behavior of menus

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
