### PR TITLE
Fix null reference crash when window is closed during drag-and-drop

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -836,6 +836,8 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
 
     auto effects = ConvertDragDropEffects(nsop);
     auto parent = _parent.tryGet();
+    if (!parent)
+      return NSDragOperationNone;
     int reffects = (int)parent->TopLevelEvents
             ->DragEvent(type, point, modifiers, effects,
                     CreateClipboard([info draggingPasteboard], nil),


### PR DESCRIPTION
## What does the pull request do?

This PR fixes a null reference crash that occurs when a window is closed from within the OnDragOver drag-and-drop event handler.

## What is the current behavior?
There is no null check for the parent window in the native OSX drag-and-drop event handler. If the window is closed while a drag operation is in progress, the handler attempts to access a released object, resulting in a crash.


## What is the updated/expected behavior with this PR?
Added null parent check, no crash is happening 


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation



## Fixed issues
fixes ticket https://support.avaloniaui.net/agent/tickets/657
-->
