### PR TITLE
remove win32 dialog dpi hack

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -127,7 +127,6 @@ namespace Avalonia.Win32
                     }
 
                 case WindowsMessage.WM_DPICHANGED:
-                    if (!_ignoreDpiChanges)
                     {
                         _dpi = (uint)wParam >> 16;
                         var newDisplayRect = Marshal.PtrToStructure<RECT>(lParam);
@@ -149,19 +148,6 @@ namespace Avalonia.Win32
 
                         return IntPtr.Zero;
                     }
-                    else
-                    {
-                        // In case parent is on another screen with different scaling, window will have header scaled with
-                        // parent's scaling factor, so need to update frame
-                        SetWindowPos(hWnd,
-                            IntPtr.Zero, 0, 0, 0, 0,
-                            SetWindowPosFlags.SWP_FRAMECHANGED |
-                            SetWindowPosFlags.SWP_NOSIZE |
-                            SetWindowPosFlags.SWP_NOMOVE |
-                            SetWindowPosFlags.SWP_NOZORDER |
-                            SetWindowPosFlags.SWP_NOACTIVATE);
-                    }
-                    break;
 
                 case WindowsMessage.WM_GETICON:
                     if (_iconImpl == null)

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -104,7 +104,6 @@ namespace Avalonia.Win32
         private bool _shown;
         private bool _hiddenWindowIsParent;
         private uint _langid;
-        private bool _ignoreDpiChanges;
         internal bool _ignoreWmChar;
         private WindowTransparencyLevel _transparencyLevel;
         private readonly WindowTransparencyLevel _defaultTransparencyLevel;
@@ -730,20 +729,7 @@ namespace Avalonia.Win32
 
             _hiddenWindowIsParent = parentHwnd == OffscreenParentWindow.Handle;
 
-            // I can't find mention of this *anywhere* online, but it seems that setting
-            // GWL_HWNDPARENT to a window which is on the non-primary monitor can cause two
-            // WM_DPICHANGED messages to be sent: the first changing the DPI to the parent's DPI,
-            // then another changing the DPI back. This then causes Windows to provide an incorrect
-            // suggested new rectangle to the WM_DPICHANGED message if the window is immediately
-            // moved to the parent window's monitor (e.g. when using
-            // WindowStartupLocation.CenterOwner) causing the window to be shown with an incorrect
-            // size.
-            //
-            // Just ignore any WM_DPICHANGED while we're setting the parent as this shouldn't
-            // change the DPI anyway.
-            _ignoreDpiChanges = true;
             SetWindowLongPtr(_hwnd, (int)WindowLongParam.GWL_HWNDPARENT, parentHwnd);
-            _ignoreDpiChanges = false;
 
             // Windows doesn't seem to respect the HWND_TOPMOST flag of a window when showing an owned window for the first time.
             // So we set the HWND_TOPMOST again before the owned window is shown. This only needs to be done once.


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Remove a dpi hack added here, https://github.com/AvaloniaUI/Avalonia/pull/16143 . This is no longer needed, as toplevels now invalidate themselves when there's any dpi changes. The issue the hack was fixing is properly fixed here https://github.com/AvaloniaUI/Avalonia/pull/18315 .

## What is the current behavior?
When a dialog window is opened, because no dpi updates are sent to it when the dialog parent is set, the dialog toplevel doesn't invalidate its visual, thus it will use the default 1x scale when rendering.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/18921
Fixes https://github.com/AvaloniaUI/Avalonia/issues/18903