### PR TITLE
Fix crash with samsung keyboard when using password textboxes

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Input/AvaloniaInputConnection.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AvaloniaInputConnection.cs
@@ -279,20 +279,20 @@ namespace Avalonia.Android.Platform.Input
 
         public ICharSequence? GetSelectedTextFormatted([GeneratedEnum] GetTextFlags flags)
         {
-            return new SpannableString(_editBuffer.SelectedText);
+            return new Java.Lang.String(_editBuffer.SelectedText ?? "");
         }
 
         public ICharSequence? GetTextAfterCursorFormatted(int n, [GeneratedEnum] GetTextFlags flags)
         {
             var end = Math.Min(_editBuffer.Selection.End, _editBuffer.Text.Length);
-            return new SpannableString(_editBuffer.Text.Substring(end, Math.Min(n, _editBuffer.Text.Length - end)));
+            return new Java.Lang.String(_editBuffer.Text.Substring(end, Math.Min(n, _editBuffer.Text.Length - end)));
         }
 
         public ICharSequence? GetTextBeforeCursorFormatted(int n, [GeneratedEnum] GetTextFlags flags)
         {
             var start = Math.Max(0, _editBuffer.Selection.Start - n);
             var length = _editBuffer.Selection.Start - start;
-            return _editBuffer.Text == null ? null : new SpannableString(_editBuffer.Text.Substring(start, length));
+            return _editBuffer.Text == null ? null : new Java.Lang.String(_editBuffer.Text.Substring(start, length));
         }
 
         public bool PerformPrivateCommand(string? action, Bundle? data)

--- a/src/Android/Avalonia.Android/Platform/Input/TextEditBuffer.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/TextEditBuffer.cs
@@ -96,7 +96,7 @@ namespace Avalonia.Android.Platform.Input
             SelectionStart = Selection.Start,
             SelectionEnd = Selection.End,
             StartOffset = 0,
-            Text = new SpannableString(Text)
+            Text = new Java.Lang.String(Text)
         };
 
         internal void Remove(int index, int length)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fix a crash on samsung keyboards on android when using password textbox. Internally, samsung keyboard casts the `ICharSequence` returned in all extracted text to a `Java.Lang.String` type, but only when the input connection is initialized with password input type. We previously returned `SpannableString`, which though is an `ICharSequence`, is not a `Java.Lang.String`, thus crashing the ime. We now return a `Java.Lang.String`. We weren't applying spans to out returning strings, so no functional difference between the two string types.

Other imes were and are not affected by the type returned.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #18772