### PR TITLE
feat: expose Popup property in PopupFlyoutBase for external access.

### DIFF
--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -79,7 +79,7 @@ namespace Avalonia.Controls.Primitives
             _popupLazy = new Lazy<Popup>(() => CreatePopup());
         }
 
-        protected Popup Popup => _popupLazy.Value;
+        public Popup Popup => _popupLazy.Value;
 
         /// <inheritdoc cref="Popup.Placement"/>
         public PlacementMode Placement


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
PopupFlyoutbase tries to hide the inner popup, so it's not intuitive to detect whether an element is inside this flyout.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Popup property is protected.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
expose Popup property in PopupFlyoutBase for external access.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #18534
