### PR TITLE
Fix the inconsistency between CalendarDatePicker drop-down calendar r…

### DIFF
--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Globalization;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
@@ -813,13 +814,13 @@ namespace Avalonia.Controls
                 {
                     // DisplayDateStart coerces to the value of the
                     // SelectedDateMin if SelectedDateMin < DisplayDateStart
-                    DateTime? selectedDateMin = SelectedDateMin(this);
 
-                    if (selectedDateMin.HasValue && DateTime.Compare(selectedDateMin.Value, newValue.Value) < 0)
-                    {
-                        SetCurrentValue(DisplayDateStartProperty, selectedDateMin.Value);
-                        return;
-                    }
+                    //DateTime? selectedDateMin = SelectedDateMin(this);
+                    //if (selectedDateMin.HasValue && DateTime.Compare(selectedDateMin.Value, newValue.Value) < 0)
+                    //{
+                    //    SetCurrentValue(DisplayDateStartProperty, selectedDateMin.Value);
+                    //    return;
+                    //}
 
                     // if DisplayDateStart > DisplayDateEnd,
                     // DisplayDateEnd = DisplayDateStart
@@ -921,13 +922,18 @@ namespace Avalonia.Controls
                 {
                     // DisplayDateEnd coerces to the value of the
                     // SelectedDateMax if SelectedDateMax > DisplayDateEnd
-                    DateTime? selectedDateMax = SelectedDateMax(this);
 
+                    /*
+                     *       When changing the start date, if SelectDate is greater than DisplayDateEnd, the start date range of CalendarDatePicker 
+                     *       will be inconsistent with the start date range of the calendar.
+
+                    DateTime? selectedDateMax = SelectedDateMax(this);
+              
                     if (selectedDateMax.HasValue && DateTime.Compare(selectedDateMax.Value, newValue.Value) > 0)
                     {
                         SetCurrentValue(DisplayDateEndProperty, selectedDateMax.Value);
                         return;
-                    }
+                    }*/
 
                     // if DisplayDateEnd < DisplayDateStart,
                     // DisplayDateEnd = DisplayDateStart
@@ -1120,11 +1126,16 @@ namespace Avalonia.Controls
                     cal._displayDateIsChanging = true;
                     if (DateTime.Compare(value.Value, cal.DisplayDateRangeStart) < 0)
                     {
-                        cal.DisplayDateStart = value;
+                        //cal.DisplayDateStart = value;
+                        //This assignment method will cause the Binding to be interrupted, causing the CalendarDatePicker
+                        //to set DisplayDateStart and not be passed to the calendar control through TemplateBinding.
+                        cal.SetCurrentValue(DisplayDateStartProperty, value);
+
                     }
                     else if (DateTime.Compare(value.Value, cal.DisplayDateRangeEnd) > 0)
                     {
-                        cal.DisplayDateEnd = value;
+                        //cal.DisplayDateEnd = value;
+                         cal.SetCurrentValue(DisplayDateEndProperty, value);
                     }
                     cal._displayDateIsChanging = false;
 


### PR DESCRIPTION
…ange and CalendarDatePicker setting range

  var dp1 = this.Get<CalendarDatePicker>("calendarDatePicker");

  dp1.SelectedDate = DateTime.Now.AddDays(1);
  dp1.DisplayDateStart = DateTime.Now.AddDays(-5);
  dp1.DisplayDateEnd = DateTime.Now.AddDays(11);

 var calendarDatePicker = this.Get<CalendarDatePicker>("calendarDatePicker");
 calendarDatePicker.SelectedDate = DateTime.Now.AddDays(60);
 calendarDatePicker.DisplayDateStart = DateTime.Now.AddDays(-2);
 calendarDatePicker.DisplayDateEnd = DateTime.Now.AddDays(64);

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fix the inconsistency between CalendarDatePicker drop-down calendar range and CalendarDatePicker setting range


## What is the current behavior?
dp1.SelectedDate = DateTime.Now.AddDays(1);
dp1.DisplayDateStart = DateTime.Now.AddDays(-5);
dp1.DisplayDateEnd = DateTime.Now.AddDays(11);

var calendarDatePicker = this.Get<CalendarDatePicker>("calendarDatePicker");
calendarDatePicker.SelectedDate = DateTime.Now.AddDays(60);
calendarDatePicker.DisplayDateStart = DateTime.Now.AddDays(-2);
calendarDatePicker.DisplayDateEnd = DateTime.Now.AddDays(64);

According to the above usage, the start time set by calendarDatePicker is inconsistent with the start time and end time of the calendar control in the drop-down control


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
