### PR TITLE
Disable Metal by default on macOS for 11.3

### DIFF
--- a/src/Avalonia.Native/AvaloniaNativePlatformExtensions.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatformExtensions.cs
@@ -65,8 +65,8 @@ namespace Avalonia
         /// <exception cref="System.InvalidOperationException">Thrown if no values were matched.</exception>
         public IReadOnlyList<AvaloniaNativeRenderingMode> RenderingMode { get; set; } = new[]
         {
-            AvaloniaNativeRenderingMode.Metal,
             AvaloniaNativeRenderingMode.OpenGl,
+            AvaloniaNativeRenderingMode.Metal,
             AvaloniaNativeRenderingMode.Software
         };
 


### PR DESCRIPTION
## What does the pull request do?
This PR sets back OpenGL as the default rendering engine on macOS for Avalonia 11.3.
Metal still has issues for now. Please read #17508 for more details - the reasoning is the same as for 11.2.
