### PR TITLE
Bump Angle version

### DIFF
--- a/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
+++ b/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />
-    <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.22045.20230930" />
+    <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.25547.20250602" />
     <PackageReference Include="MicroCom.CodeGenerator.MSBuild" Version="0.11.0" PrivateAssets="all" />
     <MicroComIdl Include="WinRT\winrt.idl" CSharpInteropPath="WinRT\WinRT.Generated.cs" />
     <MicroComIdl Include="Win32Com\win32.idl" CSharpInteropPath="Win32Com\Win32.Generated.cs" />


### PR DESCRIPTION
## How was the solution implemented (if it's not obvious)?

1. Rebased avalonia branch on top of latest Angle release.
2. [Adjusted build](https://github.com/AvaloniaUI/angle/commit/85499515ebf8f37f25857e45b89ada5e1d080649) commands to exclude several new angle backends (without that, Angle binary size was doubled with the same old build parameters)
3. Recompiled angle + released on nuget
4. Tested with SkiaSharp 2.88 and 3.0 on win-x64

There are a lot of changes in Angle for the last two years since last update. But primarily these affects other backends, like metal or vulkan, and not directx. I also checked available gles extensions just in case, nothing was removed from there in the new build.

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/18977
Fixes https://github.com/AvaloniaUI/Avalonia/issues/15751