### PR TITLE
Capture ExecutionContext for Dispatcher.InvokeAsync

### DIFF
--- a/src/Avalonia.Base/Threading/CulturePreservingExecutionContext.cs
+++ b/src/Avalonia.Base/Threading/CulturePreservingExecutionContext.cs
@@ -14,25 +14,12 @@ namespace Avalonia.Threading;
 internal sealed class CulturePreservingExecutionContext
 {
     private readonly ExecutionContext _context;
-#if NET6_0_OR_GREATER
-    private readonly CultureInfo _culture;
-    private readonly CultureInfo _uiCulture;
-#endif
     private CultureAndContext? _cultureAndContext;
 
-#if NET6_0_OR_GREATER
-    private CulturePreservingExecutionContext(ExecutionContext context, CultureInfo culture, CultureInfo uiCulture)
-    {
-        _context = context;
-        _culture = culture;
-        _uiCulture = uiCulture;
-    }
-#else
     private CulturePreservingExecutionContext(ExecutionContext context)
     {
         _context = context;
     }
-#endif
 
     /// <summary>
     /// Captures the current ExecutionContext and culture information.
@@ -51,36 +38,8 @@ internal sealed class CulturePreservingExecutionContext
         if (context == null)
             return null;
 
-#if NET6_0_OR_GREATER
-        var culture = Thread.CurrentThread.CurrentCulture;
-        var uiCulture = Thread.CurrentThread.CurrentUICulture;
-
-        return new CulturePreservingExecutionContext(context, culture, uiCulture);
-#else
         return new CulturePreservingExecutionContext(context);
-#endif
     }
-
-#if NET6_0_OR_GREATER
-    /// <summary>
-    /// Restores the captured execution context and culture information to the current thread.
-    /// This is the preferred method for .NET 6+ scenarios.
-    /// </summary>
-    /// <param name="executionContext">The execution context to restore.</param>
-    public static void Restore(CulturePreservingExecutionContext executionContext)
-    {
-        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-        if (executionContext == null)
-            ThrowNullContext();
-
-        // Restore the execution context
-        ExecutionContext.Restore(executionContext._context);
-
-        // Restore the culture information
-        Thread.CurrentThread.CurrentCulture = executionContext._culture;
-        Thread.CurrentThread.CurrentUICulture = executionContext._uiCulture;
-    }
-#endif
 
     /// <summary>
     /// Runs the specified callback in the captured execution context while preserving culture information.

--- a/src/Avalonia.Base/Threading/CulturePreservingExecutionContext.cs
+++ b/src/Avalonia.Base/Threading/CulturePreservingExecutionContext.cs
@@ -14,16 +14,25 @@ namespace Avalonia.Threading;
 internal sealed class CulturePreservingExecutionContext
 {
     private readonly ExecutionContext _context;
+#if NET6_0_OR_GREATER
     private readonly CultureInfo _culture;
     private readonly CultureInfo _uiCulture;
+#endif
     private CultureAndContext? _cultureAndContext;
 
+#if NET6_0_OR_GREATER
     private CulturePreservingExecutionContext(ExecutionContext context, CultureInfo culture, CultureInfo uiCulture)
     {
         _context = context;
         _culture = culture;
         _uiCulture = uiCulture;
     }
+#else
+    private CulturePreservingExecutionContext(ExecutionContext context)
+    {
+        _context = context;
+    }
+#endif
 
     /// <summary>
     /// Captures the current ExecutionContext and culture information.
@@ -42,10 +51,14 @@ internal sealed class CulturePreservingExecutionContext
         if (context == null)
             return null;
 
+#if NET6_0_OR_GREATER
         var culture = Thread.CurrentThread.CurrentCulture;
         var uiCulture = Thread.CurrentThread.CurrentUICulture;
 
         return new CulturePreservingExecutionContext(context, culture, uiCulture);
+#else
+        return new CulturePreservingExecutionContext(context);
+#endif
     }
 
 #if NET6_0_OR_GREATER

--- a/src/Avalonia.Base/Threading/CulturePreservingExecutionContext.cs
+++ b/src/Avalonia.Base/Threading/CulturePreservingExecutionContext.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿#if NET6_0_OR_GREATER
+// In .NET Core, the security context and call context are not supported, however,
+// the impersonation context and culture would typically flow with the execution context.
+// See: https://learn.microsoft.com/en-us/dotnet/api/system.threading.executioncontext
+//
+// So we can safely use ExecutionContext without worrying about culture flowing issues.
+#else
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -77,9 +84,6 @@ internal sealed class CulturePreservingExecutionContext
     }
 
     [DoesNotReturn]
