### PR TITLE
Cleanup InvalidationAwareSurfaceView related code

### DIFF
--- a/src/Android/Avalonia.Android/ChoreographerTimer.cs
+++ b/src/Android/Avalonia.Android/ChoreographerTimer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Android.Views;
 using Avalonia.Reactive;
 using Avalonia.Rendering;
 using static Avalonia.Android.Platform.SkiaPlatform.AndroidFramebuffer;

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/AndroidFramebuffer.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/AndroidFramebuffer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Android.Runtime;
 using Android.Views;
 using Avalonia.Platform;
@@ -61,6 +62,19 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         internal static extern void ANativeWindow_unlockAndPost(IntPtr window);
 
         [DllImport("android")]
+        internal static extern IntPtr AChoreographer_getInstance();
+
+        [DllImport("android")]
+        [UnsupportedOSPlatform("android10.0")]
+        internal static extern void AChoreographer_postFrameCallback(
+            IntPtr choreographer, delegate* unmanaged<int, IntPtr, void> callback, IntPtr data);
+
+        [DllImport("android")]
+        [SupportedOSPlatform("android10.0")]
+        internal static extern void AChoreographer_postFrameCallback64(
+            IntPtr choreographer, delegate* unmanaged<long, IntPtr, void> callback, IntPtr data);
+
+        [DllImport("android")]
         internal static extern int ANativeWindow_lock(IntPtr window, ANativeWindow_Buffer* outBuffer, ARect* inOutDirtyBounds);
         public enum AndroidPixelFormat
         {
@@ -69,6 +83,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
             WINDOW_FORMAT_RGB_565 = 4,
         }
 
+        [StructLayout(LayoutKind.Sequential)]
         internal struct ARect
         {
             public int left;
@@ -76,7 +91,8 @@ namespace Avalonia.Android.Platform.SkiaPlatform
             public int right;
             public int bottom;
         }
-        
+
+        [StructLayout(LayoutKind.Sequential)]
         internal struct ANativeWindow_Buffer
         {
             // The number of pixels that are shown horizontally.

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
@@ -7,6 +7,7 @@ using Android.Views;
 using Avalonia.Android.Platform.SkiaPlatform;
 using Avalonia.Logging;
 using Avalonia.Platform;
+using Java.Lang;
 
 namespace Avalonia.Android
 {
@@ -67,6 +68,12 @@ namespace Avalonia.Android
         {
             Logger.TryGet(LogEventLevel.Verbose, LogArea.AndroidPlatform)?
                 .Log(this, "InvalidationAwareSurfaceView RedrawNeeded");
+        }
+
+        public virtual void SurfaceRedrawNeededAsync(ISurfaceHolder holder, IRunnable drawingFinished)
+        {
+            Logger.TryGet(LogEventLevel.Verbose, LogArea.AndroidPlatform)?
+                .Log(this, "InvalidationAwareSurfaceView RedrawNeededAsync");
         }
 
         private void CacheSurfaceProperties(ISurfaceHolder holder)

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
@@ -10,7 +10,7 @@ using Avalonia.Platform;
 
 namespace Avalonia.Android
 {
-    internal abstract class InvalidationAwareSurfaceView : SurfaceView, ISurfaceHolderCallback, INativePlatformHandleSurface
+    internal abstract class InvalidationAwareSurfaceView : SurfaceView, ISurfaceHolderCallback2, INativePlatformHandleSurface
     {
         private IntPtr _nativeWindowHandle = IntPtr.Zero;
         private PixelSize _size = new(1, 1);
@@ -61,6 +61,12 @@ namespace Avalonia.Android
             _scaling = 1;
             Logger.TryGet(LogEventLevel.Verbose, LogArea.AndroidPlatform)?
                 .Log(this, "InvalidationAwareSurfaceView Destroyed");
+        }
+
+        public virtual void SurfaceRedrawNeeded(ISurfaceHolder holder)
+        {
+            Logger.TryGet(LogEventLevel.Verbose, LogArea.AndroidPlatform)?
+                .Log(this, "InvalidationAwareSurfaceView RedrawNeeded");
         }
 
         private void CacheSurfaceProperties(ISurfaceHolder holder)

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -223,12 +223,17 @@ namespace Avalonia.Android.Platform.SkiaPlatform
             public override void SurfaceRedrawNeeded(ISurfaceHolder holder)
             {
                 // Compositor Renderer handles Paint event in-sync, which is perfect for sync SurfaceRedrawNeeded
-                // In the future we might to handle SurfaceRedrawNeededAsync as well.
                 _tl.Paint?.Invoke(new Rect(new Point(), Size.ToSize(Scaling)));
                 base.SurfaceRedrawNeeded(holder);
             }
 
-            public sealed override bool OnCheckIsTextEditor()
+            public override void SurfaceRedrawNeededAsync(ISurfaceHolder holder, IRunnable drawingFinished)
+            {
+                _tl.Compositor.RequestCompositionUpdate(drawingFinished.Run);
+                base.SurfaceRedrawNeededAsync(holder, drawingFinished);
+            }
+
+            public override bool OnCheckIsTextEditor()
             {
                 return true;
             }

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -220,6 +220,14 @@ namespace Avalonia.Android.Platform.SkiaPlatform
                 }
             }
 
+            public override void SurfaceRedrawNeeded(ISurfaceHolder holder)
+            {
+                // Compositor Renderer handles Paint event in-sync, which is perfect for sync SurfaceRedrawNeeded
+                // In the future we might to handle SurfaceRedrawNeededAsync as well.
+                _tl.Paint?.Invoke(new Rect(new Point(), Size.ToSize(Scaling)));
+                base.SurfaceRedrawNeeded(holder);
+            }
+
             public sealed override bool OnCheckIsTextEditor()
             {
                 return true;

--- a/src/Android/Avalonia.Android/Platform/Specific/IAndroidView.cs
+++ b/src/Android/Avalonia.Android/Platform/Specific/IAndroidView.cs
@@ -1,9 +1,11 @@
+using System;
 using Android.Views;
 
 namespace Avalonia.Android.Platform.Specific
 {
     public interface IAndroidView
     {
+        [Obsolete("Use TopLevel.TryGetPlatformHandle instead, which can be casted to AndroidViewControlHandle.")]
         View View { get; }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

1. Remove support for ancient renderer with Invalidate/OnDraw/Paint calls. 
2. To still support surface redraw requests, handle SurfaceRedrawNeeded and call sync `topLevel.Paint ` request.
3. Simplifies `InvalidationAwareSurfaceView`, and adds caching for Size/Scaling properties. While also fixing bug where ScalingChanged wasn't raised (similar to [#18767](https://github.com/AvaloniaUI/Avalonia/pull/18767)).
4. Previously, `InvalidationAwareSurfaceView` was requesting new ANativeWindow on each Handle getter call, now it reuses ANativeWindow, and releases it on surface changes/disposal (could be a fix for [#18995](https://github.com/AvaloniaUI/Avalonia/issues/18995)?). 
5. Replaces C#-JNI with NDK in choreographer code.
6. Cleans up some code

