### PR TITLE
Fixed failing to match the focus state in ComboBox

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
@@ -158,7 +158,7 @@
     </Style>
 
     <!--  Focus Pressed State  -->
-    <Style Selector="^:focused:pressed">
+    <Style Selector="^:focus:pressed">
       <Style Selector="^ /template/ ContentControl#ContentPresenter">
         <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundFocusedPressed}" />
       </Style>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixed bug failing to match the focus state in ComboBox, take no effect when :focus:press 


## What is the current behavior?
![Before](https://github.com/user-attachments/assets/966c09c7-77cb-490d-b3dc-c67ffb4632a4)

## What is the updated/expected behavior with this PR?
![After](https://github.com/user-attachments/assets/323f11ca-9b79-44d5-a782-33bca9b1fa2c)

## How was the solution implemented (if it's not obvious)?
Fix it!

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
None
