### PR TITLE
Replace ImageSharp Image Compare with SkiaSharp implementation

### DIFF
--- a/Avalonia.sln
+++ b/Avalonia.sln
@@ -97,7 +97,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Props", "Props", "{F3AC8BC1
 		build\DevAnalyzers.props = build\DevAnalyzers.props
 		build\EmbedXaml.props = build\EmbedXaml.props
 		build\HarfBuzzSharp.props = build\HarfBuzzSharp.props
-		build\ImageSharp.props = build\ImageSharp.props
 		build\JetBrains.dotMemoryUnit.props = build\JetBrains.dotMemoryUnit.props
 		build\Microsoft.CSharp.props = build\Microsoft.CSharp.props
 		build\Microsoft.Reactive.Testing.props = build\Microsoft.Reactive.Testing.props

--- a/build/ImageSharp.props
+++ b/build/ImageSharp.props
@@ -1,5 +1,0 @@
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
-  </ItemGroup>
-</Project>

--- a/tests/Avalonia.Direct2D1.RenderTests/Avalonia.Direct2D1.RenderTests.csproj
+++ b/tests/Avalonia.Direct2D1.RenderTests/Avalonia.Direct2D1.RenderTests.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
   <Import Project="..\..\build\Moq.props" />
   <Import Project="..\..\build\Rx.props" />
+  <Import Project="..\..\build\SkiaSharp.props" />
   <Import Project="..\..\build\XUnit.props" />
   <Import Project="..\..\build\SharedVersion.props" />
 </Project>

--- a/tests/Avalonia.Direct2D1.RenderTests/Avalonia.Direct2D1.RenderTests.csproj
+++ b/tests/Avalonia.Direct2D1.RenderTests/Avalonia.Direct2D1.RenderTests.csproj
@@ -23,6 +23,5 @@
   <Import Project="..\..\build\Moq.props" />
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\XUnit.props" />
-  <Import Project="..\..\build\ImageSharp.props" />
   <Import Project="..\..\build\SharedVersion.props" />
 </Project>

--- a/tests/Avalonia.IntegrationTests.Appium/Avalonia.IntegrationTests.Appium.csproj
+++ b/tests/Avalonia.IntegrationTests.Appium/Avalonia.IntegrationTests.Appium.csproj
@@ -20,6 +20,6 @@
   </ItemGroup>
 
   <Import Project="..\..\build\XUnit.props" />
+  <Import Project="..\..\build\SkiaSharp.props" />
   <Import Project="..\..\build\Rx.props" />
-  <Import Project="..\..\build\ImageSharp.props" />
 </Project>

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -6,7 +6,7 @@ using Avalonia.Controls;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Interactions;
-using SixLabors.ImageSharp.PixelFormats;
+using SkiaSharp;
 using Xunit;
 using Xunit.Sdk;
 
@@ -222,12 +222,11 @@ namespace Avalonia.IntegrationTests.Appium
 
             window.Click();
 
-            var img = SixLabors.ImageSharp.Image.Load<Rgba32>(screenshot.AsByteArray);
-            var topLeftColor = img[10, 10];
-            var centerColor = img[img.Width / 2, img.Height / 2];
-
-            Assert.Equal(new Rgba32(0, 128, 0), topLeftColor);
-            Assert.Equal(new Rgba32(255, 0, 0), centerColor);
+            var img = SKBitmap.Decode(screenshot.AsByteArray);
+            var topLeftColor = img.GetPixel(10, 10);
+            var centerColor = img.GetPixel(img.Width / 2, img.Height / 2);
+            Assert.Equal(new SKColor(0, 128, 0), topLeftColor);
+            Assert.Equal(new SKColor(255, 0, 0), centerColor);
         }
 
         [Fact]
@@ -243,12 +242,11 @@ namespace Avalonia.IntegrationTests.Appium
 
             window.Click();
 
