### PR TITLE
Fix `MenuItem` enabled state in the presence of sub-items.

### DIFF
--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Windows.Input;
 using Avalonia.Automation;
@@ -341,7 +342,7 @@ namespace Avalonia.Controls
         /// <inheritdoc/>
         IMenuElement? IMenuItem.Parent => Parent as IMenuElement;
 
-        protected override bool IsEnabledCore => base.IsEnabledCore && _commandCanExecute;
+        protected override bool IsEnabledCore => base.IsEnabled && (HasSubMenu || _commandCanExecute);
 
         /// <inheritdoc/>
         bool IMenuElement.MoveSelection(NavigationDirection direction, bool wrap) => MoveSelection(direction, wrap);
@@ -709,6 +710,15 @@ namespace Avalonia.Controls
             else if (change.Property == GroupNameProperty)
             {
                 GroupNameChanged(change);
+            }
+            else if (change.Property == ItemCountProperty)
+            {
+                // A menu item with no sub-menu is effectively disabled if its command binding
+                // failed: this means that the effectively enabled state depends on whether the
+                // number of items in the menu is 0 or not.
+                var (o, n) = change.GetOldAndNewValue<int>();
+                if (o == 0 || n == 0)
+                    UpdateIsEffectivelyEnabled();
             }
         }
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
@@ -63,6 +63,45 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void MenuItem_With_Styled_Command_Binding_Should_Be_Enabled_With_Child_Missing_Command()
+        {
+            using var app = Application();
+
+            var viewModel = new MenuViewModel("Parent")
+            {
+                Children = [new MenuViewModel("Child")]
+            };
+
+            var contextMenu = new ContextMenu
+            {
+                ItemsSource = new[] { viewModel },
+                Styles =
+                {
+                    new Style(x => x.OfType<MenuItem>())
+                    {
+                        Setters =
+                        {
+                            new Setter(MenuItem.HeaderProperty, new Binding("Header")),
+                            new Setter(MenuItem.ItemsSourceProperty, new Binding("Children")),
+                            new Setter(MenuItem.CommandProperty, new Binding("Command"))
+                        }
+                    }
+                }
+            };
+
+            var window = new Window { ContextMenu = contextMenu };
+            window.Show();
+            contextMenu.Open();
+
+            var parentMenuItem = Assert.IsType<MenuItem>(contextMenu.ContainerFromIndex(0));
+
+            Assert.Same(parentMenuItem.DataContext, viewModel);
+            Assert.Same(parentMenuItem.ItemsSource, viewModel.Children);
+            Assert.True(parentMenuItem.IsEnabled);
+            Assert.True(parentMenuItem.IsEffectivelyEnabled);
+        }
+
+        [Fact]
         public void MenuItem_Is_Disabled_When_Bound_Command_Is_Removed()
         {
             var viewModel = new


### PR DESCRIPTION
## What does the pull request do?

If a menu has a failed `Command` binding, then like other controls which accept a `Command` - it gets disabled. 

However there is a problem when building menus from templates and bindings because a style which applies commands to menu items applies commands to _all_ menu items indiscriminately. This means that a menu which has sub-items must now have a "dummy" command to bind to, otherwise the menu item (and by extension its children) gets disabled.

This PR modifies the behavior of `MenuItem` to only disable itself when a `Command` binding fails _if_ the menu item has no sub-items. If a menu has sub-items then the binding state of `Command` is ignored.
