### PR TITLE
feat: add TreeViewItemIndentConverter for dynamic margin calculation

### DIFF
--- a/src/Avalonia.Controls/Converters/TreeViewItemIndentConverter.cs
+++ b/src/Avalonia.Controls/Converters/TreeViewItemIndentConverter.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace Avalonia.Controls.Converters;
+
+public class TreeViewItemIndentConverter : IMultiValueConverter
+{
+    public static readonly TreeViewItemIndentConverter Instance = new();
+
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Count > 1 && values[0] is int level && values[1] is double indent)
+        {
+            return new Thickness(indent * level, 0, 0, 0);
+        }
+
+        return new Thickness(0);
+    }
+}

--- a/src/Avalonia.Themes.Fluent/Controls/TreeViewItem.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/TreeViewItem.xaml
@@ -25,9 +25,6 @@
   <Thickness x:Key="TreeViewItemExpandCollapseChevronMargin">12, 0, 12, 0</Thickness>
   <StreamGeometry x:Key="TreeViewItemCollapsedChevronPathData">M 1,0 10,10 l -9,10 -1,-1 L 8,10 -0,1 Z</StreamGeometry>
   <StreamGeometry x:Key="TreeViewItemExpandedChevronPathData">M0,1 L10,10 20,1 19,0 10,8 1,0 Z</StreamGeometry>
-  <converters:MarginMultiplierConverter Indent="{StaticResource TreeViewItemIndent}"
-                                        Left="True"
-                                        x:Key="TreeViewItemLeftMarginConverter" />
 
   <ControlTheme x:Key="FluentTreeViewExpandCollapseChevron" TargetType="ToggleButton">
     <Setter Property="Margin" Value="0" />
@@ -76,8 +73,13 @@
                   MinHeight="{TemplateBinding MinHeight}"
                   TemplatedControl.IsTemplateFocusTarget="True">
             <Grid Name="PART_Header"
-                  ColumnDefinitions="Auto, *"
-                  Margin="{TemplateBinding Level, Mode=OneWay, Converter={StaticResource TreeViewItemLeftMarginConverter}}">
+                  ColumnDefinitions="Auto, *">
+              <Grid.Margin>
+                <MultiBinding Converter="{x:Static converters:TreeViewItemIndentConverter.Instance}">
+                  <Binding Path="Level" RelativeSource="{RelativeSource TemplatedParent}" />
+                  <DynamicResource ResourceKey="TreeViewItemIndent" />
+                </MultiBinding>
+              </Grid.Margin>
               <Panel Name="PART_ExpandCollapseChevronContainer"
                      Margin="{StaticResource TreeViewItemExpandCollapseChevronMargin}">
                 <ToggleButton Name="PART_ExpandCollapseChevron"

--- a/src/Avalonia.Themes.Simple/Controls/TreeViewItem.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/TreeViewItem.xaml
@@ -2,9 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="using:Avalonia.Controls.Converters"
                     x:ClassModifier="internal">
-  <converters:MarginMultiplierConverter x:Key="LeftMarginConverter"
-                                        Indent="16"
-                                        Left="True" />
+  <x:Double x:Key="TreeViewItemIndent">16</x:Double>
 
   <ControlTheme x:Key="SimpleTreeViewItemToggleButtonTheme"
                 TargetType="ToggleButton">
@@ -45,10 +43,13 @@
                   Focusable="True"
                   TemplatedControl.IsTemplateFocusTarget="True">
             <Grid Name="PART_Header"
-                  Margin="{TemplateBinding Level,
-                                           Mode=OneWay,
-                                           Converter={StaticResource LeftMarginConverter}}"
                   ColumnDefinitions="16, *">
+              <Grid.Margin>
+                <MultiBinding Converter="{x:Static converters:TreeViewItemIndentConverter.Instance}">
+                  <Binding Path="Level" RelativeSource="{RelativeSource TemplatedParent}" />
+                  <DynamicResource ResourceKey="TreeViewItemIndent" />
+                </MultiBinding>
+              </Grid.Margin>
               <ToggleButton Name="PART_ExpandCollapseChevron"
                             Focusable="False"
                             Background="Transparent"


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This pull request refactors how indentation is applied to `TreeViewItem` elements in both the Fluent and Simple themes of Avalonia.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
It introduces a new converter, `TreeViewItemIndentConverter`, to handle indentation dynamically, replacing the previous static converters and hardcoded implementations.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
### Introduction of a new converter:

* [`src/Avalonia.Controls/Converters/TreeViewItemIndentConverter.cs`](diffhunk://#diff-47d19efb5ba87f3b2340deac6a4bb5199f234401b83d8cc238d67b8fee0a1416R1-R21): Added a new `TreeViewItemIndentConverter` class implementing `IMultiValueConverter`. It calculates the indentation based on the `Level` and `Indent` values, returning a `Thickness` object.

### Updates to the Fluent theme:

* [`src/Avalonia.Themes.Fluent/Controls/TreeViewItem.xaml`](diffhunk://#diff-520d248b4dd03b1c685a85c8a8379e52934c455fd4748af1044e0aaf11df8c6cL28-L30): Replaced the `TreeViewItemLeftMarginConverter` with the new `TreeViewItemIndentConverter`. Updated the `Grid.Margin` property in the `PART_Header` element to use a `MultiBinding` with the new converter. [[1]](diffhunk://#diff-520d248b4dd03b1c685a85c8a8379e52934c455fd4748af1044e0aaf11df8c6cL28-L30) [[2]](diffhunk://#diff-520d248b4dd03b1c685a85c8a8379e52934c455fd4748af1044e0aaf11df8c6cL79-R82)

### Updates to the Simple theme:

* [`src/Avalonia.Themes.Simple/Controls/TreeViewItem.xaml`](diffhunk://#diff-7f7ceac6f760edd06e1c5e9376e1c5c94213f1aac4537e2fb377008cfd199990L5-R5): Removed the `LeftMarginConverter` and replaced it with a `TreeViewItemIndent` resource. Updated the `Grid.Margin` property in the `PART_Header` element to use a `MultiBinding` with the new `TreeViewItemIndentConverter`. [[1]](diffhunk://#diff-7f7ceac6f760edd06e1c5e9376e1c5c94213f1aac4537e2fb377008cfd199990L5-R5) [[2]](diffhunk://#diff-7f7ceac6f760edd06e1c5e9376e1c5c94213f1aac4537e2fb377008cfd199990L48-R52)

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
#18311