### PR TITLE
Make sure that tests inherit from ScopedTestBase

### DIFF
--- a/tests/Avalonia.Controls.UnitTests/ApplicationTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ApplicationTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class ApplicationTests
+    public class ApplicationTests : ScopedTestBase
     {
         [Fact]
         public void Throws_ArgumentNullException_On_Run_If_MainWindow_Is_Null()

--- a/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
@@ -16,7 +16,7 @@ using Moq;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class AutoCompleteBoxTests
+    public class AutoCompleteBoxTests : ScopedTestBase
     {
         [Fact]
         public void Search_Filters()

--- a/tests/Avalonia.Controls.UnitTests/Automation/ControlAutomationPeerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Automation/ControlAutomationPeerTests.cs
@@ -2,6 +2,7 @@
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
+using Avalonia.UnitTests;
 using Avalonia.VisualTree;
 using Xunit;
 
@@ -11,7 +12,7 @@ namespace Avalonia.Controls.UnitTests.Automation
 {
     public class ControlAutomationPeerTests
     {
-        public class Children
+        public class Children : ScopedTestBase
         {
             [Fact]
             public void Creates_Children_For_Controls_In_Visual_Tree()
@@ -149,7 +150,7 @@ namespace Avalonia.Controls.UnitTests.Automation
             }
         }
 
-        public class Parent
+        public class Parent : ScopedTestBase
         {
             [Fact]
             public void Connects_Peer_To_Tree_When_GetParent_Called()

--- a/tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj
+++ b/tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj
@@ -20,8 +20,7 @@
     <ProjectReference Include="..\..\src\Avalonia.Base\Avalonia.Base.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Controls\Avalonia.Controls.csproj" />
     <ProjectReference Include="..\Avalonia.UnitTests\Avalonia.UnitTests.csproj" />
-  </ItemGroup>
-  <ItemGroup>
+    <Compile Include="../Shared/ScopedSanityCheck.cs"/>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/tests/Avalonia.Controls.UnitTests/BorderTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/BorderTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class BorderTests
+    public class BorderTests : ScopedTestBase
     {
         [Fact]
         public void Measure_Should_Return_BorderThickness_Plus_Padding_When_No_Child_Present()
@@ -46,7 +46,7 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Rect(6, 6, 0, 0), content.Bounds);
         }
         
-        public class UseLayoutRounding
+        public class UseLayoutRounding : ScopedTestBase
         {
             [Fact]
             public void Measure_Rounds_Padding()

--- a/tests/Avalonia.Controls.UnitTests/CalendarDatePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CalendarDatePickerTests.cs
@@ -11,7 +11,7 @@ using System.Globalization;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class CalendarDatePickerTests
+    public class CalendarDatePickerTests : ScopedTestBase
     {
         private static bool CompareDates(DateTime first, DateTime second)
         {

--- a/tests/Avalonia.Controls.UnitTests/CalendarTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CalendarTests.cs
@@ -3,10 +3,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Avalonia.UnitTests;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class CalendarTests
+    public class CalendarTests : ScopedTestBase
     {
         private static bool CompareDates(DateTime first, DateTime second)
         {

--- a/tests/Avalonia.Controls.UnitTests/CanvasTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CanvasTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class CanvasTests
+    public class CanvasTests : ScopedTestBase
     {
         [Fact]
         public void Left_Property_Should_Work()

--- a/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class CarouselTests
+    public class CarouselTests : ScopedTestBase
     {
         [Fact]
         public void First_Item_Should_Be_Selected_By_Default()

--- a/tests/Avalonia.Controls.UnitTests/ClassesTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ClassesTests.cs
@@ -1,9 +1,10 @@
 using System;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class ClassesTests
+    public class ClassesTests : ScopedTestBase
     {
         [Fact]
         public void Duplicates_Should_Not_Be_Added()

--- a/tests/Avalonia.Controls.UnitTests/ComboBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ComboBoxTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class ComboBoxTests
+    public class ComboBoxTests : ScopedTestBase
     {
         MouseTestHelper _helper = new MouseTestHelper();
         

--- a/tests/Avalonia.Controls.UnitTests/ContentControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContentControlTests.cs
@@ -15,7 +15,7 @@ using System.Collections.Generic;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class ContentControlTests
+    public class ContentControlTests : ScopedTestBase
     {
         [Fact]
         public void Template_Should_Be_Instantiated()

--- a/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class ContextMenuTests
+    public class ContextMenuTests : ScopedTestBase
     {
         private Mock<IPopupImpl> popupImpl;
         private MouseTestHelper _mouse = new MouseTestHelper();

--- a/tests/Avalonia.Controls.UnitTests/DatePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DatePickerTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class DatePickerTests
+    public class DatePickerTests : ScopedTestBase
     {
         [Fact]
         public void SelectedDateChanged_Should_Fire_When_SelectedDate_Set()

--- a/tests/Avalonia.Controls.UnitTests/DecoratorTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DecoratorTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class DecoratorTests
+    public class DecoratorTests : ScopedTestBase
     {
         [Fact]
         public void Setting_Content_Should_Set_Child_Controls_Parent()
@@ -118,7 +118,7 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Size(16, 16), target.DesiredSize);
         }
 
-        public class UseLayoutRounding
+        public class UseLayoutRounding : ScopedTestBase
         {
             [Fact]
             public void Measure_Rounds_Padding()

--- a/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace Avalonia.Controls.UnitTests
 {
     
-    public class DesktopStyleApplicationLifetimeTests
+    public class DesktopStyleApplicationLifetimeTests : ScopedTestBase
     {
         IDispatcherImpl CreateDispatcherWithInstantMainLoop()
         {

--- a/tests/Avalonia.Controls.UnitTests/DockPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DockPanelTests.cs
@@ -1,8 +1,9 @@
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class DockPanelTests
+    public class DockPanelTests : ScopedTestBase
     {
         [Fact]
         public void DockPanel_Without_Child()

--- a/tests/Avalonia.Controls.UnitTests/FlyoutTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/FlyoutTests.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class FlyoutTests
+    public class FlyoutTests : ScopedTestBase
     {
         protected bool UseOverlayPopups { get; set; }
 

--- a/tests/Avalonia.Controls.UnitTests/GridLengthTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/GridLengthTests.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class GridLengthTests
+    public class GridLengthTests : ScopedTestBase
     {
         [Fact]
         public void Parse_Should_Parse_Auto()

--- a/tests/Avalonia.Controls.UnitTests/HeaderedItemsControlTests .cs
+++ b/tests/Avalonia.Controls.UnitTests/HeaderedItemsControlTests .cs
@@ -2,11 +2,12 @@ using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.LogicalTree;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class HeaderedItemsControlTests
+    public class HeaderedItemsControlTests : ScopedTestBase
     {
         [Fact]
         public void Control_Header_Should_Be_Logical_Child_Before_ApplyTemplate()

--- a/tests/Avalonia.Controls.UnitTests/HotKeyedControlsTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/HotKeyedControlsTests.cs
@@ -71,7 +71,7 @@ namespace Avalonia.Controls.UnitTests
         }
     }
 
-    public class HotKeyedControlsTests
+    public class HotKeyedControlsTests : ScopedTestBase
     {
         private static Window PreparedWindow(object content = null)
         {

--- a/tests/Avalonia.Controls.UnitTests/ImageTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ImageTests.cs
@@ -1,11 +1,12 @@
 using Moq;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class ImageTests
+    public class ImageTests : ScopedTestBase
     {
         [Fact]
         public void Measure_Should_Return_Correct_Size_For_No_Stretch()

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -24,7 +24,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class ItemsControlTests
+    public class ItemsControlTests : ScopedTestBase
     {
         [Fact]
         public void Setting_ItemsSource_Should_Populate_Items()

--- a/tests/Avalonia.Controls.UnitTests/ItemsSourceViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsSourceViewTests.cs
@@ -5,11 +5,12 @@ using System.Collections.Specialized;
 using System.Text;
 using Avalonia.Collections;
 using Avalonia.Diagnostics;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class ItemsSourceViewTests
+    public class ItemsSourceViewTests : ScopedTestBase
     {
         [Fact]
         public void Only_Subscribes_To_Source_CollectionChanged_When_CollectionChanged_Subscribed()

--- a/tests/Avalonia.Controls.UnitTests/LayoutTransformControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/LayoutTransformControlTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class LayoutTransformControlTests
+    public class LayoutTransformControlTests : ScopedTestBase
     {
         [Fact]
         public void Measure_On_Scale_x2_Is_Correct()

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests_Multiple.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class ListBoxTests_Multiple
+    public class ListBoxTests_Multiple : ScopedTestBase
     {
         private MouseTestHelper _helper = new MouseTestHelper();
 

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests_Single.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests_Single.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class ListBoxTests_Single
+    public class ListBoxTests_Single : ScopedTestBase
     {
         MouseTestHelper _mouse = new MouseTestHelper();
         

--- a/tests/Avalonia.Controls.UnitTests/LoadedTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/LoadedTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests;
 
-public class LoadedTests
+public class LoadedTests : ScopedTestBase
 {
     [Fact]
     public void Window_Loads_And_Unloads()

--- a/tests/Avalonia.Controls.UnitTests/MaskedTextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MaskedTextBoxTests.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class MaskedTextBoxTests
+    public class MaskedTextBoxTests : ScopedTestBase
     {
         [Fact]
         public void Opening_Context_Menu_Does_not_Lose_Selection()

--- a/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class MenuItemTests
+    public class MenuItemTests : ScopedTestBase
     {
         private Mock<IPopupImpl> popupImpl;
 

--- a/tests/Avalonia.Controls.UnitTests/Mixins/PressedMixinTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Mixins/PressedMixinTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Mixins
 {
-    public class PressedMixinTests
+    public class PressedMixinTests : ScopedTestBase
     {
         private MouseTestHelper _mouse = new MouseTestHelper();
 

--- a/tests/Avalonia.Controls.UnitTests/Mixins/SelectableMixinTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Mixins/SelectableMixinTests.cs
@@ -1,10 +1,11 @@
 using Avalonia.Controls.Mixins;
 using Avalonia.Controls.Primitives;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Mixins
 {
-    public class SelectableMixinTests
+    public class SelectableMixinTests : ScopedTestBase
     {
         [Fact]
         public void Selected_Class_Should_Not_Initially_Be_Added()

--- a/tests/Avalonia.Controls.UnitTests/NameScopeTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NameScopeTests.cs
@@ -1,9 +1,10 @@
 using System;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class NameScopeTests
+    public class NameScopeTests : ScopedTestBase
     {
         [Fact]
         public void Register_Registers_Element()

--- a/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class NumericUpDownTests
+    public class NumericUpDownTests : ScopedTestBase
     {
         private static TestServices Services => TestServices.StyledWindow;
 

--- a/tests/Avalonia.Controls.UnitTests/PanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/PanelTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class PanelTests
+    public class PanelTests : ScopedTestBase
     {
         [Fact]
         public void Adding_Control_To_Panel_Should_Set_Child_Controls_Parent()

--- a/tests/Avalonia.Controls.UnitTests/Platform/DefaultMenuInteractionHandlerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Platform/DefaultMenuInteractionHandlerTests.cs
@@ -4,13 +4,14 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Input.GestureRecognizers;
 using Avalonia.Interactivity;
+using Avalonia.UnitTests;
 using Avalonia.VisualTree;
 using Moq;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Platform
 {
-    public class DefaultMenuInteractionHandlerTests
+    public class DefaultMenuInteractionHandlerTests : ScopedTestBase
     {
         static PointerPressedEventArgs CreatePressed(object source) => new PointerPressedEventArgs(source,
             new FakePointer(), (Visual)source, default,0, new PointerPointProperties (RawInputModifiers.None, PointerUpdateKind.LeftButtonPressed),
@@ -21,7 +22,7 @@ namespace Avalonia.Controls.UnitTests.Platform
             new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonReleased),
             default, MouseButton.Left);
 
-        public class TopLevel
+        public class TopLevel : ScopedTestBase
         {
             [Fact]
             public void Up_Opens_MenuItem_With_SubMenu()
@@ -227,7 +228,7 @@ namespace Avalonia.Controls.UnitTests.Platform
             }
         }
 
-        public class NonTopLevel
+        public class NonTopLevel : ScopedTestBase
         {
             [Fact]
             public void Up_Selects_Previous_MenuItem()
@@ -546,7 +547,7 @@ namespace Avalonia.Controls.UnitTests.Platform
             }
         }
 
-        public class ContextMenu
+        public class ContextMenu : ScopedTestBase
         {
             [Fact]
             public void Down_Selects_Selects_First_MenuItem_When_No_Selection()

--- a/tests/Avalonia.Controls.UnitTests/Platform/ScreensTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Platform/ScreensTests.cs
@@ -102,10 +102,11 @@ public class ScreensTests : ScopedTestBase
     }
 
     [Fact]
-    public async Task Should_Raise_Event_When_Screen_Changed_From_Another_Thread()
+    public void Should_Raise_Event_When_Screen_Changed_From_Another_Thread()
     {
         using var _ = UnitTestApplication.Start(TestServices.MockThreadingInterface);
 
+        Dispatcher.UIThread.VerifyAccess();
         var hasChangedTimes = 0;
         var screens = new TestScreens();
         screens.Changed = () =>
@@ -114,7 +115,7 @@ public class ScreensTests : ScopedTestBase
             hasChangedTimes += 1;
         };
 
-        await Task.Run(() => screens.PushNewScreens([1, 2]));
+        ThreadRunHelper.RunOnDedicatedThread(() => screens.PushNewScreens([1, 2])).GetAwaiter().GetResult();
         Dispatcher.UIThread.RunJobs();
 
         Assert.Equal(1, hasChangedTimes);

--- a/tests/Avalonia.Controls.UnitTests/Platform/StorageProviderHelperTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Platform/StorageProviderHelperTests.cs
@@ -2,11 +2,12 @@ using System;
 using System.Linq;
 using System.Text;
 using Avalonia.Platform.Storage.FileIO;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Platform;
 
-public class StorageProviderHelperTests
+public class StorageProviderHelperTests : ScopedTestBase
 {
     [Fact]
     public void Can_Encode_And_Decode_Bookmark()

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_InTemplate.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_InTemplate.cs
@@ -16,7 +16,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
     /// <summary>
     /// Tests for ContentControls that are hosted in a control template.
     /// </summary>
-    public class ContentPresenterTests_InTemplate
+    public class ContentPresenterTests_InTemplate : ScopedTestBase
     {
         [Fact]
         public void Should_Register_With_Host_When_TemplatedParent_Set()

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Layout.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Layout.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Presenters
 {
-    public class ContentPresenterTests_Layout
+    public class ContentPresenterTests_Layout : ScopedTestBase
     {
         [Theory]
         [InlineData(HorizontalAlignment.Stretch, VerticalAlignment.Stretch, 0, 0, 100, 100)]
@@ -234,7 +234,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
             Assert.Equal(new Rect(32, 32, 0, 0), content.Bounds);
         }
 
-        public class UseLayoutRounding
+        public class UseLayoutRounding : ScopedTestBase
         {
             [Fact]
             public void Measure_Rounds_Padding()

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Standalone.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Standalone.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
     /// <summary>
     /// Tests for ContentControls that aren't hosted in a control template.
     /// </summary>
-    public class ContentPresenterTests_Standalone
+    public class ContentPresenterTests_Standalone : ScopedTestBase
     {
         [Fact]
         public void Should_Set_Childs_Parent_To_Itself_Standalone()

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Unrooted.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Unrooted.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
     /// <summary>
     /// Tests for ContentControls that are not attached to a logical tree.
     /// </summary>
-    public class ContentPresenterTests_Unrooted
+    public class ContentPresenterTests_Unrooted : ScopedTestBase
     {
         [Fact]
         public void Setting_Content_To_Control_Should_Not_Set_Child_Unless_UpdateChild_Called()

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Presenters
 {
-    public class ItemsPresenterTests
+    public class ItemsPresenterTests : ScopedTestBase
     {
         [Fact]
         public void Should_Register_With_Host_When_TemplatedParent_Set()
@@ -37,7 +37,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
             Assert.Equal(target.Panel, child);
         }
 
-        public class NonVirtualizingPanel
+        public class NonVirtualizingPanel : ScopedTestBase
         {
             [Fact]
             public void Creates_Containers_For_Initial_Items()

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests.cs
@@ -9,7 +9,7 @@ using Xunit.Sdk;
 
 namespace Avalonia.Controls.UnitTests.Presenters
 {
-    public class ScrollContentPresenterTests
+    public class ScrollContentPresenterTests : NameScopeTests
     {
         [Theory]
         [InlineData(HorizontalAlignment.Stretch, VerticalAlignment.Stretch, 10, 10, 80, 80)]

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests_ILogicalScrollable.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests_ILogicalScrollable.cs
@@ -3,11 +3,12 @@ using System.Reactive.Linq;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class ScrollContentPresenterTests_ILogicalScrollable
+    public class ScrollContentPresenterTests_ILogicalScrollable : ScopedTestBase
     {
         [Fact]
         public void Measure_Should_Pass_Unchanged_Bounds_To_ILogicalScrollable()

--- a/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Presenters
 {
-    public class TextPresenter_Tests
+    public class TextPresenter_Tests : ScopedTestBase
     {
         [Fact]
         public void TextPresenter_Can_Contain_Null_With_Password_Char_Set()

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupRootTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupRootTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Primitives
 {
-    public class PopupRootTests
+    public class PopupRootTests : ScopedTestBase
     {
         [Fact]
         public void PopupRoot_IsAttachedToLogicalTree_Is_True()

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -23,7 +23,7 @@ using Avalonia.Media;
 
 namespace Avalonia.Controls.UnitTests.Primitives
 {
-    public class PopupTests
+    public class PopupTests : ScopedTestBase
     {
         protected bool UsePopupHost;
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/RangeBaseTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/RangeBaseTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Primitives
 {
-    public class RangeBaseTests
+    public class RangeBaseTests : ScopedTestBase
     {
         [Fact]
         public void Maximum_Should_Be_Coerced_To_Minimum()

--- a/tests/Avalonia.Controls.UnitTests/Primitives/ScrollBarTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/ScrollBarTests.cs
@@ -4,11 +4,12 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Primitives
 {
-    public class ScrollBarTests
+    public class ScrollBarTests : ScopedTestBase
     {
         [Fact]
         public void Setting_Value_Should_Update_Track_Value()

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -1844,27 +1844,29 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact(Timeout = 2000)]
-        public async Task MoveSelection_Wrap_Does_Not_Hang_With_No_Focusable_Controls()
-        {
-            // Issue #3094.
-            var target = new TestSelector
-            {
-                Template = Template(),
-                Items =
-                {
-                    new ListBoxItem { Focusable = false },
-                    new ListBoxItem { Focusable = false },
-                },
-                SelectedIndex = 0,
-            };
-
-            target.Measure(new Size(100, 100));
-            target.Arrange(new Rect(0, 0, 100, 100));
-
+        public Task MoveSelection_Wrap_Does_Not_Hang_With_No_Focusable_Controls() =>
             // Timeout in xUnit doesn't work with synchronous methods so we need to apply hack below.
             // https://github.com/xunit/xunit/issues/2222
-            await Task.Run(() => target.MoveSelection(NavigationDirection.Next, true));
-        }
+            ThreadRunHelper.RunOnDedicatedThread(() =>
+            {
+                using var _ = UnitTestApplication.Start();
+                // Issue #3094.
+                var target = new TestSelector
+                {
+                    Template = Template(),
+                    Items =
+                    {
+                        new ListBoxItem { Focusable = false },
+                        new ListBoxItem { Focusable = false },
+                    },
+                    SelectedIndex = 0,
+                };
+
+                target.Measure(new Size(100, 100));
+                target.Arrange(new Rect(0, 0, 100, 100));
+                
+                target.MoveSelection(NavigationDirection.Next, true);
+            });
 
         [Fact]
         public void MoveSelection_Skips_Non_Focusable_Controls_When_Moving_To_Last_Item()
@@ -1907,50 +1909,54 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact(Timeout = 2000)]
-        public async Task MoveSelection_Does_Not_Hang_When_All_Items_Are_Non_Focusable_And_We_Move_To_First_Item()
-        {
-            var target = new TestSelector
-            {
-                Template = Template(),
-                Items =
-                {
-                    new ListBoxItem { Focusable = false },
-                    new ListBoxItem { Focusable = false },
-                }
-            };
-
-            target.Measure(new Size(100, 100));
-            target.Arrange(new Rect(0, 0, 100, 100));
-
+        public Task MoveSelection_Does_Not_Hang_When_All_Items_Are_Non_Focusable_And_We_Move_To_First_Item() =>
             // Timeout in xUnit doesn't work with synchronous methods so we need to apply hack below.
             // https://github.com/xunit/xunit/issues/2222
-            await Task.Run(() => target.MoveSelection(NavigationDirection.First, true));
+            ThreadRunHelper.RunOnDedicatedThread(
+                () =>
+                {
+                    using var _ = UnitTestApplication.Start();
+                    var target = new TestSelector
+                    {
+                        Template = Template(),
+                        Items =
+                        {
+                            new ListBoxItem { Focusable = false },
+                            new ListBoxItem { Focusable = false },
+                        }
+                    };
 
-            Assert.Equal(-1, target.SelectedIndex);
-        }
+                    target.Measure(new Size(100, 100));
+                    target.Arrange(new Rect(0, 0, 100, 100));
+                    
+                    target.MoveSelection(NavigationDirection.First, true);
+
+                    Assert.Equal(-1, target.SelectedIndex);
+                });
 
         [Fact(Timeout = 2000)]
-        public async Task MoveSelection_Does_Not_Hang_When_All_Items_Are_Non_Focusable_And_We_Move_To_Last_Item()
-        {
-            var target = new TestSelector
-            {
-                Template = Template(),
-                Items =
-                {
-                    new ListBoxItem { Focusable = false },
-                    new ListBoxItem { Focusable = false },
-                }
-            };
-
-            target.Measure(new Size(100, 100));
-            target.Arrange(new Rect(0, 0, 100, 100));
-
+        public Task MoveSelection_Does_Not_Hang_When_All_Items_Are_Non_Focusable_And_We_Move_To_Last_Item()
             // Timeout in xUnit doesn't work with synchronous methods so we need to apply hack below.
             // https://github.com/xunit/xunit/issues/2222
-            await Task.Run(() => target.MoveSelection(NavigationDirection.Last, true));
+            => ThreadRunHelper.RunOnDedicatedThread(() =>
+            {
+                var target = new TestSelector
+                {
+                    Template = Template(),
+                    Items =
+                    {
+                        new ListBoxItem { Focusable = false },
+                        new ListBoxItem { Focusable = false },
+                    }
+                };
 
-            Assert.Equal(-1, target.SelectedIndex);
-        }
+                target.Measure(new Size(100, 100));
+                target.Arrange(new Rect(0, 0, 100, 100));
+                
+                target.MoveSelection(NavigationDirection.Last, true);
+
+                Assert.Equal(-1, target.SelectedIndex);
+            });
 
         [Fact]
         public void MoveSelection_Does_Select_Disabled_Controls()
@@ -2247,9 +2253,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
         [Fact]
         public void Setting_IsTextSearchEnabled_Enables_Or_Disables_Text_Search()
         {
-            var pti = Mock.Of<IDispatcherImpl>(x => x.CurrentThreadIsLoopThread == true);
-            
-            using (UnitTestApplication.Start(TestServices.StyledWindow.With(dispatcherImpl: pti)))
+            using (UnitTestApplication.Start(TestServices.StyledWindow.With()))
             {
                 var items = new[]
                 {

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_AutoSelect.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_AutoSelect.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Primitives
 {
-    public class SelectingItemsControlTests_AutoSelect
+    public class SelectingItemsControlTests_AutoSelect : ScopedTestBase
     {
         [Fact]
         public void First_Item_Should_Be_Selected()

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
@@ -22,7 +22,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Primitives
 {
-    public class SelectingItemsControlTests_Multiple
+    public class SelectingItemsControlTests_Multiple : ScopedTestBase
     {
         [Fact]
         public void Setting_SelectedIndex_Should_Add_To_SelectedItems()

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_SelectedValue.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_SelectedValue.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Primitives
 {
-    public class SelectingItemsControlTests_SelectedValue
+    public class SelectingItemsControlTests_SelectedValue : ScopedTestBase
     {
         [Fact]
         public void Setting_SelectedItem_Sets_SelectedValue()

--- a/tests/Avalonia.Controls.UnitTests/Primitives/TabStripTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/TabStripTests.cs
@@ -5,11 +5,12 @@ using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.LogicalTree;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Primitives
 {
-    public class TabStripTests
+    public class TabStripTests : ScopedTestBase
     {
         [Fact]
         public void First_Tab_Should_Be_Selected_By_Default()

--- a/tests/Avalonia.Controls.UnitTests/Primitives/TemplatedControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/TemplatedControlTests.cs
@@ -14,7 +14,7 @@ using Avalonia.Media;
 
 namespace Avalonia.Controls.UnitTests.Primitives
 {
-    public class TemplatedControlTests
+    public class TemplatedControlTests : ScopedTestBase
     {
         [Fact]
         public void Template_Doesnt_Get_Executed_On_Set()

--- a/tests/Avalonia.Controls.UnitTests/Primitives/ToggleButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/ToggleButtonTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Avalonia.Controls.Primitives.UnitTests
 {
-    public class ToggleButtonTests
+    public class ToggleButtonTests : ScopedTestBase
     {
         private const string uncheckedClass = ":unchecked";
         private const string checkedClass = ":checked";

--- a/tests/Avalonia.Controls.UnitTests/Primitives/TrackTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/TrackTests.cs
@@ -1,11 +1,12 @@
 using Avalonia.Controls.Primitives;
 using Avalonia.Layout;
 using Avalonia.LogicalTree;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Primitives
 {
-    public class TrackTests
+    public class TrackTests : ScopedTestBase
     {
         [Fact]
         public void Measure_Should_Return_Thumb_DesiredWidth_In_Vertical_Orientation()

--- a/tests/Avalonia.Controls.UnitTests/Primitives/UniformGridTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/UniformGridTests.cs
@@ -1,9 +1,10 @@
 ﻿using Avalonia.Controls.Primitives;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Primitives
 {
-    public class UniformGridTests
+    public class UniformGridTests : ScopedTestBase
     {
         [Fact]
         public void Grid_Columns_Equals_Rows_For_Auto_Columns_And_Rows()

--- a/tests/Avalonia.Controls.UnitTests/RadioButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/RadioButtonTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class RadioButtonTests
+    public class RadioButtonTests : ScopedTestBase
     {
         [Theory]
         [InlineData(false)]

--- a/tests/Avalonia.Controls.UnitTests/RelativePanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/RelativePanelTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class RelativePanelTests
+    public class RelativePanelTests : ScopedTestBase
     {
         [Fact]
         public void Lays_Out_1_Child_Next_the_other()

--- a/tests/Avalonia.Controls.UnitTests/Selection/InternalSelectionModelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Selection/InternalSelectionModelTests.cs
@@ -4,11 +4,12 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using Avalonia.Collections;
 using Avalonia.Controls.Selection;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Selection
 {
-    public class InternalSelectionModelTests
+    public class InternalSelectionModelTests : ScopedTestBase
     {
         [Fact]
         public void Selecting_Item_Adds_To_WritableSelectedItems()

--- a/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Multiple.cs
@@ -3,15 +3,16 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using Avalonia.Collections;
 using Avalonia.Controls.Selection;
+using Avalonia.UnitTests;
 using Xunit;
 
 #nullable enable
 
 namespace Avalonia.Controls.UnitTests.Selection
 {
-    public class SelectionModelTests_Multiple
+    public class SelectionModelTests_Multiple : ScopedTestBase
     {
-        public class No_Source
+        public class No_Source : ScopedTestBase
         {
             [Fact]
             public void Can_Select_Multiple_Items_Before_Source_Assigned()
@@ -210,7 +211,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class SelectedIndex
+        public class SelectedIndex : ScopedTestBase
         {
             [Fact]
             public void SelectedIndex_Larger_Than_Source_Clears_Selection()
@@ -301,7 +302,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class SelectedIndexes
+        public class SelectedIndexes : ScopedTestBase
         {
             [Fact]
             public void PropertyChanged_Is_Raised_When_SelectedIndex_Changes()
@@ -323,7 +324,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class SelectedItem
+        public class SelectedItem : ScopedTestBase
         {
             [Fact]
             public void PropertyChanged_Is_Raised_When_SelectedIndex_Changes()
@@ -345,7 +346,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class SelectedItems
+        public class SelectedItems : ScopedTestBase
         {
             [Fact]
             public void PropertyChanged_Is_Raised_When_SelectedIndex_Changes()
@@ -367,7 +368,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class Select
+        public class Select : ScopedTestBase
         {
             [Fact]
             public void Select_Sets_SelectedIndex_If_Previously_Unset()
@@ -449,7 +450,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class SelectRange
+        public class SelectRange : ScopedTestBase
         {
             [Fact]
             public void SelectRange_Selects_Items()
@@ -517,7 +518,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class Deselect
+        public class Deselect : ScopedTestBase
         {
             [Fact]
             public void Deselect_Clears_Selected_Item()
@@ -558,7 +559,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class DeselectRange
+        public class DeselectRange : ScopedTestBase
         {
             [Fact]
             public void DeselectRange_Clears_Identical_Range()
@@ -630,7 +631,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class Clear
+        public class Clear : ScopedTestBase
         {
             [Fact]
             public void Clear_Raises_SelectionChanged()
@@ -656,7 +657,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class AnchorIndex
+        public class AnchorIndex : ScopedTestBase
         {
             [Fact]
             public void Setting_SelectedIndex_Sets_AnchorIndex()
@@ -768,7 +769,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class SingleSelect
+        public class SingleSelect : ScopedTestBase
         {
             [Fact]
             public void Converting_To_Single_Selection_Removes_Multiple_Selection()
@@ -816,7 +817,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class CollectionChanges
+        public class CollectionChanges : ScopedTestBase
         {
             [Fact]
             public void Adding_Item_Before_Selected_Item_Updates_Indexes()
@@ -1377,7 +1378,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class BatchUpdate
+        public class BatchUpdate : ScopedTestBase
         {
             [Fact]
             public void Correctly_Batches_Selects()
@@ -1584,7 +1585,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class LostSelection
+        public class LostSelection : ScopedTestBase
         {
             [Fact]
             public void LostSelection_Called_On_Clear()
@@ -1644,7 +1645,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class SourceReset
+        public class SourceReset : ScopedTestBase
         {
             [Fact]
             public void Can_Restore_Selection_In_SourceReset_Event()

--- a/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Single.cs
+++ b/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Single.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Avalonia.Collections;
 using Avalonia.Controls.Selection;
 using Avalonia.Controls.Utils;
+using Avalonia.UnitTests;
 using Xunit;
 using CollectionChangedEventManager = Avalonia.Controls.Utils.CollectionChangedEventManager;
 
@@ -14,7 +15,7 @@ namespace Avalonia.Controls.UnitTests.Selection
 {
     public class SelectionModelTests_Single
     {
-        public class Source
+        public class Source : ScopedTestBase
         {
             [Fact]
             public void Can_Select_Index_Before_Source_Assigned()
@@ -324,7 +325,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class SelectedIndex
+        public class SelectedIndex : ScopedTestBase
         {
             [Fact]
             public void SelectedIndex_Larger_Than_Source_Clears_Selection()
@@ -454,7 +455,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class SelectedItem
+        public class SelectedItem : ScopedTestBase
         {
             [Fact]
             public void Setting_SelectedItem_To_Valid_Item_Updates_Selection()
@@ -496,7 +497,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class SelectedIndexes
+        public class SelectedIndexes : ScopedTestBase
         {
             [Fact]
             public void PropertyChanged_Is_Raised_When_SelectedIndex_Changes()
@@ -538,7 +539,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class SelectedItems
+        public class SelectedItems : ScopedTestBase
         {
             [Fact]
             public void PropertyChanged_Is_Raised_When_SelectedIndex_Changes()
@@ -580,7 +581,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class Select
+        public class Select : ScopedTestBase
         {
             [Fact]
             public void Select_Sets_SelectedIndex()
@@ -664,7 +665,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class SelectRange
+        public class SelectRange : ScopedTestBase
         {
             [Fact]
             public void SelectRange_Throws()
@@ -675,7 +676,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class Deselect
+        public class Deselect : ScopedTestBase
         {
             [Fact]
             public void Deselect_Clears_Current_Selection()
@@ -721,7 +722,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class DeselectRange
+        public class DeselectRange : ScopedTestBase
         {
             [Fact]
             public void DeselectRange_Clears_Current_Selection_For_Intersecting_Range()
@@ -767,7 +768,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class Clear
+        public class Clear : ScopedTestBase
         {
             [Fact]
             public void Clear_Raises_SelectionChanged()
@@ -792,7 +793,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class AnchorIndex
+        public class AnchorIndex : ScopedTestBase
         {
             [Fact]
             public void Setting_SelectedIndex_Sets_AnchorIndex()
@@ -898,7 +899,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class SingleSelect
+        public class SingleSelect : ScopedTestBase
         {
             [Fact]
             public void Converting_To_Multiple_Selection_Preserves_Selection()
@@ -939,7 +940,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class CollectionChanges
+        public class CollectionChanges : ScopedTestBase
         {
             [Fact]
             public void Adding_Item_Before_Selected_Item_Updates_Indexes()
@@ -1273,7 +1274,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class BatchUpdate
+        public class BatchUpdate : ScopedTestBase
         {
             [Fact]
             public void Changes_Do_Not_Take_Effect_Until_EndUpdate_Called()
@@ -1309,7 +1310,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class LostSelection
+        public class LostSelection : ScopedTestBase
         {
             [Fact]
             public void LostSelection_Called_On_Clear()
@@ -1421,7 +1422,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             }
         }
 
-        public class UntypedInterface
+        public class UntypedInterface : ScopedTestBase
         {
             [Fact]
             public void Raises_Untyped_SelectionChanged_Event()

--- a/tests/Avalonia.Controls.UnitTests/Shapes/EllipseTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Shapes/EllipseTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Shapes
 {
-    public class EllipseTests
+    public class EllipseTests : ScopedTestBase
     {
         [Fact]
         public void Measure_Does_Not_Set_RenderedGeometry_Rect()

--- a/tests/Avalonia.Controls.UnitTests/Shapes/PathTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Shapes/PathTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Shapes
 {
-    public class PathTests
+    public class PathTests : ScopedTestBase
     {
         [Fact]
         public void Path_With_Null_Data_Does_Not_Throw_On_Measure()

--- a/tests/Avalonia.Controls.UnitTests/Shapes/PolygonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Shapes/PolygonTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Shapes;
 
-public class PolygonTests
+public class PolygonTests : ScopedTestBase
 {
     [Fact]
     public void Polygon_Will_Update_Geometry_On_Shapes_Collection_Content_Change()

--- a/tests/Avalonia.Controls.UnitTests/Shapes/PolylineTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Shapes/PolylineTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Shapes;
 
-public class PolylineTests
+public class PolylineTests : ScopedTestBase
 {
     [Fact]
     public void Polyline_Will_Update_Geometry_On_Shapes_Collection_Content_Change()

--- a/tests/Avalonia.Controls.UnitTests/Shapes/RectangleTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Shapes/RectangleTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Shapes
 {
-    public class RectangleTests
+    public class RectangleTests : ScopedTestBase
     {
         [Fact]
         public void Measure_Does_Not_Set_RenderedGeometry_Rect()

--- a/tests/Avalonia.Controls.UnitTests/SliderTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SliderTests.cs
@@ -2,11 +2,12 @@
 using System.Collections.Generic;
 using System.Text;
 using Avalonia.Layout;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class SliderTests
+    public class SliderTests : ScopedTestBase
     {
         [Fact]
         public void Default_Orientation_Should_Be_Horizontal()

--- a/tests/Avalonia.Controls.UnitTests/SplitViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SplitViewTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace Avalonia.Controls.UnitTests
 {
     
-    public class SplitViewTests
+    public class SplitViewTests : ScopedTestBase
     {
         [Fact]
         public void SplitView_PaneOpening_Should_Fire_Before_PaneOpened()

--- a/tests/Avalonia.Controls.UnitTests/StackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/StackPanelTests.cs
@@ -1,10 +1,11 @@
 using System.Linq;
 using Avalonia.Layout;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class StackPanelTests
+    public class StackPanelTests : ScopedTestBase
     {
         [Fact]
         public void Lays_Out_Children_Vertically()

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -21,7 +21,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class TabControlTests
+    public class TabControlTests : ScopedTestBase
     {
         static TabControlTests()
         {

--- a/tests/Avalonia.Controls.UnitTests/Templates/TemplateExtensionsTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Templates/TemplateExtensionsTests.cs
@@ -1,10 +1,11 @@
 using System.Linq;
 using Avalonia.Controls.UnitTests;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.Templates.UnitTests
 {
-    public class TemplateExtensionsTests
+    public class TemplateExtensionsTests : ScopedTestBase
     {
         /// <summary>
         /// Control templates can themselves contain templated controls. Make sure that

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -10,7 +10,7 @@ using static System.Net.Mime.MediaTypeNames;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class TextBlockTests
+    public class TextBlockTests : ScopedTestBase
     {
         [Fact]
         public void DefaultBindingMode_Should_Be_OneWay()

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -22,7 +22,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class TextBoxTests
+    public class TextBoxTests : ScopedTestBase
     {
         [Fact]
         public void Opening_Context_Menu_Does_not_Lose_Selection()

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests_DataValidation.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests_DataValidation.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class TextBoxTests_DataValidation
+    public class TextBoxTests_DataValidation : ScopedTestBase
     {
         [Fact]
         public void Setter_Exceptions_Should_Set_Error_Pseudoclass()

--- a/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class TimePickerTests
+    public class TimePickerTests : ScopedTestBase
     {
         [Fact]
         public void SelectedTimeChanged_Should_Fire_When_SelectedTime_Set()

--- a/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
@@ -63,7 +63,7 @@ namespace Avalonia.Controls.UnitTests
         }
     }
 
-    public abstract class ToolTipTests
+    public abstract class ToolTipTests : ScopedTestBase
     {
         protected abstract TestServices ConfigureServices(TestServices baseServices);
 

--- a/tests/Avalonia.Controls.UnitTests/TopLevelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TopLevelTests.cs
@@ -17,7 +17,7 @@ using static Avalonia.Controls.UnitTests.MaskedTextBoxTests;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class TopLevelTests
+    public class TopLevelTests : ScopedTestBase
     {
         [Fact]
         public void IsAttachedToLogicalTree_Is_True()

--- a/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class TransitioningContentControlTests
+    public class TransitioningContentControlTests : ScopedTestBase
     {
         [Fact]
         public void Transition_Should_Not_Be_Run_When_First_Shown()

--- a/tests/Avalonia.Controls.UnitTests/UserControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/UserControlTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class UserControlTests
+    public class UserControlTests : ScopedTestBase
     {
         [Fact]
         public void Should_Be_Styled_As_UserControl()

--- a/tests/Avalonia.Controls.UnitTests/Utils/AncestorFinderTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Utils/AncestorFinderTests.cs
@@ -4,12 +4,13 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Avalonia.Controls.Utils;
+using Avalonia.UnitTests;
 using Avalonia.VisualTree;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Utils
 {
-    public class AncestorFinderTests
+    public class AncestorFinderTests : ScopedTestBase
     {
         [Fact]
         public void SanityCheck()

--- a/tests/Avalonia.Controls.UnitTests/Utils/CollectionChangedEventManagerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Utils/CollectionChangedEventManagerTests.cs
@@ -4,12 +4,13 @@ using System.Collections.Specialized;
 using System.Text;
 using Avalonia.Collections;
 using Avalonia.Controls.Utils;
+using Avalonia.UnitTests;
 using Xunit;
 using CollectionChangedEventManager = Avalonia.Controls.Utils.CollectionChangedEventManager;
 
 namespace Avalonia.Controls.UnitTests.Utils
 {
-    public class CollectionChangedEventManagerTests
+    public class CollectionChangedEventManagerTests : ScopedTestBase
     {
         [Fact]
         public void AddListener_Listens_To_Events()

--- a/tests/Avalonia.Controls.UnitTests/Utils/HotKeyManagerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Utils/HotKeyManagerTests.cs
@@ -10,7 +10,7 @@ using Factory = System.Func<int, System.Action<object>, Avalonia.Controls.Window
 
 namespace Avalonia.Controls.UnitTests.Utils
 {
-    public class HotKeyManagerTests
+    public class HotKeyManagerTests : ScopedTestBase
     {
         [Fact]
         public void HotKeyManager_Should_Register_And_Unregister_Key_Binding()

--- a/tests/Avalonia.Controls.UnitTests/Utils/SafeEnumerableHashSetTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Utils/SafeEnumerableHashSetTests.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
+using Avalonia.UnitTests;
 using Avalonia.Utilities;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Utils
 {
-    public class SafeEnumerableHashSetTests
+    public class SafeEnumerableHashSetTests : ScopedTestBase
     {
         [Fact]
         public void Set_Is_Not_Copied_Outside_Enumeration()

--- a/tests/Avalonia.Controls.UnitTests/ViewboxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ViewboxTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class ViewboxTests
+    public class ViewboxTests : ScopedTestBase
     {
         [Fact]
         public void Viewbox_Stretch_Uniform_Child()

--- a/tests/Avalonia.Controls.UnitTests/WindowBaseTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowBaseTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class WindowBaseTests
+    public class WindowBaseTests : ScopedTestBase
     {
         [Fact]
         public void Activate_Should_Call_Impl_Activate()

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class WindowTests
+    public class WindowTests : ScopedTestBase
     {
         [Fact]
         public void Setting_Title_Should_Set_Impl_Title()
@@ -672,7 +672,7 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
-        public class SizingTests
+        public class SizingTests : ScopedTestBase
         {
             [Fact]
             public void Child_Should_Be_Measured_With_Width_And_Height_If_SizeToContent_Is_Manual()

--- a/tests/Avalonia.Controls.UnitTests/WrapPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WrapPanelTests.cs
@@ -1,10 +1,11 @@
 using System;
 using Avalonia.Layout;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class WrapPanelTests
+    public class WrapPanelTests : ScopedTestBase
     {
         [Fact]
         public void Lays_Out_Horizontally_On_Separate_Lines()

--- a/tests/Avalonia.LeakTests/AvaloniaObjectTests.cs
+++ b/tests/Avalonia.LeakTests/AvaloniaObjectTests.cs
@@ -11,6 +11,7 @@ using Avalonia.Data.Core;
 using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings;
 using Avalonia.Threading;
+using Avalonia.UnitTests;
 using JetBrains.dotMemoryUnit;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,7 +19,7 @@ using Xunit.Abstractions;
 namespace Avalonia.LeakTests
 {
     [DotMemoryUnit(FailIfRunWithoutSupport = false)]
-    public class AvaloniaObjectTests
+    public class AvaloniaObjectTests : ScopedTestBase
     {
         public AvaloniaObjectTests(ITestOutputHelper atr)
         {
@@ -159,7 +160,7 @@ namespace Avalonia.LeakTests
             }
 
             var weakTarget = SetupBinding();
-
+            
             CollectGarbage();
             Assert.False(weakTarget.IsAlive);
         }

--- a/tests/Avalonia.Markup.UnitTests/Avalonia.Markup.UnitTests.csproj
+++ b/tests/Avalonia.Markup.UnitTests/Avalonia.Markup.UnitTests.csproj
@@ -16,8 +16,7 @@
     <ProjectReference Include="..\..\src\Avalonia.Base\Avalonia.Base.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Controls\Avalonia.Controls.csproj" />
     <ProjectReference Include="..\Avalonia.UnitTests\Avalonia.UnitTests.csproj" />
-  </ItemGroup>
-  <ItemGroup>
+    <Compile Include="../Shared/ScopedSanityCheck.cs"/>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
@@ -7,12 +7,13 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Threading;
+using Avalonia.UnitTests;
 using Moq;
 using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Data
 {
-    public class BindingTests
+    public class BindingTests : ScopedTestBase
     {
         [Fact]
         public void OneWay_Binding_Should_Be_Set_Up()

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Converters.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Converters.cs
@@ -4,12 +4,13 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Data.Core;
+using Avalonia.UnitTests;
 using Moq;
 using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Data
 {
-    public class BindingTests_Converters
+    public class BindingTests_Converters : ScopedTestBase
     {
         [Fact]
         public void Converter_Should_Be_Used()

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_DataValidation.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_DataValidation.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Markup.UnitTests.Data
 {
     public class BindingTests_DataValidation
     {
-        public abstract class TestBase<T>
+        public abstract class TestBase<T> : ScopedTestBase
             where T : AvaloniaProperty<int>
         {
             [Fact]

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Delay.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Delay.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Data;
 
-public class BindingTests_Delay : IDisposable
+public class BindingTests_Delay : ScopedTestBase, IDisposable
 {
     private const int DelayMilliseconds = 10;
     private const string InitialFooValue = "foo";
@@ -39,6 +39,7 @@ public class BindingTests_Delay : IDisposable
     public void Dispose()
     {
         _app.Dispose();
+        base.Dispose();
     }
 
     [Fact]

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_ElementName.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_ElementName.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Data
 {
-    public class BindingTests_ElementName
+    public class BindingTests_ElementName : ScopedTestBase
     {
         [Fact]
         public void Should_Bind_To_Element_Path()

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Logging.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Logging.cs
@@ -20,9 +20,9 @@ using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Data
 {
-    public class BindingTests_Logging
+    public class BindingTests_Logging : ScopedTestBase
     {
-        public class DataContext
+        public class DataContext : ScopedTestBase
         {
             [Fact]
             public void Should_Not_Log_Missing_Member_On_Null_DataContext()
@@ -68,7 +68,7 @@ namespace Avalonia.Markup.UnitTests.Data
             }
         }
 
-        public class Source
+        public class Source : ScopedTestBase
         {
             [Fact]
             public void Should_Log_Null_Source()
@@ -96,7 +96,7 @@ namespace Avalonia.Markup.UnitTests.Data
             }
         }
 
-        public class LogicalAncestor
+        public class LogicalAncestor : ScopedTestBase
         {
             [Fact]
             public void Should_Log_Ancestor_Not_Found()
@@ -124,7 +124,7 @@ namespace Avalonia.Markup.UnitTests.Data
             }
         }
 
-        public class VisualAncestor
+        public class VisualAncestor : ScopedTestBase
         {
             [Fact]
             public void Should_Log_Ancestor_Not_Found()
@@ -187,7 +187,7 @@ namespace Avalonia.Markup.UnitTests.Data
             }
         }
 
-        public class NamedElement
+        public class NamedElement : ScopedTestBase
         {
             [Fact]
             public void Should_Log_NameScope_Not_Found()
@@ -233,7 +233,7 @@ namespace Avalonia.Markup.UnitTests.Data
             }
         }
 
-        public class Converter
+        public class Converter : ScopedTestBase
         {
             [Fact]
             public void Should_Log_Error_For_Unconvertible_Type()
@@ -275,7 +275,7 @@ namespace Avalonia.Markup.UnitTests.Data
             }
         }
 
-        public class Fallback
+        public class Fallback : ScopedTestBase
         {
             [Theory]
             [InlineData(true)]
@@ -324,7 +324,7 @@ namespace Avalonia.Markup.UnitTests.Data
             }
         }
 
-        public class NonControlDataContext
+        public class NonControlDataContext : ScopedTestBase
         {
             [Fact]
             public void Should_Not_Log_Missing_Member_On_Null_DataContext()
@@ -369,7 +369,7 @@ namespace Avalonia.Markup.UnitTests.Data
             }
         }
 
-        public class CompiledBinding
+        public class CompiledBinding : ScopedTestBase
         {
             [Fact]
             public void Should_Log_For_Invalid_DataContext_Type()

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Method.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Method.cs
@@ -2,11 +2,12 @@
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Data
 {
-    public class BindingTests_Method
+    public class BindingTests_Method : ScopedTestBase
     {
         [Fact]
         public void Binding_To_Private_Methods_Shouldnt_Work()

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_RelativeSource.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_RelativeSource.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Data
 {
-    public class BindingTests_RelativeSource
+    public class BindingTests_RelativeSource : ScopedTestBase
     {
         [Fact]
         public void Should_Bind_To_First_Ancestor()

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Self.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Self.cs
@@ -7,10 +7,11 @@ using Xunit;
 using System.Reactive.Disposables;
 using Avalonia.Markup.Data;
 using Avalonia.Controls.Primitives;
+using Avalonia.UnitTests;
 
 namespace Avalonia.Markup.UnitTests.Data
 {
-    public class BindingTests_Self
+    public class BindingTests_Self : ScopedTestBase
     {
         [Fact]
         public void Binding_To_Property_On_Self_Should_Work()

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Source.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Source.cs
@@ -5,10 +5,11 @@ using Avalonia.Markup.Data;
 using Xunit;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Avalonia.UnitTests;
 
 namespace Avalonia.Markup.UnitTests.Data
 {
-    public class BindingTests_Source
+    public class BindingTests_Source : ScopedTestBase
     {
         [Fact]
         public void Source_Should_Be_Used()

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_TemplatedParent.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_TemplatedParent.cs
@@ -4,12 +4,13 @@ using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.UnitTests;
 using Avalonia.VisualTree;
 using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Data
 {
-    public class BindingTests_TemplatedParent
+    public class BindingTests_TemplatedParent : ScopedTestBase
     {
         [Fact]
         public void OneWay_Binding_Should_Be_Set_Up()

--- a/tests/Avalonia.Markup.UnitTests/Data/MultiBindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/MultiBindingTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Data
 {
-    public class MultiBindingTests
+    public class MultiBindingTests : ScopedTestBase
     {
         [Fact]
         public void OneWay_Binding_Should_Be_Set_Up()

--- a/tests/Avalonia.Markup.UnitTests/Data/MultiBindingTests_Converters.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/MultiBindingTests_Converters.cs
@@ -6,11 +6,12 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Layout;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Data
 {
-    public class MultiBindingTests_Converters
+    public class MultiBindingTests_Converters : ScopedTestBase
     {
         [Fact]
         public void StringFormat_Should_Be_Applied()

--- a/tests/Avalonia.Markup.UnitTests/Data/TemplateBindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/TemplateBindingTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Data
 {
-    public class TemplateBindingTests
+    public class TemplateBindingTests : ScopedTestBase
     {
         [Fact]
         public void OneWay_Binding_Should_Be_Set_Up()

--- a/tests/Avalonia.Markup.UnitTests/Parsers/BindingExpressionGrammarTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/BindingExpressionGrammarTests.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
 using Avalonia.Markup.Parsers;
+using Avalonia.UnitTests;
 using Avalonia.Utilities;
 using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Parsers
 {
-    public partial class BindingExpressionGrammarTests
+    public partial class BindingExpressionGrammarTests : ScopedTestBase
     {
         [Fact]
         public void Should_Parse_Single_Property()

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionNodeFactoryTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionNodeFactoryTests.cs
@@ -4,12 +4,13 @@ using System.Linq;
 using Avalonia.Data.Core.ExpressionNodes;
 using Avalonia.Data.Core.ExpressionNodes.Reflection;
 using Avalonia.Markup.Parsers;
+using Avalonia.UnitTests;
 using Avalonia.Utilities;
 using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Parsers
 {
-    public class ExpressionNodeFactoryTests
+    public class ExpressionNodeFactoryTests : ScopedTestBase
     {
         [Fact]
         public void Should_Build_Single_Property()

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AttachedProperty.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AttachedProperty.cs
@@ -8,10 +8,11 @@ using Xunit;
 using Avalonia.Markup.Parsers;
 using Avalonia.Utilities;
 using Avalonia.Data.Core.ExpressionNodes;
+using Avalonia.UnitTests;
 
 namespace Avalonia.Markup.UnitTests.Parsers
 {
-    public class ExpressionObserverBuilderTests_AttachedProperty
+    public class ExpressionObserverBuilderTests_AttachedProperty : ScopedTestBase
     {
         private readonly Func<string, string, Type> _typeResolver;
 

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AvaloniaProperty.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AvaloniaProperty.cs
@@ -8,10 +8,11 @@ using Xunit;
 using Avalonia.Markup.Parsers;
 using Avalonia.Utilities;
 using Avalonia.Data.Core.ExpressionNodes;
+using Avalonia.UnitTests;
 
 namespace Avalonia.Markup.UnitTests.Parsers
 {
-    public class ExpressionObserverBuilderTests_AvaloniaProperty
+    public class ExpressionObserverBuilderTests_AvaloniaProperty : ScopedTestBase
     {
         public ExpressionObserverBuilderTests_AvaloniaProperty()
         {

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Indexer.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Indexer.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Parsers
 {
-    public class ExpressionObserverBuilderTests_Indexer
+    public class ExpressionObserverBuilderTests_Indexer : ScopedTestBase
     {
         [Fact]
         public async Task Should_Get_Array_Value()

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Method.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Method.cs
@@ -9,11 +9,12 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Parsers
 {
-    public class ExpressionObserverBuilderTests_Method
+    public class ExpressionObserverBuilderTests_Method : ScopedTestBase
     {
         private class TestObject
         {

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Negation.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Negation.cs
@@ -8,12 +8,13 @@ using Avalonia.Data;
 using Avalonia.Data.Core;
 using Avalonia.Data.Core.ExpressionNodes;
 using Avalonia.Markup.Parsers;
+using Avalonia.UnitTests;
 using Avalonia.Utilities;
 using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Parsers
 {
-    public class ExpressionObserverBuilderTests_Negation
+    public class ExpressionObserverBuilderTests_Negation : ScopedTestBase
     {
         [Fact]
         public async Task Should_Negate_0()

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Property.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Property.cs
@@ -6,12 +6,13 @@ using Avalonia.Data;
 using Avalonia.Data.Core;
 using Avalonia.Data.Core.ExpressionNodes;
 using Avalonia.Markup.Parsers;
+using Avalonia.UnitTests;
 using Avalonia.Utilities;
 using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Parsers
 {
-    public class ExpressionObserverBuilderTests_Property
+    public class ExpressionObserverBuilderTests_Property : ScopedTestBase
     {
         [Fact]
         public async Task Should_Return_BindingNotification_Error_For_Broken_Chain()

--- a/tests/Avalonia.Markup.UnitTests/Parsers/SelectorGrammarTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/SelectorGrammarTests.cs
@@ -1,11 +1,12 @@
 using System.Linq;
 using Avalonia.Data.Core;
 using Avalonia.Markup.Parsers;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Parsers
 {
-    public class SelectorGrammarTests
+    public class SelectorGrammarTests : ScopedTestBase
     {
         [Fact]
         public void OfType()

--- a/tests/Avalonia.Markup.UnitTests/Parsers/SelectorParserTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/SelectorParserTests.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using Avalonia.Controls;
 using Avalonia.Markup.Parsers;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Markup.UnitTests.Parsers
 {
-    public class SelectorParserTests
+    public class SelectorParserTests : ScopedTestBase
     {
         static SelectorParserTests()
         {

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Avalonia.Markup.Xaml.UnitTests.csproj
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Avalonia.Markup.Xaml.UnitTests.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\Avalonia.IntegrationTests.Appium\PlatformFactAttribute.cs">
       <Link>PlatformFactAttribute.cs</Link>
     </Compile>
+    <Compile Include="../Shared/ScopedSanityCheck.cs"/>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="xunit.runner.console" Version="2.9.2">

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -31,7 +31,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 {
-    public class CompiledBindingExtensionTests
+    public class CompiledBindingExtensionTests : XamlTestBase
     {
         static CompiledBindingExtensionTests()
         {

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Parsers/PropertyParserTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Parsers/PropertyParserTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Parsers
 {
-    public class PropertyParserTests
+    public class PropertyParserTests : XamlTestBase
     {
         [Fact]
         public void Parses_Name()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Templates/DataTemplateTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Templates/DataTemplateTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Templates
 {
-    public class DataTemplateTests
+    public class DataTemplateTests : XamlTestBase
     {
         [Fact]
         public void DataTemplate_Should_Match_Data_Of_Type()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/GenericTemplateTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/GenericTemplateTests.cs
@@ -26,7 +26,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
         public SampleTemplatedObjectTemplate Template { get; set; }
     }
     
-    public class GenericTemplateTests
+    public class GenericTemplateTests : XamlTestBase
     {
         [Fact]
         public void DataTemplate_Can_Be_Empty()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ItemsPanelTemplateTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ItemsPanelTemplateTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Xaml;
 
-public class ItemsPanelTemplateTests
+public class ItemsPanelTemplateTests : XamlTestBase
 {
     [Fact]
     public void ItemsPanelTemplate_In_Style_Allows_TemplateBinding()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/MergeResourceIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/MergeResourceIncludeTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Xaml;
 
-public class MergeResourceIncludeTests
+public class MergeResourceIncludeTests : XamlTestBase
 {
     static MergeResourceIncludeTests()
     {

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleIncludeTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Xaml;
 
-public class StyleIncludeTests
+public class StyleIncludeTests : XamlTestBase
 {
     static StyleIncludeTests()
     {

--- a/tests/Avalonia.UnitTests/ThreadRunHelper.cs
+++ b/tests/Avalonia.UnitTests/ThreadRunHelper.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Avalonia.UnitTests;
+
+public class ThreadRunHelper
+{
+    public static Task<T> RunOnDedicatedThread<T>(Func<T> cb)
+    {
+        // Task.Run(...).GetAwaiter().GetResult() can be inlined, so we have this cursed thing instead
+        var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        new Thread(() =>
+        {
+            try
+            {
+                tcs.SetResult(cb());
+            }
+            catch (Exception e)
+            {
+                tcs.SetException(e);
+            }
+        }).Start();
+        return tcs.Task;
+    }
+
+    public static Task RunOnDedicatedThread(Action cb) => RunOnDedicatedThread<object?>(() =>
+    {
+        cb();
+        return null;
+    });
+
+    public static void RunOnDedicatedThreadAndWait(Action cb) => RunOnDedicatedThread(cb).GetAwaiter().GetResult();
+}

--- a/tests/Avalonia.UnitTests/UnitTestApplication.cs
+++ b/tests/Avalonia.UnitTests/UnitTestApplication.cs
@@ -42,7 +42,7 @@ namespace Avalonia.UnitTests
             var scope = AvaloniaLocator.EnterScope();
             var oldContext = SynchronizationContext.Current;
             _ = new UnitTestApplication(services);
-            Dispatcher.ResetForUnitTests();
+            Dispatcher.ResetBeforeUnitTests();
             return Disposable.Create(() =>
             {
                 if (Dispatcher.UIThread.CheckAccess())
@@ -51,9 +51,10 @@ namespace Avalonia.UnitTests
                 }
 
                 ((ToolTipService)AvaloniaLocator.Current.GetService<IToolTipService>())?.Dispose();
-
-                scope.Dispose();
+                
                 Dispatcher.ResetForUnitTests();
+                scope.Dispose();
+                Dispatcher.ResetBeforeUnitTests();
                 SynchronizationContext.SetSynchronizationContext(oldContext);
             });
         }

--- a/tests/Shared/ScopedSanityCheck.cs
+++ b/tests/Shared/ScopedSanityCheck.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.UnitTests.Helpers;
+
+static class ScopedSanityCheck
+{
+    [ModuleInitializer]
+    public static void SanityCheck()
+    {
+        var offendingTypes = new List<string>();
+        void CheckRecursive(Type type)
+        {
+            if (type.GetMethods().Any(m => m.GetCustomAttributes(true).Any(a => a is FactAttribute or TheoryAttribute)))
+            {
+                if (!typeof(ScopedTestBase).IsAssignableFrom(type))
+                    offendingTypes.Add(type.ToString());
+            }
+
+            foreach (var t in type.GetNestedTypes())
+                CheckRecursive(t);
+        }
+        
+        foreach(var t in typeof(ScopedSanityCheck).Assembly.GetTypes())
+            CheckRecursive(t);
+
+        if (offendingTypes.Count > 0)
+            throw new Exception(
+                $"Test types:\n{string.Join("\n", offendingTypes.ToArray())}\n don't inherit from ScopedTestBase");
+    }
+}


### PR DESCRIPTION
Right now our global state (locator and random mutable static fields scattered across the codebase) can leak from one test to another.

This PR updates tests in Avalonia.Controls.UnitTests, Avalonia.Markup.UnitTests and Avalonia.Markup.Xaml.UnitTests projects to inherit from pre-existing ScopedTestBase that is responsible for resetting locator, dispatcher and Control.Loaded queue (which should be removed in 12.0), so tests are more isolated from each other.


PR also introduces `ThreadRunHelper.RunOnDedicatedThread` helper method for various cases where we need a dedicated thread.