### PR TITLE
Invoke ScalingChanged when scaling changed on iOS

### DIFF
--- a/src/iOS/Avalonia.iOS/AvaloniaView.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaView.cs
@@ -375,6 +375,11 @@ namespace Avalonia.iOS
         {
             _topLevelImpl.Resized?.Invoke(_topLevelImpl.ClientSize, WindowResizeReason.Layout);
             var scaling = (double)ContentScaleFactor;
+            if (_latestLayoutProps.scaling != scaling)
+            {
+                _topLevelImpl.ScalingChanged?.Invoke(scaling);
+            }
+
             _latestLayoutProps = (new PixelSize((int)(Bounds.Width * scaling), (int)(Bounds.Height * scaling)), scaling);
             if (_currentRenderTarget is not null)
             {


### PR DESCRIPTION
## What does the pull request do?

This PR made several optimizations about render scaling on all platforms: https://github.com/AvaloniaUI/Avalonia/pull/18315

But when iOS toplevel impl is just created, and nothing yet layouted on iOS side, View.ContentScaleFactor returns 1. For some reason, there was no code that would notify Avalonia about View.ContentScaleFactor changes that happen around LayoutSubviews is called. 

This PR fixes that.

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/18709
