### PR TITLE
[feat]Add ShowInTaskSwitcher Property for Window

### DIFF
--- a/src/Avalonia.Controls/Platform/IWindowImpl.cs
+++ b/src/Avalonia.Controls/Platform/IWindowImpl.cs
@@ -58,7 +58,12 @@ namespace Avalonia.Platform
         /// Enables or disables the taskbar icon
         /// </summary>
         void ShowTaskbarIcon(bool value);
-
+        
+        /// <summary>
+        /// Shows or hides from the task switcher
+        /// </summary>
+        void ShowInTaskSwitcher(bool value);
+        
         /// <summary>
         /// Enables or disables resizing of the window
         /// </summary>

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -152,6 +152,12 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<Window, bool>(nameof(ShowInTaskbar), true);
 
         /// <summary>
+        /// Shows or hides from the task switcher
+        /// </summary>
+        public static readonly StyledProperty<bool> ShowInTaskSwitcherProperty =
+            AvaloniaProperty.Register<Window, bool>(nameof(ShowInTaskSwitcher), true);
+
+        /// <summary>
         /// Defines the <see cref="ClosingBehavior"/> property.
         /// </summary>
         public static readonly StyledProperty<WindowClosingBehavior> ClosingBehaviorProperty =
@@ -237,7 +243,8 @@ namespace Avalonia.Controls
             CreatePlatformImplBinding(IconProperty, icon => PlatformImpl!.SetIcon((icon ?? s_defaultIcon.Value)?.PlatformImpl));
             CreatePlatformImplBinding(CanResizeProperty, canResize => PlatformImpl!.CanResize(canResize));
             CreatePlatformImplBinding(ShowInTaskbarProperty, show => PlatformImpl!.ShowTaskbarIcon(show));
-
+            CreatePlatformImplBinding(ShowInTaskSwitcherProperty, show => PlatformImpl!.ShowInTaskSwitcher(show));
+            
             CreatePlatformImplBinding(WindowStateProperty, state => PlatformImpl!.WindowState = state);
             CreatePlatformImplBinding(ExtendClientAreaToDecorationsHintProperty, hint => PlatformImpl!.SetExtendClientAreaToDecorationsHint(hint));
             CreatePlatformImplBinding(ExtendClientAreaChromeHintsProperty, hint => PlatformImpl!.SetExtendClientAreaChromeHints(hint));
