### PR TITLE
Improve pen secondary button handling on list box

### DIFF
--- a/samples/ControlCatalog/Pages/ListBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/ListBoxPage.xaml
@@ -5,6 +5,13 @@
              x:DataType="viewModels:ListBoxPageViewModel">
   <DockPanel>
     <DockPanel.Styles>
+      <Style Selector="ListBox ListBoxItem:nth-child(even)">
+        <Setter Property="ContextFlyout">
+          <MenuFlyout>
+            <MenuItem Header="Hello there" />
+          </MenuFlyout>
+        </Setter>
+      </Style>
       <Style Selector="ListBox ListBoxItem:nth-child(5n+3)">
         <Setter Property="Foreground" Value="Red" />
         <Setter Property="FontWeight" Value="Bold" />

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -166,7 +166,7 @@ namespace Avalonia.Controls
 
         internal bool UpdateSelectionFromPointerEvent(Control source, PointerEventArgs e)
         {
-            var hotkeys = TopLevel.GetTopLevel(source)?.PlatformSettings?.HotkeyConfiguration;
+            var hotkeys = Application.Current!.PlatformSettings?.HotkeyConfiguration;
             var toggle = hotkeys is not null && e.KeyModifiers.HasAllFlags(hotkeys.CommandModifiers);
 
             return UpdateSelectionFromEventSource(

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -166,6 +166,7 @@ namespace Avalonia.Controls
 
         internal bool UpdateSelectionFromPointerEvent(Control source, PointerEventArgs e)
         {
+            // TODO: use TopLevel.PlatformSettings here, but first need to update our tests to use TopLevels. 
             var hotkeys = Application.Current!.PlatformSettings?.HotkeyConfiguration;
             var toggle = hotkeys is not null && e.KeyModifiers.HasAllFlags(hotkeys.CommandModifiers);
 

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -166,7 +166,7 @@ namespace Avalonia.Controls
 
         internal bool UpdateSelectionFromPointerEvent(Control source, PointerEventArgs e)
         {
-            var hotkeys = Application.Current!.PlatformSettings?.HotkeyConfiguration;
+            var hotkeys = TopLevel.GetTopLevel(source)?.PlatformSettings?.HotkeyConfiguration;
             var toggle = hotkeys is not null && e.KeyModifiers.HasAllFlags(hotkeys.CommandModifiers);
 
             return UpdateSelectionFromEventSource(

--- a/src/Avalonia.Controls/ListBoxItem.cs
+++ b/src/Avalonia.Controls/ListBoxItem.cs
@@ -64,9 +64,11 @@ namespace Avalonia.Controls
                 if (p.Properties.PointerUpdateKind is PointerUpdateKind.LeftButtonPressed or 
                     PointerUpdateKind.RightButtonPressed)
                 {
-                    if (p.Pointer.Type == PointerType.Mouse)
+                    if (p.Pointer.Type == PointerType.Mouse
+                        || (p.Pointer.Type == PointerType.Pen && p.Properties.IsRightButtonPressed))
                     {
-                        // If the pressed point comes from a mouse, perform the selection immediately.
+                        // If the pressed point comes from a mouse or right-click pen, perform the selection immediately.
+                        // In case of pen, only right-click is accepted, as left click (a tip touch) is used for scrolling. 
                         e.Handled = owner.UpdateSelectionFromPointerEvent(this, e);
                     }
                     else

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
@@ -611,17 +611,6 @@ namespace Avalonia.Controls.UnitTests
                 }.RegisterInNameScope(scope));
         }
 
-        private static FuncControlTemplate ListBoxItemTemplate()
-        {
-            return new FuncControlTemplate<ListBoxItem>((parent, scope) =>
-                new ContentPresenter
-                {
-                    Name = "PART_ContentPresenter",
-                    [!ContentPresenter.ContentProperty] = parent[!ListBoxItem.ContentProperty],
-                    [!ContentPresenter.ContentTemplateProperty] = parent[!ListBoxItem.ContentTemplateProperty],
-                }.RegisterInNameScope(scope));
-        }
-
         private static FuncControlTemplate ScrollViewerTemplate()
         {
             return new FuncControlTemplate<ScrollViewer>((parent, scope) =>
@@ -645,21 +634,7 @@ namespace Avalonia.Controls.UnitTests
         private static void Prepare(ListBox target)
         {
             target.Width = target.Height = 100;
-
-            var root = new TestRoot(target)
-            {
-                Resources =
-                {
-                    { 
-                        typeof(ListBoxItem),
-                        new ControlTheme(typeof(ListBoxItem))
-                        {
-                            Setters = { new Setter(ListBoxItem.TemplateProperty, ListBoxItemTemplate()) }
-                        }
-                    }
-                }
-            };
-
+            var root = new TestRoot(target);
             root.LayoutManager.ExecuteInitialLayoutPass();
         }
 
@@ -1263,7 +1238,6 @@ namespace Avalonia.Controls.UnitTests
                     {
                         new ListBoxItem()
                         {
-                            Template = ListBoxItemTemplate(),
                             Content = target,
                         }
                     }

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests_Single.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests_Single.cs
@@ -23,26 +23,29 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Focusing_Item_With_Tab_Should_Not_Select_It()
         {
-            var target = new ListBox
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
-                Template = new FuncControlTemplate(CreateListBoxTemplate),
-                ItemsSource = new[] { "Foo", "Bar", "Baz " },
-            };
+                var target = new ListBox
+                {
+                    Template = new FuncControlTemplate(CreateListBoxTemplate),
+                    ItemsSource = new[] { "Foo", "Bar", "Baz " },
+                };
 
-            ApplyTemplate(target);
+                Prepare(target);
 
-            target.Presenter.Panel.Children[0].RaiseEvent(new GotFocusEventArgs
-            {
-                NavigationMethod = NavigationMethod.Tab,
-            });
+                target.Presenter.Panel.Children[0].RaiseEvent(new GotFocusEventArgs
+                {
+                    NavigationMethod = NavigationMethod.Tab,
+                });
 
-            Assert.Equal(-1, target.SelectedIndex);
+                Assert.Equal(-1, target.SelectedIndex);
+            }
         }
 
         [Fact]
         public void Pressing_Space_On_Focused_Item_With_Ctrl_Pressed_Should_Select_It()
         {
-            using (UnitTestApplication.Start())
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
                 var target = new ListBox
                 {
@@ -50,7 +53,7 @@ namespace Avalonia.Controls.UnitTests
                     ItemsSource = new[] { "Foo", "Bar", "Baz " },
                 };
                 AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
-                ApplyTemplate(target);
+                Prepare(target);
 
                 target.Presenter.Panel.Children[0].RaiseEvent(new GotFocusEventArgs
                 {
@@ -72,7 +75,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Clicking_Item_Should_Select_It()
         {
-            using (UnitTestApplication.Start())
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
                 var target = new ListBox
                 {
@@ -80,7 +83,7 @@ namespace Avalonia.Controls.UnitTests
                     ItemsSource = new[] { "Foo", "Bar", "Baz " },
                 };
                 AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
-                ApplyTemplate(target);
+                Prepare(target);
                 _mouse.Click(target.Presenter.Panel.Children[0]);
 
                 Assert.Equal(0, target.SelectedIndex);
@@ -90,7 +93,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Clicking_Selected_Item_Should_Not_Deselect_It()
         {
-            using (UnitTestApplication.Start())
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
                 var target = new ListBox
                 {
@@ -98,7 +101,7 @@ namespace Avalonia.Controls.UnitTests
                     ItemsSource = new[] { "Foo", "Bar", "Baz " },
                 };
                 AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
-                ApplyTemplate(target);
+                Prepare(target);
                 target.SelectedIndex = 0;
 
                 _mouse.Click(target.Presenter.Panel.Children[0]);
@@ -110,7 +113,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Clicking_Item_Should_Select_It_When_SelectionMode_Toggle()
         {
-            using (UnitTestApplication.Start())
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
                 var target = new ListBox
                 {
@@ -119,7 +122,7 @@ namespace Avalonia.Controls.UnitTests
                     SelectionMode = SelectionMode.Single | SelectionMode.Toggle,
                 };
                 AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
-                ApplyTemplate(target);
+                Prepare(target);
 
                 _mouse.Click(target.Presenter.Panel.Children[0]);
 
@@ -130,7 +133,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Clicking_Selected_Item_Should_Deselect_It_When_SelectionMode_Toggle()
         {
-            using (UnitTestApplication.Start())
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
                 var target = new ListBox
                 {
@@ -140,7 +143,7 @@ namespace Avalonia.Controls.UnitTests
                 };
 
                 AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
-                ApplyTemplate(target);
+                Prepare(target);
                 target.SelectedIndex = 0;
 
                 _mouse.Click(target.Presenter.Panel.Children[0]);
@@ -152,7 +155,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Clicking_Selected_Item_Should_Not_Deselect_It_When_SelectionMode_ToggleAlwaysSelected()
         {
-            using (UnitTestApplication.Start())
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
                 var target = new ListBox
                 {
@@ -161,7 +164,7 @@ namespace Avalonia.Controls.UnitTests
                     SelectionMode = SelectionMode.Toggle | SelectionMode.AlwaysSelected,
                 };
                 AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
-                ApplyTemplate(target);
+                Prepare(target);
                 target.SelectedIndex = 0;
 
                 _mouse.Click(target.Presenter.Panel.Children[0]);
@@ -173,7 +176,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Clicking_Another_Item_Should_Select_It_When_SelectionMode_Toggle()
         {
-            using (UnitTestApplication.Start())
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
                 var target = new ListBox
                 {
@@ -182,7 +185,7 @@ namespace Avalonia.Controls.UnitTests
                     SelectionMode = SelectionMode.Single | SelectionMode.Toggle,
                 };
                 AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
-                ApplyTemplate(target);
+                Prepare(target);
                 target.SelectedIndex = 1;
 
                 _mouse.Click(target.Presenter.Panel.Children[0]);
@@ -194,45 +197,48 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Setting_Item_IsSelected_Sets_ListBox_Selection()
         {
-            var target = new ListBox
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
-                Template = new FuncControlTemplate(CreateListBoxTemplate),
-                ItemsSource = new[] { "Foo", "Bar", "Baz " },
-            };
+                var target = new ListBox
+                {
+                    Template = new FuncControlTemplate(CreateListBoxTemplate),
+                    ItemsSource = new[] { "Foo", "Bar", "Baz " },
+                };
 
-            ApplyTemplate(target);
+                Prepare(target);
 
-            ((ListBoxItem)target.GetLogicalChildren().ElementAt(1)).IsSelected = true;
+                ((ListBoxItem)target.GetLogicalChildren().ElementAt(1)).IsSelected = true;
 
-            Assert.Equal("Bar", target.SelectedItem);
-            Assert.Equal(1, target.SelectedIndex);
+                Assert.Equal("Bar", target.SelectedItem);
+                Assert.Equal(1, target.SelectedIndex);
+            }
         }
 
         [Fact]
         public void SelectedItem_Should_Not_Cause_StackOverflow()
         {
-            var viewModel = new TestStackOverflowViewModel()
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
-                Items = new List<string> { "foo", "bar", "baz" }
-            };
+                var viewModel = new TestStackOverflowViewModel() { Items = new List<string> { "foo", "bar", "baz" } };
 
-            var target = new ListBox
-            {
-                Template = new FuncControlTemplate(CreateListBoxTemplate),
-                DataContext = viewModel,
-                ItemsSource = viewModel.Items
-            };
+                var target = new ListBox
+                {
+                    Template = new FuncControlTemplate(CreateListBoxTemplate),
+                    DataContext = viewModel,
+                    ItemsSource = viewModel.Items
+                };
 
-            target.Bind(ListBox.SelectedItemProperty,
-                new Binding("SelectedItem") { Mode = BindingMode.TwoWay });
+                target.Bind(ListBox.SelectedItemProperty,
+                    new Binding("SelectedItem") { Mode = BindingMode.TwoWay });
 
-            Assert.Equal(0, viewModel.SetterInvokedCount);
+                Assert.Equal(0, viewModel.SetterInvokedCount);
 
-            // In Issue #855, a Stackoverflow occurred here.
-            target.SelectedItem = viewModel.Items[2];
+                // In Issue #855, a Stackoverflow occurred here.
+                target.SelectedItem = viewModel.Items[2];
 
-            Assert.Equal(viewModel.Items[1], target.SelectedItem);
-            Assert.Equal(1, viewModel.SetterInvokedCount);
+                Assert.Equal(viewModel.Items[1], target.SelectedItem);
+                Assert.Equal(1, viewModel.SetterInvokedCount);
+            }
         }
 
         private class TestStackOverflowViewModel : INotifyPropertyChanged
@@ -295,20 +301,11 @@ namespace Avalonia.Controls.UnitTests
             }.RegisterInNameScope(scope);
         }
 
-        private static void ApplyTemplate(ListBox target)
+        private static void Prepare(ListBox target)
         {
-            // Apply the template to the ListBox itself.
-            target.ApplyTemplate();
-
-            // Then to its inner ScrollViewer.
-            var scrollViewer = (ScrollViewer)target.GetVisualChildren().Single();
-            scrollViewer.ApplyTemplate();
-
-            // Then make the ScrollViewer create its child.
-            scrollViewer.Presenter.UpdateChild();
-
-            // Now the ItemsPresenter should be registered, so apply its template.
-            target.Presenter.ApplyTemplate();
+            target.Width = target.Height = 100;
+            var root = new TestRoot(target);
+            root.LayoutManager.ExecuteInitialLayoutPass();
         }
     }
 }

--- a/tests/Avalonia.UnitTests/MouseTestHelper.cs
+++ b/tests/Avalonia.UnitTests/MouseTestHelper.cs
@@ -4,9 +4,9 @@ using Avalonia.VisualTree;
 
 namespace Avalonia.UnitTests
 {
-    public class MouseTestHelper
+    public class MouseTestHelper(PointerType pointerType = PointerType.Mouse)
     {
-        private readonly Pointer _pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, true);
+        private readonly Pointer _pointer = new Pointer(Pointer.GetNextFreeId(), pointerType, true);
         private ulong _nextStamp = 1;
         private ulong Timestamp() => _nextStamp++;
 

--- a/tests/Avalonia.UnitTests/TouchTestHelper.cs
+++ b/tests/Avalonia.UnitTests/TouchTestHelper.cs
@@ -19,7 +19,8 @@ namespace Avalonia.UnitTests
         public void Down(Interactive target, Interactive source, Point position = default, KeyModifiers modifiers = default)
         {
             _pointer.Capture((IInputElement)target);
-            source.RaiseEvent(new PointerPressedEventArgs(source, _pointer, (Visual)source, position, Timestamp(), PointerPointProperties.None,
+            source.RaiseEvent(new PointerPressedEventArgs(source, _pointer, (Visual)source, position, Timestamp(),
+                new(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed),
                 modifiers));
         }
 
@@ -28,7 +29,7 @@ namespace Avalonia.UnitTests
         public void Move(Interactive target, Interactive source, in Point position, KeyModifiers modifiers = default)
         {
             var e = new PointerEventArgs(InputElement.PointerMovedEvent, source, _pointer, (Visual)target, position,
-                Timestamp(), PointerPointProperties.None, modifiers);
+                Timestamp(), new(RawInputModifiers.LeftMouseButton, PointerUpdateKind.Other), modifiers);
             if (_pointer.CapturedGestureRecognizer != null)
                 _pointer.CapturedGestureRecognizer.PointerMovedInternal(e);
             else
@@ -41,8 +42,8 @@ namespace Avalonia.UnitTests
 
         public void Up(Interactive target, Interactive source, Point position = default, KeyModifiers modifiers = default)
         {
-            var e = new PointerReleasedEventArgs(source, _pointer, (Visual)target, position, Timestamp(), PointerPointProperties.None,
-                modifiers, MouseButton.None);
+            var e = new PointerReleasedEventArgs(source, _pointer, (Visual)target, position, Timestamp(),
+                new(RawInputModifiers.None, PointerUpdateKind.LeftButtonReleased), modifiers, MouseButton.Left);
 
             if (_pointer.CapturedGestureRecognizer != null)
                 _pointer.CapturedGestureRecognizer.PointerReleasedInternal(e);


### PR DESCRIPTION
## What does the pull request do?

Historically, pen input in Avalonia copies touch input behavior way too much. It makes sense in some areas, like primary button press to scroll. But not so much with secondary/right button press. Touch doesn't have a secondary button at all, but pen should copy mouse behavior there.

Some operations are hard to achieve with pen, now are possible/easier with this PR: dnd with pen (at least in-process), selecting item AND showing context menu on same press+release combo.

This PR makes following changes:
1. Scroll gesture recognizer to only accept primary button input to scroll. Secondary button pen press is ignored.
2. ListBoxItem selects and handles input on secondary pen button pressed.

This PR behavior is closer to WPF than UWP though, as UWP doesn't select list item if there is a context menu. But majority of modern windows apps follow WPF logic from my observation (including this PR).

## What is the current behavior?

|           |   **left press**   |   **right press**  |   **left release**   | **right release** |  **holding** |
|:---------:|:------------------:|:------------------:|:--------------------:|:-----------------:|:------------:|
| **mouse** | select, start dnd* | select             | -                    | already selected + context menu      | N/A          |
|  **pen**  | scroll             | scroll | select (in tap area) | context menu (or select, if no context menu) | context menu |
| **touch** | scroll             | N/A                | select (in tap area) | N/A               | context menu, start dnd* |

## What is the updated/expected behavior with this PR?

|           |   **left press**   |   **right press**  |   **left release**   | **right release** |  **holding** |
|:---------:|:------------------:|:------------------:|:--------------------:|:-----------------:|:------------:|
| **mouse** | select, start dnd* | select             | -                    | already selected + context menu      | N/A          |
|  **pen**  | scroll             | select, start dnd* | select (in tap area) | already selected + context menu     | context menu |
| **touch** | scroll             | N/A                | select (in tap area) | N/A               | context menu, start dnd* |

\* DND related rules are not part of this PR, and not part of Avalonia itself. User applications and third-party controls decide themselves when to call `DragDrop.Do` (by filtering pointer props usually in PointerPressed event). I added these columns for the completion.

Pending: TreeDataGrid changes for the same rules.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

Pen right click has different behavior now.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues

Fixes https://support.avaloniaui.net/agent/tickets/444
