### PR TITLE
[Avalonia.Native] Replace manual input tracking with NSEvent

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -13,7 +13,6 @@
 {
     ComObjectWeakPtr<TopLevelImpl> _parent;
     NSTrackingArea* _area;
-    bool _isLeftPressed, _isMiddlePressed, _isRightPressed, _isXButton1Pressed, _isXButton2Pressed;
     AvnInputModifiers _modifierState;
     NSEvent* _lastMouseDownEvent;
     AvnPixelSize _lastPixelSize;
@@ -446,7 +445,6 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
 
 - (void)mouseDown:(NSEvent *)event
 {
-    _isLeftPressed = true;
     _lastMouseDownEvent = event;
     [self mouseEvent:event withType:LeftButtonDown];
 }
@@ -459,15 +457,12 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
     {
         case 2:
         case 3:
-            _isMiddlePressed = true;
             [self mouseEvent:event withType:MiddleButtonDown];
             break;
         case 4:
-            _isXButton1Pressed = true;
             [self mouseEvent:event withType:XButton1Down];
             break;
         case 5:
-            _isXButton2Pressed = true;
             [self mouseEvent:event withType:XButton2Down];
             break;
 
@@ -478,14 +473,12 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
 
 - (void)rightMouseDown:(NSEvent *)event
 {
-    _isRightPressed = true;
     _lastMouseDownEvent = event;
     [self mouseEvent:event withType:RightButtonDown];
 }
 
 - (void)mouseUp:(NSEvent *)event
 {
-    _isLeftPressed = false;
     [self mouseEvent:event withType:LeftButtonUp];
 }
 
@@ -495,15 +488,12 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
     {
         case 2:
         case 3:
-            _isMiddlePressed = false;
             [self mouseEvent:event withType:MiddleButtonUp];
             break;
         case 4:
-            _isXButton1Pressed = false;
             [self mouseEvent:event withType:XButton1Up];
             break;
         case 5:
-            _isXButton2Pressed = false;
             [self mouseEvent:event withType:XButton2Up];
             break;
 
@@ -514,7 +504,6 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
 
 - (void)rightMouseUp:(NSEvent *)event
 {
-    _isRightPressed = false;
     [self mouseEvent:event withType:RightButtonUp];
 }
 
@@ -595,15 +584,6 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
 - (void)setModifiers:(NSEventModifierFlags)modifierFlags
 {
     _modifierState = [self getModifiers:modifierFlags];
-}
-
-- (void)resetPressedMouseButtons
-{
-    _isLeftPressed = false;
-    _isRightPressed = false;
-    _isMiddlePressed = false;
-    _isXButton1Pressed = false;
-    _isXButton2Pressed = false;
 }
 
 - (void)flagsChanged:(NSEvent *)event
@@ -752,15 +732,17 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
     if (mod & NSEventModifierFlagCommand)
         rv |= Windows;
 
-    if (_isLeftPressed)
+    NSUInteger pressedButtons = [NSEvent pressedMouseButtons];
+        
+    if (pressedButtons & (1 << 0))  // Left mouse button
         rv |= LeftMouseButton;
-    if (_isMiddlePressed)
-        rv |= MiddleMouseButton;
-    if (_isRightPressed)
+    if (pressedButtons & (1 << 1))  // Right mouse button
         rv |= RightMouseButton;
-    if (_isXButton1Pressed)
+    if (pressedButtons & (1 << 2))  // Middle mouse button
+        rv |= MiddleMouseButton;
+    if (pressedButtons & (1 << 3))  // X1 button
         rv |= XButton1MouseButton;
-    if (_isXButton2Pressed)
+    if (pressedButtons & (1 << 4))  // X2 button
         rv |= XButton2MouseButton;
 
     return (AvnInputModifiers)rv;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Replaces the manual bool setting used in `AvnView` with an `NSEvent` check that will validate the current state of the buttons.


## What is the current behavior?
`AvnView` uses the raw NSView events to detect state changes for buttons, and sets internal bools to validate the state

https://github.com/AvaloniaUI/Avalonia/blob/1a9463effdad93cd0075eb12c4090bd0abd7a45c/native/Avalonia.Native/src/OSX/AvnView.mm#L16

This mostly worked, but would have issues if any of the NSEvents happened to collide or be swallowed. You can reproduce this in an XPF app if you trigger maximizing a window from code-behind with a double click (Ex. with a custom titlebar). This would set the left mouse button as set, and the maximizing effect would swallow the second click for "up", leaving it set to down. You would have no way to reset it unless you clicked the mouse again. 

## What is the updated/expected behavior with this PR?
The current state of the input buttons should be correct in all conditions without needing to set the values manually.

## How was the solution implemented (if it's not obvious)?
Removing the manual tracking and using `NSEvent` inside of `getModifiers` to directly check the state of the buttons.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
