### PR TITLE
Invalidate ScrollContentPresenter measure on Can...Scroll

### DIFF
--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -109,6 +109,7 @@ namespace Avalonia.Controls.Presenters
         static ScrollContentPresenter()
         {
             ClipToBoundsProperty.OverrideDefaultValue(typeof(ScrollContentPresenter), true);
+            AffectsMeasure<ScrollContentPresenter>(CanHorizontallyScrollProperty, CanVerticallyScrollProperty);
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
@@ -477,7 +477,55 @@ namespace Avalonia.Controls.UnitTests
             var result = converter.Convert(args, typeof(ScrollBarVisibility), "0", System.Globalization.CultureInfo.CurrentCulture);
             Assert.Equal(true, result);
         }
-        
+
+        [Fact]
+        public void ScrollBar_Visibility_Should_Invalidate_Measure_And_Arrange()
+        {
+            var panel = new TestPanel()
+            {
+                DesiredWidth = 100_000
+            };
+            var target = new ScrollViewer
+            {
+                Content = panel,
+                Template = new FuncControlTemplate<ScrollViewer>(CreateTemplate),
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto
+            };
+            var root = new TestRoot(target);
+            root.LayoutManager.ExecuteInitialLayoutPass();
+            panel.Reset();
+
+            target.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
+            root.LayoutManager.ExecuteLayoutPass();
+            Assert.Equal(1, panel.MeasureOverrideCalls);
+            Assert.Equal(1, panel.ArrangeOverrideCalls);
+        }
+
+        public class TestPanel : Panel
+        {
+            public int DesiredWidth { get; set; }
+            public int MeasureOverrideCalls { get; private set; }
+            public int ArrangeOverrideCalls { get; private set; }
+
+            protected override Size MeasureOverride(Size availableSize)
+            {
+                MeasureOverrideCalls++;
+                return new Size(DesiredWidth, 1);
+            }
+
+            protected override Size ArrangeOverride(Size finalSize)
+            {
+                ArrangeOverrideCalls++;
+                return base.ArrangeOverride(finalSize);
+            }
+
+            public void Reset()
+            {
+                MeasureOverrideCalls = 0;
+                ArrangeOverrideCalls = 0;
+            }
+        }
+
         private Point GetRootPoint(Visual control, Point p)
         {
             if (control.GetVisualRoot() is Visual root &&


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

While thinking more about https://github.com/AvaloniaUI/Avalonia/discussions/18733 — a panel that has two modes: layout all items side by side, or layout all items to fit within the available size (items may overlap) — I came up with an alternative solution. Instead of binding to the scrollbar width, it should be possible to bind ScrollBarVisibility depending on the mode, and the panel should be able to get the "available width" from the respective argument in Measure. However, changing ScrollBarVisibility did not trigger a Measure.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

When a ScrollViewer's ScrollBarVisibility is changed, neither Measure nor Arrange is triggered, even though the available space may have changed.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

A change to ScrollBarVisibility will now invalidate Measure on the children.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Since the direct visual parent of a ScrollViewer's logical child is the ScrollContentPresenter, I had to add AffectsMeasure to the ScrollContentPresenter. If the inner child changes its desired size, it will automatically invalidate Arrange, so there is no need to add AffectsArrange.

Additionally, WPF also invalidates Measure in ScrollContentPresenter: https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ScrollContentPresenter.cs#L221

If there is any better way to write the test without writing a custom panel class, please let me know :)

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
