### PR TITLE
Replace raw pointer with ComObjectWeakPtr<T>

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -363,7 +363,7 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
         auto windowBase = _parent.tryGetWithCast<WindowBaseImpl>();
         
         if(windowBase != nullptr){
-            auto parent = windowBase->Parent;
+            auto parent = windowBase->Parent.tryGet();
             
             if(parent != nullptr){
                 auto parentWindow = parent->Window;

--- a/native/Avalonia.Native/src/OSX/PopupImpl.mm
+++ b/native/Avalonia.Native/src/OSX/PopupImpl.mm
@@ -45,8 +45,9 @@ public:
     
     virtual bool ShouldTakeFocusOnShow() override
     {
+        auto parent = Parent.tryGet();
         // Don't steal the focus from another windows if our parent is inactive
-        if (Parent != nullptr && Parent->Window != nullptr && ![Parent->Window isKeyWindow])
+        if (parent != nullptr && parent->Window != nullptr && ![parent->Window isKeyWindow])
             return false;
 
         return WindowBaseImpl::ShouldTakeFocusOnShow();

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
@@ -108,7 +108,7 @@ protected:
     std::list<WindowBaseImpl*> _children;
 
 public:
-    WindowBaseImpl* Parent = nullptr;
+    ComObjectWeakPtr<WindowBaseImpl> Parent = nullptr;
     NSWindow * Window;
     ComPtr<IAvnWindowBaseEvents> BaseEvents;
 };

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -503,16 +503,19 @@ HRESULT WindowBaseImpl::SetParent(IAvnWindowBase *parent) {
     START_COM_CALL;
 
     @autoreleasepool {
-        if(Parent != nullptr)
+        
+        auto oldParent = Parent.tryGet();
+        
+        if(oldParent != nullptr)
         {
-            Parent->_children.remove(this);
+            oldParent->_children.remove(this);
         }
 
         auto cparent = dynamic_cast<WindowImpl *>(parent);
         
         Parent = cparent;
        
-        if(Parent != nullptr && Window != nullptr){
+        if(cparent != nullptr && Window != nullptr){
             // If one tries to show a child window with a minimized parent window, then the parent window will be
             // restored but macOS isn't kind enough to *tell* us that, so the window will be left in a non-interactive
             // state. Detect this and explicitly restore the parent window ourselves to avoid this situation.

--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -546,7 +546,7 @@ bool WindowImpl::IsModal() {
 }
 
 bool WindowImpl::IsOwned() {
-    return Parent != nullptr;
+    return Parent.tryGet() != nullptr;
 }
 
 NSWindowStyleMask WindowImpl::CalculateStyleMask() {


### PR DESCRIPTION
This doesn't have any behavioral changes, but prevents potential native crashes when parent window got somehow destroyed before the current one.