### PR TITLE
Android - Revert changes preventing status bar theme from being updated

### DIFF
--- a/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
+++ b/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
@@ -224,12 +224,6 @@ namespace Avalonia.Android.Platform
             {
                 _statusBarTheme = value;
 
-                // On api 35, there's no system bar theme. Updating the status bar theme has no effect, and navigation bar now has a special style that
-                // makes it invisible if you change the nav bar appearance. By default, android applies a 80% opacity filter over any color drawn on the 
-                // activity behind, forcing you to always use a light foreground, i.e. dark appearance. Thus we skip updating any colors.
-                if (_isDisplayEdgeToEdgeForced)
-                    return;
-
                 var compat = new WindowInsetsControllerCompat(Window, _topLevel.View);
 
                 if (_isDefaultSystemBarLightTheme == null)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Partially revert theme related changes introduced in #19034 .Status bar theme can be changed. Only Navbar theme is ignored on api 35+.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