-            var img = SixLabors.ImageSharp.Image.Load<Rgba32>(screenshot.AsByteArray);
-            var topLeftColor = img[10, 10];
-            var centerColor = img[img.Width / 2, img.Height / 2];
-
-            Assert.Equal(new Rgba32(0, 128, 0), topLeftColor);
-            Assert.Equal(new Rgba32(255, 0, 0), centerColor);
+            var img = SKBitmap.Decode(screenshot.AsByteArray);
+            var topLeftColor = img.GetPixel(10, 10);
+            var centerColor = img.GetPixel(img.Width / 2, img.Height / 2);
+            Assert.Equal(new SKColor(0, 128, 0), topLeftColor);
+            Assert.Equal(new SKColor(255, 0, 0), centerColor);
         }
 
         [PlatformFact(TestPlatforms.Windows)]

--- a/tests/Avalonia.RenderTests.WpfCompare/Avalonia.RenderTests.WpfCompare.csproj
+++ b/tests/Avalonia.RenderTests.WpfCompare/Avalonia.RenderTests.WpfCompare.csproj
@@ -17,7 +17,6 @@
   <Import Project="..\..\build\Moq.props" />
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\XUnit.props" />
-  <Import Project="..\..\build\ImageSharp.props" />
   <Import Project="..\..\build\SkiaSharp.props" />
   <Import Project="..\..\build\SharedVersion.props" />
 </Project>

--- a/tests/Avalonia.RenderTests/ImageHash/CompareHash.cs
+++ b/tests/Avalonia.RenderTests/ImageHash/CompareHash.cs
@@ -1,0 +1,96 @@
+// <copyright file="CompareHash.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace Avalonia.UnitTests;
+
+/// <summary>
+/// Utility to compare 64 bit hashes using the Hamming distance.
+/// </summary>
+public static class CompareHash
+{
+    /// <summary>
+    /// Array used for BitCount method (used in Similarity comparisons).
+    /// Array corresponds to the number of 1's per value.
+    /// ie. index 0 => byte 0x00 = 0000 0000 -> 0 high bits
+    /// ie. index 1 => byte 0x01 = 0000 0001 -> 1 high bit
+    /// ie. index 3 => byte 0x03 = 0000 0011 -> 2 high bits
+    /// ie. index 255 =>    0xFF = 1111 1111 -> 8 high bits
+    /// etc.
+    /// </summary>
+    private static readonly byte[] bitCounts =
+        {
+                0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+                1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+                1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+                2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+                1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+                2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+                2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+                3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7, 4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8,
+        };
+
+    /// <summary>
+    /// Returns a percentage-based similarity value between the two given hashes. The higher
+    /// the percentage, the closer the hashes are to being identical.
+    /// </summary>
+    /// <param name="hash1">The first hash.</param>
+    /// <param name="hash2">The second hash.</param>
+    /// <returns>The similarity percentage.</returns>
+    public static double Similarity(ulong hash1, ulong hash2)
+    {
+        return (64 - BitCount(hash1 ^ hash2)) * 100 / 64.0;
+    }
+
+    /// <summary>
+    /// Returns a percentage-based similarity value between the two given hashes. The higher
+    /// the percentage, the closer the hashes are to being identical.
+    /// </summary>
+    /// <param name="hash1">The first hash. Cannot be null and must have a length of 8.</param>
+    /// <param name="hash2">The second hash. Cannot be null and must have a length of 8.</param>
+    /// <returns>The similarity percentage.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="hash1"/> or <paramref name="hash2"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="hash1"/> or <paramref name="hash2"/> has a length other than <c>8</c>.</exception>
+    public static double Similarity(byte[] hash1, byte[] hash2)
+    {
+        if (hash1 == null)
+        {
+            throw new ArgumentNullException(nameof(hash1));
+        }
+
+        if (hash2 == null)
+        {
+            throw new ArgumentNullException(nameof(hash2));
+        }
+
+        if (hash1.Length != 8)
+        {
+            throw new ArgumentOutOfRangeException(nameof(hash1));
+        }
+
+        if (hash2.Length != 8)
+        {
+            throw new ArgumentOutOfRangeException(nameof(hash2));
+        }
+
+        var h1 = BitConverter.ToUInt64(hash1, 0);
+        var h2 = BitConverter.ToUInt64(hash2, 0);
+        return Similarity(h1, h2);
+    }
+
+    /// <summary>Counts bits Utility function for similarity.</summary>
+    /// <param name="num">The hash we are counting.</param>
+    /// <returns>The total bit count.</returns>
+    private static uint BitCount(ulong num)
+    {
+        uint count = 0;
+        for (; num > 0; num >>= 8)
+        {
+            count += bitCounts[num & 0xff];
+        }
+
+        return count;
+    }
+}

