### PR TITLE
Fix an issue where input controls initialized with `InputMethod.IsInputMethodEnable=false` could still use IME in their initial state.

### DIFF
--- a/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
+++ b/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
@@ -85,9 +85,6 @@ namespace Avalonia.Win32.Input
         {
             Hwnd = hwnd;
             _parent = parent;
-            _langId = PRIMARYLANGID(LGID(HKL));
-
-            _parent = parent;
 
             var langId = PRIMARYLANGID(LGID(HKL));
 


### PR DESCRIPTION
## What does the pull request do?
This PR fixes incorrect IME state management when initializing input controls with disabled IME. The changes ensure proper language ID tracking and IME state updates.

## What is the current behavior?
- Input controls initialized with `InputMethod.IsInputMethodEnable=false` can still use IME in their initial state
- Premature `_langId` assignment in `SetLanguageAndWindow` prevents proper detection of language ID changes

## What is the updated/expected behavior with this PR?
- IME should remain disabled for controls initialized with `InputMethod.IsInputMethodEnable=false`
- IME state updates should correctly reflect language ID changes through the `SetLanguageAndWindow` method

## How was the solution implemented (if it's not obvious)?
- Removed premature `_langId` assignment in `Imm32InputMethod.SetLanguageAndWindow`
- Ensured subsequent logic uses updated language ID values for IME state management
- Modified IME enable/disable flow to respect the initial `IsInputMethodEnable` setting

## Checklist

- [ ] Added XML documentation to any related classes?
- [ ] Added unit tests (if possible)?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #11273 