### PR TITLE
Pick nearest parent if container query doesn't specify container name

### DIFF
--- a/src/Avalonia.Base/Styling/Activators/ContainerQueryActivatorBase.cs
+++ b/src/Avalonia.Base/Styling/Activators/ContainerQueryActivatorBase.cs
@@ -74,7 +74,8 @@ namespace Avalonia.Styling.Activators
         internal static Layoutable? GetContainer(Visual visual, string? containerName)
         {
             return visual.GetVisualAncestors().Where(x => x is Layoutable layoutable &&
-                (Container.GetName(layoutable) == containerName)).FirstOrDefault() as Layoutable;
+                ((containerName == null && Container.GetSizing(layoutable) != ContainerSizing.Normal)
+                || (containerName != null && Container.GetName(layoutable) == containerName))).FirstOrDefault() as Layoutable;
         }
 
         private void HeightChanged(object? sender, EventArgs e)

--- a/src/Avalonia.Base/Styling/ScreenQueries.cs
+++ b/src/Avalonia.Base/Styling/ScreenQueries.cs
@@ -67,11 +67,22 @@ namespace Avalonia.Styling
                 SelectorMatch.AlwaysThisInstance : SelectorMatch.NeverThisInstance;
         }
 
-        public override string ToString() => "width";
+        public override string ToString() => ToString(null);
 
         public override string ToString(ContainerQuery? owner)
         {
-            throw new NotImplementedException();
+            var prop = Argument.@operator switch
+            {
+                StyleQueryComparisonOperator.None => "",
+                StyleQueryComparisonOperator.Equals => "width",
+                StyleQueryComparisonOperator.LessThan => "",
+                StyleQueryComparisonOperator.GreaterThan => "",
+                StyleQueryComparisonOperator.LessThanOrEquals => "max-width",
+                StyleQueryComparisonOperator.GreaterThanOrEquals => "min-width",
+                _ => throw new NotImplementedException(),
+            };
+
+            return $"{prop}:{Argument.value}";
         }
     }
 
@@ -137,11 +148,22 @@ namespace Avalonia.Styling
                 SelectorMatch.AlwaysThisInstance : SelectorMatch.NeverThisInstance;
         }
 
-        public override string ToString() => "height";
+        public override string ToString() => ToString(null);
 
         public override string ToString(ContainerQuery? owner)
         {
-            throw new NotImplementedException();
+            var prop = Argument.@operator switch
+            {
+                StyleQueryComparisonOperator.None => "",
+                StyleQueryComparisonOperator.Equals => "height",
+                StyleQueryComparisonOperator.LessThan => "",
+                StyleQueryComparisonOperator.GreaterThan => "",
+                StyleQueryComparisonOperator.LessThanOrEquals => "max-height",
+                StyleQueryComparisonOperator.GreaterThanOrEquals => "min-height",
+                _ => throw new NotImplementedException(),
+            };
+
+            return $"{prop}:{Argument.value}";
         }
     }
 }

--- a/src/Avalonia.Base/Styling/ScreenQueries.cs
+++ b/src/Avalonia.Base/Styling/ScreenQueries.cs
@@ -112,8 +112,6 @@ namespace Avalonia.Styling
                 return SelectorMatch.NeverThisInstance;
             }
 
-            var isvalueTrue = IsTrue(argument.@operator, argument.value);
-
             bool IsTrue(StyleQueryComparisonOperator comparisonOperator, double value)
             {
                 switch (comparisonOperator)

--- a/tests/Avalonia.Base.UnitTests/Styling/ContainerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/ContainerTests.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Base.UnitTests.Styling
             containerQuery1.Children.Add(new Style(x => x.Is<Border>())
             {
                 Setters = { new Setter(Control.WidthProperty, 200.0) }
-            });            
+            });
             var containerQuery2 = new ContainerQuery(x => new WidthQuery(x, StyleQueryComparisonOperator.GreaterThan, 500));
             containerQuery2.Children.Add(new Style(x => x.Is<Border>())
             {
@@ -43,11 +43,13 @@ namespace Avalonia.Base.UnitTests.Styling
                 Name = "Child",
                 HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch
             };
+            var stack = new StackPanel();
+            stack.Children.Add(child);
             var border = new Border()
             {
                 HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch,
                 VerticalAlignment = Avalonia.Layout.VerticalAlignment.Stretch,
-                Child = child,
+                Child = stack,
                 Name = "Parent"
             };
             Container.SetSizing(border, Avalonia.Styling.ContainerSizing.Width);
@@ -55,13 +57,13 @@ namespace Avalonia.Base.UnitTests.Styling
             root.Child = border;
 
             root.LayoutManager.ExecuteInitialLayoutPass();
-            Assert.Equal(child.Width, 200.0);
+            Assert.Equal(200, child.Width);
 
             root.ClientSize = new Size(600, 600);
             root.InvalidateMeasure();
 
             root.LayoutManager.ExecuteLayoutPass();
-            Assert.Equal(child.Width, 500.0);
+            Assert.Equal(500, child.Width);
         }
 
         [Fact]
