### PR TITLE
bugfix:Window should show in task switcher after set ShowInTaskbar to false while shown.

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Avalonia.Collections.Pooled;
 using Avalonia.Controls;
 using Avalonia.Controls.Platform;
@@ -103,6 +102,7 @@ namespace Avalonia.Win32
         private ExtendClientAreaChromeHints _extendChromeHints = ExtendClientAreaChromeHints.Default;
         private bool _isCloseRequested;
         private bool _shown;
+        private bool _hiddenWindowIsParent;
         private uint _langid;
         private bool _ignoreDpiChanges;
         internal bool _ignoreWmChar;
@@ -727,7 +727,9 @@ namespace Avalonia.Win32
             {
                 parentHwnd = OffscreenParentWindow.Handle;
             }
-            
+
+            _hiddenWindowIsParent = parentHwnd == OffscreenParentWindow.Handle;
+
             // I can't find mention of this *anywhere* online, but it seems that setting
             // GWL_HWNDPARENT to a window which is on the non-primary monitor can cause two
             // WM_DPICHANGED messages to be sent: the first changing the DPI to the parent's DPI,
@@ -1387,7 +1389,19 @@ namespace Avalonia.Win32
                     if (newProperties.ShowInTaskbar)
                     {
                         exStyle |= WindowStyles.WS_EX_APPWINDOW;
+                    }
+                    else
+                    {
+                        // To hide a non-owned window's taskbar icon we need to parent it to a hidden window.
+                        if (_parent is null)
+                        {
+                            _hiddenWindowIsParent = true;
+                        }
 
+                        exStyle &= ~WindowStyles.WS_EX_APPWINDOW;
+                    }
+                    if (_hiddenWindowIsParent)
+                    {
                         // Can't enable the taskbar icon by clearing the parent window unless the window
                         // is hidden. Hide the window and show it again with the same activation state
                         // when we've finished. Interestingly it seems to work fine the other way.
@@ -1395,16 +1409,11 @@ namespace Avalonia.Win32
                         var activated = GetActiveWindow() == _hwnd;
 
                         if (shown)
+                        {
                             Hide();
-
-                        SetParent(null);
-
-                        if (shown)
                             Show(activated, false);
-                    }
-                    else
-                    {
-                        exStyle &= ~WindowStyles.WS_EX_APPWINDOW;
+                        }
+                        _hiddenWindowIsParent = false;
                     }
                 }
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Avalonia.Collections.Pooled;
 using Avalonia.Controls;
 using Avalonia.Controls.Platform;
@@ -711,8 +712,8 @@ namespace Avalonia.Win32
         public virtual void Show(bool activate, bool isDialog)
         {
             SetParent(_parent);
-            DispatcherTimer.RunOnce(() => { ShowWindow(_showWindowState, activate); },
-                                    new TimeSpan(0, 0, 0, 0, 50));
+            Thread.Sleep(50);
+            ShowWindow(_showWindowState, activate);
         }
 
         public Action? GotInputWhenDisabled { get; set; }

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1392,17 +1392,15 @@ namespace Avalonia.Win32
 
                 if ((oldProperties.ShowInTaskbar != newProperties.ShowInTaskbar) || forceChanges)
                 {
-                        // Can't enable the taskbar icon by clearing the parent window unless the window
-                        // is hidden. Hide the window and show it again with the same activation state
-                        // when we've finished. Interestingly it seems to work fine the other way.
-                        var shown = IsWindowVisible(_hwnd);
-                        var activated = GetActiveWindow() == _hwnd;
+                    // Refresh the window to ensure its ShowInTaskbar can be correctly applied.    
+                    var shown = IsWindowVisible(_hwnd);
+                    var activated = GetActiveWindow() == _hwnd;
 
-                        if (shown)
-                        {
-                            Hide();
-                            Show(activated, false);
-                        }
+                    if (shown)
+                    {
+                        Hide();
+                        Show(activated, false);
+                    }
                 }
 
                 WindowStyles style = WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_OVERLAPPEDWINDOW | WindowStyles.WS_CLIPSIBLINGS;

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -711,7 +711,8 @@ namespace Avalonia.Win32
         public virtual void Show(bool activate, bool isDialog)
         {
             SetParent(_parent);
-            ShowWindow(_showWindowState, activate);
+            DispatcherTimer.RunOnce(() => { ShowWindow(_showWindowState, activate); },
+                                    new TimeSpan(0, 0, 0, 0, 50));
         }
 
         public Action? GotInputWhenDisabled { get; set; }

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1384,39 +1384,6 @@ namespace Avalonia.Win32
             {
                 var exStyle = WindowStyles.WS_EX_WINDOWEDGE | (UseRedirectionBitmap ? 0 : WindowStyles.WS_EX_NOREDIRECTIONBITMAP);
 
-                if (oldProperties.ShowInTaskbar != newProperties.ShowInTaskbar || forceChanges)
-                {
-                    if (newProperties.ShowInTaskbar)
-                    {
-                        exStyle |= WindowStyles.WS_EX_APPWINDOW;
-                    }
-                    else
-                    {
-                        // To hide a non-owned window's taskbar icon we need to parent it to a hidden window.
-                        if (_parent is null)
-                        {
-                            _hiddenWindowIsParent = true;
-                        }
-
-                        exStyle &= ~WindowStyles.WS_EX_APPWINDOW;
-                    }
-                    if (_hiddenWindowIsParent)
-                    {
-                        // Can't enable the taskbar icon by clearing the parent window unless the window
-                        // is hidden. Hide the window and show it again with the same activation state
-                        // when we've finished. Interestingly it seems to work fine the other way.
-                        var shown = IsWindowVisible(_hwnd);
-                        var activated = GetActiveWindow() == _hwnd;
-
-                        if (shown)
-                        {
-                            Hide();
-                            Show(activated, false);
-                        }
-                        _hiddenWindowIsParent = false;
-                    }
-                }
-
                 if (newProperties.ShowInTaskbar)
                 {
                     exStyle |= WindowStyles.WS_EX_APPWINDOW;
@@ -1424,6 +1391,17 @@ namespace Avalonia.Win32
                 else
                 {
                     exStyle &= ~WindowStyles.WS_EX_APPWINDOW;
+                }
+                if (_parent is null && oldProperties.ShowInTaskbar != newProperties.ShowInTaskbar || forceChanges)
+                {
+                    var shown = IsWindowVisible(_hwnd);
+                    var activated = GetActiveWindow() == _hwnd;
+
+                    if (shown)
+                    {
+                        Hide();
+                        Show(activated, false);
+                    }
                 }
 
                 WindowStyles style = WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_OVERLAPPEDWINDOW | WindowStyles.WS_CLIPSIBLINGS;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Changing ShowInTaskbar to false after showing the window will hide it in the task switcher. #18728
It seems that Avalonia does not give enough time for OS to change a `Window`'s parent and makes a race hazard.
This bug can be fixed by a delay of around 50ms between each `SetParent()`s, but this will cause an obvious flash, so I decide to fix it by refreshing the window. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Changing `ShowInTaskbar` to *false* after showing the window will hide it in the task switcher.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Now set `ShowInTaskbar=false` after shown will not hide it in the task switcher.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Refreshing (hide and reshow) the window can let the window show in task switcher again.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #18728 