--- a/tests/Avalonia.RenderTests/ImageHash/CompareHash.cs
+++ b/tests/Avalonia.RenderTests/ImageHash/CompareHash.cs
@@ -1,7 +1,3 @@
-// <copyright file="CompareHash.cs" company="Drastic Actions">
-// Copyright (c) Drastic Actions. All rights reserved.
-// </copyright>
-
 using System;
 
 namespace Avalonia.UnitTests;

--- a/tests/Avalonia.RenderTests/ImageHash/HashAlgorithms/AverageHash.cs
+++ b/tests/Avalonia.RenderTests/ImageHash/HashAlgorithms/AverageHash.cs
@@ -1,7 +1,3 @@
-// <copyright file="AverageHash.cs" company="Drastic Actions">
-// Copyright (c) Drastic Actions. All rights reserved.
-// </copyright>
-
 using System;
 using SkiaSharp;
 

--- a/tests/Avalonia.RenderTests/ImageHash/HashAlgorithms/AverageHash.cs
+++ b/tests/Avalonia.RenderTests/ImageHash/HashAlgorithms/AverageHash.cs
@@ -1,0 +1,68 @@
+// <copyright file="AverageHash.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+using System;
+using SkiaSharp;
+
+namespace Avalonia.UnitTests;
+
+public class AverageHash : IImageHash
+{
+    private const int WIDTH = 8;
+    private const int HEIGHT = 8;
+    private const int NRPIXELS = WIDTH * HEIGHT;
+    private const ulong MOSTSIGNIFICANTBITMASK = 1UL << (NRPIXELS - 1);
+
+    /// <inheritdoc />
+    public ulong Hash(SKBitmap bitmap)
+    {
+        if (bitmap == null)
+        {
+            throw new ArgumentNullException(nameof(bitmap));
+        }
+
+        // Resize the bitmap
+        using (SKBitmap resizedBitmap = bitmap.Resize(new SKImageInfo(WIDTH, HEIGHT), SKFilterQuality.High))
+        {
+            // Convert the bitmap to grayscale
+            using (SKBitmap grayscaleBitmap = resizedBitmap.ConvertToGrayscale())
+            {
+                var hash = 0UL;
+
+                // Compute the average value
+                var averageValue = 0U;
+                for (var y = 0; y < HEIGHT; y++)
+                {
+                    Span<byte> row = grayscaleBitmap.GetPixelRow(y);
+                    for (var x = 0; x < WIDTH; x++)
+                    {
+                        averageValue += row[x];
+                    }
+                }
+
+                averageValue /= NRPIXELS;
+
+                // Compute the hash: each bit is a pixel
+                // 1 = higher than average, 0 = lower than average
+                var mask = MOSTSIGNIFICANTBITMASK;
+
+                for (var y = 0; y < HEIGHT; y++)
+                {
+                    Span<byte> row = grayscaleBitmap.GetPixelRow(y);
+                    for (var x = 0; x < WIDTH; x++)
+                    {
+                        if (row[x] >= averageValue)
+                        {
+                            hash |= mask;
+                        }
+
+                        mask >>= 1;
+                    }
+                }
+
+                return hash;
+            }
+        }
+    }
+}

