### PR TITLE
Fix WindowCloseReason Passed During System Shutdown

### DIFF
--- a/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -188,7 +188,10 @@ namespace Avalonia.Controls.ApplicationLifetimes
                     if (w.Owner is null)
                     {
                         var ignoreCancel = force || (ShutdownMode == ShutdownMode.OnMainWindowClose && w != MainWindow);
-                        w.CloseCore(WindowCloseReason.ApplicationShutdown, isProgrammatic, ignoreCancel);
+                        var reason = e.IsOSShutdown ?
+                            WindowCloseReason.OSShutdown :
+                            WindowCloseReason.ApplicationShutdown;
+                        w.CloseCore(reason, isProgrammatic, ignoreCancel);
                     }
                 }
 

--- a/src/Avalonia.Controls/ApplicationLifetimes/ShutdownRequestedEventArgs.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/ShutdownRequestedEventArgs.cs
@@ -4,6 +4,9 @@ namespace Avalonia.Controls.ApplicationLifetimes
 {
     public class ShutdownRequestedEventArgs : CancelEventArgs
     {
-
+        /// <summary>
+        /// Is the operating system shutting down
+        /// </summary>
+        internal bool IsOSShutdown { get; init; }
     }
 }

--- a/src/Avalonia.X11/X11PlatformLifetimeEvents.cs
+++ b/src/Avalonia.X11/X11PlatformLifetimeEvents.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
@@ -229,7 +229,10 @@ namespace Avalonia.X11
         {
             if (state is IntPtr smcConn)
             {
-                var e = new ShutdownRequestedEventArgs();
+                var e = new ShutdownRequestedEventArgs()
+                {
+                    IsOSShutdown = true,
+                };
 
                 if (_platform.Options.EnableSessionManagement)
                 {

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -148,11 +148,22 @@ namespace Avalonia.Win32
             {
                 if (ShutdownRequested != null)
                 {
-                    var e = new ShutdownRequestedEventArgs();
+                    // https://learn.microsoft.com/en-us/windows/win32/shutdown/wm-queryendsession
+                    // > LPARAM lParam   // logoff option
+                    // >
+                    // > This parameter can be one or more of the following values. If this parameter is 0, the system is shutting down or restarting (it is not possible to determine which event is occurring).
+                    // >
+                    // > - ENDSESSION_CLOSEAPP 0x00000001 The application is using a file that must be replaced, the system is being serviced, or system resources are exhausted. For more information, see Guidelines for Applications.
+                    // > - ENDSESSION_CRITICAL 0x40000000 The application is forced to shut down.
+                    // > - ENDSESSION_LOGOFF 0x80000000 The user is logging off.
+                    var e = new ShutdownRequestedEventArgs()
+                    {
+                        IsOSShutdown = lParam == IntPtr.Zero,
+                    };
 
                     ShutdownRequested(this, e);
 
-                    if(e.Cancel)
+                    if (e.Cancel)
                     {
                         return IntPtr.Zero;
                     }


### PR DESCRIPTION


<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Fix https://github.com/AvaloniaUI/Avalonia/issues/19027

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

It can not pass the OSShutdown enum to WindowCloseReason of WindowClosingEventArgs.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

It can pass the OSShutdown enum to WindowCloseReason of WindowClosingEventArgs.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)? Sorry, no.
- [ ] Added XML documentation to any related classes? No.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

The `WindowClosingEventArgs.CloseReason` will change from `WindowCloseReason.ApplicationShutdown` to `WindowCloseReason.OSShutdown` when the System Shutdown.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fix https://github.com/AvaloniaUI/Avalonia/issues/19027