### PR TITLE
Fixed invalid monitor detection when changing window position

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -527,8 +527,7 @@ namespace Avalonia.Win32
                 
                 if (ShCoreAvailable && Win32Platform.WindowsVersion >= PlatformConstants.Windows8_1)
                 {
-                    var monitor = MonitorFromPoint(new POINT() { X = value.X, Y = value.Y },
-                        MONITOR.MONITOR_DEFAULTTONEAREST);
+                    var monitor = MonitorFromWindow(Handle.Handle, MONITOR.MONITOR_DEFAULTTONEAREST);
 
                     if (GetDpiForMonitor(
                             monitor,


### PR DESCRIPTION
A regression got introduced by https://github.com/AvaloniaUI/Avalonia/pull/16158 that would cause a window to jump between DPIs when showing.

Regression is caused by using a random API to get the window's monitor instead of one specifically designated for getting a window's monitor 