### PR TITLE
Multiple TextLine.GetTextRunBounds fixes

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
@@ -1123,7 +1123,6 @@ namespace Avalonia.Media.TextFormatting
             var runWidth = endX - startX;
 
             var textSourceIndex = startIndex + Math.Max(0, currentPosition - firstCluster) + clusterOffset;
-            //var textSourceIndex = offset + startHit.FirstCharacterIndex;
 
             return new TextRunBounds(new Rect(startX, 0, runWidth, Height), textSourceIndex, characterLength, currentRun);
         }
@@ -1211,7 +1210,6 @@ namespace Avalonia.Media.TextFormatting
             var runWidth = endX - startX;
 
              var textSourceIndex = startIndex + Math.Max(0, currentPosition - firstCluster) + clusterOffset;
-            //var textSourceIndex = offset + startHit.FirstCharacterIndex;
 
             return new TextRunBounds(new Rect(startX, 0, runWidth, Height), textSourceIndex, characterLength, currentRun);
         }

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
@@ -887,6 +887,93 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
         }
 
         [Fact]
+        public void Should_Throw_ArgumentOutOfRangeException_For_Zero_TextLength()
+        {
+            using (Start())
+            {
+                var typeface = Typeface.Default;
+
+                var defaultProperties = new GenericTextRunProperties(typeface);
+                var textSource = new CustomTextBufferTextSource(new TextCharacters("1234", defaultProperties));
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, double.PositiveInfinity,
+                        new GenericTextParagraphProperties(defaultProperties));
+
+                Assert.NotNull(textLine);
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => textLine.GetTextBounds(0, 0));
+            }     
+        }
+
+        [Fact]
+        public void Should_GetTextBounds_For_Negative_TextLength()
+        {
+            using (Start())
+            {
+                var typeface = Typeface.Default;
+
+                var defaultProperties = new GenericTextRunProperties(typeface);
+                var textSource = new CustomTextBufferTextSource(new TextCharacters("1234", defaultProperties));
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, double.PositiveInfinity,
+                        new GenericTextParagraphProperties(defaultProperties));
+
+                Assert.NotNull(textLine);
+
+                var textBounds = textLine.GetTextBounds(0, -1);
+
+                Assert.NotNull(textBounds);
+
+                Assert.NotEmpty(textBounds);
+
+                var firstBounds = textBounds[0];
+
+                Assert.Empty(firstBounds.TextRunBounds);
+
+                Assert.Equal(0, firstBounds.Rectangle.Width);
+
+                Assert.Equal(0, firstBounds.Rectangle.Left);
+            }
+        }
+
+        [Fact]
+        public void Should_GetTextBounds_For_Exceeding_TextLength()
+        {
+            using (Start())
+            {
+                var typeface = Typeface.Default;
+
+                var defaultProperties = new GenericTextRunProperties(typeface);
+                var textSource = new CustomTextBufferTextSource(new TextCharacters("1234", defaultProperties));
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, double.PositiveInfinity,
+                        new GenericTextParagraphProperties(defaultProperties));
+
+                Assert.NotNull(textLine);
+
+                var textBounds = textLine.GetTextBounds(10, 1);
+
+                Assert.NotNull(textBounds);
+
+                Assert.NotEmpty(textBounds);
+
+                var firstBounds = textBounds[0];
+
+                Assert.Empty(firstBounds.TextRunBounds);
+
+                Assert.Equal(0, firstBounds.Rectangle.Width);
+
+                Assert.Equal(textLine.WidthIncludingTrailingWhitespace, firstBounds.Rectangle.Right);
+            }
+        }
+
+        [Fact]
         public void Should_GetTextBounds_For_Mixed_Hidden_Runs_With_Ligature()
         {
             using (Start())

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
@@ -886,6 +886,235 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
             }
         }
 
