### PR TITLE
android: better api level detection for display edge to edge and ignore system bar color changes if on api level 35

### DIFF
--- a/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
+++ b/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
@@ -17,9 +17,6 @@ namespace Avalonia.Android.Platform
 {
     internal sealed class AndroidInsetsManager : WindowInsetsAnimationCompat.Callback, IInsetsManager, IOnApplyWindowInsetsListener, ViewTreeObserver.IOnGlobalLayoutListener, IInputPane
     {
-        // For now, we check if running under net 9. TODO: remove runtime check when we target net 10
-        private static bool IsDisplayEdgeToEdgeForced = System.Environment.Version.Major >=9 && Build.VERSION.SdkInt >= (BuildVersionCodes)35;
-
         private readonly Activity _activity;
         private readonly TopLevelImpl _topLevel;
         private bool _displaysEdgeToEdge;
@@ -32,6 +29,7 @@ namespace Avalonia.Android.Platform
         private Insets? _previousImeInset;
         private bool _displayEdgeToEdgePreference;
         private readonly bool _usesLegacyLayouts;
+        private readonly bool _isDisplayEdgeToEdgeForced;
 
         private AndroidWindow Window => _activity.Window ?? throw new InvalidOperationException("Activity.Window must be set."); 
         
@@ -67,7 +65,7 @@ namespace Avalonia.Android.Platform
 
         private void UpdateDisplayEdgeToEgdeState()
         {
-            if (IsDisplayEdgeToEdgeForced)
+            if (_isDisplayEdgeToEdgeForced)
             {
                 _displaysEdgeToEdge = true;
                 return;
@@ -97,6 +95,9 @@ namespace Avalonia.Android.Platform
         {
             _activity = activity;
             _topLevel = topLevel;
+
+            // Better detection for target sdk and running api level. Apps can change their target sdk and bypass dotnet's fixed target sdk level.
+            _isDisplayEdgeToEdgeForced = _activity.ApplicationContext?.ApplicationInfo?.TargetSdkVersion == (BuildVersionCodes)35 && Build.VERSION.SdkInt >= (BuildVersionCodes)35;
 
             ViewCompat.SetOnApplyWindowInsetsListener(Window.DecorView, this);
 
@@ -223,6 +224,12 @@ namespace Avalonia.Android.Platform
             {
                 _statusBarTheme = value;
 
+                // On api 35, there's no system bar theme. Updating the status bar theme has no effect, and navigation bar now has a special style that
+                // makes it invisible if you change the nav bar appearance. By default, android applies a 80% opacity filter over any color drawn on the 
+                // activity behind, forcing you to always use a light foreground, i.e. dark appearance. Thus we skip updating any colors.
+                if (_isDisplayEdgeToEdgeForced)
+                    return;
+
                 var compat = new WindowInsetsControllerCompat(Window, _topLevel.View);
 
                 if (_isDefaultSystemBarLightTheme == null)
@@ -281,7 +288,7 @@ namespace Avalonia.Android.Platform
             {
                 _systemBarColor = value;
 
-                if (IsDisplayEdgeToEdgeForced)
+                if (_isDisplayEdgeToEdgeForced)
                     return;
 
                 if (_systemBarColor is { } color && !_displaysEdgeToEdge && _activity.Window != null)

--- a/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
+++ b/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
@@ -289,7 +289,12 @@ namespace Avalonia.Android.Platform
                 _systemBarColor = value;
 
                 if (_isDisplayEdgeToEdgeForced)
+                {
+                    // Allow having fully transparent navbars when on api level 35
+                    if (OperatingSystem.IsAndroidVersionAtLeast(35))
+                        Window.NavigationBarContrastEnforced = _systemBarColor != Colors.Transparent;
                     return;
+                }
 
                 if (_systemBarColor is { } color && !_displaysEdgeToEdge && _activity.Window != null)
                 {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Follow up for https://github.com/AvaloniaUI/Avalonia/pull/18844 .
This time system bar theme is now ignored for android 15 when targeting api level 35. This fixes an issue where you app is in light mode, all theme colors are light, but because on the new nav bar filter that android applies to darken the nav bar over the activity, setting the system bar to light theme appearance, thus giving it a dark foreground, will cause the nav bar buttons to disappear.

Now, android will always use a light foreground color if nav bar is visible, or will detect and use the requested  DayNight config of the app when system bars are hidden.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
