### PR TITLE
Allow localhost proxies to access Preview server

### DIFF
--- a/src/Avalonia.DesignerSupport/Remote/HtmlTransport/HtmlTransport.cs
+++ b/src/Avalonia.DesignerSupport/Remote/HtmlTransport/HtmlTransport.cs
@@ -124,6 +124,10 @@ namespace Avalonia.DesignerSupport.Remote.HtmlTransport
                         }
                         else
                         {
+                            if (req.Headers.TryGetValue("Origin", out var origin))
+                            {
+                                throw new Exception($"Origin '{origin}' doesn't match Url");
+                            }
                             throw new Exception("Origin doesn't match Url");
                         }
                     }
@@ -134,7 +138,7 @@ namespace Avalonia.DesignerSupport.Remote.HtmlTransport
         bool IsValidOrigin(SimpleWebSocketHttpRequest request)
         {
             return request.Headers.TryGetValue("Origin", out var origin) &&
-                   (origin == _listenUri.OriginalString || origin.StartsWith("vscode-webview:"));
+                   (origin == _listenUri.OriginalString || origin.StartsWith("vscode-webview:") || origin.StartsWith("http://localhost:"));
         }
 
         async void SocketReceiveWorker(SimpleWebSocket socket)


### PR DESCRIPTION
## What does the pull request do?

In Visual Studio Code, when you do `Avalonia: Show Preview`, the Avalonia.Designer.HostApp.dll will not abort if the viewer is on a localhost proxy.

For example, when running Avalonia in GitHub Codespaces, the Codespaces port forwarding will appear as http://localhost:PORT to the Preview server (Avalonia.Designer.HostApp.dll).

But since the Preview server is bound to an IP address like http://127.0.0.1:PORT, the existing Origin validation will not accept http://localhost:PORT.

## What is the current behavior?

```text
Initializing application in design mode
Obtaining AppBuilder instance from ScoutTrainingApp.Desktop.Program
HtmlTransportStartedMessage
    Uri: http://127.0.0.1:8000/
Triggering XAML update
...
Unhandled exception. System.Exception: Origin doesn't match Url
   at Avalonia.DesignerSupport.Remote.HtmlTransport.HtmlWebSocketTransport.AcceptWorker()
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_1(Object state)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
```


## What is the updated/expected behavior with this PR?

The expected behavior is no aborting of Avalonia.Designer.HostApp.dll.

## How was the solution implemented (if it's not obvious)?

Accept `http://localhost:PORT` as a valid Origin.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
