### PR TITLE
fix TextBox multiline selection with up/down keys till start/end of text

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -705,7 +705,7 @@ namespace Avalonia.Controls.Presenters
             CaretChanged();
         }
 
-        public void MoveCaretVertical(LogicalDirection direction = LogicalDirection.Forward)
+        public void MoveCaretVertical(LogicalDirection direction = LogicalDirection.Forward, bool isSelecting = false)
         {
             var lineIndex = TextLayout.GetLineIndexFromCharacterIndex(CaretIndex, _lastCharacterHit.TrailingLength > 0);
 
@@ -720,34 +720,62 @@ namespace Avalonia.Controls.Presenters
             {
                 if (lineIndex + 1 > TextLayout.TextLines.Count - 1)
                 {
-                    return;
+                    if (!isSelecting)
+                    {
+                        return;
+                    }
+
+                    // no vertical movement down possible, but move to the end of the last line if needed
+
+                    var textLine = TextLayout.TextLines[TextLayout.TextLines.Count - 1];
+
+                    if (currentX >= textLine.Width)
+                    {
+                        return;
+                    }
+
+                    currentX = textLine.Width;
                 }
+                else
+                {
+                    var textLine = TextLayout.TextLines[lineIndex];
 
-                var textLine = TextLayout.TextLines[lineIndex];
-
-                currentY += textLine.Height;
+                    currentY += textLine.Height;
+                }
             }
             else
             {
                 if (lineIndex - 1 < 0)
                 {
-                    return;
+                    if (!isSelecting)
+                    {
+                        return;
+                    }
+
+                    // no vertical movement up possible, but move to the start of the first line if needed
+
+                    if (currentX <= 0)
+                    {
+                        return;
+                    }
+
+                    currentX = 0;
                 }
+                else
+                {
+                    var textLine = TextLayout.TextLines[--lineIndex];
 
-                var textLine = TextLayout.TextLines[--lineIndex];
-
-                currentY -= textLine.Height;
+                    currentY -= textLine.Height;
+                }
             }
-
-            var navigationPosition = _navigationPosition;
 
             MoveCaretToPoint(new Point(currentX, currentY));
 
-            _navigationPosition = navigationPosition.WithY(_caretBounds.Y);
+            _navigationPosition = new Point(_caretBounds.X, _caretBounds.Y);
 
             CaretChanged();
         }
-        
+
         private void EnsureCaretTimer()
         {
             if (_caretTimer == null)

--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -705,7 +705,7 @@ namespace Avalonia.Controls.Presenters
             CaretChanged();
         }
 
-        public void MoveCaretVertical(LogicalDirection direction = LogicalDirection.Forward, bool isSelecting = false)
+        public void MoveCaretVertical(LogicalDirection direction = LogicalDirection.Forward)
         {
             var lineIndex = TextLayout.GetLineIndexFromCharacterIndex(CaretIndex, _lastCharacterHit.TrailingLength > 0);
 
@@ -720,58 +720,30 @@ namespace Avalonia.Controls.Presenters
             {
                 if (lineIndex + 1 > TextLayout.TextLines.Count - 1)
                 {
-                    if (!isSelecting)
-                    {
-                        return;
-                    }
-
-                    // no vertical movement down possible, but move to the end of the last line if needed
-
-                    var textLine = TextLayout.TextLines[TextLayout.TextLines.Count - 1];
-
-                    if (currentX >= textLine.Width)
-                    {
-                        return;
-                    }
-
-                    currentX = textLine.Width;
+                    return;
                 }
-                else
-                {
-                    var textLine = TextLayout.TextLines[lineIndex];
 
-                    currentY += textLine.Height;
-                }
+                var textLine = TextLayout.TextLines[lineIndex];
+
+                currentY += textLine.Height;
             }
             else
             {
                 if (lineIndex - 1 < 0)
                 {
-                    if (!isSelecting)
-                    {
-                        return;
-                    }
-
-                    // no vertical movement up possible, but move to the start of the first line if needed
-
-                    if (currentX <= 0)
-                    {
-                        return;
-                    }
-
-                    currentX = 0;
+                    return;
                 }
-                else
-                {
-                    var textLine = TextLayout.TextLines[--lineIndex];
 
-                    currentY -= textLine.Height;
-                }
+                var textLine = TextLayout.TextLines[--lineIndex];
+
+                currentY -= textLine.Height;
             }
+
+            var navigationPosition = _navigationPosition;
 
             MoveCaretToPoint(new Point(currentX, currentY));
 
-            _navigationPosition = new Point(_caretBounds.X, _caretBounds.Y);
+            _navigationPosition = navigationPosition.WithY(_caretBounds.Y);
 
             CaretChanged();
         }

--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -747,7 +747,7 @@ namespace Avalonia.Controls.Presenters
 
             CaretChanged();
         }
