### PR TITLE
Fix Windows Alt codes

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -180,11 +180,12 @@ namespace Avalonia.Win32
                     return LoadIcon(requestIcon, requestDpi)?.Handle ?? default;
 
                 case WindowsMessage.WM_KEYDOWN:
+                    e = TryCreateRawKeyEventArgs(RawKeyEventType.KeyDown, timestamp, wParam, lParam, true);
+                    break;
+
                 case WindowsMessage.WM_SYSKEYDOWN:
-                    {
-                        e = TryCreateRawKeyEventArgs(RawKeyEventType.KeyDown, timestamp, wParam, lParam);
-                        break;
-                    }
+                    e = TryCreateRawKeyEventArgs(RawKeyEventType.KeyDown, timestamp, wParam, lParam, false);
+                    break;
 
                 case WindowsMessage.WM_SYSCOMMAND:
                     // Disable system handling of Alt/F10 menu keys.
@@ -199,11 +200,15 @@ namespace Avalonia.Win32
                     }
 
                 case WindowsMessage.WM_KEYUP:
+                    e = TryCreateRawKeyEventArgs(RawKeyEventType.KeyUp, timestamp, wParam, lParam, true);
+                    _ignoreWmChar = false;
+                    break;
+
                 case WindowsMessage.WM_SYSKEYUP:
-                    {
-                        e = TryCreateRawKeyEventArgs(RawKeyEventType.KeyUp, timestamp, wParam, lParam);
-                        break;
-                    }
+                    e = TryCreateRawKeyEventArgs(RawKeyEventType.KeyUp, timestamp, wParam, lParam, false);
+                    _ignoreWmChar = false;
+                    break;
+
                 case WindowsMessage.WM_CHAR:
                     {
                         if (Imm32InputMethod.Current.IsComposing)
@@ -219,6 +224,7 @@ namespace Avalonia.Win32
                             e = new RawTextInputEventArgs(WindowsKeyboardDevice.Instance, timestamp, Owner, text);
                         }
 
+                        _ignoreWmChar = false;
                         break;
                     }
 
@@ -881,7 +887,7 @@ namespace Avalonia.Win32
                         // is handled.
                         _ignoreWmChar = e.Handled;
                     }
-                 }
+                }
 
                 if (s_intermediatePointsPooledList.Count > 0)
                 {
@@ -1314,13 +1320,16 @@ namespace Avalonia.Win32
             return modifiers;
         }
 
-        private RawKeyEventArgs? TryCreateRawKeyEventArgs(RawKeyEventType eventType, ulong timestamp, IntPtr wParam, IntPtr lParam)
+        private RawKeyEventArgs? TryCreateRawKeyEventArgs(RawKeyEventType eventType, ulong timestamp, IntPtr wParam, IntPtr lParam, bool useKeySymbol)
         {
             var virtualKey = ToInt32(wParam);
             var keyData = ToInt32(lParam);
             var key = KeyInterop.KeyFromVirtualKey(virtualKey, keyData);
             var physicalKey = KeyInterop.PhysicalKeyFromVirtualKey(virtualKey, keyData);
-            var keySymbol = KeyInterop.GetKeySymbol(virtualKey, keyData);
+
+            // Avoid calling GetKeySymbol() for WM_SYSKEYDOWN/UP:
+            // it ultimately calls User32!ToUnicodeEx, which messes up the keyboard state in this case.
+            var keySymbol = useKeySymbol ? KeyInterop.GetKeySymbol(virtualKey, keyData) : null;
 
             if (key == Key.None && physicalKey == PhysicalKey.None && string.IsNullOrWhiteSpace(keySymbol))
                 return null;


### PR DESCRIPTION
## What does the pull request do?
This PR fixes Alt codes (alt+numpad) on Windows.
This is an alternative to #18612.

## What is the current behavior?
Using Alt codes produce the wrong characters.
See #15938 for more details.

## What is the updated/expected behavior with this PR?
Alt codes are correctly handled and produce the expected characters.

## How was the solution implemented (if it's not obvious)?
The issue was introduced in #12549, which added the `KeySymbol` property.
The `KeySymbol` is computed using Win32 [ToUnicodeEx](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-tounicodeex), which can mess up the keyboard state (even though we're explicitly passing a flag to avoid that...)

`WM_SYSKEYDOWN/UP` never produces any key symbol anyways, so this PR avoids calling `ToUnicodeEx` in this case.

## Fixed issues
 - Fixes #15938
 - Fixes #18159
