### PR TITLE
Android - Reset android input method focus and connection state when text input focus is removed

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
@@ -91,6 +91,7 @@ namespace Avalonia.Android.Platform.Input
             {
                 _host.ClearFocus();
                 _imm.RestartInput(View);
+                _inputConnection = null;
                 _imm.HideSoftInputFromWindow(_host.WindowToken, HideSoftInputFlags.ImplicitOnly);
             }
         }
@@ -152,7 +153,6 @@ namespace Avalonia.Android.Platform.Input
             {
                 if (_client == null)
                 {
-                    _inputConnection = null;
                     return null!;
                 }
 

--- a/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
@@ -89,6 +89,8 @@ namespace Avalonia.Android.Platform.Input
             }
             else
             {
+                _host.ClearFocus();
+                _imm.RestartInput(View);
                 _imm.HideSoftInputFromWindow(_host.WindowToken, HideSoftInputFlags.ImplicitOnly);
             }
         }
@@ -149,7 +151,10 @@ namespace Avalonia.Android.Platform.Input
             _host.InitEditorInfo((topLevel, outAttrs) =>
             {
                 if (_client == null)
+                {
+                    _inputConnection = null;
                     return null!;
+                }
 
                 _inputConnection = new AvaloniaInputConnection(topLevel, this);
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This  pr disconnects the current input connection on android when text input is unfocused. It also removes focus from the host view when this occurs.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. --> 
Where an active input connection is present while the textbox is unfocused, it consumes key events instead of the AvaloniaView.
Also multiple KeyUp events are raised due this invalid focus state. Both the AvaloniaView and the TopLevelImpl view will raise separate KeyUp events when a textbox is unfocused and a button is released. This prevents toggle switches from properly toggling their state.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/19077
