### PR TITLE
Fixes for DataValidationErrors not working correctly with Bindings (issue #18693)

### DIFF
--- a/src/Avalonia.Controls/DataValidationErrors.cs
+++ b/src/Avalonia.Controls/DataValidationErrors.cs
@@ -18,7 +18,6 @@ namespace Avalonia.Controls
     [PseudoClasses(":error")]
     public class DataValidationErrors : ContentControl
     {
-        private static bool s_overridingErrors;
         
         /// <summary>
         /// Defines the DataValidationErrors.Errors attached property.
@@ -49,6 +48,12 @@ namespace Avalonia.Controls
         /// </summary>
         private static readonly AttachedProperty<IEnumerable<object>?> OriginalErrorsProperty =
             AvaloniaProperty.RegisterAttached<DataValidationErrors, Control, IEnumerable<object>?>("OriginalErrors");
+        
+        /// <summary>
+        /// Prevents executing ErrorsChanged after they are updated internally from OnErrorsOrConverterChanged
+        /// </summary>
+        private static readonly AttachedProperty<bool> OverridingErrorsInternallyProperty =
+            AvaloniaProperty.RegisterAttached<DataValidationErrors, Control, bool>("OverridingErrorsInternally", defaultValue: false);
 
         private Control? _owner;
 
@@ -96,9 +101,10 @@ namespace Avalonia.Controls
 
         private static void ErrorsChanged(AvaloniaPropertyChangedEventArgs e)
         {
-            if (s_overridingErrors) return;
-
             var control = (Control)e.Sender;
+            
+            if (control.GetValue(OverridingErrorsInternallyProperty)) return;
+            
             var errors = (IEnumerable<object>?)e.NewValue;
 
             // Update original errors
@@ -140,14 +146,14 @@ namespace Avalonia.Controls
                     .Where(e => e is not null))?
                 .ToArray();
 
-            s_overridingErrors = true;
+            control.SetCurrentValue(OverridingErrorsInternallyProperty, true);
             try
             {
                 control.SetCurrentValue(ErrorsProperty, newErrors!);
             }
             finally
             {
-                s_overridingErrors = false;
+                control.SetCurrentValue(OverridingErrorsInternallyProperty, false);
             }
 
             control.SetValue(HasErrorsProperty, newErrors?.Any() == true);

--- a/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
@@ -422,6 +422,28 @@ namespace Avalonia.Controls.UnitTests
         }
         
         [Fact]
+        public void Text_Validation_TextBox_Errors_Binding()
+        {
+            RunTest((control, textbox) =>
+            {
+                // simulate the TemplateBinding that would be used within the AutoCompleteBox control theme for the inner PART_TextBox
+                //      DataValidationErrors.Errors="{TemplateBinding (DataValidationErrors.Errors)}"
+                textbox.Bind(DataValidationErrors.ErrorsProperty, control.GetBindingObservable(DataValidationErrors.ErrorsProperty));
+                
+                var exception = new InvalidCastException("failed validation");
+                var textObservable = new BehaviorSubject<BindingNotification>(new BindingNotification(exception, BindingErrorType.DataValidationError));
+                control.Bind(AutoCompleteBox.TextProperty, textObservable);
+                Dispatcher.UIThread.RunJobs();
+                
+                Assert.Equal(DataValidationErrors.GetHasErrors(control), true);
+                Assert.Equal(DataValidationErrors.GetErrors(control).SequenceEqual(new[] { exception }), true);
+                
+                Assert.Equal(DataValidationErrors.GetHasErrors(textbox), true);
+                Assert.Equal(DataValidationErrors.GetErrors(textbox).SequenceEqual(new[] { exception }), true);
+            });
+        }
+        
+        [Fact]
         public void SelectedItem_Validation()
         {
             RunTest((control, textbox) =>

--- a/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
@@ -435,11 +435,11 @@ namespace Avalonia.Controls.UnitTests
                 control.Bind(AutoCompleteBox.TextProperty, textObservable);
                 Dispatcher.UIThread.RunJobs();
                 
-                Assert.Equal(DataValidationErrors.GetHasErrors(control), true);
-                Assert.Equal(DataValidationErrors.GetErrors(control).SequenceEqual(new[] { exception }), true);
+                Assert.True(DataValidationErrors.GetHasErrors(control));
+                Assert.Equal([exception], DataValidationErrors.GetErrors(control));
                 
-                Assert.Equal(DataValidationErrors.GetHasErrors(textbox), true);
-                Assert.Equal(DataValidationErrors.GetErrors(textbox).SequenceEqual(new[] { exception }), true);
+                Assert.True(DataValidationErrors.GetHasErrors(textbox));
+                Assert.Equal([exception], DataValidationErrors.GetErrors(textbox));
             });
         }
         


### PR DESCRIPTION
## What does the pull request do?
It fixes an issue ( #18693 ) with the `DataValidationErrors` class, where using Bindings to update a control's `DataValidationErrors.Errors` based on another control's `DataValidationErrors.Errors` property leads to the `DataValidationErrors.HasErrors` property not updating for the control using the Binding. This mainly affects the AutoCompleteBox control, but would theoretically affect every time Bindings are used with `DataValidationErrors.Errors`

## What is the current behavior?
When using bindings as described above, updating the `Errors` property for the main control leads to the following:
- After the main control's `DataValidationErrors.Errors` property changes, the `private static void ErrorsChanged(AvaloniaPropertyChangedEventArgs e)` handler is called for the main control
- This in turn calls `private static void OnErrorsOrConverterChanged(Control control)` where the `Errors` property is updated once more, but not before setting `s_overridingErrors` to true
- `ErrorsChanged` gets called a second time for the main control, as the property has changed, but this time `s_overridingErrors` is true and the handler exits immediately
- `ErrorsChanged` gets called for the secondary control as well, but the `s_overridingErrors` flag is still set to true, therefore the handler exits immediately again and never updates the secondary control's `HasErrors` property!

## What is the updated/expected behavior with this PR?
- After the main control enters its `ErrorsChanged` handler, it calls the `OnErrorsOrConverterChanged` where it once again updates the `Errors` property
- The `ErrorsChanged` handler gets called again, but this time returns immediately for the main control
- The `ErrorsChanged` handler gets called for the secondary control, but this time the handler does not exit immediately, instead allowing the `OnErrorsOrConverterChanged` to be called for the 2nd control as well, updating the `HasErrors` property


## How was the solution implemented (if it's not obvious)?
The `DataValidationErrors` class's `private static bool s_overridingErrors` field was replaced with `private static readonly AttachedProperty<bool> OverridingErrorsInternallyProperty`

I have also included a unit test in `AutoCompleteTextBoxTests` called `Text_Validation_TextBox_Errors_Binding` that checks the secondary control's `Errors` and `HasErrors` properties get updated correctly.

The test fails before the fix, and passes after the fix.

## Checklist
- [X] Added unit tests (if possible)?
- [X] Added XML documentation to any related classes?

## Breaking changes
None that I am aware of...

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #18693
