### PR TITLE
Ignore child margin when positioning a popup

### DIFF
--- a/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
+++ b/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
@@ -24,6 +24,7 @@ namespace Avalonia.Controls.Primitives
         private Point _lastRequestedPosition;
         private PopupPositionRequest? _popupPositionRequest;
         private Size _popupSize;
+        private Thickness _childMargin;
         private bool _needsUpdate;
 
         static OverlayPopupHost()
@@ -142,9 +143,23 @@ namespace Avalonia.Controls.Primitives
         /// <inheritdoc />
         protected override Size ArrangeOverride(Size finalSize)
         {
+            var reposition = false;
+
+            var newMargin = Presenter?.Child?.Margin ?? default;
+            if (newMargin != _childMargin)
+            {
+                _childMargin = newMargin;
+                reposition = true;
+            }
+
             if (_popupSize != finalSize)
             {
                 _popupSize = finalSize;
+                reposition = true;
+            }
+
+            if (reposition)
+            {
                 _needsUpdate = true;
                 UpdatePosition();
             }
@@ -156,7 +171,7 @@ namespace Avalonia.Controls.Primitives
             if (_needsUpdate && _popupPositionRequest is not null)
             {
                 _needsUpdate = false;
-                _positioner.Update(TopLevel.GetTopLevel(_overlayLayer)!, _popupPositionRequest, _popupSize, FlowDirection);
+                _positioner.Update(TopLevel.GetTopLevel(_overlayLayer)!, _popupPositionRequest, _popupSize, _childMargin, FlowDirection);
             }
         }
 

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/CustomPopupPlacement.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/CustomPopupPlacement.cs
@@ -8,9 +8,10 @@ public record CustomPopupPlacement
     private PopupGravity _gravity;
     private PopupAnchor _anchor;
 
-    internal CustomPopupPlacement(Size popupSize, Visual target)
+    internal CustomPopupPlacement(Size popupSize, Thickness deflate, Visual target)
     {
         PopupSize = popupSize;
+        Deflate = deflate;
         Target = target;
     }
 
@@ -18,6 +19,12 @@ public record CustomPopupPlacement
     /// The <see cref="Size"/> of the <see cref="Popup"/> control.
     /// </summary>
     public Size PopupSize { get; }
+
+    /// <summary>
+    /// Gets or sets how far to deflate <see cref="PopupSize"/> when positioning the popup.
+    /// </summary>
+    /// <inheritdoc cref="PopupPositionerParameters.Deflate"/>
+    public Thickness Deflate { get; }
 
     /// <summary>
     /// Placement target of the popup.

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
@@ -79,6 +79,15 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
         public Size Size { get; set; }
 
         /// <summary>
+        /// Gets or sets how far to deflate <see cref="Size"/> when positioning the popup.
+        /// </summary>
+        /// <remarks>
+        /// This is normally set to the margin of the popup's child. This allows out-of-bounds effects 
+        /// like drop shadows to be drawn without affecting the final position of the child.
+        /// </remarks>
+        public Thickness Deflate { get; set; }
+
+        /// <summary>
         /// Specifies the anchor rectangle within the parent that the popup will be placed relative
         /// to, in device-independent pixels.
         /// </summary>
@@ -453,6 +462,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             TopLevel topLevel,
             PopupPositionRequest positionRequest,
             Size popupSize,
+            Thickness deflate,
             FlowDirection flowDirection)
         {
             if (popupSize == default)
@@ -460,20 +470,14 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
                 return;
             }
 
-            var parameters = BuildParameters(topLevel, positionRequest, popupSize, flowDirection);
-            positioner.Update(parameters);
-        }
+            var positionerParameters = new PopupPositionerParameters
+            {
+                Offset = positionRequest.Offset,
+                Size = popupSize,
+                Deflate = deflate,
+                ConstraintAdjustment = positionRequest.ConstraintAdjustment
+            };
 
-        private static PopupPositionerParameters BuildParameters(
-            TopLevel topLevel,
-            PopupPositionRequest positionRequest,
-            Size popupSize,
-            FlowDirection flowDirection)
-        {
-            PopupPositionerParameters positionerParameters = default;
-            positionerParameters.Offset = positionRequest.Offset;
-            positionerParameters.Size = popupSize;
-            positionerParameters.ConstraintAdjustment = positionRequest.ConstraintAdjustment;
             if (positionRequest.Placement == PlacementMode.Pointer)
             {
                 // We need a better way for tracking the last pointer position
@@ -493,6 +497,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
 
                 var customPlacementParameters = new CustomPopupPlacement(
                     popupSize,
+                    deflate,
                     positionRequest.Target)
                 {
                     AnchorRectangle = positionerParameters.AnchorRectangle,
@@ -563,7 +568,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
                 }
             }
 
-            return positionerParameters;
+            positioner.Update(positionerParameters);
         }
 
         private static Rect CalculateAnchorRect(TopLevel topLevel, PopupPositionRequest positionRequest)

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
@@ -84,7 +84,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
         public void Update(PopupPositionerParameters parameters)
         {
             var rect = Calculate(
-                parameters.Size * _popup.Scaling,
+                parameters.Size.Deflate(parameters.Deflate) * _popup.Scaling,
                 new Rect(
                     parameters.AnchorRectangle.TopLeft * _popup.Scaling,
                     parameters.AnchorRectangle.Size * _popup.Scaling),
@@ -92,14 +92,16 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
                 parameters.Gravity,
                 parameters.ConstraintAdjustment,
                 parameters.Offset * _popup.Scaling);
-           
+
+            rect = rect.Inflate(parameters.Deflate * _popup.Scaling);
+
             _popup.MoveAndResize(
                 rect.Position,
                 rect.Size / _popup.Scaling);
         }
 
         
