### PR TITLE
[Grid] Fix ColumnSpacing property name

### DIFF
--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -1,4 +1,4 @@
-// This source file is adapted from the Windows Presentation Foundation project. 
+﻿// This source file is adapted from the Windows Presentation Foundation project. 
 // (https://github.com/dotnet/wpf/) 
 // 
 // Licensed to The Avalonia Project under MIT License, courtesy of The .NET Foundation.
@@ -2730,7 +2730,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="ColumnSpacing"/> property.
         /// </summary>
         public static readonly StyledProperty<double> ColumnSpacingProperty =
-            AvaloniaProperty.Register<Grid, double>(nameof(ColumnSpacingProperty));
+            AvaloniaProperty.Register<Grid, double>(nameof(ColumnSpacing));
 
         /// <summary>
         /// Column property. This is an attached property.


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR fixes the name of the styled property `ColumnSpacingProperty`.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
![2025-04-07 114755](https://github.com/user-attachments/assets/6bf7069f-e760-43ce-93f2-f9776b8292d5)


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
![2025-04-07 121423](https://github.com/user-attachments/assets/40e2dba5-839a-41d0-9639-228e070bde04)


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
