### PR TITLE
Explicit dispose of GRBackendRenderTarget and SKSurfaceProperties

### DIFF
--- a/src/Skia/Avalonia.Skia/Gpu/OpenGl/FboSkiaSurface.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/OpenGl/FboSkiaSurface.cs
@@ -89,10 +89,10 @@ namespace Avalonia.Skia
                 throw new OpenGlException("Unable to create FBO with stencil");
             }
 
-            var target = new GRBackendRenderTarget(pixelSize.Width, pixelSize.Height, 0, 8,
+            using var target = new GRBackendRenderTarget(pixelSize.Width, pixelSize.Height, 0, 8,
                 new GRGlFramebufferInfo((uint)_fbo, SKColorType.Rgba8888.ToGlSizedFormat()));
-            _surface = SKSurface.Create(_grContext, target,
-                surfaceOrigin, SKColorType.Rgba8888, new SKSurfaceProperties(SKPixelGeometry.RgbHorizontal));
+            using var properties = new SKSurfaceProperties(SKPixelGeometry.RgbHorizontal);
+            _surface = SKSurface.Create(_grContext, target, surfaceOrigin, SKColorType.Rgba8888, properties);
             CanBlit = gl.IsBlitFramebufferAvailable;
         }
         


### PR DESCRIPTION
## What does the pull request do?
Calls Dispose explicitly instead of relying on finalizer

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
none

## Obsoletions / Deprecations
none

## Fixed issues
Fixes #19092 
