### PR TITLE
Fix incorrect CandidateWindow position when using Pinyin IMEs in Windows

### DIFF
--- a/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
+++ b/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
@@ -211,27 +211,6 @@ namespace Avalonia.Win32.Input
             var s = _parent?.DesktopScaling ?? 1;
             var (x1, y1, x2, y2) = ((int) (p1.X * s), (int) (p1.Y * s), (int) (p2.X * s), (int) (p2.Y * s));
 
-            if (!ShowCompositionWindow && _langId == LANG_ZH)
-            {
-                // Chinese IMEs ignore function calls to ::ImmSetCandidateWindow()
-                // when a user disables TSF (Text Service Framework) and CUAS (Cicero
-                // Unaware Application Support).
-                // On the other hand, when a user enables TSF and CUAS, Chinese IMEs
-                // ignore the position of the current system caret and uses the
-                // parameters given to ::ImmSetCandidateWindow() with its 'dwStyle'
-                // parameter CFS_CANDIDATEPOS.
-                // Therefore, we do not only call ::ImmSetCandidateWindow() but also
-                // set the positions of the temporary system caret.
-                var candidateForm = new CANDIDATEFORM
-                {
-                    dwIndex = 0,
-                    dwStyle = CFS_CANDIDATEPOS,
-                    ptCurrentPos = new POINT {X = x2, Y = y2}
-                };
-
-                ImmSetCandidateWindow(himc, ref candidateForm);
-            }
-
             _caretManager.TryMove(x2, y2);
 
             if (ShowCompositionWindow)
@@ -250,14 +229,8 @@ namespace Avalonia.Win32.Input
                 y2 += CaretMargin;
             }
 
-            // Need to return here since some Chinese IMEs would stuck if set
-            // candidate window position with CFS_EXCLUDE style.
-            if (_langId == LANG_ZH)
-            {
-                return;
-            }
 
-            // Japanese IMEs and Korean IMEs also use the rectangle given to
+            // Chinese, Japanese, and Korean(CJK) IMEs also use the rectangle given to
             // ::ImmSetCandidateWindow() with its 'dwStyle' parameter CFS_EXCLUDE
             // to move their candidate windows when a user disables TSF and CUAS.
             // Therefore, we also set this parameter here.


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This pull request addresses an issue where the IME CandidateWindow is not correctly positioned when using Pinyin IMEs on Windows. The fix ensures that the CandidateWindow aligns properly with the caret position, improving user experience when typing Chinese characters with Pinyin Input Method Editors.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The CandidateWindow's top position does not align correctly with the caret position. This behavior is inconsistent with most major UI frameworks and leads to a poor user experience when inputting Chinese characters using Pinyin IMEs.
This issue was observed in different Chinese IMEs, including older ones on Windows 7.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The CandidateWindow now aligns correctly with the caret position. This behavior has been tested on multiple Chinese IMEs, including those available on Windows 7, and all display as expected.
The fix ensures compatibility across various IMEs and improves usability.

![image](https://github.com/user-attachments/assets/78451477-aa28-4d62-aa4e-3f2d5ce66a00)
![image](https://github.com/user-attachments/assets/6dfb20a6-0d63-448e-8243-7783ae249a11)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Most Chinese input methods after Windows XP have been improved. However, the input method implementation in Avalonia appears to be based on the [IMESharp code](https://github.com/ryancheung/ImeSharp), which in turn follows logic originating from [Chromium's code](https://chromium.googlesource.com/experimental/chromium/src/+blame/09911bf300f1a419907a9412154760efd0b7abc3/chrome/browser/ime_input.cc) as early as 2008 or even earlier. Windows 7 was officially released on October 22, 2009, while Windows Vista was released on November 30, 2006.

Will Avalonia's Windows input method switch to [TSF](https://learn.microsoft.com/windows/win32/tsf/text-services-framework) in the future? [TSF](https://learn.microsoft.com/windows/win32/tsf/text-services-framework)  has been a modern framework since Windows XP.

Perhaps we can also refer to the implementations of [WPF](https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputMethod.cs) (TSF) and modern [Chromium](https://github.com/chromium/chromium/blob/master/ui/base/ime/win/tsf_bridge.cc) (TSF).

If we implement TSF, it may potentially resolve many of the previous IME-related issues, though the workload would be significant.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
-->
Fixes #18748 
