### PR TITLE
Fixed RectangleGeometry not cloning its radius properties

### DIFF
--- a/src/Avalonia.Base/Media/RectangleGeometry.cs
+++ b/src/Avalonia.Base/Media/RectangleGeometry.cs
@@ -100,7 +100,7 @@ namespace Avalonia.Media
         }
 
         /// <inheritdoc/>
-        public override Geometry Clone() => new RectangleGeometry(Rect);
+        public override Geometry Clone() => new RectangleGeometry(Rect, RadiusX, RadiusY);
 
         private protected sealed override IGeometryImpl? CreateDefiningGeometry()
         {


### PR DESCRIPTION
`RectangleGeometry.Clone` didn't copy the `RadiusX` or `RadiusY` properties. Now it does.

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
I didn't bother filing a bug for this trivial change.