### PR TITLE
[ANDROID] Skip glWaitClient/glWaitGL/glWaitNative

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -30,7 +30,7 @@ using ClipboardManager = Android.Content.ClipboardManager;
 
 namespace Avalonia.Android.Platform.SkiaPlatform
 {
-    class TopLevelImpl : IAndroidView, ITopLevelImpl, EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo
+    class TopLevelImpl : IAndroidView, ITopLevelImpl, EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfoWithWaitPolicy
     {
         private readonly IGlPlatformSurface _gl;
         private readonly IFramebufferPlatformSurface _framebuffer;
@@ -302,6 +302,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         public AcrylicPlatformCompensationLevels AcrylicCompensationLevels => new AcrylicPlatformCompensationLevels(1, 1, 1);
 
         IntPtr EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo.Handle => ((IPlatformHandle)_view).Handle;
+        bool EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfoWithWaitPolicy.SkipWaits => true;
 
         public PixelSize Size => _view.Size;
 

--- a/src/Avalonia.OpenGL/Egl/EglGlPlatformSurface.cs
+++ b/src/Avalonia.OpenGL/Egl/EglGlPlatformSurface.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia.Metadata;
 using Avalonia.OpenGL.Surfaces;
 
 namespace Avalonia.OpenGL.Egl
@@ -10,6 +11,12 @@ namespace Avalonia.OpenGL.Egl
             IntPtr Handle { get; }
             PixelSize Size { get; }
             double Scaling { get; }
+        }
+        
+        [PrivateApi]
+        public interface IEglWindowGlPlatformSurfaceInfoWithWaitPolicy : IEglWindowGlPlatformSurfaceInfo
+        {
+            public bool SkipWaits { get; }
         }
         
         private readonly IEglWindowGlPlatformSurfaceInfo _info;
@@ -40,7 +47,10 @@ namespace Avalonia.OpenGL.Egl
                 _info = info;
                 _currentSize = info.Size;
                 _handle = _info.Handle;
+                SkipWaits = info is IEglWindowGlPlatformSurfaceInfoWithWaitPolicy { SkipWaits: true };
             }
+
+            private protected override bool SkipWaits { get; }
 
             public override void Dispose() => _glSurface?.Dispose();
 


### PR DESCRIPTION
Disable explicit waits on Android when using EGL. Those serve no value when resize/rotate operation leads to render target being re-created anyway.