### PR TITLE
Set build number to version on CI

### DIFF
--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -20,6 +20,7 @@ using static Nuke.Common.Tools.VSWhere.VSWhereTasks;
 using static Serilog.Log;
 using MicroCom.CodeGenerator;
 using NuGet.Configuration;
+using Nuke.Common.CI.AzurePipelines;
 using Nuke.Common.IO;
 
 /*
@@ -79,6 +80,9 @@ partial class Build : NukeBuild
         ExecWait("dotnet workloads:", "dotnet", "workload list");
         Information("Processor count: " + Environment.ProcessorCount);
         Information("Available RAM: " + GC.GetGCMemoryInfo().TotalAvailableMemoryBytes / 0x100000 + "MB");
+
+        if (Host is AzurePipelines azurePipelines)
+            azurePipelines.UpdateBuildNumber(Parameters.Version);
     }
 
     DotNetConfigHelper ApplySettingCore(DotNetConfigHelper c)

--- a/nukebuild/BuildParameters.cs
+++ b/nukebuild/BuildParameters.cs
@@ -94,8 +94,7 @@ public partial class Build
             IsRunningOnUnix = Environment.OSVersion.Platform == PlatformID.Unix ||
                               Environment.OSVersion.Platform == PlatformID.MacOSX;
             IsRunningOnWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            IsRunningOnAzure = Host is AzurePipelines ||
-                               Environment.GetEnvironmentVariable("LOGNAME") == "vsts";
+            IsRunningOnAzure = Host is AzurePipelines;
 
             if (IsRunningOnAzure)
             {


### PR DESCRIPTION
## What does the pull request do?
This PR sets the build number to the version being currently built in our Azure DevOps pipeline, making it easier to find a specific build.

## What is the current behavior?
The build number looks like `20250307.4`.

## What is the updated/expected behavior with this PR?
The build number looks like `11.3.999-cibuild0055774-alpha`.
