### PR TITLE
Fix caret handles not updating to the latest caret points

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -455,13 +455,13 @@ namespace Avalonia.Controls.Presenters
 
         internal (Point, Point) GetCaretPoints()
         {
-            var x = Math.Floor(_caretBounds.X) + 0.5;
-            var y = Math.Floor(_caretBounds.Y) + 0.5;
-            var b = Math.Ceiling(_caretBounds.Bottom) - 0.5;
-
             var caretIndex = _lastCharacterHit.FirstCharacterIndex + _lastCharacterHit.TrailingLength;
             var lineIndex = TextLayout.GetLineIndexFromCharacterIndex(caretIndex, _lastCharacterHit.TrailingLength > 0);
             var textLine = TextLayout.TextLines[lineIndex];
+
+            var x = Math.Floor(_caretBounds.X) + 0.5;
+            var y = Math.Floor(_caretBounds.Y) + 0.5;
+            var b = Math.Ceiling(_caretBounds.Bottom) - 0.5;
 
             if (_caretBounds.X > 0 && _caretBounds.X >= textLine.WidthIncludingTrailingWhitespace)
             {

--- a/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
+++ b/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
@@ -296,15 +296,6 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
-        private void Presenter_CaretBoundsChanged(object? sender, EventArgs e)
-        {
-            if (ShowHandles)
-            {
-                MoveHandlesToSelection();
-                EnsureVisible();
-            }
-        }
-
         private void TextBox_SizeChanged(object? sender, SizeChangedEventArgs e)
         {
             InvalidateMeasure();

--- a/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
+++ b/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
@@ -262,6 +262,21 @@ namespace Avalonia.Controls.Primitives
         {
             if (_presenter == textPresenter)
                 return;
+
+            if (_textBox != null)
+            {
+                _textBox.RemoveHandler(TextBox.TextChangingEvent, TextChanged);
+                _textBox.RemoveHandler(KeyDownEvent, TextBoxKeyDown);
+                _textBox.RemoveHandler(PointerReleasedEvent, TextBoxPointerReleased);
+                _textBox.RemoveHandler(Gestures.HoldingEvent, TextBoxHolding);
+
+                _textBox.PropertyChanged -= TextBoxPropertyChanged;
+                _textBox.EffectiveViewportChanged -= TextBoxEffectiveViewportChanged;
+                _textBox.SizeChanged -= TextBox_SizeChanged;
+
+                _textBox = null;
+            }
+
             _presenter = textPresenter;
             if (_presenter != null)
             {
@@ -279,21 +294,14 @@ namespace Avalonia.Controls.Primitives
                     _textBox.SizeChanged += TextBox_SizeChanged;
                 }
             }
-            else
+        }
+
+        private void Presenter_CaretBoundsChanged(object? sender, EventArgs e)
+        {
+            if (ShowHandles)
             {
-                if (_textBox != null)
-                {
-                    _textBox.RemoveHandler(TextBox.TextChangingEvent, TextChanged);
-                    _textBox.RemoveHandler(KeyDownEvent, TextBoxKeyDown);
-                    _textBox.RemoveHandler(PointerReleasedEvent, TextBoxPointerReleased);
-                    _textBox.RemoveHandler(Gestures.HoldingEvent, TextBoxHolding);
-
-                    _textBox.PropertyChanged -= TextBoxPropertyChanged;
-                    _textBox.EffectiveViewportChanged -= TextBoxEffectiveViewportChanged;
-                    _textBox.SizeChanged -= TextBox_SizeChanged;
-                }
-
-                _textBox = null;
+                MoveHandlesToSelection();
+                EnsureVisible();
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Ensures that position of the text selection handles, specifically the caret handle, always matches the position of the caret in the text presenter.

Also ensures textbox events are removed in the selection handle canvas when the textbox is detached from tree.

## What is the current behavior?
When `GetCaretPoints` is called internally, the caret bounds position is read and then the line and text index is read to determine if the caret is within the text. During the line index query, the caret bound may be updated again to the actual caret position, thus making the previously read caret position invalid. The update is done in the same function call, so the return value of `GetCaretPoints` will be inaccurate.


## What is the updated/expected behavior with this PR?
The return value of `GetCaretPoints` will always be the position after the text layout is updated to reflect the current caret location.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
