### PR TITLE
[Avalonia.Native] Don't change SetWindowState on move in macOS 15+

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -437,7 +437,11 @@
 
             // Works around macos 15.x+ tiling and stage manager features where
             // the window size may reset during stage manager transitions
-            if(@available(macOS 15, *))
+            if (@available(macOS 15, *))
+            {
+                // No action needed for macOS 15 and later
+            }
+            else
             {
                 window->SetWindowState(Normal);
             }

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -437,8 +437,7 @@
 
             // Works around macos 15.x+ tiling and stage manager features where
             // the window size may reset during stage manager transitions
-            NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
-            if(version.majorVersion < 15)
+            if(@available(macOS 15, *))
             {
                 window->SetWindowState(Normal);
             }

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -435,7 +435,10 @@
                 return;
             }
 
-            if(window->WindowState() == Maximized)
+            // Works around macos 15.x+ tiling and stage manager features where
+            // the window size may reset during stage manager transitions
+            NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
+            if(version.majorVersion < 15)
             {
                 window->SetWindowState(Normal);
             }


### PR DESCRIPTION
## What does the pull request do?
Adds an `@available` check around `windowDidMove.window->SetWindowState(Normal);`, so it will only be invoked on macOS versions less than 15.


## What is the current behavior?
In macOS, if you maximize a window by double-clicking on it and try to drag it, it will cause it to resize to the original, non-maximum size. In Avalonia.Native, this case is being done via code and it's breaking on 15+ due to changes in how the window tiling and stage manager work.

https://github.com/user-attachments/assets/06a4d324-1f5e-4409-bdcc-7820e502d3b1

This also breaks Stage Manager. If you have a maximized window when using Stage Manager, switch apps, then return to the Avalonia app, it will have resized back to its original size, when it shouldn't.

This is because code in `windowDidMove` is being invoked by Stage Manager (as the window did move according to macOS) and is being reset by Avalonia.Native to have a "normal" state.

If the `SetWindowState(Normal)` is avoided for macOS 15+ versions, the window logic for resizing should be correct.


## What is the updated/expected behavior with this PR?


https://github.com/user-attachments/assets/464955e9-e8a5-40de-9b8d-3d518c47affc

The window drag should now, hopefully, match standard macOS windows.

## How was the solution implemented (if it's not obvious)?
Version check and only run the original `SetWindowState(Normal)` code on macOS versions less than 14.

If you use a negation for `@available` Xcode throws a warning saying you shouldn't do that and recommends utilizing the wrapping I have instead.