-#if NET6_0_OR_GREATER
-    [StackTraceHidden]
-#endif
     private static void ThrowNullContext()
     {
         throw new InvalidOperationException("ExecutionContext cannot be null.");
@@ -149,3 +153,4 @@ internal sealed class CulturePreservingExecutionContext
         }
     }
 }
+#endif

--- a/src/Avalonia.Base/Threading/CulturePreservingExecutionContext.cs
+++ b/src/Avalonia.Base/Threading/CulturePreservingExecutionContext.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Threading;
+
+namespace Avalonia.Threading;
+
+/// <summary>
+/// An ExecutionContext that preserves culture information across async operations.
+/// This is a modernized version that removes legacy compatibility switches and
+/// includes nullable reference type annotations.
+/// </summary>
+internal sealed class CulturePreservingExecutionContext
+{
+    private readonly ExecutionContext _context;
+    private readonly CultureInfo _culture;
+    private readonly CultureInfo _uiCulture;
+    private CultureAndContext? _cultureAndContext;
+
+    private CulturePreservingExecutionContext(ExecutionContext context, CultureInfo culture, CultureInfo uiCulture)
+    {
+        _context = context;
+        _culture = culture;
+        _uiCulture = uiCulture;
+    }
+
+    /// <summary>
+    /// Captures the current ExecutionContext and culture information.
+    /// </summary>
+    /// <returns>A new CulturePreservingExecutionContext instance, or null if no context needs to be captured.</returns>
+    public static CulturePreservingExecutionContext? Capture()
+    {
+        var context = ExecutionContext.Capture();
+        if (context == null)
+            return null;
+
+        var culture = Thread.CurrentThread.CurrentCulture;
+        var uiCulture = Thread.CurrentThread.CurrentUICulture;
+
+        return new CulturePreservingExecutionContext(context, culture, uiCulture);
+    }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Restores the captured execution context and culture information to the current thread.
+    /// This is the preferred method for .NET 6+ scenarios.
+    /// </summary>
+    /// <param name="executionContext">The execution context to restore.</param>
+    public static void Restore(CulturePreservingExecutionContext executionContext)
+    {
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+        if (executionContext == null)
+            ThrowNullContext();
+
+        // Restore the execution context
+        ExecutionContext.Restore(executionContext._context);
+
+        // Restore the culture information
+        Thread.CurrentThread.CurrentCulture = executionContext._culture;
+        Thread.CurrentThread.CurrentUICulture = executionContext._uiCulture;
+    }
+#endif
+
+    /// <summary>
+    /// Runs the specified callback in the captured execution context while preserving culture information.
+    /// This method is used for .NET Framework and earlier .NET versions.
+    /// </summary>
+    /// <param name="executionContext">The execution context to run in.</param>
+    /// <param name="callback">The callback to execute.</param>
+    /// <param name="state">The state to pass to the callback.</param>
+    public static void Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, object? state)
+    {
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+        if (callback == null)
+            return;
+
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+        if (executionContext == null)
+            ThrowNullContext();
+
+        // Save culture information - we will need this to restore just before
+        // the callback is actually invoked from CallbackWrapper.
+        executionContext._cultureAndContext = CultureAndContext.Initialize(callback, state);
+
+        try
+        {
+            ExecutionContext.Run(
+                executionContext._context,
+                s_callbackWrapperDelegate,
+                executionContext._cultureAndContext);
+        }
+        finally
+        {
+            // Restore culture information - it might have been modified during callback execution.
+            executionContext._cultureAndContext.RestoreCultureInfos();
+        }
+    }
+
+    [DoesNotReturn]
+#if NET6_0_OR_GREATER
+    [StackTraceHidden]
+#endif
+    private static void ThrowNullContext()
+    {
+        throw new InvalidOperationException("ExecutionContext cannot be null.");
+    }
+
+    private static readonly ContextCallback s_callbackWrapperDelegate = CallbackWrapper;
+
+    /// <summary>
+    /// Executes the callback and saves culture values immediately afterwards.
+    /// </summary>
+    /// <param name="obj">Contains the actual callback and state.</param>
+    private static void CallbackWrapper(object? obj)
+    {
+        var cultureAndContext = (CultureAndContext)obj!;
+
+        // Restore culture information saved during Run()
+        cultureAndContext.RestoreCultureInfos();
+
+        try
+        {
+            // Execute the actual callback
+            cultureAndContext.Callback(cultureAndContext.State);
+        }
+        finally
+        {
+            // Save any culture changes that might have occurred during callback execution
+            cultureAndContext.CaptureCultureInfos();
+        }
+    }
+
+    /// <summary>
+    /// Helper class to manage culture information across execution contexts.
+    /// </summary>
+    private sealed class CultureAndContext
+    {
+        public ContextCallback Callback { get; }
+        public object? State { get; }
+
+        private CultureInfo? _culture;
+        private CultureInfo? _uiCulture;
+
+        private CultureAndContext(ContextCallback callback, object? state)
+        {
+            Callback = callback;
+            State = state;
+            CaptureCultureInfos();
+        }
+
+        public static CultureAndContext Initialize(ContextCallback callback, object? state)
+        {
+            return new CultureAndContext(callback, state);
+        }
+
+        public void CaptureCultureInfos()
+        {
+            _culture = Thread.CurrentThread.CurrentCulture;
+            _uiCulture = Thread.CurrentThread.CurrentUICulture;
+        }
+
+        public void RestoreCultureInfos()
+        {
+            if (_culture != null)
+                Thread.CurrentThread.CurrentCulture = _culture;
+
+            if (_uiCulture != null)
+                Thread.CurrentThread.CurrentUICulture = _uiCulture;
+        }
+    }
+}

