### PR TITLE
Fix DirectX signatures

### DIFF
--- a/src/Windows/Avalonia.Win32/DirectX/directx.idl
+++ b/src/Windows/Avalonia.Win32/DirectX/directx.idl
@@ -19,7 +19,7 @@
 @clr-map INT16 short
 @clr-map INT32 int
 @clr-map INT64 long
-@clr-map UINT ushort
+@clr-map UINT uint
 @clr-map UINT16 ushort
 @clr-map ULONG uint
 @clr-map UINT32 uint


### PR DESCRIPTION
## What does the pull request do?
This PR changes the DirectX signatures to properly use 32-bit integers for `UINT` types.
This only worked because parameters gets aligned to 32 bits on the stack on x86, and are passed by register on x64.