### PR TITLE
Fix Windows IME

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -223,8 +223,6 @@ namespace Avalonia.Win32
 
                             e = new RawTextInputEventArgs(WindowsKeyboardDevice.Instance, timestamp, Owner, text);
                         }
-
-                        _ignoreWmChar = false;
                         break;
                     }
 


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a recent regression causing duplicate IME inputs on Windows, introduced by #18624.

## Notes
We need integration tests for this. It should in theory be feasible by installing language packs on the agent, switching the IME and simulating key presses. However, since this might take a while to get right, this will be done separately.

## Fixed issues
 - Fixes #18644