--- a/src/Avalonia.Base/Threading/CulturePreservingExecutionContext.cs
+++ b/src/Avalonia.Base/Threading/CulturePreservingExecutionContext.cs
@@ -31,6 +31,13 @@ internal sealed class CulturePreservingExecutionContext
     /// <returns>A new CulturePreservingExecutionContext instance, or null if no context needs to be captured.</returns>
     public static CulturePreservingExecutionContext? Capture()
     {
+        // ExecutionContext.SuppressFlow had been called.
+        // We expect ExecutionContext.Capture() to return null, so match that behavior and return null.
+        if (ExecutionContext.IsFlowSuppressed())
+        {
+            return null;
+        }
+
         var context = ExecutionContext.Capture();
         if (context == null)
             return null;

--- a/src/Avalonia.Base/Threading/DispatcherOperation.cs
+++ b/src/Avalonia.Base/Threading/DispatcherOperation.cs
@@ -269,13 +269,6 @@ public class DispatcherOperation
         {
             using (AvaloniaSynchronizationContext.Ensure(Dispatcher, Priority))
             {
-#if NET6_0_OR_GREATER
-                if (_executionContext is { } executionContext)
-                {
-                    CulturePreservingExecutionContext.Restore(executionContext);
-                }
-                InvokeCore();
-#else
                 if (_executionContext is { } executionContext)
                 {
                     CulturePreservingExecutionContext.Run(executionContext, _ => InvokeCore(), null);
@@ -284,7 +277,6 @@ public class DispatcherOperation
                 {
                     InvokeCore();
                 }
-#endif
             }
         }
         finally

--- a/src/Avalonia.Base/Threading/DispatcherOperation.cs
+++ b/src/Avalonia.Base/Threading/DispatcherOperation.cs
@@ -277,7 +277,12 @@ public class DispatcherOperation
             {
                 if (_executionContext is { } executionContext)
                 {
+#if NET6_0_OR_GREATER
+                    ExecutionContext.Restore(executionContext);
+                    InvokeCore();
+#else
                     ExecutionContext.Run(executionContext, static s => ((DispatcherOperation)s!).InvokeCore(), this);
+#endif
                 }
                 else
                 {

--- a/src/Avalonia.Base/Threading/DispatcherOperation.cs
+++ b/src/Avalonia.Base/Threading/DispatcherOperation.cs
@@ -28,18 +28,19 @@ public class DispatcherOperation
 
     protected internal object? Callback;
     protected object? TaskSource;
-    
+
     internal DispatcherOperation? SequentialPrev { get; set; }
     internal DispatcherOperation? SequentialNext { get; set; }
     internal DispatcherOperation? PriorityPrev { get; set; }
     internal DispatcherOperation? PriorityNext { get; set; }
     internal PriorityChain? Chain { get; set; }
-    
+
     internal bool IsQueued => Chain != null;
 
     private EventHandler? _aborted;
     private EventHandler? _completed;
     private DispatcherPriority _priority;
+    private ExecutionContext? _executionContext;
 
     internal DispatcherOperation(Dispatcher dispatcher, DispatcherPriority priority, Action callback, bool throwOnUiThread) :
         this(dispatcher, priority, throwOnUiThread)
@@ -52,6 +53,7 @@ public class DispatcherOperation
         ThrowOnUiThread = throwOnUiThread;
         Priority = priority;
         Dispatcher = dispatcher;
+        _executionContext = ExecutionContext.Capture();
     }
 
     internal string DebugDisplay
@@ -103,7 +105,7 @@ public class DispatcherOperation
                 _completed += value;
             }
         }
-        
+
         remove
         {
             lock(Dispatcher.InstanceLock)
@@ -112,7 +114,7 @@ public class DispatcherOperation
             }
         }
     }
