### PR TITLE
Remove Keyboard Theme Override

### DIFF
--- a/src/iOS/Avalonia.iOS/TextInputResponder.Properties.cs
+++ b/src/iOS/Avalonia.iOS/TextInputResponder.Properties.cs
@@ -34,9 +34,6 @@ partial class AvaloniaView
                     _ => UIKeyboardType.Default
                 };
 
-        [Export("keyboardAppearance")]
-        public UIKeyboardAppearance KeyboardAppearance => UIKeyboardAppearance.Alert;
-
         [Export("returnKeyType")]
         public UIReturnKeyType ReturnKeyType
         {


### PR DESCRIPTION
Fixes #18917 

## What does the pull request do?

The Text responder is being set with an overridden `UIKeyboardAppearance` of `Alert`, which is [deprecated](https://developer.apple.com/documentation/uikit/uikeyboardappearance) and is forcing the keyboard to always appear in Dark mode. Most likely this is due to an underlying SDK change.

Removing the override allows it to use the default theme either set in the app, or on device.

<img width="596" alt="スクリーンショット 2025-05-26 15 25 23" src="https://github.com/user-attachments/assets/59b9f705-e3e1-4f6f-8b23-be3551a17535" />

<img width="601" alt="スクリーンショット 2025-05-26 15 25 35" src="https://github.com/user-attachments/assets/211318ca-afcc-47f2-89cf-b04bcc7e39e1" />
