### PR TITLE
Fix infinite animation memory leak.

### DIFF
--- a/src/Avalonia.Base/Styling/StyleInstance.cs
+++ b/src/Avalonia.Base/Styling/StyleInstance.cs
@@ -25,6 +25,7 @@ namespace Avalonia.Styling
         private bool _isActive;
         private List<ISetterInstance>? _setters;
         private List<IAnimation>? _animations;
+        private List<IDisposable>? _animationApplyDisposables;
         private LightweightSubject<bool>? _animationTrigger;
 
         public StyleInstance(
@@ -69,8 +70,9 @@ namespace Avalonia.Styling
             if (_animations is not null && control is Animatable animatable)
             {
                 _animationTrigger ??= new LightweightSubject<bool>();
+                _animationApplyDisposables ??= new List<IDisposable>();
                 foreach (var animation in _animations)
-                    animation.Apply(animatable, null, _animationTrigger);
+                    _animationApplyDisposables.Add(animation.Apply(animatable, null, _animationTrigger));
 
                 if (_activator is null)
                     _animationTrigger.OnNext(true);
@@ -81,6 +83,13 @@ namespace Avalonia.Styling
         {
             base.Dispose();
             _activator?.Dispose();
+            if (_animationApplyDisposables != null)
+            {
+                foreach (var item in _animationApplyDisposables)
+                {
+                    item.Dispose();
+                }
+            }
         }
 
         public new void MakeShared() => base.MakeShared();


### PR DESCRIPTION
## What does the pull request do?
Fix infinite animation memory leak.

## What is the current behavior?
Memory leak, even after the window is closed.
Here's a example code to reproduce.
```
<Window xmlns="https://github.com/avaloniaui"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
        xmlns:local="using:AvaloniaTestApp"
        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
        x:Class="AvaloniaTestApp.MainWindow"
        Title="AvaloniaTestApp">
  <Window.Styles>
    <Style Selector="Button">
      <Style.Animations>
        <Animation FillMode="None"
                   IterationCount="Infinite"
                   PlaybackDirection="Normal"
                   Duration="0:0:1.5">
          <KeyFrame Cue="0%">
            <Setter Property="Opacity" Value="0.2" />
          </KeyFrame>
          <KeyFrame Cue="20%">
            <Setter Property="Opacity" Value="0.1" />
          </KeyFrame>
          <KeyFrame Cue="50%">
            <Setter Property="Opacity" Value="0.05" />
          </KeyFrame>
          <KeyFrame Cue="80%">
            <Setter Property="Opacity" Value="0.1" />
          </KeyFrame>
          <KeyFrame Cue="100%">
            <Setter Property="Opacity" Value="0.2" />
          </KeyFrame>
        </Animation>

      </Style.Animations>
    </Style>
  </Window.Styles>
  <Button Background="Red" Width="100" Height="100"/>
</Window>
```

Here's the key retention paths from dotMemory.
![dotMemory](https://github.com/user-attachments/assets/a166bb4e-ed30-4178-a33f-26f95d0452f7)


## What is the updated/expected behavior with this PR?
No memory leak.


## How was the solution implemented (if it's not obvious)?
Dispose when `StyleInstance` dispose.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None.

## Obsoletions / Deprecations

## Fixed issues
None.