-    
+
     public bool Abort()
     {
         if (Dispatcher.Abort(this))
@@ -155,7 +157,7 @@ public class DispatcherOperation
                     // we throw an exception instead.
                     throw new InvalidOperationException("A thread cannot wait on operations already running on the same thread.");
                 }
-                
+
                 var cts = new CancellationTokenSource();
                 EventHandler finishedHandler = delegate
                 {
@@ -241,7 +243,7 @@ public class DispatcherOperation
     }
 
     public Task GetTask() => GetTaskCore();
-    
+
     /// <summary>
     ///     Returns an awaiter for awaiting the completion of the operation.
     /// </summary>
@@ -259,21 +261,38 @@ public class DispatcherOperation
         AbortTask();
         _aborted?.Invoke(this, EventArgs.Empty);
     }
-    
+
     internal void Execute()
     {
         Debug.Assert(Status == DispatcherOperationStatus.Executing);
         try
         {
             using (AvaloniaSynchronizationContext.Ensure(Dispatcher, Priority))
+            {
+#if NET6_0_OR_GREATER
+                if (_executionContext is { } executionContext)
+                {
+                    ExecutionContext.Restore(executionContext);
+                }
                 InvokeCore();
+#else
+                if (_executionContext is { } executionContext)
+                {
+                    ExecutionContext.Run(executionContext, _ => InvokeCore(), null);
+                }
+                else
+                {
+                    InvokeCore();
+                }
+#endif
+            }
         }
         finally
         {
             _completed?.Invoke(this, EventArgs.Empty);
         }
     }
-    
+
     protected virtual void InvokeCore()
     {
         try
@@ -305,7 +324,7 @@ public class DispatcherOperation
     }
 
     internal virtual object? GetResult() => null;
