### PR TITLE
Fix DateTimePickerPanel scrolling exception

### DIFF
--- a/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
@@ -234,7 +234,7 @@ namespace Avalonia.Controls.Primitives
                         else
                             break;
                     }
-                    children.MoveRange(0, numCountsToMove, children.Count);
+                    children.MoveRange(0, numCountsToMove, children.Count - 1);
 
                     var scrollHeight = _extent.Height - Viewport.Height;
                     if (ShouldLoop && value.Y >= scrollHeight - _extentOne)

--- a/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
@@ -275,6 +275,40 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        [Theory]
+        [InlineData("PART_HourSelector")]
+        [InlineData("PART_MinuteSelector")]
+        [InlineData("PART_SecondSelector")]
+        public void Selector_ScrollUp_Should_Work(string selectorName)
+            => TestSelectorScrolling(selectorName, panel => panel.ScrollUp());
+
+        [Theory]
+        [InlineData("PART_HourSelector")]
+        [InlineData("PART_MinuteSelector")]
+        [InlineData("PART_SecondSelector")]
+        public void Selector_ScrollDown_Should_Work(string selectorName)
+            => TestSelectorScrolling(selectorName, panel => panel.ScrollDown());
+
+        private static void TestSelectorScrolling(string selectorName, Action<DateTimePickerPanel> scroll)
+        {
+            using var app = UnitTestApplication.Start(Services);
+
+            var presenter = new TimePickerPresenter { Template = CreatePickerTemplate() };
+            presenter.ApplyTemplate();
+            presenter.Measure(new Size(1000, 1000));
+
+            var panel = presenter
+                .GetVisualDescendants()
+                .OfType<DateTimePickerPanel>()
+                .FirstOrDefault(panel => panel.Name == selectorName);
+
+            Assert.NotNull(panel);
+
+            var previousOffset = panel.Offset;
+            scroll(panel);
+            Assert.NotEqual(previousOffset, panel.Offset);
+        }
+
         private static TestServices Services => TestServices.MockThreadingInterface.With(
             fontManagerImpl: new HeadlessFontManagerStub(),
             standardCursorFactory: Mock.Of<ICursorFactory>(),
@@ -398,12 +432,14 @@ namespace Avalonia.Controls.UnitTests
                 {
                     Name = "PART_HourSelector",
                     PanelType = DateTimePickerPanelType.Hour,
+                    ShouldLoop = true
                 }.RegisterInNameScope(scope);
 
                 var minuteSelector = new DateTimePickerPanel
                 {
                     Name = "PART_MinuteSelector",
                     PanelType = DateTimePickerPanelType.Minute,
+                    ShouldLoop = true
                 }.RegisterInNameScope(scope);
 
                 var secondHost = new Panel
@@ -415,6 +451,7 @@ namespace Avalonia.Controls.UnitTests
                 {
                     Name = "PART_SecondSelector",
                     PanelType = DateTimePickerPanelType.Second,
+                    ShouldLoop = true
                 }.RegisterInNameScope(scope);
 
                 var periodHost = new Panel
@@ -443,7 +480,7 @@ namespace Avalonia.Controls.UnitTests
                     Name = "PART_ThirdSpacer"
                 }.RegisterInNameScope(scope);
 
-                var contentPanel = new StackPanel();
+                var contentPanel = new Panel();
                 contentPanel.Children.AddRange(new Control[] { acceptButton, hourSelector, minuteSelector, secondHost, secondSelector, periodHost, periodSelector, pickerContainer, secondSpacer, thirdSpacer });
                 return contentPanel;
             });


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a crash occurring when `DatePicker` or `TimePicker` is scrolled down.

This was introduced by #17171. That PR was fine, but the `DateTimePickerPanel` relied on being able to call `MoveRange()` with an index outside of the collection, which isn't allowed anymore.

Unit tests have been added.

## Time spent
To fix the issue: about 4.2 seconds.
To write the failing tests: about +∞ + 2 years.

## Fixed issues
 - Fixes #18580 
