### PR TITLE
[Avalonia.Native] Respect info.plist values for setActivationPolicy

### DIFF
--- a/native/Avalonia.Native/src/OSX/app.mm
+++ b/native/Avalonia.Native/src/OSX/app.mm
@@ -30,8 +30,6 @@ ComPtr<IAvnApplicationEvents> _events;
             break;
         }
         
-        [[NSApplication sharedApplication] setActivationPolicy: AvnDesiredActivationPolicy];
-        
         [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"NSFullScreenMenuItemEverywhere"];
         
         [[NSApplication sharedApplication] setHelpMenu: [[NSMenu new] initWithTitle:@""]];

--- a/native/Avalonia.Native/src/OSX/main.mm
+++ b/native/Avalonia.Native/src/OSX/main.mm
@@ -129,14 +129,22 @@ public:
         }
     }
     
-    virtual HRESULT SetShowInDock(int show)  override
+    virtual HRESULT SetShowInDock(int show) override
     {
         START_COM_CALL;
         
         @autoreleasepool
         {
-            [[NSApplication sharedApplication] setActivationPolicy: show
-             ? NSApplicationActivationPolicyRegular : NSApplicationActivationPolicyAccessory];
+            NSApplication* app = [NSApplication sharedApplication];
+            NSApplicationActivationPolicy requestedPolicy = show
+                ? NSApplicationActivationPolicyRegular
+                : NSApplicationActivationPolicyAccessory;
+            
+            if ([app activationPolicy] != requestedPolicy)
+            {
+                [app setActivationPolicy:requestedPolicy];
+            }
+            
             return S_OK;
         }
     }

--- a/native/Avalonia.Native/src/OSX/main.mm
+++ b/native/Avalonia.Native/src/OSX/main.mm
@@ -135,8 +135,8 @@ public:
         
         @autoreleasepool
         {
-            AvnDesiredActivationPolicy = show
-                ? NSApplicationActivationPolicyRegular : NSApplicationActivationPolicyAccessory;
+            [[NSApplication sharedApplication] setActivationPolicy: show
+             ? NSApplicationActivationPolicyRegular : NSApplicationActivationPolicyAccessory];
             return S_OK;
         }
     }


### PR DESCRIPTION
## What does the pull request do?
Replace the implementation of `SetShowInDock` to directly set `[[NSApplication sharedApplication] setActivationPolicy` if it's invoked, and remove the hardcoded setting of `[[NSApplication sharedApplication] setActivationPolicy` in the AppDelegate startup.

## What is the current behavior?

The current behavior only looks at `MacOSPlatformOptions.ShowInDock` for a bool value that gets set during App startup. This value changes an internal value within the Avalonia.Native library for changing the `activationPolicy` value in the app delegate.

If a user has changed their App Activation Policy (Ex. Via `info.plist`), The following code would run that would automatically trigger setting `[[NSApplication sharedApplication] setActivationPolicy`. 

https://github.com/AvaloniaUI/Avalonia/blob/cf0158ddba21ae9c7d591bc93bf03d371f2dad98/native/Avalonia.Native/src/OSX/app.mm#L24-L39

The default for this is `NSApplicationActivationPolicyRegular`, meaning if a user had not also set a builder option to set it, ex.

```csharp
internal static AppBuilder BuildAvaloniaApp()
        => AppBuilder.Configure<App>()
            .With(new MacOSPlatformOptions { ShowInDock = false })
            .UsePlatformDetect()
...
```

then it would show again. If they changed their info.plist to one where it's an accessory (So, it should be hidden from the start) _and_ change the `ShowInDock` value to false, calling the `setActivationPolicy` again in startup would cause the app icon to appear, then disappear. I replicated similar behavior in a straight ObjC app by setting the setActivationPolicy policy in startup, even if it was for the same value.

Ideally, it shouldn't need to set it twice, and should respect the user's info.plist value for what the activation policy is. `setActivationPolicy` should only be invoked if 

- The user has set `ShowInDock` to a value,
- it's different than whatever the users `info.plist` value is.

## What is the updated/expected behavior with this PR?

- The `Info.plist` value will always precede Avalonia settings. Setting LSUIElement to true, for example, should always be respected from startup.
- If you do set `ShowInDock` as a builder setting, and the value picked is different from whatever the App default is based on info.plist (or if the user has set it in code themselves before the AppDelegate code has started, ex `Main.cs`) then it will trigger setting `setActivationPolicy` 
