### PR TITLE
Fix Window.Show when MinWidth > MaxWidth

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -734,9 +734,11 @@ namespace Avalonia.Controls
                     double.IsNaN(Width) ? ClientSize.Width : Width,
                     double.IsNaN(Height) ? ClientSize.Height : Height);
 
+                var minMax = new MinMax(this);
+
                 initialSize = new Size(
-                MathUtilities.Clamp(initialSize.Width, MinWidth, MaxWidth),
-                MathUtilities.Clamp(initialSize.Height, MinHeight, MaxHeight));
+                    MathUtilities.Clamp(initialSize.Width, minMax.MinWidth, minMax.MaxWidth),
+                    MathUtilities.Clamp(initialSize.Height, minMax.MinHeight, minMax.MaxHeight));
 
                 var clientSizeChanged = initialSize != ClientSize;
                 ClientSize = initialSize; // ClientSize is required for Measure and Arrange
@@ -746,14 +748,14 @@ namespace Avalonia.Controls
 
                 if (SizeToContent.HasFlag(SizeToContent.Width))
                 {
-                    initialSize = initialSize.WithWidth(MathUtilities.Clamp(_arrangeBounds.Width, MinWidth, MaxWidth));
+                    initialSize = initialSize.WithWidth(MathUtilities.Clamp(_arrangeBounds.Width, minMax.MinWidth, minMax.MaxWidth));
                     clientSizeChanged |= initialSize != ClientSize;
                     ClientSize = initialSize;
                 }
 
                 if (SizeToContent.HasFlag(SizeToContent.Height))
                 {
-                    initialSize = initialSize.WithHeight(MathUtilities.Clamp(_arrangeBounds.Height, MinHeight, MaxHeight));
+                    initialSize = initialSize.WithHeight(MathUtilities.Clamp(_arrangeBounds.Height, minMax.MinHeight, minMax.MaxHeight));
                     clientSizeChanged |= initialSize != ClientSize;
                     ClientSize = initialSize;
                 }

--- a/src/Avalonia.Dialogs/AboutAvaloniaDialog.xaml
+++ b/src/Avalonia.Dialogs/AboutAvaloniaDialog.xaml
@@ -1,7 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:dialogs="using:Avalonia.Dialogs"
-        MaxWidth="400"
+        MaxWidth="430"
         MaxHeight="475"
         MinWidth="430"
         MinHeight="475"

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -1091,6 +1091,25 @@ namespace Avalonia.Controls.UnitTests
                     Assert.True(task.IsCompletedSuccessfully);
                 }
             }
+
+            [Fact]
+            public void Show_Works_When_Min_Dimension_Greater_Than_Max()
+            {
+                using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+                var target = new Window
+                {
+                    MinWidth = 100,
+                    MaxWidth = 80,
+                    MinHeight = 200,
+                    MaxHeight = 180
+                };
+
+                Show(target);
+
+                Assert.Equal(100, target.Width);
+                Assert.Equal(200, target.Height);
+            }
             
             protected virtual void Show(Window window)
             {


### PR DESCRIPTION
## What does the pull request do?
This PR fixes `Window.Show` throwing in 11.3 when `MinWidth` is greater than `MaxWidth` (also applies to `MinHeight`/`MaxHeight`).

This used to work in previous versions: the issue was introduced by #16158.

A unit test has been added.

This PR also changes `AboutAvaloniaDialog`, which had wrong dimensions (and where the bug was found).

## What is the current behavior?
Having `MinWidth/Height` greater than `MaxWidth/MaxHeight` throws.

## What is the updated/expected behavior with this PR?
Having `MinWidth/Height` greater than `MaxWidth/MaxHeight` works, with the maximum value winning.

## How was the solution implemented (if it's not obvious)?
The existing internal `MinMax` structure is used, which already coerces the values properly.