--- a/tests/Avalonia.RenderTests/ImageHash/HashAlgorithms/DifferenceHash.cs
+++ b/tests/Avalonia.RenderTests/ImageHash/HashAlgorithms/DifferenceHash.cs
@@ -1,0 +1,52 @@
+using System;
+using SkiaSharp;
+
+namespace Avalonia.UnitTests;
+
+public class DifferenceHash : IImageHash
+{
+    private const int WIDTH = 9;
+    private const int HEIGHT = 8;
+
+    /// <inheritdoc />
+    public ulong Hash(SKBitmap bitmap)
+    {
+        if (bitmap == null)
+        {
+            throw new ArgumentNullException(nameof(bitmap));
+        }
+
+        // Resize the bitmap
+        using (SKBitmap resizedBitmap = bitmap.Resize(new SKImageInfo(WIDTH, HEIGHT), SKFilterQuality.High))
+        {
+            // Convert the bitmap to grayscale
+            using (SKBitmap grayscaleBitmap = resizedBitmap.ConvertToGrayscale())
+            {
+                var hash = 0UL;
+
+                // Compute the hash
+                var mask = 1UL << ((HEIGHT * (WIDTH - 1)) - 1);
+
+                for (var y = 0; y < HEIGHT; y++)
+                {
+                    Span<byte> row = grayscaleBitmap.GetPixelRow(y);
+                    byte leftPixel = row[0];
+
+                    for (var index = 1; index < WIDTH; index++)
+                    {
+                        byte rightPixel = row[index];
+                        if (leftPixel < rightPixel)
+                        {
+                            hash |= mask;
+                        }
+
+                        leftPixel = rightPixel;
+                        mask >>= 1;
+                    }
+                }
+
+                return hash;
+            }
+        }
+    }
+}

