### PR TITLE
add ThemeVariantValues

### DIFF
--- a/src/Headless/Avalonia.Headless.NUnit/ThemeVariantValuesAttribute.cs
+++ b/src/Headless/Avalonia.Headless.NUnit/ThemeVariantValuesAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections;
+using Avalonia.Styling;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace Avalonia.Headless.NUnit;
+
+[AttributeUsage(AttributeTargets.Parameter)]
+public sealed class ThemeVariantValuesAttribute : NUnitAttribute, IParameterDataSource
+{
+    static readonly object[] data = [ThemeVariant.Light, ThemeVariant.Dark];
+
+    IEnumerable IParameterDataSource.GetData(IParameterInfo parameter)
+    {
+        if (parameter.ParameterType == typeof(ThemeVariant))
+        {
+            return data;
+        }
+
+        throw new($"Parameter {parameter.ParameterInfo.Name} must be a ThemeVariant to use {nameof(ThemeVariantValuesAttribute)}.");
+    }
+}

--- a/tests/Avalonia.Headless.NUnit.UnitTests/ThemeVariantAttributeTests.cs
+++ b/tests/Avalonia.Headless.NUnit.UnitTests/ThemeVariantAttributeTests.cs
@@ -1,0 +1,18 @@
+﻿using Avalonia.Controls;
+using Avalonia.Styling;
+
+namespace Avalonia.Headless.NUnit.UnitTests;
+
+public class ThemeVariantValuesAttributeTests
+{
+    [AvaloniaTest, Timeout(10000)]
+    public void ThemeVariantValuesTest([ThemeVariantValues] ThemeVariant theme)
+    {
+        Application.Current!.RequestedThemeVariant = theme;
+
+        var window = new Window();
+        window.Show();
+
+        Assert.AreEqual(theme, window.ActualThemeVariant);
+    }
+}


### PR DESCRIPTION
thoughts on adding a `ThemeVariantValuesAttribute` to `Avalonia.Headless.NUnit`

so we can do the following in a parmaterized test

```
public class ThemeVariantValuesAttributeTests
{
    [AvaloniaTest]
    public void ThemeVariantValuesTest([ThemeVariantValues] ThemeVariant theme)
    {
        Application.Current!.RequestedThemeVariant = theme;

        var window = new Window();
        window.Show();

        Assert.AreEqual(theme, window.ActualThemeVariant);
    }
}
```

For my use case it would be really helpful when using snapshot testing to ensure the rendering in different themes

https://github.com/VerifyTests/Verify.Avalonia?tab=readme-ov-file#window-test

if you like the idea, i can add some docs to the PR
