### PR TITLE
Fix height queries not matching when container name is set, remove unused query grammer and allow nesting selector in container styles

### DIFF
--- a/src/Avalonia.Base/Styling/NestingSelector.cs
+++ b/src/Avalonia.Base/Styling/NestingSelector.cs
@@ -27,6 +27,14 @@ namespace Avalonia.Styling
                     SelectorMatch.AlwaysThisType :
                     SelectorMatch.NeverThisType;
             }
+            else if (parent is ContainerQuery query && query.Parent is ControlTheme queryTheme)
+            {
+                if (queryTheme.TargetType is null)
+                    throw new InvalidOperationException("ControlTheme has no TargetType.");
+                return queryTheme.TargetType.IsAssignableFrom(StyledElement.GetStyleKey(control)) ?
+                    SelectorMatch.AlwaysThisType :
+                    SelectorMatch.NeverThisType;
+            }
 
             throw new InvalidOperationException(
                 "Nesting selector was specified but cannot determine parent selector.");

--- a/src/Avalonia.Base/Styling/ScreenQueries.cs
+++ b/src/Avalonia.Base/Styling/ScreenQueries.cs
@@ -64,7 +64,7 @@ namespace Avalonia.Styling
             }
 
             return IsTrue(argument.@operator, argument.value) ?
-                new SelectorMatch(SelectorMatchResult.AlwaysThisInstance) : SelectorMatch.NeverThisInstance;
+                SelectorMatch.AlwaysThisInstance : SelectorMatch.NeverThisInstance;
         }
 
         public override string ToString() => "width";
@@ -90,7 +90,7 @@ namespace Avalonia.Styling
 
             if (subscribe)
             {
-                return new SelectorMatch(new HeightActivator(visual, Argument));
+                return new SelectorMatch(new HeightActivator(visual, Argument, containerName));
             }
 
             if (ContainerQueryActivatorBase.GetContainer(visual, containerName) is { } container
@@ -104,9 +104,9 @@ namespace Avalonia.Styling
             return SelectorMatch.NeverThisInstance;
         }
 
-        internal static SelectorMatch Evaluate(VisualQueryProvider screenSizeProvider, (StyleQueryComparisonOperator @operator, double value) argument)
+        internal static SelectorMatch Evaluate(VisualQueryProvider queryProvider, (StyleQueryComparisonOperator @operator, double value) argument)
         {
-            var height = screenSizeProvider.Height;
+            var height = queryProvider.Height;
             if (double.IsNaN(height))
             {
                 return SelectorMatch.NeverThisInstance;

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/ContainerQueryGrammar.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/ContainerQueryGrammar.cs
@@ -169,50 +169,6 @@ namespace Avalonia.Markup.Parsers
 
             return double.Parse(number.ToString());
         }
-        
-        private static StyleQueryComparisonOperator ParseOperator(ref CharacterReader r)
-        {
-            r.SkipWhitespace();
-            var queryOperator = r.TakeWhile(x => !char.IsWhiteSpace(x));
-
-            return queryOperator.ToString() switch
-            {
-                "=" => StyleQueryComparisonOperator.Equals,
-                "<" => StyleQueryComparisonOperator.LessThan,
-                ">" => StyleQueryComparisonOperator.GreaterThan,
-                "<=" => StyleQueryComparisonOperator.LessThanOrEquals,
-                ">=" => StyleQueryComparisonOperator.GreaterThanOrEquals,
-                "" => StyleQueryComparisonOperator.None,
-                _ => throw new ExpressionParseException(r.Position, $"Expected a comparison operator after.")
-            };
-        }
-        
-        private static T ParseEnum<T>(ref CharacterReader r) where T: struct
-        {
-            var identifier = r.ParseIdentifier();
-
-            if (Enum.TryParse<T>(identifier.ToString(), true, out T value))
-                return value;
-
-            throw new ExpressionParseException(r.Position, $"Expected a {typeof(T)} after.");
-        }
-        
-        private static string ParseString(ref CharacterReader r) 
-        {
-            return r.ParseIdentifier().ToString();
-        }
-
-        private static void Expect(ref CharacterReader r, char c)
-        {
-            if (r.End)
-            {
-                throw new ExpressionParseException(r.Position, $"Expected '{c}', got end of selector.");
-            }
-            else if (!r.TakeIf(')'))
-            {
-                throw new ExpressionParseException(r.Position, $"Expected '{c}', got '{r.Peek}'.");
-            }
-        }
 
         public class OrSyntax : ISyntax
         {

--- a/tests/Avalonia.Base.UnitTests/Styling/ContainerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/ContainerTests.cs
@@ -111,7 +111,7 @@ namespace Avalonia.Base.UnitTests.Styling
         }
 
         [Fact]
-        public void Container_Queries_Matches_Name()
+        public void Container_Width_Queries_Matches_Name()
         {
             using var app = UnitTestApplication.Start();
             var root = new LayoutTestRoot()
@@ -159,6 +159,57 @@ namespace Avalonia.Base.UnitTests.Styling
 
             root.LayoutManager.ExecuteLayoutPass();
             Assert.Equal(child.Width, 300.0);
+        }
+
+        [Fact]
+        public void Container_Height_Queries_Matches_Name()
+        {
+            using var app = UnitTestApplication.Start();
+            var root = new LayoutTestRoot()
+            {
+                ClientSize = new Size(600, 600)
+            };
+            var containerQuery1 = new ContainerQuery(x => new HeightQuery(x, StyleQueryComparisonOperator.LessThanOrEquals, 500));
+            containerQuery1.Children.Add(new Style(x => x.Is<Border>())
+            {
+                Setters = { new Setter(Control.HeightProperty, 200.0) }
+            });
+            var containerQuery2 = new ContainerQuery(x => new HeightQuery(x, StyleQueryComparisonOperator.LessThanOrEquals, 500), "TEST");
+            containerQuery2.Children.Add(new Style(x => x.Is<Border>())
+            {
+                Setters = { new Setter(Control.HeightProperty, 300.0) }
+            });
+            root.Styles.Add(containerQuery2);
+            root.Styles.Add(containerQuery1);
+            var child = new Border()
+            {
+                Name = "Child",
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Stretch
+            };
+            var controlInner = new ContentControl()
+            {
+                Width = 400,
+                Height = 400,
+                Content = child,
+                Name = "Inner"
+            };
+            Container.SetSizing(controlInner, Avalonia.Styling.ContainerSizing.Height);
+            Container.SetName(controlInner, "TEST");
+            var border = new Border()
+            {
+                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch,
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Stretch,
+                Child = controlInner,
+                Name = "Parent"
+            };
+            Container.SetSizing(border, Avalonia.Styling.ContainerSizing.Height);
+
+            root.Child = border;
+
+            root.LayoutManager.ExecuteInitialLayoutPass();
+
+            root.LayoutManager.ExecuteLayoutPass();
+            Assert.Equal(child.Height, 300.0);
         }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes the following issues
1. Height queries weren't setting their container name.
2. There was some code used for cut query grammer still left over.
3. Query in ControlThemes didn't allow styles to use nested operator. It still wouldn't apply the styles to the container since containers can't be styled by containing styles, but it shouldn't crash if a user decides to use them.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
