### PR TITLE
Fix for #19035 On macOS, the SuggestedStartLocation is not set if the FileTypeChoices is not null

### DIFF
--- a/native/Avalonia.Native/src/OSX/StorageProvider.mm
+++ b/native/Avalonia.Native/src/OSX/StorageProvider.mm
@@ -235,11 +235,6 @@ public:
                 panel.title = [NSString stringWithUTF8String:title];
             }
             
-            if(initialDirectory != nullptr)
-            {
-                auto directoryString = [NSString stringWithUTF8String:initialDirectory];
-                panel.directoryURL = [NSURL URLWithString:directoryString];
-            }
             
             if(initialFile != nullptr)
             {
@@ -247,6 +242,12 @@ public:
             }
             
             SetAccessoryView(panel, filters, false);
+            
+            if(initialDirectory != nullptr)
+            {
+                auto directoryString = [NSString stringWithUTF8String:initialDirectory];
+                panel.directoryURL = [NSURL URLWithString:directoryString];
+            }
             
             auto handler = ^(NSModalResponse result) {
                 if(result == NSFileHandlingPanelOKButton)
@@ -304,11 +305,6 @@ public:
                 panel.title = [NSString stringWithUTF8String:title];
             }
             
-            if(initialDirectory != nullptr)
-            {
-                auto directoryString = [NSString stringWithUTF8String:initialDirectory];
-                panel.directoryURL = [NSURL URLWithString:directoryString];
-            }
             
             if(initialFile != nullptr)
             {
@@ -316,6 +312,12 @@ public:
             }
             
             SetAccessoryView(panel, filters, true);
+            
+            if(initialDirectory != nullptr)
+            {
+                auto directoryString = [NSString stringWithUTF8String:initialDirectory];
+                panel.directoryURL = [NSURL URLWithString:directoryString];
+            }
             
             auto handler = ^(NSModalResponse result) {
                 if(result == NSFileHandlingPanelOKButton)


### PR DESCRIPTION
## What does the pull request do?
fix the issue #19035 : 
The SuggestedStartLocation is not used by the StorageProvider window on macOS if the FileTypeChoices is set.
The SetAccessoryView in AvaloniaNative reset the directoryURL.


## What is the current behavior?
In AvaloniaNative, the directoryURL is set before the SetAccessoryView. The SetAccessoryView is messing with directoryURL  and fallback to the defaultFolder instead of the SuggestedStartLocation.

## What is the updated/expected behavior with this PR?
In AvaloniaNative, the AccessoryView is set before the DirectoryURL, keeping the SuggestedStartLocation


## How was the solution implemented (if it's not obvious)?
the set of directoryURL is done after the SetAccessoryView instead of before.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
none

## Obsoletions / Deprecations


## Fixed issues
Fixes #19035 
