### PR TITLE
Limit use of deprecated Android display API

### DIFF
--- a/src/Android/Avalonia.Android/Avalonia.Android.csproj
+++ b/src/Android/Avalonia.Android/Avalonia.Android.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.5" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.5" />
+    <PackageReference Include="Xamarin.AndroidX.Window" Version="1.3.0.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Avalonia.Base\Avalonia.Base.csproj" />


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
`Display.GetRealMetrics` was deprecated in api 30, and we currently still use it for non-primary screen info on android. This PR removes the api usage for API 30+, replacing it with AndroidX compat api, i.e `WindowMetricsCalculator`. `WindowMetricsCalculator` does support api 21 and above, but as there's no way to get a UIContext below api 30, we still use the old Display api for them.
Also fix wrongful setting of IsPrimary with the context's main display, instead of the system's main display(ID 0). An app can be launched on secondary display and that display will be the app's context display, but not the primary display.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
