### PR TITLE
Added small banner about accelerate.

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainView.xaml
@@ -20,7 +20,7 @@
       <Setter Property="Margin" Value="10 0 -20 0"/>
     </Style>
   </UserControl.Styles>
-  <Grid Name="rootGrid" RowDefinitions="Auto,Auto,*,Auto,Auto">
+  <Grid Name="rootGrid" RowDefinitions="Auto,Auto,Auto,*,Auto,Auto">
     <Menu>
       <MenuItem Header="_File">
         <MenuItem Header="E_xit" Command="{Binding $parent[Window].Close}" />
@@ -251,24 +251,36 @@
         </MenuItem>
       </MenuItem>
     </Menu>
+    
 
-    <TabStrip Grid.Row="1" SelectedIndex="{Binding SelectedTab, Mode=TwoWay}">
+   <HyperlinkButton Grid.Row="1"
+                    CornerRadius="0"
+                    NavigateUri="https://avaloniaui.net/accelerate" 
+                    Content="Try the new Avalonia Dev Tools – now available in Accelerate." 
+                    Background="#F3ECC0" Foreground="#746D44"
+                    Height="30"
+                    HorizontalAlignment="Stretch"
+                    HorizontalContentAlignment="Center" VerticalContentAlignment="Bottom"
+                    FontWeight="Bold" FontSize="14"/>
+
+
+    <TabStrip Grid.Row="2" SelectedIndex="{Binding SelectedTab, Mode=TwoWay}">
       <TabStripItem Content="Logical Tree" />
       <TabStripItem Content="Visual Tree" />
       <TabStripItem Content="Events" />
       <TabStripItem Content="HotKeys" IsVisible="False" />
     </TabStrip>
 
-    <ContentControl Grid.Row="2"
+    <ContentControl Grid.Row="3"
                     BorderBrush="{DynamicResource ThemeControlMidBrush}"
                     BorderThickness="0,1,0,0"
                     Content="{Binding Content}" />
 
-    <GridSplitter Name="consoleSplitter" Grid.Row="3" Height="1"
+    <GridSplitter Name="consoleSplitter" Grid.Row="4" Height="1"
                   Background="{DynamicResource ThemeControlMidBrush}"
                   IsVisible="False" />
 
-    <Border Grid.Row="4"
+    <Border Grid.Row="5"
             BorderBrush="{DynamicResource ThemeControlMidBrush}"
             BorderThickness="0,1,0,0">
       <Grid ColumnDefinitions="*, Auto">


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
It adds a small and subtle banner to the OSS dev tools to let folks know that a new version exists as part of accelerate. 
![image](https://github.com/user-attachments/assets/d0ea7bf0-1db1-4a0d-b0b2-8015d4ea4c03)


## What is the current behavior?
No banner. 


## What is the updated/expected behavior with this PR?
The banner is displayed to users of the OSS Dev Tools. If they click the hyperlink, they'll be taken to the Accelerate page. 


## How was the solution implemented (if it's not obvious)?
I used a Hyperlink button, set its width to stretch and some suitable text. 


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
None
