### PR TITLE
Added IPlatformSingleViewApplicationLifetime

### DIFF
--- a/samples/ControlCatalog.iOS/AppDelegate.cs
+++ b/samples/ControlCatalog.iOS/AppDelegate.cs
@@ -1,25 +1,42 @@
-using Foundation;
-using UIKit;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.iOS;
-using Avalonia.Media;
+using Foundation;
 
-namespace ControlCatalog
+namespace ControlCatalog;
+
+// The UIApplicationDelegate for the application. This class is responsible for launching the 
+// User Interface of the application, as well as listening (and optionally responding) to 
+// application events from iOS.
+public abstract class ControlCatalogAppDelegate<TApp>(AppViewControllerKind appViewControllerKind) : AvaloniaAppDelegate<TApp>(appViewControllerKind)
+where TApp : Application, new()
 {
-    // The UIApplicationDelegate for the application. This class is responsible for launching the 
-    // User Interface of the application, as well as listening (and optionally responding) to 
-    // application events from iOS.
-    [Register("AppDelegate")]
-    public partial class AppDelegate : AvaloniaAppDelegate<App>
+    protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
     {
-        protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
+        return base.CustomizeAppBuilder(builder)
+            .AfterSetup(_ =>
+            {
+                Pages.EmbedSample.Implementation = new EmbedSampleIOS();
+            });
+    }
+}
+
+[Register(nameof(SingleViewAppDelegate))]
+public partial class SingleViewAppDelegate() : ControlCatalogAppDelegate<App>(AppViewControllerKind.Avalonia);
+
+[Register(nameof(PlatformViewAppDelegate))]
+public partial class PlatformViewAppDelegate() : ControlCatalogAppDelegate<PlatformViewAppDelegate.PlatformViewApp>(AppViewControllerKind.Platform)
+{
+    public class PlatformViewApp : App
+    {
+        protected override void CreateRootControl(object viewModel)
         {
-            return base.CustomizeAppBuilder(builder)
-                .AfterSetup(_ =>
-                {
-                    Pages.EmbedSample.Implementation = new EmbedSampleIOS();
-                });
+            var view = new AvaloniaView();
+            var controller = new DefaultAvaloniaViewController() { View = view };
+            view.InitWithController(controller);
+            ((IUIViewControllerApplicationLifetime)ApplicationLifetime).PlatformView = controller;
+
+            view.Content = new MainView { DataContext = viewModel };
         }
     }
 }

--- a/samples/ControlCatalog.iOS/Main.cs
+++ b/samples/ControlCatalog.iOS/Main.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using UIKit;
 
 namespace ControlCatalog.iOS
@@ -7,9 +9,10 @@ namespace ControlCatalog.iOS
         // This is the main entry point of the application.
         static void Main(string[] args)
         {
-            // if you want to use a different Application Delegate class from "AppDelegate"
-            // you can specify it here.
-            UIApplication.Main(args, null, typeof(AppDelegate));
+            var delegateType = args.Contains("-PlatformView", StringComparer.InvariantCultureIgnoreCase) ?
+                typeof(PlatformViewAppDelegate) : typeof(SingleViewAppDelegate);
+
+            UIApplication.Main(args, null, delegateType);
         }
     }
 }

--- a/samples/ControlCatalog/App.xaml.cs
+++ b/samples/ControlCatalog/App.xaml.cs
@@ -38,16 +38,22 @@ namespace ControlCatalog
             SetCatalogThemes(CatalogTheme.Fluent);
         }
 
