### PR TITLE
Fix Windows ALT codes (#15938, #18159)

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1258,6 +1258,9 @@ namespace Avalonia.Win32.Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool GetKeyboardState(byte* lpKeyState);
 
+        [DllImport("user32.dll")]
+        public static extern short GetKeyState(int nVirtKey);
+
         [DllImport("user32.dll", EntryPoint = "MapVirtualKeyW")]
         public static extern uint MapVirtualKey(uint uCode, uint uMapType);
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -867,6 +867,48 @@ namespace Avalonia.Win32
             {
                 Input(e);
 
+                // Notes: Keyboard input
+                // ---------------------
+                //
+                // Standard keyboard input produces the following sequence of messages:
+                //
+                // - WM_KEYDOWN: 'A'
+                // - WM_CHAR: 'A'
+                // - WM_KEYUP: 'A'
+                //
+                // Note that the WM_CHAR message is created and posted to the thread's message queue
+                // by TranslateMessage() in the message loop.
+                //
+                // Keyboard navigation (e.g. using arrow keys) produces the following sequence of
+                // messages:
+                //
+                // - WM_KEYDOWN: VK_RIGHT
+                // - WM_KEYUP: VK_RIGHT
+                //
+                // Entering an ALT code produces the following sequence of messages:
+                //
+                // - WM_SYSKEYDOWN: VK_MENU ... ALT key is pressed.
+                // - WM_SYSKEYDOWN: VK_NUMPAD1
+                // - WM_SYSKEYUP: VK_NUMPAD1
+                // - WM_KEYUP: VK_MENU ........ ALT key is released.
+                // - WM_CHAR: '☺'
+                //
+                // With an Input Method Editor (IME), users can enter complex scripts, such as 
+                // Japanese characters. Examples messages:
+                //
+                // - WM_KEYDOWN: VK_PROCESSKEY
+                // - WM_KEYUP: 'K'
+                // - WM_KEYUP: 'A'
+                // - WM_KEYDOWN: VK_PROCESSKEY
+                // - WM_CHAR: 'カ'
+                // - WM_KEYUP VK_RETURN
+                //
+                // References:
+                // - Microsoft: Win32 Keyboard Input
+                //   https://learn.microsoft.com/en-us/windows/win32/learnwin32/keyboard-input
+                // - Wikipedia: ALT codes
+                //   https://en.wikipedia.org/wiki/Alt_code
+
                 if (message == WindowsMessage.WM_KEYDOWN)
                 {
                     if(e is RawKeyEventArgs args && args.Key == Key.ImeProcessed)
@@ -881,7 +923,11 @@ namespace Avalonia.Win32
                         // is handled.
                         _ignoreWmChar = e.Handled;
                     }
-                 }
+                } 
+                else if (message == WindowsMessage.WM_KEYUP)
+                {
+                    _ignoreWmChar = false;
+                }
 
                 if (s_intermediatePointsPooledList.Count > 0)
                 {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

This PR fixes ALT codes for Windows. 

## What is the current behavior?

On Windows, [ALT codes](https://en.wikipedia.org/wiki/Alt_code) can be entered by holding `ALT` and entering a number on the numpad. For example: ALT+5 produces '♣'. This behavior is currently broken:

- The wrong ALT codes are produced. For example, `ALT+5` produces '7' (`ALT+55`) instead of '♣'.
- Pressing the ALT code really quickly may sometimes produce the right ALT code.
- The resulting character does not appear when entered after pressing an arrow key (or other navigation key).
- ALT in combination with arrow keys insert unexpected symbols. For example, pressing `ALT+↓` produces the ALT code for `ALT+22`.

## What is the updated/expected behavior with this PR?

ALT codes are now produced correctly and no longer swallowed.
Other ALT combinations (non-numpad keys) no longer produce ALT codes.

Tested on: Windows 11 Pro (Version 24H2, OS build 26100.3476)

I have tested ALT codes with English (US) and German keyboard layouts:

✅ ALT codes are produced correctly.
✅ German AltGr combinations continue to work as expected.
✅ IME (such as Japanese characters) continues to work as expected.

## How was the solution implemented (if it's not obvious)?

The main changes:
- Calling `TranslateMessage` while entering an ALT code seems to mess up the keyboard input.
- `_ignoreWmChar` needs to be reset, otherwise it can swallow input.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
–

## Obsoletions / Deprecations
–

## Fixed issues

Fixes #15938
Fixes #18159
