### PR TITLE
Fix insets on android 15

### DIFF
--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -110,6 +110,18 @@
     <Right>target/netstandard2.0/Avalonia.Controls.dll</Right>
   </Suppression>
   <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Avalonia.Controls.Platform.IInsetsManager.DisplayEdgeToEdgePreference</Target>
+    <Left>baseline/netstandard2.0/Avalonia.Controls.dll</Left>
+    <Right>target/netstandard2.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Avalonia.Controls.Platform.IInsetsManager.DisplaysEdgeToEdge</Target>
+    <Left>baseline/netstandard2.0/Avalonia.Controls.dll</Left>
+    <Right>target/netstandard2.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0009</DiagnosticId>
     <Target>T:Avalonia.Diagnostics.StyleDiagnostics</Target>
     <Left>baseline/netstandard2.0/Avalonia.Base.dll</Left>

--- a/samples/ControlCatalog/MainView.xaml.cs
+++ b/samples/ControlCatalog/MainView.xaml.cs
@@ -108,14 +108,14 @@ namespace ControlCatalog
                     ViewModel.SafeAreaPadding = insets.SafeAreaPadding;
                 };
 
-                ViewModel.DisplayEdgeToEdge = insets.DisplayEdgeToEdge;
+                ViewModel.DisplayEdgeToEdge = insets.DisplayEdgeToEdgePreference;
                 ViewModel.IsSystemBarVisible = insets.IsSystemBarVisible ?? true;
 
                 ViewModel.PropertyChanged += async (sender, args) =>
                 {
                     if (args.PropertyName == nameof(ViewModel.DisplayEdgeToEdge))
                     {
-                        insets.DisplayEdgeToEdge = ViewModel.DisplayEdgeToEdge;
+                        insets.DisplayEdgeToEdgePreference = ViewModel.DisplayEdgeToEdge;
                     }
                     else if (args.PropertyName == nameof(ViewModel.IsSystemBarVisible))
                     {
@@ -124,7 +124,7 @@ namespace ControlCatalog
 
                     // Give the OS some time to apply new values and refresh the view model.
                     await Task.Delay(100);
-                    ViewModel.DisplayEdgeToEdge = insets.DisplayEdgeToEdge;
+                    ViewModel.DisplayEdgeToEdge = insets.DisplayEdgeToEdgePreference;
                     ViewModel.IsSystemBarVisible = insets.IsSystemBarVisible ?? true;
                 };
             }

--- a/samples/SafeAreaDemo/ViewModels/MainViewModel.cs
+++ b/samples/SafeAreaDemo/ViewModels/MainViewModel.cs
@@ -72,7 +72,7 @@ namespace SafeAreaDemo.ViewModels
 
                 if (_insetsManager != null)
                 {
-                    _insetsManager.DisplayEdgeToEdge = value;
+                    _insetsManager.DisplayEdgeToEdgePreference = value;
                 }
 
                 this.RaisePropertyChanged();
@@ -129,7 +129,7 @@ namespace SafeAreaDemo.ViewModels
             {
                 _insetsManager.SafeAreaChanged += InsetsManager_SafeAreaChanged;
 
-                _displayEdgeToEdge = _insetsManager.DisplayEdgeToEdge;
+                _displayEdgeToEdge = _insetsManager.DisplayEdgeToEdgePreference;
                 _hideSystemBars = !(_insetsManager.IsSystemBarVisible ?? false);
             }
 

--- a/src/Avalonia.Controls/Platform/IInsetsManager.cs
+++ b/src/Avalonia.Controls/Platform/IInsetsManager.cs
@@ -17,7 +17,19 @@ namespace Avalonia.Controls.Platform
         /// <summary>
         /// Gets or sets whether the window draws edge to edge. behind any visible system bars.
         /// </summary>
+        bool DisplayEdgeToEdgePreference { get; set; }
+
+
+        [Obsolete("Use DisplayEdgeToEdgePreference")]
+        /// <summary>
+        /// Gets or sets whether the window draws edge to edge. behind any visible system bars.
+        /// </summary>
         bool DisplayEdgeToEdge { get; set; }
+
+        /// <summary>
+        /// Gets whether the window is currently displaying edge to edge.
+        /// </summary>
+        bool DisplaysEdgeToEdge { get; }
 
         /// <summary>
         /// Gets the current safe area padding.
@@ -39,9 +51,12 @@ namespace Avalonia.Controls.Platform
     public abstract class InsetsManagerBase : IInsetsManager
     {
         public virtual bool? IsSystemBarVisible { get; set; }
-        public virtual bool DisplayEdgeToEdge { get; set; }
+        public virtual bool DisplayEdgeToEdgePreference { get; set; }
+        public virtual bool DisplayEdgeToEdge { get => DisplaysEdgeToEdge; set => DisplayEdgeToEdgePreference = value; }
         public virtual Thickness SafeAreaPadding { get; protected set; }
         public virtual Color? SystemBarColor { get; set; }
+        public virtual bool DisplaysEdgeToEdge => DisplayEdgeToEdgePreference;
+
         public event EventHandler<SafeAreaChangedArgs>? SafeAreaChanged;
 
         protected void OnSafeAreaChanged(SafeAreaChangedArgs eventArgs)

--- a/src/Avalonia.Controls/Platform/IInsetsManager.cs
+++ b/src/Avalonia.Controls/Platform/IInsetsManager.cs
@@ -20,10 +20,10 @@ namespace Avalonia.Controls.Platform
         bool DisplayEdgeToEdgePreference { get; set; }
 
 
-        [Obsolete("Use DisplayEdgeToEdgePreference")]
         /// <summary>
         /// Gets or sets whether the window draws edge to edge. behind any visible system bars.
         /// </summary>
+        [Obsolete("Use DisplayEdgeToEdgePreference")]
         bool DisplayEdgeToEdge { get; set; }
 
         /// <summary>

--- a/src/Browser/Avalonia.Browser/BrowserInsetsManager.cs
+++ b/src/Browser/Avalonia.Browser/BrowserInsetsManager.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Browser
             }
         }
 
-        public override bool DisplayEdgeToEdge { get; set; }
+        public override bool DisplayEdgeToEdgePreference { get; set; }
 
         public override Thickness SafeAreaPadding
         {

--- a/src/iOS/Avalonia.iOS/InsetsManager.cs
+++ b/src/iOS/Avalonia.iOS/InsetsManager.cs
@@ -35,7 +35,7 @@ internal class InsetsManager : InsetsManagerBase
     }
     public event EventHandler<bool>? DisplayEdgeToEdgeChanged;
 
-    public override bool DisplayEdgeToEdge
+    public override bool DisplayEdgeToEdgePreference
     {
         get => _displayEdgeToEdge;
         set


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Disables updating any system bar properties when setting display edge to edge on Android 15. It is also not possible to change system bar color on android 15. This change only affects projects targeting net9 and above.

More information about the new behavior here #18835 .

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
`IInsetsManager` has a new property `DisplayEdgeToEdgePreference ` and `DisplaysEdgeToEdge`.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
`IInsetsManager.DisplayEdgeToEdge` is deprecated for `IInsetsManager.DisplayEdgeToEdgePreference`
## Fixed issues
Fixes #18835
