### PR TITLE
Fix memory leak by clearing shared array pool references in LightweightObservableBase

### DIFF
--- a/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
+++ b/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Reactive
         private List<IObserver<T>>? _observers = new List<IObserver<T>>();
 
         public bool HasObservers => _observers?.Count > 0;
-        
+
         public IDisposable Subscribe(IObserver<T> observer)
         {
             _ = observer ?? throw new ArgumentNullException(nameof(observer));
@@ -168,6 +168,8 @@ namespace Avalonia.Reactive
                     for(int i = 0; i < count; i++)
                     {
                         observers[i].OnNext(value);
+                        // Avoid memory leak by clearing the reference.
+                        observers[i] = null!;
                     }
 
                     ArrayPool<IObserver<T>>.Shared.Return(observers);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

The `LightweightObservableBase<T>` holds `IObserver<T>` references in the `PublishNext` method for a brief moment. However, it does not clear the shared array after returning it to the pool. This can cause a memory leak that persists for about 30 seconds, even when the GC runs multiple collection cycles.

This pull request clears the references to observers in the shared array after calling the `OnNext` method. This way, we can prevent the memory leak.

```diff
    protected void PublishNext(T value)
    {
        // Some codes ...
        count = _observers.Count;
        switch (count)
        {
            case 3:
                observer0 = _observers[0];
                observer1 = _observers[1];
                observer2 = _observers[2];
                break;
            case 2:
                observer0 = _observers[0];
                observer1 = _observers[1];
                break;
            case 1:
                observer0 = _observers[0];
                break;
            case 0:
                return;
            default:
            {
                observers = ArrayPool<IObserver<T>>.Shared.Rent(count);
                _observers.CopyTo(observers);
                break;
            }
        }
        // Some codes ...
        for(int i = 0; i < count; i++)
        {
            observers[i].OnNext(value);
++          // Clear reference to avoid memory leak.
++          observers[i] = null!;
        }

        ArrayPool<IObserver<T>>.Shared.Return(observers);
        // Some codes ...
    }
```

Looking at the code in `LightweightObservableBase`, we can see that when the subscriber count exceeds 3, a shared array is rented from the pool. Therefore, to reproduce the memory leak, we need more than 3 subscribers to the same observable.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

See the image below. This is a memory analysis from dotMemory.

![Key Retention Path of a Window](https://github.com/user-attachments/assets/a68bf040-36db-4b1e-b239-b60603e27db1)

After the `Window` is closed, pressing the `Force GC` button on dotMemory several times shows that the `Window` is still retained in memory. After about 30 seconds, the `Window` will finally be collected by the GC.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

After the `Window` is closed, it should be collected by the GC during the next garbage collection cycle. The memory analysis should no longer show the `Window` being retained in memory.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

This is a simple fix. We clear the references to observers in the shared array after calling the `OnNext` method. An alternative solution would be to pass `true` to `ArrayPool<T>.Shared.Return`, but that approach may be slightly slower than the solution implemented in this pull request.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

None. There are no breaking changes in this pull request.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
