### PR TITLE
Fix typo: `ExternalGLibMainLoopExceptionLogger`

### DIFF
--- a/samples/XEmbedSample/Program.cs
+++ b/samples/XEmbedSample/Program.cs
@@ -20,7 +20,7 @@ class Program
             .With(new X11PlatformOptions()
             {
                 UseGLibMainLoop = true,
-                ExterinalGLibMainLoopExceptionLogger = e => Console.WriteLine(e.ToString())
+                ExternalGLibMainLoopExceptionLogger = e => Console.WriteLine(e.ToString())
             })
             .UseX11()
             .SetupWithoutStarting();

--- a/src/Avalonia.X11/Dispatching/GLibDispatcherImpl.cs
+++ b/src/Avalonia.X11/Dispatching/GLibDispatcherImpl.cs
@@ -237,7 +237,7 @@ internal class GlibDispatcherImpl :
         }
         else
         {
-            var externalLogger = _platform.Options.ExterinalGLibMainLoopExceptionLogger;
+            var externalLogger = _platform.Options.ExternalGLibMainLoopExceptionLogger;
             if (externalLogger != null)
                 externalLogger.Invoke(e);
             else

--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -384,8 +384,8 @@ namespace Avalonia
         /// will likely brick GLib machinery since it's not aware of managed Exceptions
         /// This property allows to inspect such exceptions before they will be ignored
         /// </summary>
-        public Action<Exception>? ExterinalGLibMainLoopExceptionLogger { get; set; }
-        
+        public Action<Exception>? ExternalGLibMainLoopExceptionLogger { get; set; }
+
         public X11PlatformOptions()
         {
             try


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Rename `X11PlatformOptions.ExterinalGLibMainLoopExceptionLogger` (note: "Exterinal") to `X11PlatformOptions.ExternalGLibMainLoopExceptionLogger` (note: "External")

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Removes `ExterinalGLibMainLoopExceptionLogger` in favor of the new name-fixed property.

## Breaking changes
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

Removes `ExterinalGLibMainLoopExceptionLogger`, replaced with `ExternalGLibMainLoopExceptionLogger`