+        protected virtual void CreateRootControl(object viewModel)
+        {
+            switch (ApplicationLifetime)
+            {
+                case IClassicDesktopStyleApplicationLifetime desktopLifetime:
+                    desktopLifetime.MainWindow = new MainWindow { DataContext = viewModel };
+                    break;
+                case ISingleViewApplicationLifetime singleViewLifetime:
+                    singleViewLifetime.MainView = new MainView { DataContext = viewModel };
+                    break;
+            }
+        }
+
         public override void OnFrameworkInitializationCompleted()
         {
-            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
-            {
-                desktopLifetime.MainWindow = new MainWindow { DataContext = new MainWindowViewModel() };
-            }
-            else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewLifetime)
-            {
-                singleViewLifetime.MainView = new MainView { DataContext = new MainWindowViewModel() };
-            }
+            CreateRootControl(new MainWindowViewModel());
 
             if (this.TryGetFeature<IActivatableLifetime>() is {} activatableApplicationLifetime)
             {

--- a/src/Avalonia.Controls/ApplicationLifetimes/IPlatformSingleViewApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/IPlatformSingleViewApplicationLifetime.cs
@@ -1,0 +1,22 @@
+using Avalonia.Metadata;
+
+namespace Avalonia.Controls.ApplicationLifetimes;
+
+/// <summary>
+/// Represents an application lifetime where a platform-specific root view is controlled by the 
+/// application. This allows Avalonia to be used alongside other native views created by external 
+/// components.
+/// </summary>
+[NotClientImplementable]
+public interface IPlatformSingleViewApplicationLifetime : IApplicationLifetime;
+
+/// <inheritdoc cref="IPlatformSingleViewApplicationLifetime"/>
+/// <typeparam name="T">The platform-specific type which is expected as the root view element.</typeparam>
+[NotClientImplementable]
+public interface IPlatformSingleViewApplicationLifetime<T> : IPlatformSingleViewApplicationLifetime
+{
+    /// <summary>
+    /// Gets or sets the root UI element of the application.
+    /// </summary>
+    T? PlatformView { get; set; }
+}

--- a/src/iOS/Avalonia.iOS/UIViewControllerLifetime.cs
+++ b/src/iOS/Avalonia.iOS/UIViewControllerLifetime.cs
@@ -1,0 +1,18 @@
+﻿using Avalonia.Controls.ApplicationLifetimes;
+using UIKit;
+
+namespace Avalonia.iOS;
+
+/// <inheritdoc cref="IPlatformSingleViewApplicationLifetime"/>
+public interface IUIViewControllerApplicationLifetime : IPlatformSingleViewApplicationLifetime<UIViewController>;
+
+internal class UIViewControllerLifetime : IUIViewControllerApplicationLifetime
+{
+    public required UIWindow Window { get; init; }
+
+    public UIViewController? PlatformView
+    { 
+        get => Window.RootViewController; 
+        set => Window.RootViewController = value; 
+    }
+}


### PR DESCRIPTION
In our iOS app the user can navigate between multiple views, one of which is a native component overlaid by a second, partially transparent Avalonia view. We found that Avalonia doesn't support this arrangement, and that we had to hack it in by copying and altering `AvaloniaAppDelegate` so that we can create our own `UINavigationController` as the root view. While this works fine, it's not very maintainable and we are also unable to generate a functional application lifetime.

So this PR adds a new application lifetime where a platform-specific root view is controlled by the application. This allows Avalonia to be used alongside other native views created by external components in whatever way the application sees fit.

`ControlCatalog.iOS` can be started with the new lifetime by launching it with a "-PlatformView" argument...in principle. I've not actually worked out how to pass launch arguments to an iOS app, but altering the source code allows easy testing of the new behaviour even without this.

## What is the current behavior?
Avalonia views can only coexist with native views by using `NativeControlHost`. This is always drawn over Avalonia's output, which doesn't meet our requirements. It's also not possible to use native view transition animations, because there is only ever one native view.

## What is the updated/expected behavior with this PR?

By passing `AppViewControllerKind.Platform` as a constructor parameter to `Avalonia.iOS.AvaloniaAppDelegate`, a new lifetime type implementing the interface `IPlatformSingleViewApplicationLifetime` will be created.

The application is responsible for providing a platform-specific UI component to this lifetime. This could be an instance of the existing `DefaultAvaloniaViewController` type, or something entirely unrelated to Avalonia.

## How was the solution implemented (if it's not obvious)?

This PR implements the new lifetime **only for iOS**. It will need to be extended to other relevant platforms (certainly Android, possibly browser too?) by other people more familiar with them. It isn't relevant for desktop platforms.

There are three new public interfaces:

* `IPlatformSingleViewApplicationLifetime` in `Avalonia.Controls`. This allows platform-agnostic code to identify that a platform lifetime is in use, but is otherwise entirely opaque.
* `IPlatformSingleViewApplicationLifetime<T>` in `Avalonia.Controls`. This defines the `PlatformView` property and technically allows you to access it if you can provide the correct type for `T`.
* `IUIViewControllerApplicationLifetime` in `Avalonia.iOS`. This defines `T` and is the interface which will probably see the most use. Each platform supporting this feature should have its own equivalent.

There is also a new enum value on iOS which can be passed to a new `AvaloniaAppDelegate` constructor to request a platform lifetime. The lifetime itself does nothing except forward the native window's `RootViewController` property to its own `PlatformView` property. It's up to the application to provide a value.

## Breaking changes
None. This is an entirely additive change.

## Obsoletions / Deprecations
None.