### PR TITLE
[Avalonia.Native] Add shouldResize value to SetWindowState, don't resize on Window move

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -435,9 +435,17 @@
                 return;
             }
 
-            if(window->WindowState() == Maximized)
+            // We should only return the window state to normal if
+            // the internal window state is maximized, and macOS says
+            // the window is no longer zoomed (I.E, the user has moved it)
+            // Stage Manager will "move" the window when repositioning it
+            // So if the window was "maximized" before, it should stay maximized
+            if(window->WindowState() == Maximized && !window->IsZoomed())
             {
-                window->SetWindowState(Normal);
+                // If we're moving the window while maximized,
+                // we need to let macOS handle if it should be resized
+                // And not handle it ourselves.
+                window->SetWindowState(Normal, false);
             }
         }
 

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -435,12 +435,18 @@
                 return;
             }
 
+            // If the window has been moved into a position where it's "zoomed"
+            // Then it should be set as Maximized.
+            if (window->WindowState() != Maximized && window->IsZoomed())
+            {
+                window->SetWindowState(Maximized, false);
+            }
             // We should only return the window state to normal if
             // the internal window state is maximized, and macOS says
             // the window is no longer zoomed (I.E, the user has moved it)
             // Stage Manager will "move" the window when repositioning it
             // So if the window was "maximized" before, it should stay maximized
-            if(window->WindowState() == Maximized && !window->IsZoomed())
+            else if(window->WindowState() == Maximized && !window->IsZoomed())
             {
                 // If we're moving the window while maximized,
                 // we need to let macOS handle if it should be resized

--- a/native/Avalonia.Native/src/OSX/WindowImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.h
@@ -71,6 +71,8 @@ BEGIN_INTERFACE_MAP()
     void ExitFullScreenMode ();
 
     virtual HRESULT SetWindowState (AvnWindowState state) override;
+    
+    virtual HRESULT SetWindowState (AvnWindowState state, bool shouldResize);
 
     virtual bool IsModal() override;
     

--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -478,61 +478,63 @@ HRESULT WindowImpl::SetWindowState(AvnWindowState state, bool shouldResize) {
         if (_shown) {
             _actualWindowState = _lastWindowState;
 
-            switch (state) {
-                case Maximized:
-                    if (currentState == FullScreen) {
-                        ExitFullScreenMode();
-                    }
-
-                    lastPositionSet.X = 0;
-                    lastPositionSet.Y = 0;
-
-                    if ([Window isMiniaturized]) {
-                        [Window deminiaturize:Window];
-                    }
-
-                    if (!IsZoomed()) {
-                        DoZoom();
-                    }
-                    break;
-
-                case Minimized:
-                    if (currentState == FullScreen) {
-                        ExitFullScreenMode();
-                    } else {
-                        [Window miniaturize:Window];
-                    }
-                    break;
-
-                case FullScreen:
-                    if ([Window isMiniaturized]) {
-                        [Window deminiaturize:Window];
-                    }
-
-                    EnterFullScreenMode();
-                    break;
-
-                case Normal:
-                    if ([Window isMiniaturized]) {
-                        [Window deminiaturize:Window];
-                    }
-
-                    if (currentState == FullScreen) {
-                        ExitFullScreenMode();
-                    }
-
-                    if (IsZoomed() && shouldResize == true) {
-                        if (_decorations == SystemDecorationsFull) {
-                            DoZoom();
-                        } else {
-                            [Window setFrame:_preZoomSize display:true];
-                            auto newFrame = [Window contentRectForFrameRect:[Window frame]].size;
-
-                            [View setFrameSize:newFrame];
+            if (shouldResize) {
+                switch (state) {
+                    case Maximized:
+                        if (currentState == FullScreen) {
+                            ExitFullScreenMode();
                         }
 
-                    }
-                    break;
+                        lastPositionSet.X = 0;
+                        lastPositionSet.Y = 0;
+
+                        if ([Window isMiniaturized]) {
+                            [Window deminiaturize:Window];
+                        }
+
+                        if (!IsZoomed()) {
+                            DoZoom();
+                        }
+                        break;
+
+                    case Minimized:
+                        if (currentState == FullScreen) {
+                            ExitFullScreenMode();
+                        } else {
+                            [Window miniaturize:Window];
+                        }
+                        break;
+
+                    case FullScreen:
+                        if ([Window isMiniaturized]) {
+                            [Window deminiaturize:Window];
+                        }
+
+                        EnterFullScreenMode();
+                        break;
+
+                    case Normal:
+                        if ([Window isMiniaturized]) {
+                            [Window deminiaturize:Window];
+                        }
+
+                        if (currentState == FullScreen) {
+                            ExitFullScreenMode();
+                        }
+
+                        if (IsZoomed()) {
+                            if (_decorations == SystemDecorationsFull) {
+                                DoZoom();
+                            } else {
+                                [Window setFrame:_preZoomSize display:true];
+                                auto newFrame = [Window contentRectForFrameRect:[Window frame]].size;
+
+                                [View setFrameSize:newFrame];
+                            }
+
+                        }
+                        break;
+                }
             }
 
             WindowEvents->WindowStateChanged(_actualWindowState);

--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -451,6 +451,10 @@ void WindowImpl::ExitFullScreenMode() {
 }
 
 HRESULT WindowImpl::SetWindowState(AvnWindowState state) {
+    return SetWindowState(state, true);
+}
+
+HRESULT WindowImpl::SetWindowState(AvnWindowState state, bool shouldResize) {
     START_COM_CALL;
 
     @autoreleasepool {
@@ -517,7 +521,7 @@ HRESULT WindowImpl::SetWindowState(AvnWindowState state) {
                         ExitFullScreenMode();
                     }
 
-                    if (IsZoomed()) {
+                    if (IsZoomed() && shouldResize == true) {
                         if (_decorations == SystemDecorationsFull) {
                             DoZoom();
                         } else {


### PR DESCRIPTION
Hopefully, it fixes what I was trying to do with https://github.com/AvaloniaUI/Avalonia/pull/19073 and does the correct thing now. Thanks to @MrJul for helping me through this!

## What does the pull request do?
Adds `WindowImpl::SetWindowState(AvnWindowState state, bool shouldResize)` to `WindowImpl`, to allow us not to force window resizing on `windowDidMove`. This should let macOS handle it itself, and keep the existing internal WindowState in line with what it was before. It also fixes Stage Manager support so it won't resize the window when switching apps, and will keep the Maximized/Normal state when switching apps.

## What is the current behavior?
View https://github.com/AvaloniaUI/Avalonia/pull/19073 for that. In short, dragging a window from a "zoomed" state (AKA Maximized) will force it to resize and cause it to break its frame. macOS handles window resizing from that state itself, and the code within the Window State Change and windowDidMove conflict, causing it to break. This would also break stage manager; when switching apps, the window size would shrink if zoomed in.

## What is the updated/expected behavior with this PR?

https://github.com/user-attachments/assets/c86bcded-a72e-4013-8a66-75b1e23f3def

https://github.com/user-attachments/assets/234b58ee-8d31-4d10-b8a0-37c6e53c4f5c

https://github.com/drasticactions/avalonia-repros/tree/window-move


## How was the solution implemented (if it's not obvious)?
I added a new method for `SetWindowState` to include a `shouldResize` value, with the original `SetWindowState` calling into it with `true` to keep existing functionality. Then, I updated the `windowDidMove` method to call `false` for `SetWindowState` and handle the case where the window was already maximized but it was called anyway, in the case of Stage Manager.
