### PR TITLE
Don't expect WasmRuntimeAssetsLocation to be always set

### DIFF
--- a/samples/ControlCatalog/Pages/TabControlPage.xaml
+++ b/samples/ControlCatalog/Pages/TabControlPage.xaml
@@ -9,7 +9,7 @@
             <Style Selector="DockPanel.WithContentTemplates">
                 <Style Selector="^ TabItem">
                     <Setter Property="ContentTemplate">
-                        <DataTemplate x:CompileBindings="False">
+                        <DataTemplate x:DataType="x:Object">
                             <Border BorderBrush="Red" BorderThickness="10">
                                 <ContentPresenter Content="{Binding}"/>
                             </Border>

--- a/src/Browser/Avalonia.Browser/Rendering/RenderWorker.cs
+++ b/src/Browser/Avalonia.Browser/Rendering/RenderWorker.cs
@@ -59,7 +59,9 @@ internal partial class RenderWorker
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, "System.Runtime.InteropServices.JavaScript.JSHostImplementation", 
             "System.Runtime.InteropServices.JavaScript")]
         [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Private runtime API")]
+        [UnconditionalSuppressMessage("Trimming", "IL2036", Justification = "Private runtime API")]
         [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Private runtime API")]
+        [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "Private runtime API")]
         static JSWebWorkerClone()
         {
             var syncContext = typeof(System.Runtime.InteropServices.JavaScript.JSHost)
@@ -107,13 +109,15 @@ internal partial class RenderWorker
     }
     
     // TODO: Use this class instead of JSWebWorkerClone once https://github.com/dotnet/runtime/issues/102010 is fixed
+    // TODO12: It was fixed in .NET 10
     class JSWebWorkerWrapper
     {
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, "System.Runtime.InteropServices.JavaScript.JSWebWorker", 
             "System.Runtime.InteropServices.JavaScript")]
-        [UnconditionalSuppressMessage("Trimming", 
-            "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
-            Justification = "Private runtime API")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Private runtime API")]
+        [UnconditionalSuppressMessage("Trimming", "IL2036", Justification = "Private runtime API")]
+        [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Private runtime API")]
+        [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "Private runtime API")]
         static JSWebWorkerWrapper()
         {
             var type = typeof(System.Runtime.InteropServices.JavaScript.JSHost)

--- a/src/Browser/Avalonia.Browser/build/Avalonia.Browser.props
+++ b/src/Browser/Avalonia.Browser/build/Avalonia.Browser.props
@@ -7,6 +7,9 @@
     
     <ShouldIncludeNativeSkiaSharp Condition=" '$(ShouldIncludeNativeSkiaSharp)' == '' ">true</ShouldIncludeNativeSkiaSharp>
     <ShouldIncludeNativeHarfBuzzSharp Condition=" '$(ShouldIncludeNativeHarfBuzzSharp)' == '' ">true</ShouldIncludeNativeHarfBuzzSharp>
+
+    <_AvaloniaRuntimeAssetsLocation>$(WasmRuntimeAssetsLocation)</_AvaloniaRuntimeAssetsLocation>
+    <_AvaloniaRuntimeAssetsLocation Condition="'$(_AvaloniaRuntimeAssetsLocation)' == ''">_framework</_AvaloniaRuntimeAssetsLocation>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)/../build/Microsoft.AspNetCore.StaticWebAssets.props" />

--- a/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
+++ b/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
@@ -13,8 +13,7 @@
   
   <!-- Fallback for applications without StaticWebAssetsEnabled (legacy WASM SDK) -->
   <ItemGroup Condition="'$(ShouldIncludeAvaloniaLegacyAssets)' == 'true'">
-    <WasmExtraFilesToDeploy Condition="'$(WasmRuntimeAssetsLocation)' == ''" Include="$(MSBuildThisFileDirectory)/../staticwebassets/**/*.*" />
-    <WasmExtraFilesToDeploy Condition="'$(WasmRuntimeAssetsLocation)' != ''" Include="$(MSBuildThisFileDirectory)/../staticwebassets/**/*.*" TargetPath="$(WasmRuntimeAssetsLocation)/%(FileName)%(Extension)" />
+    <WasmExtraFilesToDeploy Include="$(MSBuildThisFileDirectory)/../staticwebassets/**/*.*" TargetPath="$(_AvaloniaRuntimeAssetsLocation)/%(FileName)%(Extension)" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(ShouldIncludeNativeSkiaSharp)' == 'true' or '$(ShouldIncludeNativeHarfBuzzSharp)' == 'true'">

--- a/src/Browser/Avalonia.Browser/build/Microsoft.AspNetCore.StaticWebAssets.props
+++ b/src/Browser/Avalonia.Browser/build/Microsoft.AspNetCore.StaticWebAssets.props
@@ -10,7 +10,7 @@
       <SourceId>Avalonia.Browser</SourceId>
       <ContentRoot>$(_AvaloniaWebAssetsFolder)</ContentRoot>
       <BasePath>/</BasePath>
-      <RelativePath>$(WasmRuntimeAssetsLocation)/%(FileName)%(Extension)</RelativePath>
+      <RelativePath>$(_AvaloniaRuntimeAssetsLocation)/%(FileName)%(Extension)</RelativePath>
       <AssetKind>All</AssetKind>
       <AssetMode>All</AssetMode>
       <AssetRole>Primary</AssetRole>


### PR DESCRIPTION
## What does the pull request do?

1. Don't expect WasmRuntimeAssetsLocation to be always set
2. Fix trimming warnings

Closes https://github.com/AvaloniaUI/Avalonia/issues/17388