-
+        
         private void EnsureCaretTimer()
         {
             if (_caretTimer == null)

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1472,7 +1472,7 @@ namespace Avalonia.Controls
                                 ClearSelectionAndMoveCaretToTextPosition(LogicalDirection.Backward);
                             }
 
-                            _presenter.MoveCaretVertical(LogicalDirection.Backward);
+                            _presenter.MoveCaretVertical(LogicalDirection.Backward, selection);
 
                             if (caretIndex != _presenter.CaretIndex)
                             {
@@ -1499,7 +1499,7 @@ namespace Avalonia.Controls
                                 ClearSelectionAndMoveCaretToTextPosition(LogicalDirection.Forward);
                             }
 
-                            _presenter.MoveCaretVertical();
+                            _presenter.MoveCaretVertical(LogicalDirection.Forward, selection);
 
                             if (caretIndex != _presenter.CaretIndex)
                             {

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -2009,39 +2009,39 @@ namespace Avalonia.Controls
                 return;
             }
 
-            if (!isSelecting && SelectionStart != SelectionEnd)
-            {
-                ClearSelectionAndMoveCaretToTextPosition(direction);
-            }
-
-            var oldCaretIndex = _presenter.CaretIndex;
-            _presenter.MoveCaretVertical(direction);
-            var newCaretIndex = _presenter.CaretIndex;
-
-            if (isSelecting && oldCaretIndex == newCaretIndex)
-            {
-                var text = Text ?? string.Empty;
-
-                // caret did not move while we are selecting so we could not move to previous/next line,
-                // but check if we are already at the 'boundary' of the text
-                if (direction == LogicalDirection.Forward && newCaretIndex < text.Length)
-                {
-                    // include selection till end of the text
-                    _presenter.MoveCaretToTextPosition(text.Length);
-                }
-                else if (direction == LogicalDirection.Backward && newCaretIndex > 0)
-                {
-                    // include selection till start of the text
-                    _presenter.MoveCaretToTextPosition(0);
-                }
-            }
-
             if (isSelecting)
             {
+                var oldCaretIndex = _presenter.CaretIndex;
+                _presenter.MoveCaretVertical(direction);
+                var newCaretIndex = _presenter.CaretIndex;
+
+                if (oldCaretIndex == newCaretIndex)
+                {
+                    var text = Text ?? string.Empty;
+
+                    // caret did not move while we are selecting so we could not move to previous/next line,
+                    // but check if we are already at the 'boundary' of the text
+                    if (direction == LogicalDirection.Forward && newCaretIndex < text.Length)
+                    {
+                        _presenter.MoveCaretToTextPosition(text.Length);
+                    }
+                    else if (direction == LogicalDirection.Backward && newCaretIndex > 0)
+                    {
+                        _presenter.MoveCaretToTextPosition(0);
+                    }
+                }
+
                 SetCurrentValue(SelectionEndProperty, _presenter.CaretIndex);
             }
             else
             {
+                if (SelectionStart != SelectionEnd)
+                {
+                    ClearSelectionAndMoveCaretToTextPosition(direction);
+                }
+
+                _presenter.MoveCaretVertical(direction);
+
                 SetCurrentValue(CaretIndexProperty, _presenter.CaretIndex);
             }
         }

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1464,59 +1464,23 @@ namespace Avalonia.Controls
                         break;
 
                     case Key.Up:
+                        selection = DetectSelection();
+                        MoveVertical(LogicalDirection.Backward, selection);
+                        if (caretIndex != _presenter.CaretIndex)
                         {
-                            selection = DetectSelection();
-
-                            if (!selection && SelectionStart != SelectionEnd)
-                            {
-                                ClearSelectionAndMoveCaretToTextPosition(LogicalDirection.Backward);
-                            }
-
-                            _presenter.MoveCaretVertical(LogicalDirection.Backward, selection);
-
-                            if (caretIndex != _presenter.CaretIndex)
-                            {
-                                movement = true;
-                            }
-
-                            if (selection)
-                            {
-                                SetCurrentValue(SelectionEndProperty, _presenter.CaretIndex);
-                            }
-                            else
-                            {
-                                SetCurrentValue(CaretIndexProperty, _presenter.CaretIndex);
-                            }
-
-                            break;
+                            movement = true;
                         }
+                        break;
+
                     case Key.Down:
