### PR TITLE
fix: Enhance font weight determination for variable fonts

### DIFF
--- a/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
+++ b/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
@@ -90,9 +90,7 @@ namespace Avalonia.Skia
 
             FontSimulations = fontSimulations;
 
-            var fontWeight = _os2Table != null ? (FontWeight)_os2Table.WeightClass : FontWeight.Normal;
-
-            Weight = (fontSimulations & FontSimulations.Bold) != 0 ? FontWeight.Bold : fontWeight;
+            Weight = (fontSimulations & FontSimulations.Bold) != 0 ? FontWeight.Bold : (FontWeight)typeface.FontWeight;
 
             var style = _os2Table != null ? GetFontStyle(_os2Table.FontStyle) : FontStyle.Normal;
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes #18875 , enhance font weight determination for variable fonts.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Font weight of the variable fonts is not correct.

![image](https://github.com/user-attachments/assets/57c7da45-e8cb-46e8-9db5-b98e65704012)


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
![image](https://github.com/user-attachments/assets/ddaf3870-09a1-4eb6-8c1f-bef5979a3ac5)

```axaml
    <!-- Cascadia Code font -->
    <TextBlock Text="This is normal text in Cascadia Code font"
               FontFamily="Cascadia Code"
               FontSize="16" />
    <TextBlock Text="This is bold text in Cascadia Code font"
               FontFamily="Cascadia Code"
               FontWeight="Bold"
               FontSize="16" />

    <!-- Noto Sans font -->
    <TextBlock Text="This is normal text in Noto Sans font"
               FontFamily="Noto Sans SC"
               FontSize="16" />
    <TextBlock Text="This is bold text in Noto Sans font"
               FontFamily="Noto Sans SC"
               FontWeight="Bold"
               FontSize="16" />

    <!-- Dejavu Sans Mono font -->
    <TextBlock Text="This is normal text in Dejavu Sans Mono font"
               FontFamily="Dejavu Sans Mono"
               FontSize="16" />
    <TextBlock Text="This is bold text in Dejavu Sans Mono font"
               FontFamily="Dejavu Sans Mono"
               FontWeight="Bold"
               FontSize="16" />

    <!-- 思源黑体 CN font -->
    <TextBlock Text="This is normal text in 思源黑体 CN font"
               FontFamily="思源黑体 CN"
               FontSize="16" />
    <TextBlock Text="This is bold text in 思源黑体 CN font"
               FontFamily="思源黑体 CN"
               FontWeight="Bold"
               FontSize="16" />

    <!-- Roboto Flex font -->
    <TextBlock Text="This is normal text in Roboto Flex font"
               FontFamily="Roboto Flex"
               FontSize="16" />
    <TextBlock Text="This is bold text in Roboto Flex font"
               FontFamily="Roboto Flex"
               FontWeight="Bold"
               FontSize="16" />
  </StackPanel>
```

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Added variable font detection via 'fvar' table check

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #18875