@@ -89,11 +91,13 @@ namespace Avalonia.Base.UnitTests.Styling
                 Name = "Child",
                 VerticalAlignment = Avalonia.Layout.VerticalAlignment.Stretch
             };
+            var stack = new StackPanel();
+            stack.Children.Add(child);
             var border = new Border()
             {
                 HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch,
                 VerticalAlignment = Avalonia.Layout.VerticalAlignment.Stretch,
-                Child = child,
+                Child = stack,
                 Name = "Parent"
             };
             Container.SetSizing(border, Avalonia.Styling.ContainerSizing.Height);
@@ -101,13 +105,13 @@ namespace Avalonia.Base.UnitTests.Styling
             root.Child = border;
 
             root.LayoutManager.ExecuteInitialLayoutPass();
-            Assert.Equal(child.Height, 200.0);
+            Assert.Equal(200, child.Height);
 
             root.ClientSize = new Size(600, 600);
             root.InvalidateMeasure();
 
             root.LayoutManager.ExecuteLayoutPass();
-            Assert.Equal(child.Height, 500.0);
+            Assert.Equal(500, child.Height);
         }
 
         [Fact]
@@ -128,8 +132,8 @@ namespace Avalonia.Base.UnitTests.Styling
             {
                 Setters = { new Setter(Control.WidthProperty, 300.0) }
             });
-            root.Styles.Add(containerQuery2);
             root.Styles.Add(containerQuery1);
+            root.Styles.Add(containerQuery2);
             var child = new Border()
             {
                 Name = "Child",
@@ -144,11 +148,13 @@ namespace Avalonia.Base.UnitTests.Styling
             };
             Container.SetSizing(controlInner, Avalonia.Styling.ContainerSizing.Width);
             Container.SetName(controlInner, "TEST");
+            var stack = new StackPanel();
+            stack.Children.Add(controlInner);
             var border = new Border()
             {
                 HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch,
                 VerticalAlignment = Avalonia.Layout.VerticalAlignment.Stretch,
-                Child = controlInner,
+                Child = stack,
                 Name = "Parent"
             };
             Container.SetSizing(border, Avalonia.Styling.ContainerSizing.Width);
@@ -158,7 +164,7 @@ namespace Avalonia.Base.UnitTests.Styling
             root.LayoutManager.ExecuteInitialLayoutPass();
 
             root.LayoutManager.ExecuteLayoutPass();
-            Assert.Equal(child.Width, 300.0);
+            Assert.Equal(300, child.Width);
         }
 
         [Fact]
@@ -174,13 +180,13 @@ namespace Avalonia.Base.UnitTests.Styling
             {
                 Setters = { new Setter(Control.HeightProperty, 200.0) }
             });
-            var containerQuery2 = new ContainerQuery(x => new HeightQuery(x, StyleQueryComparisonOperator.LessThanOrEquals, 500), "TEST");
+            var containerQuery2 = new ContainerQuery(x => new HeightQuery(x, StyleQueryComparisonOperator.LessThanOrEquals, 450), "TEST");
             containerQuery2.Children.Add(new Style(x => x.Is<Border>())
             {
                 Setters = { new Setter(Control.HeightProperty, 300.0) }
             });
-            root.Styles.Add(containerQuery2);
             root.Styles.Add(containerQuery1);
+            root.Styles.Add(containerQuery2);
             var child = new Border()
             {
                 Name = "Child",
@@ -195,11 +201,13 @@ namespace Avalonia.Base.UnitTests.Styling
             };
             Container.SetSizing(controlInner, Avalonia.Styling.ContainerSizing.Height);
             Container.SetName(controlInner, "TEST");
+            var stack = new StackPanel();
+            stack.Children.Add(controlInner);
             var border = new Border()
             {
                 HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch,
                 VerticalAlignment = Avalonia.Layout.VerticalAlignment.Stretch,
-                Child = controlInner,
+                Child = stack,
                 Name = "Parent"
             };
             Container.SetSizing(border, Avalonia.Styling.ContainerSizing.Height);
@@ -209,7 +217,7 @@ namespace Avalonia.Base.UnitTests.Styling
             root.LayoutManager.ExecuteInitialLayoutPass();
 
             root.LayoutManager.ExecuteLayoutPass();
-            Assert.Equal(child.Height, 300.0);
+            Assert.Equal(300, child.Height);
         }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Currently, container queries do exact name match when searching for a container to evaluate. Thus, a  query with null name will only match with a container with null name. This isn't how css searches and is different from the expected behavior. This PR fixes it. Now it will only match exact name if the name is set to a non-null value, otherwise it matches the nearest container, irrespective of the container name.
Tests have been updated.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ x ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