+                        selection = DetectSelection();
+                        MoveVertical(LogicalDirection.Forward, selection);
+                        if (caretIndex != _presenter.CaretIndex)
                         {
-                            selection = DetectSelection();
-
-                            if (!selection && SelectionStart != SelectionEnd)
-                            {
-                                ClearSelectionAndMoveCaretToTextPosition(LogicalDirection.Forward);
-                            }
-
-                            _presenter.MoveCaretVertical(LogicalDirection.Forward, selection);
-
-                            if (caretIndex != _presenter.CaretIndex)
-                            {
-                                movement = true;
-                            }
-
-                            if (selection)
-                            {
-                                SetCurrentValue(SelectionEndProperty, _presenter.CaretIndex);
-                            }
-                            else
-                            {
-                                SetCurrentValue(CaretIndexProperty, _presenter.CaretIndex);
-                            }
-
-                            break;
+                            movement = true;
                         }
+                        break;
+
                     case Key.Back:
                         {
                             SnapshotUndoRedo();
@@ -2035,6 +1999,50 @@ namespace Avalonia.Controls
                 {
                     SetCurrentValue(SelectionStartProperty, selectionStart);
                 }
+            }
+        }
+
+        private void MoveVertical(LogicalDirection direction, bool isSelecting)
+        {
+            if (_presenter is null)
+            {
+                return;
+            }
+
+            if (!isSelecting && SelectionStart != SelectionEnd)
+            {
+                ClearSelectionAndMoveCaretToTextPosition(direction);
+            }
+
+            var oldCaretIndex = _presenter.CaretIndex;
+            _presenter.MoveCaretVertical(direction);
+            var newCaretIndex = _presenter.CaretIndex;
+
+            if (isSelecting && oldCaretIndex == newCaretIndex)
+            {
+                var text = Text ?? string.Empty;
+
+                // caret did not move while we are selecting so we could not move to previous/next line,
+                // but check if we are already at the 'boundary' of the text
+                if (direction == LogicalDirection.Forward && newCaretIndex < text.Length)
+                {
+                    // include selection till end of the text
+                    _presenter.MoveCaretToTextPosition(text.Length);
+                }
+                else if (direction == LogicalDirection.Backward && newCaretIndex > 0)
+                {
+                    // include selection till start of the text
+                    _presenter.MoveCaretToTextPosition(0);
+                }
+            }
+
+            if (isSelecting)
+            {
+                SetCurrentValue(SelectionEndProperty, _presenter.CaretIndex);
+            }
+            else
+            {
+                SetCurrentValue(CaretIndexProperty, _presenter.CaretIndex);
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -1875,6 +1875,68 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(4)]
+        [InlineData(8)]
+        public void When_Selecting_Multiline_Selection_Should_Be_Extended_With_Up_Arrow_Key_Till_Start_Of_Text(int caretOffsetFromEnd)
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = """
+                           AAAAAA
+                           BBBB
+                           CCCCCCCC
+                           """,
+                    AcceptsReturn = true
+                };
+                tb.ApplyTemplate();
+                tb.Measure(Size.Infinity);
+                tb.CaretIndex = tb.Text.Length - caretOffsetFromEnd;
+
+                RaiseKeyEvent(tb, Key.Up, KeyModifiers.Shift);
+                RaiseKeyEvent(tb, Key.Up, KeyModifiers.Shift);
+                RaiseKeyEvent(tb, Key.Up, KeyModifiers.Shift);
+                RaiseKeyEvent(tb, Key.Up, KeyModifiers.Shift);
+
+                Assert.Equal(0, tb.SelectionEnd);
+            }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(3)]
+        [InlineData(6)]
+        public void When_Selecting_Multiline_Selection_Should_Be_Extended_With_Down_Arrow_Key_Till_End_Of_Text(int caretOffsetFromStart)
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = """
+                           AAAAAA
+                           BBBB
+                           CCCCCCCC
+                           """,
+                    AcceptsReturn = true
+                };
+                tb.ApplyTemplate();
+                tb.Measure(Size.Infinity);
+                tb.CaretIndex = caretOffsetFromStart;
+
+                RaiseKeyEvent(tb, Key.Down, KeyModifiers.Shift);
+                RaiseKeyEvent(tb, Key.Down, KeyModifiers.Shift);
+                RaiseKeyEvent(tb, Key.Down, KeyModifiers.Shift);
+                RaiseKeyEvent(tb, Key.Down, KeyModifiers.Shift);
+
+                Assert.Equal(tb.Text.Length, tb.SelectionEnd);
+            }
+        }
+
         [Fact]
         public void TextBox_In_AdornerLayer_Will_Not_Cause_Collection_Modified_In_VisualLayerManager_Measure()
         {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fix TextBox with multiline text during selection (Shift) with Up/Down keys


## What is the current behavior?
In TextBox with multiline text while selecting (holding Shift):
pressing Down key on last line is not extending selection till the end of the last line text
pressing Up key on first line is not extending selection till the start of the first line text


## What is the updated/expected behavior with this PR?
In TextBox with multiline text while selecting (holding Shift):
pressing Down key on last line will extend selection till the end of the last line text
pressing Up key on first line will extend selection till the start of the first line text


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
