### PR TITLE
Switch to using animation request for scroll inertia dispatch

### DIFF
--- a/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Diagnostics;
+using System.Security.Cryptography;
+using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Threading;
 
@@ -20,19 +22,24 @@ namespace Avalonia.Input.GestureRecognizers
         private bool _scrolling;
         private Point _trackedRootPoint;
         private IPointer? _tracking;
+        private Stopwatch? _stopWatch;
         private int _gestureId;
         private Point _pointerPressedPoint;
         private VelocityTracker? _velocityTracker;
 
         // Movement per second
-        private Vector _inertia;
+        private Vector? _inertia;
         private ulong? _lastMoveTimestamp;
+        private TimeSpan _lastTime;
+        private TimeSpan _inertiaStartTime;
+        private int _currentInertiaGestureId;
+        private DispatcherOperation? _inertiaDispatchOperation;
 
         /// <summary>
         /// Defines the <see cref="CanHorizontallyScroll"/> property.
         /// </summary>
         public static readonly DirectProperty<ScrollGestureRecognizer, bool> CanHorizontallyScrollProperty =
-            AvaloniaProperty.RegisterDirect<ScrollGestureRecognizer, bool>(nameof(CanHorizontallyScroll), 
+            AvaloniaProperty.RegisterDirect<ScrollGestureRecognizer, bool>(nameof(CanHorizontallyScroll),
                 o => o.CanHorizontallyScroll, (o, v) => o.CanHorizontallyScroll = v);
 
         /// <summary>
@@ -47,7 +54,7 @@ namespace Avalonia.Input.GestureRecognizers
         /// </summary>
         public static readonly DirectProperty<ScrollGestureRecognizer, bool> IsScrollInertiaEnabledProperty =
             AvaloniaProperty.RegisterDirect<ScrollGestureRecognizer, bool>(nameof(IsScrollInertiaEnabled),
-                o => o.IsScrollInertiaEnabled, (o,v) => o.IsScrollInertiaEnabled = v);
+                o => o.IsScrollInertiaEnabled, (o, v) => o.IsScrollInertiaEnabled = v);
 
         /// <summary>
         /// Defines the <see cref="ScrollStartDistance"/> property.
