### PR TITLE
Fix BindingEvaluator.ClearDataContext

### DIFF
--- a/src/Avalonia.Controls/Utils/BindingEvaluator.cs
+++ b/src/Avalonia.Controls/Utils/BindingEvaluator.cs
@@ -39,7 +39,7 @@ internal sealed class BindingEvaluator<T> : StyledElement, IDisposable
     }
 
     public void ClearDataContext()
-        => DataContext = this;
+        => DataContext = null;
 
     public void Dispose()
     {

--- a/tests/Avalonia.Controls.UnitTests/Utils/BindingEvaluatorTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Utils/BindingEvaluatorTests.cs
@@ -1,0 +1,21 @@
+﻿#nullable enable
+
+using Avalonia.Controls.Utils;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests.Utils;
+
+public class BindingEvaluatorTests : ScopedTestBase
+{
+    [Fact]
+    public void ClearDataContext_Sets_DataContext_To_Null()
+    {
+        var evaluator = new BindingEvaluator<string?>();
+        evaluator.Evaluate("foo");
+        Assert.Equal("foo", evaluator.DataContext);
+
+        evaluator.ClearDataContext();
+        Assert.Null(evaluator.DataContext);
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
This PR fixes `BindingEvaluator.ClearDataContext`, which wasn't really clearing the data context.

## What is the current behavior?
The data context is set to the binding evaluator itself, causing exceptions.
The issue was introduced in #18405.

## What is the updated/expected behavior with this PR?
The data context is correctly set to `null`.

## Fixed issues
 - Fixes #18822