### PR TITLE
Fixed transitions with delay but no duration completing instantly

### DIFF
--- a/src/Avalonia.Base/Animation/TransitionInstance.cs
+++ b/src/Avalonia.Base/Animation/TransitionInstance.cs
@@ -33,9 +33,17 @@ namespace Avalonia.Animation
             //                   ^- normalizedDelayEnd
             //                    [<----   normalizedInterpVal   --->]
 
-            var normalizedInterpVal = 1d;
+            double normalizedInterpVal;
 
-            if (!MathUtilities.AreClose(_duration.TotalSeconds, 0d))
+            if (t < _delay)
+            {
+                normalizedInterpVal = 0d;
+            }
+            else if (MathUtilities.AreClose(_duration.TotalSeconds, 0d))
+            {
+                normalizedInterpVal = 1d;
+            }
+            else
             {
                 var normalizedTotalDur = _delay + _duration;
                 var normalizedDelayEnd = _delay.TotalSeconds / normalizedTotalDur.TotalSeconds;

--- a/tests/Avalonia.Base.UnitTests/Animation/TransitionsTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Animation/TransitionsTests.cs
@@ -84,7 +84,8 @@ namespace Avalonia.Base.UnitTests.Animation
             var clock = new TestClock();
 
             var i = -1;
-            
+            var completed = false;
+
             new TransitionInstance(clock, TimeSpan.FromMilliseconds(30), TimeSpan.FromMilliseconds(70)).Subscribe(
                 nextValue =>
                 {
@@ -124,12 +125,50 @@ namespace Avalonia.Base.UnitTests.Animation
                             Assert.Equal(1d, nextValue);
                             break;
                     }
-                });
+                }, () => completed = true);
 
             for (var z = 0; z <= 10; z++)
             {
                 clock.Pulse(TimeSpan.FromMilliseconds(10));
             }
+
+            Assert.True(completed);
+        }
+
+        [Fact]
+        public void TransitionInstance_With_Delay_But_Zero_Duration_Is_Completed_After_Delay()
+        {
+            var clock = new TestClock();
+
+            var i = -1;
+            var completed = false;
+
+            new TransitionInstance(clock, TimeSpan.FromMilliseconds(30), TimeSpan.Zero).Subscribe(
+                nextValue =>
+                {
+                    switch (i++)
+                    {
+                        case 0:
+                            Assert.Equal(0, nextValue);
+                            break;
+                        case 1:
+                            Assert.Equal(0, nextValue);
+                            break;
+                        case 2:
+                            Assert.Equal(0, nextValue);
+                            break;
+                        case 3: // one iteration sooner than the test above, because the start of the transition is also the end
+                            Assert.Equal(1, nextValue);
+                            break;
+                    }
+                }, () => completed = true);
+
+            for (var z = 0; z <= 4; z++)
+            {
+                clock.Pulse(TimeSpan.FromMilliseconds(10));
+            }
+
+            Assert.True(completed);
         }
     }
 }


### PR DESCRIPTION
If the duration of a transition is near zero, on its first update it skips straight to the completed state. This transition's delay is ignored.

This is corrected by the changes in this PR. The changes also prevent Avalonia ever calculating an interpolated value during the delay, since the result will always be zero.

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #18845
