### PR TITLE
Fix focus not being lost when a parent element is hidden

### DIFF
--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -720,9 +720,19 @@ namespace Avalonia.Input
             {
                 PseudoClasses.Set(":focus-within", change.GetNewValue<bool>());
             }
-            else if (change.Property == IsVisibleProperty && !change.GetNewValue<bool>() && IsFocused)
+            else if (change.Property == IsVisibleProperty)
             {
-                FocusManager.GetFocusManager(this)?.ClearFocus();
+                if (!change.GetNewValue<bool>() && IsKeyboardFocusWithin && FocusManager.GetFocusManager(this) is { } focusManager)
+                {
+                    if (focusManager.GetFocusedElement() is { } focusedElement && VisualParent != null)
+                    {
+                        focusManager.ClearFocusOnElementRemoved(focusedElement, VisualParent);
+                    }
+                    else
+                    {
+                        focusManager.ClearFocus();
+                    }
+                }
             }
         }
 

--- a/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
@@ -203,7 +203,7 @@ namespace Avalonia.Base.UnitTests.Input
             }
         }
 
-        [Fact(Skip = "Need to implement IsEffectivelyVisible change notifications.")]
+        [Fact]
         public void Focus_Should_Be_Cleared_When_Control_Is_Effectively_Hidden()
         {
             Border container;


### PR DESCRIPTION
`InputElement` now clears focus from child elements when `IsVisible` changes to false. Previously, it only cleared focus from itself.

The `FocusManager.ClearFocusOnElementRemoved` method is now called, with `FocusManager.ClearFocus` used only as a fallback in case we can't provide parameters (which would indicate an invalid state). This seems sensible to me since as far as the focus manager is concerned, a hidden element has been removed.

The `Focus_Should_Be_Cleared_When_Control_Is_Effectively_Hidden` test has also been enabled.

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #18817