-    
+
     protected virtual void AbortTask()
     {
         object? taskSource;
@@ -401,14 +420,14 @@ internal sealed class SendOrPostCallbackDispatcherOperation : DispatcherOperatio
 {
     private readonly object? _arg;
 
-    internal SendOrPostCallbackDispatcherOperation(Dispatcher dispatcher, DispatcherPriority priority, 
-        SendOrPostCallback callback, object? arg, bool throwOnUiThread) 
+    internal SendOrPostCallbackDispatcherOperation(Dispatcher dispatcher, DispatcherPriority priority,
+        SendOrPostCallback callback, object? arg, bool throwOnUiThread)
         : base(dispatcher, priority, throwOnUiThread)
     {
         Callback = callback;
         _arg = arg;
     }
-    
+
     protected override void InvokeCore()
     {
         try

--- a/src/Avalonia.Base/Threading/DispatcherOperation.cs
+++ b/src/Avalonia.Base/Threading/DispatcherOperation.cs
@@ -271,7 +271,7 @@ public class DispatcherOperation
             {
                 if (_executionContext is { } executionContext)
                 {
-                    CulturePreservingExecutionContext.Run(executionContext, _ => InvokeCore(), null);
+                    CulturePreservingExecutionContext.Run(executionContext, s => ((DispatcherOperation)s!).InvokeCore(), this);
                 }
                 else
                 {

--- a/src/Avalonia.Base/Threading/DispatcherOperation.cs
+++ b/src/Avalonia.Base/Threading/DispatcherOperation.cs
@@ -5,6 +5,12 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
+#if NET6_0_OR_GREATER
+using ExecutionContext = System.Threading.ExecutionContext;
+#else
+using ExecutionContext = Avalonia.Threading.CulturePreservingExecutionContext;
+#endif
+
 namespace Avalonia.Threading;
 
 [DebuggerDisplay("{DebugDisplay}")]
@@ -40,7 +46,7 @@ public class DispatcherOperation
     private EventHandler? _aborted;
     private EventHandler? _completed;
     private DispatcherPriority _priority;
-    private readonly CulturePreservingExecutionContext? _executionContext;
+    private readonly ExecutionContext? _executionContext;
 
     internal DispatcherOperation(Dispatcher dispatcher, DispatcherPriority priority, Action callback, bool throwOnUiThread) :
         this(dispatcher, priority, throwOnUiThread)
@@ -53,7 +59,7 @@ public class DispatcherOperation
         ThrowOnUiThread = throwOnUiThread;
         Priority = priority;
         Dispatcher = dispatcher;
-        _executionContext = CulturePreservingExecutionContext.Capture();
+        _executionContext = ExecutionContext.Capture();
     }
 
     internal string DebugDisplay
@@ -271,7 +277,7 @@ public class DispatcherOperation
             {
                 if (_executionContext is { } executionContext)
                 {
-                    CulturePreservingExecutionContext.Run(executionContext, s => ((DispatcherOperation)s!).InvokeCore(), this);
+                    ExecutionContext.Run(executionContext, static s => ((DispatcherOperation)s!).InvokeCore(), this);
                 }
                 else
                 {

--- a/src/Avalonia.Base/Threading/DispatcherOperation.cs
+++ b/src/Avalonia.Base/Threading/DispatcherOperation.cs
@@ -40,7 +40,7 @@ public class DispatcherOperation
     private EventHandler? _aborted;
     private EventHandler? _completed;
     private DispatcherPriority _priority;
-    private ExecutionContext? _executionContext;
+    private readonly CulturePreservingExecutionContext? _executionContext;
 
     internal DispatcherOperation(Dispatcher dispatcher, DispatcherPriority priority, Action callback, bool throwOnUiThread) :
         this(dispatcher, priority, throwOnUiThread)
@@ -53,7 +53,7 @@ public class DispatcherOperation
         ThrowOnUiThread = throwOnUiThread;
         Priority = priority;
         Dispatcher = dispatcher;
-        _executionContext = ExecutionContext.Capture();
+        _executionContext = CulturePreservingExecutionContext.Capture();
     }
 
     internal string DebugDisplay
@@ -272,13 +272,13 @@ public class DispatcherOperation
 #if NET6_0_OR_GREATER
                 if (_executionContext is { } executionContext)
                 {
-                    ExecutionContext.Restore(executionContext);
+                    CulturePreservingExecutionContext.Restore(executionContext);
                 }
                 InvokeCore();
 #else
                 if (_executionContext is { } executionContext)
                 {
-                    ExecutionContext.Run(executionContext, _ => InvokeCore(), null);
+                    CulturePreservingExecutionContext.Run(executionContext, _ => InvokeCore(), null);
                 }
                 else
                 {

--- a/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
+++ b/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
@@ -629,16 +629,18 @@ public partial class DispatcherTests
         {
             var testObject = new AsyncLocalTestClass();
 
-            // Test 1: Verify Invoke() preserves the execution context.
+            // Test 1: Verify Task.Run preserves the execution context.
+            // First, test Task.Run to ensure that the preceding validation always passes, serving as a baseline for the subsequent Invoke/InvokeAsync tests.
+            // This way, if a later test fails, we have the .NET framework's baseline behavior for reference.
             testObject.AsyncLocalField.Value = "Initial Value";
-            Dispatcher.UIThread.Invoke(() =>
+            var task1 = Task.Run(() =>
             {
                 test1 = testObject.AsyncLocalField.Value;
             });
 
-            // Test 2: Verify Task.Run preserves the execution context.
+            // Test 2: Verify Invoke preserves the execution context.
             testObject.AsyncLocalField.Value = "Initial Value";
-            var task2 = Task.Run(() =>
+            Dispatcher.UIThread.Invoke(() =>
             {
                 test2 = testObject.AsyncLocalField.Value;
             });
@@ -652,7 +654,7 @@ public partial class DispatcherTests
 
             _ = Dispatcher.UIThread.InvokeAsync(async () =>
             {
-                await Task.WhenAll(task2);
+                await Task.WhenAll(task1);
                 tokenSource.Cancel();
             });
 
@@ -726,13 +728,17 @@ public partial class DispatcherTests
             // This culture tag is Sumerian and is extremely unlikely to be set as the default on any device,
             // ensuring that this test will not be affected by the user's environment.
             Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("sux-Shaw-UM");
-            Dispatcher.UIThread.Invoke(() =>
+
+            // Test 1: Verify Task.Run preserves the culture in the execution context.
+            // First, test Task.Run to ensure that the preceding validation always passes, serving as a baseline for the subsequent Invoke/InvokeAsync tests.
+            // This way, if a later test fails, we have the .NET framework's baseline behavior for reference.
+            var task1 = Task.Run(() =>
             {
                 test1 = Thread.CurrentThread.CurrentCulture.Name;
             });
 
-            // Test 2: Verify Task.Run preserves the culture in the execution context.
-            var task2 = Task.Run(() =>
+            // Test 2: Verify Invoke preserves the execution context.
+            Dispatcher.UIThread.Invoke(() =>
             {
                 test2 = Thread.CurrentThread.CurrentCulture.Name;
             });
@@ -745,7 +751,7 @@ public partial class DispatcherTests
 
             _ = Dispatcher.UIThread.InvokeAsync(async () =>
             {
-                await Task.WhenAll(task2);
+                await Task.WhenAll(task1);
                 tokenSource.Cancel();
             });
         });


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

To make `AsyncLocal<T>` work correctly with `Dispatcher.InvokeAsync`, we need to capture the current `ExecutionContext` and pass it to the dispatcher. This allows the async local state to be preserved across asynchronous calls.

See the code below for implementation details.

```csharp
public MainWindow()
{
    InitializeComponent();
    Loaded += OnLoaded;
}

private readonly AsyncLocal<object?> _service = new AsyncLocal<object?>();

private async void OnLoaded(object? sender, RoutedEventArgs e)
{
    // Test 1:
    _service.Value = new object();
    Dispatcher.UIThread.Invoke(() =>
    {
        var foo = _service.Value;
        Console.WriteLine($"Service value 1: {foo}");
    });

    // Test 2:
    _service.Value = new object();
    Task.Run(() =>
    {
        var foo = _service.Value;
        Console.WriteLine($"Service value 2: {foo}");
    });

    // Test 3:
    _service.Value = new object();
    Dispatcher.UIThread.InvokeAsync(() =>
    {
        var foo = _service.Value;
        Console.WriteLine($"Service value 3: {foo}");
    });
}
```

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

The code block above generates the following output when run:

```
Service value 1: System.Object
Service value 2: System.Object
Service value 3:
```

The third test returns `null`, which shows that the `AsyncLocal<T>` value is not preserved when using `Dispatcher.InvokeAsync`.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

The third test should now return the same value as the first two tests, preserving the `AsyncLocal<T>` state across asynchronous calls.

To fix the third test, we can add multiple lines as shown below:

```diff
    _service.Value = new object();
++  var context = ExecutionContext.Capture();
    Dispatcher.UIThread.InvokeAsync(() =>
    {
++      ExecutionContext.Restore(context);
        var foo = _service.Value;
        Console.WriteLine($"Service value: {foo}");
    });
```

WPF works correctly because it captures the `ExecutionContext` in the constructor of `DispatcherOperation` and restores it in the `InvokeAsync` method. I believe we should make Avalonia work the same way as WPF's `DispatcherOperation` and .NET's `Task.Run` method.

- [The `Capture` code in WPF](https://github.com/dotnet/wpf/blob/a57aae82cc2e6693e450186e5216a88a3bb48304/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherOperation.cs#L38)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

I added a new field `ExecutionContext? _executionContext` to the `DispatcherOperation` class and modified the constructor to capture the current `ExecutionContext`. Then, I restored the captured context before executing the `InvokeCore` method.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

If someone uses `AsyncLocal<T>` to store values and expects `null` in this situation, this PR may break their code. However, this is not a common use case, and the fix is necessary to ensure that `AsyncLocal<T>` works correctly with all other asynchronous methods in .NET.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
