### PR TITLE
[Issue 18734] Handle case when adorner is added to adorner layer children before being attached to visual tree

### DIFF
--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -280,13 +280,35 @@ namespace Avalonia.Controls.Primitives
                 case NotifyCollectionChangedAction.Add:
                     foreach (Visual i in e.NewItems!)
                     {
-                        UpdateAdornedElement(i, i.GetValue(AdornedElementProperty));
+                        if (!i.IsAttachedToVisualTree)
+                        {
+                            i.AttachedToVisualTree += AdornerAttachedToVisualTree;
+                        }
+                        else
+                        {
+                            UpdateAdornedElement(i, i.GetValue(AdornedElementProperty));
+                        }
+                    }
+
+                    break;
+                case NotifyCollectionChangedAction.Remove:
+                    foreach (Visual i in e.OldItems!)
+                    {
+                        i.AttachedToVisualTree -= AdornerAttachedToVisualTree;
                     }
 
                     break;
             }
 
             InvalidateArrange();
+        }
+
+        private void AdornerAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+        {
+            if (sender is Visual visual)
+            {
+                UpdateAdornedElement(visual, visual.GetValue(AdornedElementProperty));
+            }
         }
 
         private void UpdateAdornedElement(Visual adorner, Visual? adorned)

--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -291,13 +291,6 @@ namespace Avalonia.Controls.Primitives
                     }
 
                     break;
-                case NotifyCollectionChangedAction.Remove:
-                    foreach (Visual i in e.OldItems!)
-                    {
-                        i.AttachedToVisualTree -= AdornerAttachedToVisualTree;
-                    }
-
-                    break;
             }
 
             InvalidateArrange();
@@ -307,6 +300,7 @@ namespace Avalonia.Controls.Primitives
         {
             if (sender is Visual visual)
             {
+                visual.AttachedToVisualTree -= AdornerAttachedToVisualTree;
                 UpdateAdornedElement(visual, visual.GetValue(AdornedElementProperty));
             }
         }


### PR DESCRIPTION
## What does the pull request do?
When adorner layer is detached then attached to visual tree, the adorner element is added to the layer's children before the element is attached to the visual tree. This results in `adorner.CompositionVisual` being null, and logic that would otherwise be run is skipped. Adorners in this scenario are then drawn in the incorrect position. This PR adds logic to handle that case and draw adorners correctly.


## What is the current behavior?
Visual layer managers which appear in scenarios where they may be detached and then attached to the visual tree will draw adorners incorrectly.


## What is the updated/expected behavior with this PR?
Adorners are drawn correctly when contained in visual layer managers that may be detached from the visual tree


## How was the solution implemented (if it's not obvious)?
Modify the `ChildrenCollectionChanged` function of `AdornerLayer.cs` to add logic which:

1. Checks if the adorner is already attached to visual tree. If so, call `UpdateAdornedElement` as before
2. Otherwise, add a listener for when the adorner is attached to the visual tree, then call `UpdateAdornedElement`
3. Add a case for `NotifyCollectionChangedAction.Remove` which removes the handler added in step 2


## Checklist
- [ ] Added unit tests (if possible)?

## Breaking changes
N/A

## Fixed issues
Fixes #18734 (and also fixes the related exception mentioned in that issue)