### PR TITLE
Make Flyout IsOpen setter public

### DIFF
--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -45,6 +45,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Avalonia.Controls.Primitives.FlyoutBase.IsOpenProperty</Target>
+    <Left>baseline/netstandard2.0/Avalonia.Controls.dll</Left>
+    <Right>target/netstandard2.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Controls.Primitives.IPopupHost.ConfigurePosition(Avalonia.Visual,Avalonia.Controls.PlacementMode,Avalonia.Point,Avalonia.Controls.Primitives.PopupPositioning.PopupAnchor,Avalonia.Controls.Primitives.PopupPositioning.PopupGravity,Avalonia.Controls.Primitives.PopupPositioning.PopupPositionerConstraintAdjustment,System.Nullable{Avalonia.Rect})</Target>
     <Left>baseline/netstandard2.0/Avalonia.Controls.dll</Left>
     <Right>target/netstandard2.0/Avalonia.Controls.dll</Right>

--- a/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
@@ -7,9 +7,8 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Defines the <see cref="IsOpen"/> property
         /// </summary>
-        public static readonly DirectProperty<FlyoutBase, bool> IsOpenProperty =
-            AvaloniaProperty.RegisterDirect<FlyoutBase, bool>(nameof(IsOpen),
-                x => x.IsOpen);
+        public static readonly StyledProperty<bool> IsOpenProperty =
+            AvaloniaProperty.Register<FlyoutBase, bool>(nameof(IsOpen));
 
         /// <summary>
         /// Defines the <see cref="Target"/> property
@@ -23,7 +22,6 @@ namespace Avalonia.Controls.Primitives
         public static readonly AttachedProperty<FlyoutBase?> AttachedFlyoutProperty =
             AvaloniaProperty.RegisterAttached<FlyoutBase, Control, FlyoutBase?>("AttachedFlyout", null);
 
-        private bool _isOpen;
         private Control? _target;
 
         public event EventHandler? Opened;
@@ -34,8 +32,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public bool IsOpen
         {
-            get => _isOpen;
-            protected set => SetAndRaise(IsOpenProperty, ref _isOpen, value);
+            get => GetValue(IsOpenProperty);
+            set => SetValue(IsOpenProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -22,11 +22,11 @@ namespace Avalonia.Controls.Primitives
         /// <inheritdoc cref="Popup.HorizontalOffsetProperty"/>
         public static readonly StyledProperty<double> HorizontalOffsetProperty =
             Popup.HorizontalOffsetProperty.AddOwner<PopupFlyoutBase>();
-        
+
         /// <inheritdoc cref="Popup.VerticalOffsetProperty"/>
         public static readonly StyledProperty<double> VerticalOffsetProperty =
             Popup.VerticalOffsetProperty.AddOwner<PopupFlyoutBase>();
-            
+
         /// <inheritdoc cref="Popup.PlacementAnchorProperty"/>
         public static readonly StyledProperty<PopupAnchor> PlacementAnchorProperty =
             Popup.PlacementAnchorProperty.AddOwner<PopupFlyoutBase>();
@@ -50,19 +50,19 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public static readonly StyledProperty<bool> OverlayDismissEventPassThroughProperty =
             Popup.OverlayDismissEventPassThroughProperty.AddOwner<PopupFlyoutBase>();
-        
+
         /// <summary>
         /// Defines the <see cref="OverlayInputPassThroughElement"/> property
         /// </summary>
         public static readonly StyledProperty<IInputElement?> OverlayInputPassThroughElementProperty =
             Popup.OverlayInputPassThroughElementProperty.AddOwner<PopupFlyoutBase>();
-        
+
         /// <summary>
         /// Defines the <see cref="PlacementConstraintAdjustment"/> property
         /// </summary>
         public static readonly StyledProperty<PopupPositionerConstraintAdjustment> PlacementConstraintAdjustmentProperty =
             Popup.PlacementConstraintAdjustmentProperty.AddOwner<PopupFlyoutBase>();
-        
+
         private readonly Lazy<Popup> _popupLazy;
         private Rect? _enlargedPopupRect;
         private PixelRect? _enlargePopupRectScreenPixelRect;
@@ -147,7 +147,7 @@ namespace Avalonia.Controls.Primitives
             get => GetValue(OverlayDismissEventPassThroughProperty);
             set => SetValue(OverlayDismissEventPassThroughProperty, value);
         }
-        
+
         /// <summary>
         /// Gets or sets an element that should receive pointer input events even when underneath
         /// the flyout's overlay.
@@ -164,7 +164,7 @@ namespace Avalonia.Controls.Primitives
             get => GetValue(PlacementConstraintAdjustmentProperty);
             set => SetValue(PlacementConstraintAdjustmentProperty, value);
         }
-        
+
         IPopupHost? IPopupHostProvider.PopupHost => Popup?.Host;
 
         event Action<IPopupHost?>? IPopupHostProvider.PopupHostChanged
@@ -172,7 +172,7 @@ namespace Avalonia.Controls.Primitives
             add => _popupHostChangedHandler += value;
             remove => _popupHostChangedHandler -= value;
         }
-        
+
         public event EventHandler<CancelEventArgs>? Closing;
         public event EventHandler? Opening;
 
@@ -219,7 +219,7 @@ namespace Avalonia.Controls.Primitives
                 }
             }
 
-            IsOpen = false;
+            SetCurrentValue(IsOpenProperty, false);
             Popup.IsOpen = false;
 
             Popup.PlacementTarget = null;
@@ -281,7 +281,8 @@ namespace Avalonia.Controls.Primitives
             }
 
             PositionPopup(showAtPointer);
-            IsOpen = Popup.IsOpen = true;
+            SetCurrentValue(IsOpenProperty, true);
+            Popup.IsOpen = true;
             OnOpened();
 
             placementTarget.DetachedFromVisualTree += PlacementTarget_DetachedFromVisualTree;
@@ -331,7 +332,7 @@ namespace Avalonia.Controls.Primitives
                     if (Popup?.Host is PopupRoot root)
                     {
                         // Get the popup root bounds and convert to screen coordinates
-                        
+
                         var tmp = root.Bounds.Inflate(100);
                         _enlargePopupRectScreenPixelRect = new PixelRect(root.PointToScreen(tmp.TopLeft), root.PointToScreen(tmp.BottomRight));
                     }
@@ -373,7 +374,7 @@ namespace Avalonia.Controls.Primitives
         {
             Opening?.Invoke(this, args);
         }
-        
+
         protected virtual void OnClosing(CancelEventArgs args)
         {
             Closing?.Invoke(this, args);
@@ -402,7 +403,7 @@ namespace Avalonia.Controls.Primitives
 
         private void OnPopupOpened(object? sender, EventArgs e)
         {
-            IsOpen = true;
+            SetCurrentValue(IsOpenProperty, true);
 
             _popupHostChangedHandler?.Invoke(Popup.Host);
         }
@@ -525,7 +526,7 @@ namespace Avalonia.Controls.Primitives
 
         internal static void SetPresenterClasses(Control? presenter, Classes classes)
         {
-            if(presenter is null)
+            if (presenter is null)
             {
                 return;
             }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Makes `IsOpen` setter public as discussed in #18716


## What is the current behavior?

Setter is protected and the property is not a `StyledProperty`


## What is the updated/expected behavior with this PR?

Setter is public and changed to be a `StyledProperty` as discussed in https://github.com/AvaloniaUI/Avalonia/issues/18716#issuecomment-2961880955


## How was the solution implemented (if it's not obvious)?


## Checklist

- [x] Added unit tests (if possible)? None added but existing tests run
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
#18716