@@ -377,6 +384,16 @@ namespace Avalonia.Controls
         {
             get => GetValue(ShowInTaskbarProperty);
             set => SetValue(ShowInTaskbarProperty, value);
+        }
+        
+        /// <summary>
+        /// Shows or hides from the task switcher
+        /// </summary>
+        /// 
+        public bool ShowInTaskSwitcher
+        {
+            get => GetValue(ShowInTaskSwitcherProperty);
+            set => SetValue(ShowInTaskSwitcherProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
+++ b/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
@@ -129,6 +129,10 @@ namespace Avalonia.DesignerSupport.Remote
         {
         }
 
+        public void ShowInTaskSwitcher(bool value)
+        {
+        }
+
         public void CanResize(bool value)
         {
         }

--- a/src/Avalonia.DesignerSupport/Remote/Stubs.cs
+++ b/src/Avalonia.DesignerSupport/Remote/Stubs.cs
@@ -148,6 +148,10 @@ namespace Avalonia.DesignerSupport.Remote
         {
         }
 
+        public void ShowInTaskSwitcher(bool value)
+        {
+        }
+
         public void CanResize(bool value)
         {
         }

--- a/src/Avalonia.Native/WindowImpl.cs
+++ b/src/Avalonia.Native/WindowImpl.cs
@@ -209,7 +209,7 @@ namespace Avalonia.Native
 
         public void ShowInTaskSwitcher(bool value)
         {
-            //TODO: where's the entry??
+            // TODO: I cannot find a way to change NSWindow CollectionBehaviors.
         }
 
         public void SetIcon(IWindowIconImpl icon)

--- a/src/Avalonia.Native/WindowImpl.cs
+++ b/src/Avalonia.Native/WindowImpl.cs
@@ -207,6 +207,11 @@ namespace Avalonia.Native
             // NO OP On OSX
         }
 
+        public void ShowInTaskSwitcher(bool value)
+        {
+            //NO OP On OSX
+        }
+
         public void SetIcon(IWindowIconImpl icon)
         {
             // NO OP on OSX

--- a/src/Avalonia.Native/WindowImpl.cs
+++ b/src/Avalonia.Native/WindowImpl.cs
@@ -209,7 +209,7 @@ namespace Avalonia.Native
 
         public void ShowInTaskSwitcher(bool value)
         {
-            //NO OP On OSX
+            //TODO: where's the entry??
         }
 
         public void SetIcon(IWindowIconImpl icon)

--- a/src/Avalonia.X11/X11Atoms.cs
+++ b/src/Avalonia.X11/X11Atoms.cs
@@ -166,6 +166,7 @@ namespace Avalonia.X11
         public IntPtr _XEMBED_INFO;
         public IntPtr _MOTIF_WM_HINTS;
         public IntPtr _NET_WM_STATE_SKIP_TASKBAR;
+        public IntPtr _NET_WM_STATE_SKIP_PAGER;
         public IntPtr _NET_WM_STATE_ABOVE;
         public IntPtr _NET_WM_STATE_MODAL;
         public IntPtr _NET_WM_STATE_HIDDEN;

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -1448,6 +1448,12 @@ namespace Avalonia.X11
         {
             ChangeWMAtoms(!value, _x11.Atoms._NET_WM_STATE_SKIP_TASKBAR);
         }
+        
+
+        public void ShowInTaskSwitcher(bool value)
+        {
+            ChangeWMAtoms(!value, _x11.Atoms._NET_WM_STATE_SKIP_PAGER);
+        }
 
         private void ChangeWMAtoms(bool enable, params IntPtr[] atoms)
         {

--- a/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -174,6 +174,11 @@ namespace Avalonia.Headless
 
         }
 
+        public void ShowInTaskSwitcher(bool value)
+        {
+            
+        }
+
         public void CanResize(bool value)
         {
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -863,6 +863,18 @@ namespace Avalonia.Win32
             UpdateWindowProperties(newWindowProperties);
         }
 
+
+        public void ShowInTaskSwitcher(bool value)
+        {
+            var newWindowProperties = _windowProperties;
+
+            newWindowProperties.ShowInTaskSwitcher = value;
+
+            UpdateWindowProperties(newWindowProperties);//TODO
+            
+        }
+
+
         public void CanResize(bool value)
         {
             var newWindowProperties = _windowProperties;
@@ -1380,6 +1392,10 @@ namespace Avalonia.Win32
             // according to the new values already.
             _windowProperties = newProperties;
 
+            //TODO NOTE: Should I write ShowInTaskSwitcher here or in the if, like ShowInTaskbar?
+            //IMPORTANT: Check line 1427~1437
+            //THIS COMMENT SHOULD BE DELETED LATER
+            
             if (oldProperties.IsFullScreen == newProperties.IsFullScreen)
             {
                 var exStyle = WindowStyles.WS_EX_WINDOWEDGE | (UseRedirectionBitmap ? 0 : WindowStyles.WS_EX_NOREDIRECTIONBITMAP);
@@ -1669,6 +1685,7 @@ namespace Avalonia.Win32
         protected struct WindowProperties
         {
             public bool ShowInTaskbar;
+            public bool ShowInTaskSwitcher;//TODO
             public bool IsResizable;
             public SystemDecorations Decorations;
             public bool IsFullScreen;

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1403,54 +1403,43 @@ namespace Avalonia.Win32
                     {
                         exStyle |= WindowStyles.WS_EX_APPWINDOW;
 
-                        if (_hiddenWindowIsParent)
-                        {
-                            // Can't enable the taskbar icon by clearing the parent window unless the window
-                            // is hidden. Hide the window and show it again with the same activation state
-                            // when we've finished. Interestingly it seems to work fine the other way.
-                            var shown = IsWindowVisible(_hwnd);
-                            var activated = GetActiveWindow() == _hwnd;
-
-                            if (shown)
-                                Hide();
-
-                            _hiddenWindowIsParent = false;
-                            SetParent(null);
-
-                            if (shown)
-                                Show(activated, false);
-                        }
+                        // if (_hiddenWindowIsParent)
+                        // {
+                        //     // Can't enable the taskbar icon by clearing the parent window unless the window
+                        //     // is hidden. Hide the window and show it again with the same activation state
+                        //     // when we've finished. Interestingly it seems to work fine the other way.
+                        //     _hiddenWindowIsParent = false;
+                        //     SetParent(null);
+                        // }
                     }
                     else
                     {
                         // To hide a non-owned window's taskbar icon we need to parent it to a hidden window.
-                        if (_parent is null)
-                        {
-                            SetWindowLongPtr(_hwnd, (int)WindowLongParam.GWL_HWNDPARENT, OffscreenParentWindow.Handle);
-                            _hiddenWindowIsParent = true;
-                        }
-
+                        // if (_parent is null)
+                        // {
+                        //     SetWindowLongPtr(_hwnd, (int)WindowLongParam.GWL_HWNDPARENT, OffscreenParentWindow.Handle);
+                        //     _hiddenWindowIsParent = true;
+                        // }
                         exStyle &= ~WindowStyles.WS_EX_APPWINDOW;
                     }
-                }
+                    var shown = IsWindowVisible(_hwnd);
+                    var activated = GetActiveWindow() == _hwnd;
 
-                if (newProperties.ShowInTaskbar)
-                {
-                    exStyle |= WindowStyles.WS_EX_APPWINDOW;
-                }
-                else
-                {
-                    exStyle &= ~WindowStyles.WS_EX_APPWINDOW;
+                    if (shown)
+                    {
+                        Hide();
+                        Show(activated, false);
+                    }
                 }
                 
                 if (!newProperties.ShowInTaskSwitcher)
                 {
                     exStyle |= WindowStyles.WS_EX_TOOLWINDOW;
                     exStyle &= ~WindowStyles.WS_EX_APPWINDOW;
-                    // If ShowInTaskSwitcher=false, the window will NOT show in taskbar. That is a side effect.
+                    // As a side effect, if ShowInTaskSwitcher=false, the window will NOT show in taskbar.
                     // So if you applied ShowInTaskSwitcher=false, please also set ShowInTaskbar=false if it should be.
-                    // I cannot find a better implementation. So this will stay here as a temporary one.
-                    // If I got a better solution, I will create a PR to change it.
+                    // I found a better implementation, but needs further tests. So this will stay here as a temporary one.
+                    // I will create a PR to change it when tests were done.
                 }
                 else
                 {
@@ -1458,6 +1447,7 @@ namespace Avalonia.Win32
                     if (newProperties.ShowInTaskbar)
                     {
                         exStyle |= WindowStyles.WS_EX_APPWINDOW;
+                        SetExtendedStyle(GetExtendedStyle() | WindowStyles.WS_EX_APPWINDOW, false);
                     }
                 }
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -870,7 +870,7 @@ namespace Avalonia.Win32
 
             newWindowProperties.ShowInTaskSwitcher = value;
 
-            UpdateWindowProperties(newWindowProperties);//TODO
+            UpdateWindowProperties(newWindowProperties);
             
         }
 
@@ -1443,13 +1443,22 @@ namespace Avalonia.Win32
                     exStyle &= ~WindowStyles.WS_EX_APPWINDOW;
                 }
                 
-                if (newProperties.ShowInTaskSwitcher)// TODO: NEED TEST
+                if (!newProperties.ShowInTaskSwitcher)
                 {
                     exStyle |= WindowStyles.WS_EX_TOOLWINDOW;
+                    exStyle &= ~WindowStyles.WS_EX_APPWINDOW;
+                    // If ShowInTaskSwitcher=false, the window will NOT show in taskbar. That is a side effect.
+                    // So if you applied ShowInTaskSwitcher=false, please also set ShowInTaskbar=false if it should be.
+                    // I cannot find a better implementation. So this will stay here as a temporary one.
+                    // If I got a better solution, I will create a PR to change it.
                 }
                 else
                 {
                     exStyle &= ~WindowStyles.WS_EX_TOOLWINDOW;
+                    if (newProperties.ShowInTaskbar)
+                    {
+                        exStyle |= WindowStyles.WS_EX_APPWINDOW;
+                    }
                 }
 
                 WindowStyles style = WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_OVERLAPPEDWINDOW | WindowStyles.WS_CLIPSIBLINGS;

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1392,9 +1392,6 @@ namespace Avalonia.Win32
             // according to the new values already.
             _windowProperties = newProperties;
 
-            //TODO NOTE: Should I write ShowInTaskSwitcher here or in the if, like ShowInTaskbar?
-            //IMPORTANT: Check line 1427~1437
-            //THIS COMMENT SHOULD BE DELETED LATER
             
             if (oldProperties.IsFullScreen == newProperties.IsFullScreen)
             {
@@ -1444,6 +1441,15 @@ namespace Avalonia.Win32
                 else
                 {
                     exStyle &= ~WindowStyles.WS_EX_APPWINDOW;
+                }
+                
+                if (newProperties.ShowInTaskSwitcher)// TODO: NEED TEST
+                {
+                    exStyle |= WindowStyles.WS_EX_TOOLWINDOW;
+                }
+                else
+                {
+                    exStyle &= ~WindowStyles.WS_EX_TOOLWINDOW;
                 }
 
                 WindowStyles style = WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_OVERLAPPEDWINDOW | WindowStyles.WS_CLIPSIBLINGS;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Add ShowInTaskSwitcher Property for Window #18689


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
*`ShowInTaskSwitcher` defaults to true*.
If `ShowInTaskSwitcher = false`, the `Window` shouldn't advent in Task Switcher(`Alt+Tab` for Windows/Linux and maybe `Cmd+Alt` for Mac)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Windows:
set `WS_EX_TOOLWINDOW`
Linux:
Add some `Atom` like `_NET_WM_STATE_SKIP_PAGER`
Mac:
set `NSWindowCollectionBehavior.IgnoreCycle`

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
