### PR TITLE
[Avalonia.Controls] feature: Remove the need for MenuItem Icon to be a ILogical

### DIFF
--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using System.Windows.Input;
 using Avalonia.Automation;
@@ -571,7 +570,7 @@ namespace Avalonia.Controls
                 }
             }
         }
-        
+
         /// <summary>
         /// Closes all submenus of the menu item.
         /// </summary>
@@ -609,12 +608,12 @@ namespace Avalonia.Controls
             }
 
         }
-        
+
         private static void OnAccessKeyPressed(MenuItem sender, AccessKeyPressedEventArgs e)
         {
-            if (e is not { Handled: false, Target: null }) 
+            if (e is not { Handled: false, Target: null })
                 return;
-            
+
             e.Target = sender;
             e.Handled = true;
         }
@@ -789,15 +788,23 @@ namespace Avalonia.Controls
         {
             var (oldValue, newValue) = e.GetOldAndNewValue<object?>();
 
-            if (oldValue is ILogical oldLogical)
+            if (oldValue is { })
             {
-                LogicalChildren.Remove(oldLogical);
+                if (oldValue is ILogical oldLogical)
+                {
+                    LogicalChildren.Remove(oldLogical);
+                }
+
                 PseudoClasses.Remove(":icon");
             }
 
-            if (newValue is ILogical newLogical)
+            if (newValue is { })
             {
-                LogicalChildren.Add(newLogical);
+                if (newValue is ILogical newLogical)
+                {
+                    LogicalChildren.Add(newLogical);
+                }
+
                 PseudoClasses.Add(":icon");
             }
         }


### PR DESCRIPTION
## What does the pull request do?
Allow any type to be used as `MenuItem.Icon` as it's already of `object?` type and displayed using a `ContentPresenter` in various themes/styles.

## What is the current behavior?
Currently, if the value is not a `ILogical`, the pseudo class `:icon` won't be set and the icon won't be displayed.

## What is the updated/expected behavior with this PR?
The pseudo class change now only check weither the value is not null, allowing to display anything as icon and relying on data template for more possibilities.

## Fixed issues
Fixes #19063


It seems my ide config cleaned up some white space in the process, tell me if I should only keep the `IconChanged` part :)