--- a/tests/Avalonia.RenderTests/ImageHash/HashAlgorithms/PerceptualHash.cs
+++ b/tests/Avalonia.RenderTests/ImageHash/HashAlgorithms/PerceptualHash.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using SkiaSharp;
+
+namespace Avalonia.UnitTests;
+
+public class PerceptualHash : IImageHash
+{
+    private const int SIZE = 64;
+    private static readonly double sqrt2DivSize = Math.Sqrt(2D / SIZE);
+    private static readonly double sqrt2 = 1 / Math.Sqrt(2);
+    private static readonly List<Vector<double>>[] dctCoeffsSimd = GenerateDctCoeffsSimd();
+
+    /// <inheritdoc />
+    public ulong Hash(SKBitmap bitmap)
+    {
+        if (bitmap == null)
+        {
+            throw new ArgumentNullException(nameof(bitmap));
+        }
+
+        var rows = new double[SIZE, SIZE];
+        var sequence = new double[SIZE];
+        var matrix = new double[SIZE, SIZE];
+
+        using (SKBitmap resizedBitmap = bitmap.Resize(new SKImageInfo(SIZE, SIZE), SKFilterQuality.High))
+        {
+            // Convert the bitmap to grayscale
+            using (SKBitmap grayscaleBitmap = resizedBitmap.ConvertToGrayscale())
+            {
+                // Calculate the DCT for each row.
+                for (var y = 0; y < SIZE; y++)
+                {
+                    var rowSpan = grayscaleBitmap.GetPixelRow(y);
+
+                    for (var x = 0; x < SIZE; x++)
+                    {
+                        sequence[x] = rowSpan[x];
+                    }
+
+                    Dct1D_SIMD(sequence, rows, y);
+                }
+
+                // Calculate the DCT for each column.
+                for (var x = 0; x < 8; x++)
+                {
+                    for (var y = 0; y < SIZE; y++)
+                    {
+                        sequence[y] = rows[y, x];
+                    }
+
+                    Dct1D_SIMD(sequence, matrix, x, limit: 8);
+                }
+
+                // Only use the top 8x8 values.
+                var top8X8 = new double[SIZE];
+                for (var y = 0; y < 8; y++)
+                {
+                    for (var x = 0; x < 8; x++)
+                    {
+                        top8X8[(y * 8) + x] = matrix[y, x];
+                    }
+                }
+
+                // Get Median.
+                var median = CalculateMedian64Values(top8X8);
+
+                // Calculate hash.
+                var mask = 1UL << (SIZE - 1);
+                var hash = 0UL;
+
+                for (var i = 0; i < SIZE; i++)
+                {
+                    if (top8X8[i] > median)
+                    {
+                        hash |= mask;
+                    }
+
+                    mask >>= 1;
+                }
+
+                return hash;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static double CalculateMedian64Values(IReadOnlyCollection<double> values)
+    {
+        Debug.Assert(values.Count == 64, "This DCT method works with 64 doubles.");
+        return values.OrderBy(value => value).Skip(31).Take(2).Average();
+    }
+
+    private static List<Vector<double>>[] GenerateDctCoeffsSimd()
+    {
+        var results = new List<Vector<double>>[SIZE];
+        for (var coef = 0; coef < SIZE; coef++)
+        {
+            var singleResultRaw = new double[SIZE];
+            for (var i = 0; i < SIZE; i++)
+            {
+                singleResultRaw[i] = Math.Cos(((2.0 * i) + 1.0) * coef * Math.PI / (2.0 * SIZE));
+            }
+
+            var singleResultList = new List<Vector<double>>();
+            var stride = Vector<double>.Count;
+            Debug.Assert(SIZE % stride == 0, "Size must be a multiple of SIMD stride");
+            for (var i = 0; i < SIZE; i += stride)
+            {
+                var v = new Vector<double>(singleResultRaw, i);
+                singleResultList.Add(v);
+            }
+
+            results[coef] = singleResultList;
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// One dimensional Discrete Cosine Transformation.
+    /// </summary>
+    /// <param name="valuesRaw">Should be an array of doubles of length 64.</param>
+    /// <param name="coefficients">Coefficients.</param>
+    /// <param name="ci">Coefficients index.</param>
+    /// <param name="limit">Limit.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Dct1D_SIMD(double[] valuesRaw, double[,] coefficients, int ci, int limit = SIZE)
+    {
+        Debug.Assert(valuesRaw.Length == 64, "This DCT method works with 64 doubles.");
+
+        var valuesList = new List<Vector<double>>();
+        var stride = Vector<double>.Count;
+        for (var i = 0; i < valuesRaw.Length; i += stride)
+        {
+            valuesList.Add(new Vector<double>(valuesRaw, i));
+        }
+
+        for (var coef = 0; coef < limit; coef++)
+        {
+            for (var i = 0; i < valuesList.Count; i++)
+            {
+                coefficients[ci, coef] += System.Numerics.Vector.Dot(valuesList[i], dctCoeffsSimd[coef][i]);
+            }
+
+            coefficients[ci, coef] *= sqrt2DivSize;
+            if (coef == 0)
+            {
+                coefficients[ci, coef] *= sqrt2;
+            }
+        }
+    }
+}

--- a/tests/Avalonia.RenderTests/ImageHash/IImageHash.cs
+++ b/tests/Avalonia.RenderTests/ImageHash/IImageHash.cs
@@ -1,0 +1,20 @@
+// <copyright file="IImageHash.cs" company="Drastic Actions">
+// Copyright (c) Drastic Actions. All rights reserved.
+// </copyright>
+
+using System;
+using SkiaSharp;
+
+namespace Avalonia.UnitTests;
+
+/// <summary>
+/// Interface for perceptual image hashing algorithm.
+/// </summary>
+public interface IImageHash
+{
+    /// <summary>Hash the image using the algorithm.</summary>
+    /// <param name="bitmap">image to calculate hash from.</param>
+    /// <returns>hash value of the image.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="bitmap"/> is <c>null</c>.</exception>
+    ulong Hash(SKBitmap bitmap);
+}

--- a/tests/Avalonia.RenderTests/ImageHash/IImageHash.cs
+++ b/tests/Avalonia.RenderTests/ImageHash/IImageHash.cs
@@ -1,7 +1,3 @@
-// <copyright file="IImageHash.cs" company="Drastic Actions">
-// Copyright (c) Drastic Actions. All rights reserved.
-// </copyright>
-
 using System;
 using SkiaSharp;
 

--- a/tests/Avalonia.RenderTests/ImageHash/ImageHashExtensions.cs
+++ b/tests/Avalonia.RenderTests/ImageHash/ImageHashExtensions.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using SkiaSharp;
+
+namespace Avalonia.UnitTests;
+
+public static class ImageHashExtensions
+{
+    /// <summary>
+    /// Gets the pixel row for a given Y value.
+    /// </summary>
+    /// <param name="bitmap">The SKBitmap.</param>
+    /// <param name="y">The Y value.</param>
+    /// <returns>Array of bytes.</returns>
+    public static byte[] GetPixelRow(this SKBitmap bitmap, int y)
+    {
+        var pixels = bitmap.GetPixelSpan();
+        int width = bitmap.Width;
+        var rowPixels = new byte[width];
+
+        for (int x = 0; x < width; x++)
+        {
+            rowPixels[x] = pixels[(y * width) + x];
+        }
+
+        return rowPixels;
+    }
+
+    /// <summary>Calculate the hash of the image (stream) using the hashImplementation.</summary>
+    /// <param name="hashImplementation">HashImplementation to calculate the hash.</param>
+    /// <param name="stream">Stream should 'contain' raw image data.</param>
+    /// <returns>hash value.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="hashImplementation"/> or <paramref name="stream"/> is <c>null</c>.</exception>
+    public static ulong Hash(this IImageHash hashImplementation, Stream stream)
+    {
+        if (hashImplementation == null)
+        {
+            throw new ArgumentNullException(nameof(hashImplementation));
+        }
+
+        if (stream == null)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        using var image = SKBitmap.Decode(stream);
+        return hashImplementation.Hash(image);
+    }
+    
+    /// <summary>Calculate the hash of the image (byte array) using the hashImplementation.</summary>
+    /// <param name="hashImplementation">HashImplementation to calculate the hash.</param>
+    /// <param name="byteArray">ByteArray should 'contain' raw image data.</param>
+    /// <returns>hash value.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="hashImplementation"/> or <paramref name="byteArray"/> is <c>null</c>.</exception>
+    public static ulong Hash(this IImageHash hashImplementation, byte[] byteArray)
+    {
+        if (hashImplementation == null)
+        {
+            throw new ArgumentNullException(nameof(hashImplementation));
+        }
+
+        if (byteArray == null)
+        {
+            throw new ArgumentNullException(nameof(byteArray));
+        }
+
+        using var image = SKBitmap.Decode(byteArray);
+        return hashImplementation.Hash(image);
+    }
+
+    /// <summary>
+    /// Converts a given SKBitmap to grayscale.
+    /// </summary>
+    /// <param name="resizedBitmap">The original bitmap.</param>
+    /// <returns>Grayscale Image.</returns>
+    public static SKBitmap ConvertToGrayscale(this SKBitmap resizedBitmap)
+    {
+        SKBitmap grayscaleBitmap =
+            new SKBitmap(resizedBitmap.Width, resizedBitmap.Height, SKColorType.Gray8, SKAlphaType.Opaque);
+
+        using (SKCanvas canvas = new SKCanvas(grayscaleBitmap))
+        {
+            using (SKPaint paint = new SKPaint())
+            {
+                paint.ColorFilter = SKColorFilter.CreateColorMatrix(new float[]
+                {
+                    0.299f, 0.299f, 0.299f, 0f, 0f,
+                    0.587f, 0.587f, 0.587f, 0f, 0f,
+                    0.114f, 0.114f, 0.114f, 0f, 0f,
+                    0f, 0f, 0f, 1f, 0f,
+                });
+                canvas.DrawBitmap(resizedBitmap, 0, 0, paint);
+            }
+        }
+
+        return grayscaleBitmap;
+    }
+}

--- a/tests/Avalonia.Skia.RenderTests/Avalonia.Skia.RenderTests.csproj
+++ b/tests/Avalonia.Skia.RenderTests/Avalonia.Skia.RenderTests.csproj
@@ -35,7 +35,6 @@
   <Import Project="..\..\build\Moq.props" />
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\XUnit.props" />
-  <Import Project="..\..\build\ImageSharp.props" />
   <Import Project="..\..\build\SkiaSharp.props" />
   <Import Project="..\..\build\SharedVersion.props" />
 </Project>

--- a/tests/Avalonia.Skia.RenderTests/CrossTestBase.cs
+++ b/tests/Avalonia.Skia.RenderTests/CrossTestBase.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using Avalonia.Skia.RenderTests;
 using Avalonia.Skia.RenderTests.CrossUI;
 using CrossUI;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
 #if AVALONIA_SKIA


### PR DESCRIPTION
## What does the pull request do?
This PR removes ImageSharp from the tests and replaces it with a [SkiaSharp implementation](https://github.com/drasticactions/Drastic.ImageHash) I wrote (Itself based on an [ImageSharp](https://github.com/coenm/ImageHash) implementation) for hashing and comparing the images. The current ImageSharp version referenced here is throwing Nuget security issues, but since you're already pulling in SkiaSharp, we could also reduce the dependency list and use that for this instead.

Functionally, the tests should perform the same as they have before.