-        private Rect Calculate(Size translatedSize, 
+        private Rect Calculate(Size translatedSize,
             Rect anchorRect, PopupAnchor anchor, PopupGravity gravity,
             PopupPositionerConstraintAdjustment constraintAdjustment, Point offset)
         {

--- a/src/Avalonia.Controls/Primitives/PopupRoot.cs
+++ b/src/Avalonia.Controls/Primitives/PopupRoot.cs
@@ -30,6 +30,7 @@ namespace Avalonia.Controls.Primitives
 
         private PopupPositionRequest? _popupPositionRequest;
         private Size _popupSize;
+        private Thickness _childMargin;
         private bool _needsUpdate;
 
         /// <summary>
@@ -37,14 +38,14 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         static PopupRoot()
         {
-            BackgroundProperty.OverrideDefaultValue(typeof(PopupRoot), Brushes.White);            
+            BackgroundProperty.OverrideDefaultValue(typeof(PopupRoot), Brushes.White);
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PopupRoot"/> class.
         /// </summary>
         public PopupRoot(TopLevel parent, IPopupImpl impl)
-            : this(parent, impl,null)
+            : this(parent, impl, null)
         {
         }
 
@@ -66,7 +67,7 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Gets the platform-specific window implementation.
         /// </summary>
-        public new IPopupImpl? PlatformImpl => (IPopupImpl?)base.PlatformImpl;               
+        public new IPopupImpl? PlatformImpl => (IPopupImpl?)base.PlatformImpl;
 
         /// <summary>
         /// Gets or sets a transform that will be applied to the popup.
@@ -132,7 +133,7 @@ namespace Avalonia.Controls.Primitives
             {
                 _needsUpdate = false;
                 PlatformImpl?.PopupPositioner?
-                    .Update(ParentTopLevel, _popupPositionRequest, _popupSize, FlowDirection);
+                    .Update(ParentTopLevel, _popupPositionRequest, _popupSize, _childMargin, FlowDirection);
             }
         }
 
@@ -159,7 +160,7 @@ namespace Avalonia.Controls.Primitives
         public void TakeFocus() => PlatformImpl?.TakeFocus();
 
         Visual IPopupHost.HostedVisualTreeRoot => this;
-        
+
         protected override Size MeasureOverride(Size availableSize)
         {
             var maxAutoSize = PlatformImpl?.MaxAutoSizeHint ?? Size.Infinity;
@@ -202,9 +203,23 @@ namespace Avalonia.Controls.Primitives
 
         protected sealed override Size ArrangeSetBounds(Size size)
         {
+            var reposition = false;
+
+            var newMargin = Presenter?.Child?.Margin ?? default;
+            if (newMargin != _childMargin)
+            {
+                _childMargin = newMargin;
+                reposition = true;
+            }
+
             if (_popupSize != size)
             {
                 _popupSize = size;
+                reposition = true;
+            }
+
+            if (reposition)
+            {
                 _needsUpdate = true;
                 UpdatePosition();
             }


### PR DESCRIPTION
This PR brings an overlooked aspect of WPF's popup positioning to Avalonia. The margins of a popup's child are now ignored when positioning the popup, but still count toward the popup's size. This enables the child's margin to be used as a drawing surface for out-of-bounds effects like drop shadows, without affecting the child's final position.

This means that a popup with a child margin now sits closer to the target, and can also fit into smaller gaps without being repositioned.

## What is the current behavior?

WPF:

![Image](https://github.com/user-attachments/assets/b3c5b5a0-6db3-4755-b921-f1734697e898)

Avalonia:

![Image](https://github.com/user-attachments/assets/59c3fd7a-ff8b-4159-b83b-95e37894747d)

See #18810 for the XAML which generates the screenshots above.


## What is the updated/expected behavior with this PR?

![image](https://github.com/user-attachments/assets/ca2cb2a2-7fa3-4a16-a141-2cf4d828e5ad)

Note that on desktop platforms the margin area is part of the popup window, and so cannot be clicked through to reach the target window. WPF behaves in the same way, and if Microsoft couldn't make click-through work then I don't think I will fare any better! There may be a solution on other desktop platforms but I've not done any investigation into this.

If overlay popups are used then the popup margin (and any effects drawn within it) can be clicked through, the same as with any other Avalonia visual.

## How was the solution implemented (if it's not obvious)?

A new property has been added: `PopupPositionerParameters.Deflate`. We deflate the popup size by this amount when calculating a position, then inflate the returned bounds by the same amount before generating popup geometry. Render scaling is accounted for.

Changes to the margin of the popup child now trigger repositioning of the popup, even if the overall size didn't change.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

If the popup child's margin actually was intended to affect the popup's position, the UI author will have to wrap the child in a new panel/grid/decorator without a margin to restore their intended popup position.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #18810 