+        [Fact]
+        public void Should_GetTextBounds_For_Mixed_Hidden_Runs_With_Ligature()
+        {
+            using (Start())
+            {
+                var typeface = new Typeface(FontFamily.Parse("resm:Avalonia.Skia.UnitTests.Fonts?assembly=Avalonia.Skia.UnitTests#Manrope"));
+
+                var defaultProperties = new GenericTextRunProperties(typeface);
+                var textSource = new CustomTextBufferTextSource(
+                    new TextHidden(1), 
+                    new TextCharacters("Authenti", defaultProperties), 
+                    new TextHidden(1), 
+                    new TextHidden(1),
+                    new TextCharacters("ff", defaultProperties),
+                    new TextHidden(1), 
+                    new TextHidden(1));
+
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, double.PositiveInfinity,
+                        new GenericTextParagraphProperties(defaultProperties));
+
+                Assert.NotNull(textLine);
+
+                var textBounds = textLine.GetTextBounds(12, 1);
+
+                Assert.NotEmpty(textBounds);
+
+                var firstBounds = textBounds[0];
+
+                Assert.NotNull(firstBounds.TextRunBounds);
+                Assert.NotEmpty(firstBounds.TextRunBounds);
+
+                var firstRun = firstBounds.TextRunBounds[0];
+
+                Assert.NotNull(firstRun);
+
+                Assert.Equal(12, firstRun.TextSourceCharacterIndex);
+            }
+        }
+
+        [Fact]
+        public void Should_GetTextBounds_For_Mixed_Hidden_Runs()
+        {
+            using (Start())
+            {
+                var typeface = new Typeface(FontFamily.Parse("resm:Avalonia.Skia.UnitTests.Fonts?assembly=Avalonia.Skia.UnitTests#Manrope"));
+
+                var defaultProperties = new GenericTextRunProperties(typeface);
+                var textSource = new CustomTextBufferTextSource(
+                    new TextHidden(1),
+                    new TextCharacters("Authenti", defaultProperties),
+                    new TextHidden(1),
+                    new TextHidden(1),
+                    new TextEndOfParagraph(1));
+
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, double.PositiveInfinity,
+                        new GenericTextParagraphProperties(defaultProperties));
+
+                Assert.NotNull(textLine);
+
+                var textBounds = textLine.GetTextBounds(8, 1);
+
+                Assert.NotEmpty(textBounds);
+
+                var firstBounds = textBounds[0];
+
+                Assert.NotNull(firstBounds.TextRunBounds);
+                Assert.NotEmpty(firstBounds.TextRunBounds);
+
+                var firstRun = firstBounds.TextRunBounds[0];
+
+                Assert.NotNull(firstRun);
+
+                Assert.Equal(8, firstRun.TextSourceCharacterIndex);
+            }
+        }
+
+        [Win32Fact("Windows font")]
+        public void Should_GetTextBounds_Within_Cluster()
+        {
+            using (Start())
+            {
+                var typeface = new Typeface("Segoe UI Emoji");
+
+                var defaultProperties = new GenericTextRunProperties(typeface);
+                var textSource = new CustomTextBufferTextSource(new TextCharacters("🙈", defaultProperties));
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, double.PositiveInfinity,
+                        new GenericTextParagraphProperties(defaultProperties));
+
+                Assert.NotNull(textLine);
+
+                var textBounds = textLine.GetTextBounds(0, 1);
+
+                Assert.NotEmpty(textBounds);
+
+                var runBounds = textBounds[0].TextRunBounds[0];
+
+                Assert.Equal(0, runBounds.TextSourceCharacterIndex);
+
+                textBounds = textLine.GetTextBounds(1, 1);
+
+                Assert.NotEmpty(textBounds);
+
+                runBounds = textBounds[0].TextRunBounds[0];
+
+                Assert.Equal(1, runBounds.TextSourceCharacterIndex);
+
+                textBounds = textLine.GetTextBounds(2, 1);
+
+                Assert.NotEmpty(textBounds);
+
+                Assert.NotNull(textBounds[0].TextRunBounds);
+
+                Assert.Empty(textBounds[0].TextRunBounds);
+            }
+        }
+
+        [Win32Fact("Windows font")]
+        public void Should_GetTextBounds_After_Last_Index()
+        {
+            using (Start())
+            {
+                var typeface = new Typeface("Segoe UI Emoji");
+
+                var defaultProperties = new GenericTextRunProperties(typeface);
+                var textSource = new CustomTextBufferTextSource(new TextCharacters("🙈", defaultProperties));
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, double.PositiveInfinity,
+                        new GenericTextParagraphProperties(defaultProperties));
+
+                Assert.NotNull(textLine);
+
+                var textBounds = textLine.GetTextBounds(2, 1);
+
+                Assert.NotEmpty(textBounds);
+
+                var firstBounds = textBounds[0];
+
+                Assert.Equal(textLine.Width, firstBounds.Rectangle.Right);
+
+                Assert.NotNull(firstBounds.TextRunBounds);
+
+                Assert.Empty(firstBounds.TextRunBounds);
+            }
+        }
+
+        [Fact]
+        public void Should_Get_Run_Bounds()
+        {
+            using (Start())
+            {
+                var typeface = new Typeface(FontFamily.Parse("resm:Avalonia.Skia.UnitTests.Fonts?assembly=Avalonia.Skia.UnitTests#Manrope"));
+                var defaultProperties = new GenericTextRunProperties(typeface);
+                var textSource = new CustomTextBufferTextSource(
+                    new TextCharacters("He", defaultProperties), 
+                    new TextCharacters("Wo", defaultProperties),
+                    new TextCharacters("ff", defaultProperties));
+
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, double.PositiveInfinity,
+                        new GenericTextParagraphProperties(defaultProperties));
+
+                Assert.NotNull(textLine);
+
+                var textBounds = textLine.GetTextBounds(1, 1);
+
+                Assert.NotEmpty(textBounds);
+
+                textBounds = textLine.GetTextBounds(2, 1);
+
+                Assert.NotEmpty(textBounds);
+
+                textBounds = textLine.GetTextBounds(4, 1);
+
+                Assert.NotEmpty(textBounds);
+            }
+        }
+
+        private class TextHidden : TextRun
+        {
+            public TextHidden(int length)
+            {
+                Length = length;
+            }
+
+            public override int Length { get; }
+        }
+
+        private class CustomTextBufferTextSource : ITextSource
+        {
+            private IReadOnlyList<TextRun> _textRuns;
+
+            public CustomTextBufferTextSource(params TextRun[] textRuns)
+            {
+                _textRuns = textRuns;
+            }
+
+            public TextRun? GetTextRun(int textSourceIndex)
+            {
+                var pos = 0;
+
+                for(var i = 0; i < _textRuns.Count; i++)
+                {
+                    var currentRun = _textRuns[i];
+
+                    if(pos + currentRun.Length > textSourceIndex)
+                    {
+                        return currentRun;
+                    }
+
+                    pos += currentRun.Length;
+                }
+
+                return null;
+            }
+        }
+
         private class MixedTextBufferTextSource : ITextSource
         {
             public TextRun? GetTextRun(int textSourceIndex)


### PR DESCRIPTION


<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR introduces multiple fixes

- Adjust TextLineImpl.GetTextRunBounds so it properly handles substitutions
- Adjust TextLineImpl.GetTextRunBounds so it properly reports out of text range bounds 
- Adjust TextLineImpl.GetTextRunBounds so it properly reports text source run indices

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