@@ -102,6 +109,7 @@ namespace Avalonia.Input.GestureRecognizers
             {
                 EndGesture();
                 _tracking = e.Pointer;
+                _inertia = null;
                 _gestureId = ScrollGestureEventArgs.GetNextFreeId();
                 _trackedRootPoint = _pointerPressedPoint = point.Position;
                 _velocityTracker = new VelocityTracker();
@@ -121,7 +129,7 @@ namespace Avalonia.Input.GestureRecognizers
                     if (CanVerticallyScroll && Math.Abs(_trackedRootPoint.Y - rootPoint.Y) > ScrollStartDistance)
                         _scrolling = true;
                     if (_scrolling)
-                    {                        
+                    {
                         // Correct _trackedRootPoint with ScrollStartDistance, so scrolling does not start with a skip of ScrollStartDistance
                         _trackedRootPoint = new Point(
                             _trackedRootPoint.X - (_trackedRootPoint.X >= rootPoint.X ? ScrollStartDistance : -ScrollStartDistance),
@@ -147,7 +155,8 @@ namespace Avalonia.Input.GestureRecognizers
 
         protected override void PointerCaptureLost(IPointer pointer)
         {
-            if (pointer == _tracking) EndGesture();
+            if (pointer == _tracking)
+                EndGesture();
         }
 
         void EndGesture()
@@ -155,15 +164,17 @@ namespace Avalonia.Input.GestureRecognizers
             _tracking = null;
             if (_scrolling)
             {
+                _stopWatch?.Stop();
                 _inertia = default;
                 _scrolling = false;
                 Target!.RaiseEvent(new ScrollGestureEndedEventArgs(_gestureId));
                 _gestureId = 0;
                 _lastMoveTimestamp = null;
             }
-            
-        }
 
+            _inertiaDispatchOperation = null;
+
+        }
 
         protected override void PointerReleased(PointerReleasedEventArgs e)
         {
@@ -172,7 +183,8 @@ namespace Avalonia.Input.GestureRecognizers
                 _inertia = _velocityTracker?.GetFlingVelocity().PixelsPerSecond ?? Vector.Zero;
 
                 e.Handled = true;
-                if (_inertia == default
+                if (_inertia == null
+                    || _inertia == Vector.Zero
                     || e.Timestamp == 0
                     || _lastMoveTimestamp == 0
                     || e.Timestamp - _lastMoveTimestamp > 200
@@ -181,53 +193,70 @@ namespace Avalonia.Input.GestureRecognizers
                 else
                 {
                     _tracking = null;
-                    var savedGestureId = _gestureId;
-                    var st = Stopwatch.StartNew();
-                    var lastTime = TimeSpan.Zero;
-                    Target!.RaiseEvent(new ScrollGestureInertiaStartingEventArgs(_gestureId, _inertia));
-                    DispatcherTimer.Run(() =>
-                    {
-                        // Another gesture has started, finish the current one
-                        if (_gestureId != savedGestureId)
-                        {
-                            return false;
-                        }
-
-                        var elapsedSinceLastTick = st.Elapsed - lastTime;
-                        lastTime = st.Elapsed;
-
-                        var speed = _inertia * Math.Pow(InertialResistance, st.Elapsed.TotalSeconds);
-                        var distance = speed * elapsedSinceLastTick.TotalSeconds;
-                        var scrollGestureEventArgs = new ScrollGestureEventArgs(_gestureId, distance);
-                        Target!.RaiseEvent(scrollGestureEventArgs);
-
-                        if (!scrollGestureEventArgs.Handled || scrollGestureEventArgs.ShouldEndScrollGesture)
-                        {
-                            EndGesture();
-                            return false;
-                        }
-
-                        // EndGesture using InertialScrollSpeedEnd only in the direction of scrolling
-                        if (CanVerticallyScroll && CanHorizontallyScroll && Math.Abs(speed.X) < InertialScrollSpeedEnd && Math.Abs(speed.Y) <= InertialScrollSpeedEnd)
-                        {
-                            EndGesture();
-                            return false;
-                        }
-                        else if (CanVerticallyScroll && Math.Abs(speed.Y) <= InertialScrollSpeedEnd)
-                        {
-                            EndGesture();
-                            return false;
-                        }
-                        else if (CanHorizontallyScroll && Math.Abs(speed.X) < InertialScrollSpeedEnd)
-                        {
-                            EndGesture();
-                            return false;
-                        }
-
-                        return true;
-                    }, TimeSpan.FromMilliseconds(16), DispatcherPriority.Background);
+                    _stopWatch = Stopwatch.StartNew();
+                    _lastTime = _stopWatch.Elapsed;
+                    _inertiaStartTime = _lastTime;
+                    _currentInertiaGestureId = _gestureId;
+                    Target!.RaiseEvent(new ScrollGestureInertiaStartingEventArgs(_gestureId, _inertia.Value));
+                    MediaContext.Instance.RequestAnimationFrame(OnAnimationRequested);
                 }
             }
+        }
+
+        private void OnAnimationRequested(TimeSpan _)
+        {
+            // Another gesture has started, finish the current one
+            if (_gestureId != _currentInertiaGestureId || _inertia == null)
+            {
+                _inertia = null;
+                return;
+            }
+
+            _inertiaDispatchOperation = Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                if (_stopWatch == null)
+                    return;
+
+                var timeSpan = _stopWatch.Elapsed;
+                var elapsedSinceLastTick = timeSpan - _lastTime;
+                _lastTime = timeSpan;
+
+                var speed = _inertia * Math.Pow(InertialResistance, (_lastTime - _inertiaStartTime).TotalSeconds);
+                var distance = speed * elapsedSinceLastTick.TotalSeconds;
+                if (speed is not { } && distance is not { })
+                {
+                    EndGesture();
+                    return;
+                }
+                var scrollGestureEventArgs = new ScrollGestureEventArgs(_gestureId, distance!.Value);
+                Target!.RaiseEvent(scrollGestureEventArgs);
+
+                if (!scrollGestureEventArgs.Handled || scrollGestureEventArgs.ShouldEndScrollGesture)
+                {
+                    EndGesture();
+                    return;
+                }
+
+                var sp = speed!.Value;
+
+                // EndGesture using InertialScrollSpeedEnd only in the direction of scrolling
+                if (CanVerticallyScroll && CanHorizontallyScroll && Math.Abs(sp.X) < InertialScrollSpeedEnd && Math.Abs(sp.Y) <= InertialScrollSpeedEnd)
+                {
+                    return;
+                }
+                else if (CanVerticallyScroll && Math.Abs(sp.Y) <= InertialScrollSpeedEnd)
+                {
+                    EndGesture();
+                    return;
+                }
+                else if (CanHorizontallyScroll && Math.Abs(sp.X) < InertialScrollSpeedEnd)
+                {
+                    EndGesture();
+                    return;
+                }
+            }, DispatcherPriority.Input);
+
+            MediaContext.Instance.RequestAnimationFrame(OnAnimationRequested);
         }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR dispatches scroll inertia events on animation tick. This provides much smoother inertia scrolling on high framerate devices.


## What is the current behavior?
Scroll inertia was dispatched on 16ms interval, limiting it to 60fps. Devices with higher framerate or variable framerate will have choppy scroll animations when inertia is started.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
