### PR TITLE
Fixed core `GotFocus` and `LostFocus` handling being skippable

### DIFF
--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -211,8 +211,8 @@ namespace Avalonia.Input
         {
             IsEnabledProperty.Changed.Subscribe(IsEnabledChanged);
 
-            GotFocusEvent.AddClassHandler<InputElement>((x, e) => x.OnGotFocus(e));
-            LostFocusEvent.AddClassHandler<InputElement>((x, e) => x.OnLostFocus(e));
+            GotFocusEvent.AddClassHandler<InputElement>((x, e) => x.OnGotFocusCore(e));
+            LostFocusEvent.AddClassHandler<InputElement>((x, e) => x.OnLostFocusCore(e));
             KeyDownEvent.AddClassHandler<InputElement>((x, e) => x.OnKeyDown(e));
             KeyUpEvent.AddClassHandler<InputElement>((x, e) => x.OnKeyUp(e));
             TextInputEvent.AddClassHandler<InputElement>((x, e) => x.OnTextInput(e));
@@ -535,25 +535,39 @@ namespace Avalonia.Input
             UpdateIsEffectivelyEnabled();
         }
 
-        /// <summary>
-        /// Called before the <see cref="GotFocus"/> event occurs.
-        /// </summary>
-        /// <param name="e">The event args.</param>
-        protected virtual void OnGotFocus(GotFocusEventArgs e)
+        private void OnGotFocusCore(GotFocusEventArgs e)
         {
             var isFocused = e.Source == this;
             _isFocusVisible = isFocused && (e.NavigationMethod == NavigationMethod.Directional || e.NavigationMethod == NavigationMethod.Tab);
             IsFocused = isFocused;
+            OnGotFocus(e);
         }
 
         /// <summary>
-        /// Called before the <see cref="LostFocus"/> event occurs.
+        /// Invoked when an unhandled <see cref="GotFocusEvent"/> reaches an element in its 
+        /// route that is derived from this class. Implement this method to add class handling 
+        /// for this event.
         /// </summary>
-        /// <param name="e">The event args.</param>
-        protected virtual void OnLostFocus(RoutedEventArgs e)
+        /// <param name="e">Data about the event.</param>
+        protected virtual void OnGotFocus(GotFocusEventArgs e)
+        {
+        }
+
+        private void OnLostFocusCore(RoutedEventArgs e)
         {
             _isFocusVisible = false;
             IsFocused = false;
+            OnLostFocus(e);
+        }
+
+        /// <summary>
+        /// Invoked when an unhandled <see cref="LostFocusEvent"/> reaches an element in its 
+        /// route that is derived from this class. Implement this method to add class handling 
+        /// for this event.
+        /// </summary>
+        /// <param name="e">Data about the event.</param>
+        protected virtual void OnLostFocus(RoutedEventArgs e)
+        {            
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -557,10 +557,6 @@ namespace Avalonia.Input
         }
 
         /// <summary>
-        /// Called before the <see cref="KeyDown"/> event occurs.
-        /// </summary>
-        /// <param name="e">The event args.</param>
-        /// <summary>
         /// Invoked when an unhandled <see cref="KeyDownEvent"/> reaches an element in its 
         /// route that is derived from this class. Implement this method to add class handling 
         /// for this event.


### PR DESCRIPTION
`InputElement.OnGotFocus` and `OnLostFocus` set critical private state, yet are virtual methods. So a derived class could override them and not call the base method, breaking the object's state.

The core functionality is now executed in a private method, before the virtual method call. Derived classes executing code before the core functionality doesn't make sense, because at that point the object is out of sync with the focus manager.

## Breaking changes
Strictly speaking, someone could have been intentionally breaking Avalonia's focus management, either by not executing the core event handling or by relying on their code executing before it. Doesn't seem like a valid use case to me. Such behaviour is far more likely to be a bug.


## Obsoletions / Deprecations
None