### PR TITLE
Fix typo in PseudoClassesExtensions class name

### DIFF
--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -2,6 +2,12 @@
 <!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Avalonia.Controls.PseudolassesExtensions</Target>
+    <Left>baseline/netstandard2.0/Avalonia.Base.dll</Left>
+    <Right>target/netstandard2.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Diagnostics.AppliedStyle.get_HasActivator</Target>
     <Left>baseline/netstandard2.0/Avalonia.Base.dll</Left>

--- a/src/Avalonia.Base/Controls/PseudoClassesExtensions.cs
+++ b/src/Avalonia.Base/Controls/PseudoClassesExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace Avalonia.Controls
 {
-    public static class PseudolassesExtensions
+    public static class PseudoClassesExtensions
     {
         /// <summary>
         /// Adds or removes a pseudoclass depending on a boolean value.


### PR DESCRIPTION
## What does the pull request do?

This pull request includes a single change to fix a typo in the name of the `PseudoClassesExtensions` class in the `src/Avalonia.Base/Controls/PseudoClassesExtensions.cs` file. The class name was corrected from `PseudolassesExtensions` to `PseudoClassesExtensions`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
PseudolassesExtensions

## Obsoletions / Deprecations
PseudolassesExtensions

## Fixed issues