### PR TITLE
Added missing class event handler methods

### DIFF
--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -238,6 +238,10 @@ namespace Avalonia.Input
             PointerCaptureLostEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerCaptureLost(e));
             PointerWheelChangedEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerWheelChanged(e));
 
+            TappedEvent.AddClassHandler<InputElement>((x, e) => x.OnTapped(e));
+            DoubleTappedEvent.AddClassHandler<InputElement>((x, e) => x.OnDoubleTapped(e));
+            HoldingEvent.AddClassHandler<InputElement>((x, e) => x.OnHolding(e));
+
             // Gesture only handlers
             PointerMovedEvent.AddClassHandler<InputElement>((x, e) => x.OnGesturePointerMoved(e), handledEventsToo: true);
             PointerPressedEvent.AddClassHandler<InputElement>((x, e) => x.OnGesturePointerPressed(e), handledEventsToo: true);
@@ -743,6 +747,36 @@ namespace Avalonia.Input
         /// </summary>
         /// <param name="e">Data about the event.</param>
         protected virtual void OnPointerWheelChanged(PointerWheelEventArgs e)
+        {
+        }
+
+        /// <summary>
+        /// Invoked when an unhandled <see cref="TappedEvent"/> reaches an element in its 
+        /// route that is derived from this class. Implement this method to add class handling 
+        /// for this event.
+        /// </summary>
+        /// <param name="e">Data about the event.</param>
+        protected virtual void OnTapped(TappedEventArgs e)
+        {
+        }
+
+        /// <summary>
+        /// Invoked when an unhandled <see cref="DoubleTappedEvent"/> reaches an element in its 
+        /// route that is derived from this class. Implement this method to add class handling 
+        /// for this event.
+        /// </summary>
+        /// <param name="e">Data about the event.</param>
+        protected virtual void OnDoubleTapped(TappedEventArgs e)
+        {
+        }
+
+        /// <summary>
+        /// Invoked when an unhandled <see cref="HoldingEvent"/> reaches an element in its 
+        /// route that is derived from this class. Implement this method to add class handling 
+        /// for this event.
+        /// </summary>
+        /// <param name="e">Data about the event.</param>
+        protected virtual void OnHolding(HoldingRoutedEventArgs e)
         {
         }
 

--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -200,6 +200,11 @@ namespace Avalonia.Input
         public static readonly RoutedEvent<TappedEventArgs> TappedEvent = Gestures.TappedEvent;
 
         /// <summary>
+        /// Defines the <see cref="RightTapped"/> event.
+        /// </summary>
+        public static readonly RoutedEvent<TappedEventArgs> RightTappedEvent = Gestures.RightTappedEvent;
+
+        /// <summary>
         /// Defines the <see cref="Holding"/> event.
         /// </summary>
         public static readonly RoutedEvent<HoldingRoutedEventArgs> HoldingEvent = Gestures.HoldingEvent;
@@ -239,6 +244,7 @@ namespace Avalonia.Input
             PointerWheelChangedEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerWheelChanged(e));
 
             TappedEvent.AddClassHandler<InputElement>((x, e) => x.OnTapped(e));
+            RightTappedEvent.AddClassHandler<InputElement>((x, e) => x.OnRightTapped(e));
             DoubleTappedEvent.AddClassHandler<InputElement>((x, e) => x.OnDoubleTapped(e));
             HoldingEvent.AddClassHandler<InputElement>((x, e) => x.OnHolding(e));
 
@@ -401,6 +407,15 @@ namespace Avalonia.Input
         {
             add { AddHandler(TappedEvent, value); }
             remove { RemoveHandler(TappedEvent, value); }
+        }
+
+        /// <summary>
+        /// Occurs when a right tap gesture occurs on the control.
+        /// </summary>
+        public event EventHandler<TappedEventArgs>? RightTapped
+        {
+            add { AddHandler(RightTappedEvent, value); }
+            remove { RemoveHandler(RightTappedEvent, value); }
         }
 
         /// <summary>
@@ -757,6 +772,16 @@ namespace Avalonia.Input
         /// </summary>
         /// <param name="e">Data about the event.</param>
         protected virtual void OnTapped(TappedEventArgs e)
+        {
+        }
+
+        /// <summary>
+        /// Invoked when an unhandled <see cref="RightTappedEvent"/> reaches an element in its 
+        /// route that is derived from this class. Implement this method to add class handling 
+        /// for this event.
+        /// </summary>
+        /// <param name="e">Data about the event.</param>
+        protected virtual void OnRightTapped(TappedEventArgs e)
         {
         }
 

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -386,12 +386,12 @@ namespace Avalonia.Controls
             InitializeIfNeeded();
 
             ScheduleOnLoadedCore();
-
-            Holding += OnHoldEvent;
         }
 
-        private void OnHoldEvent(object? sender, HoldingRoutedEventArgs e)
+        protected override void OnHolding(HoldingRoutedEventArgs e)
         {
+            base.OnHolding(e);
+
             if (e.Source == this && !e.Handled && e.HoldingState == HoldingState.Started)
             {
                 // Trigger ContentRequest when hold has started
@@ -408,8 +408,6 @@ namespace Avalonia.Controls
             base.OnDetachedFromVisualTreeCore(e);
 
             OnUnloadedCore();
-
-            Holding -= OnHoldEvent;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Class event handlers methods are virtual, and so give derived classes full control over class event handling. Without them the only option would be to register a new class event handler, which would only execute after any base handler. A method gives the derived class the chance to execute code before the base class does, or not to call the base class method at all. I found some cases where methods which should exist did not.

* `InputElement.OnTapped`
* `InputElement.OnRightTapped`
* `InputElement.OnDoubleTapped`
* `InputElement.OnHolding`
* ~`MenuItem.OnPointerEnteredItem`~
* ~`MenuItem.OnPointerExitedItem`~

### Moved handling of `Holding` event in `Control` to the class method

This allows derived types to more easily override their holding behaviour, and eliminates one event subscription per `Control`, which is a very common type.

I didn't find any other instance subscriptions which could be converted to class handlers.

## Breaking changes
Because `Control` was subscribing to the `Holding` event in `OnAttachedToVisualTree`, there was an opportunity for an event subscription to be added before this point, which could then handle the hold event and prevent the built-in event handler from executing. This can be much more easily achieved per-instance by setting the attached property `Gesture.IsHoldingEnabled` to `false`. And of course, you can now disable/replace the behaviour entirely in a derived class.

## Obsoletions / Deprecations
None.