### PR TITLE
Fix random NRE inside `Compositor.CommitCore()` callback.

### DIFF
--- a/src/Avalonia.Base/Media/MediaContext.Compositor.cs
+++ b/src/Avalonia.Base/Media/MediaContext.Compositor.cs
@@ -31,7 +31,7 @@ partial class MediaContext
         _pendingCompositionBatches[compositor] = commit;
         commit.Processed.ContinueWith(_ =>
             _dispatcher.Post(() => CompositionBatchFinished(compositor, commit), DispatcherPriority.Send),
-            TaskContinuationOptions.ExecuteSynchronously);
+            CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
         return commit;
     }
     

--- a/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Numerics;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Collections;
 using Avalonia.Collections.Pooled;
@@ -187,7 +188,7 @@ internal class CompositingRenderer : IRendererWithCompositor, IHitTester
             {
                 _queuedSceneInvalidation = false;
                 SceneInvalidated?.Invoke(this, new SceneInvalidatedEventArgs(_root, new Rect(_root.ClientSize)));
-            }, DispatcherPriority.Input), TaskContinuationOptions.ExecuteSynchronously);
+            }, DispatcherPriority.Input), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
         }
     }
 

--- a/src/Avalonia.Base/Rendering/Composition/Compositor.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Compositor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
@@ -114,7 +115,7 @@ namespace Avalonia.Rendering.Composition
                 if (pending != null)
                     pending.Processed.ContinueWith(
                         _ => Dispatcher.Post(_triggerCommitRequested, DispatcherPriority.Send),
-                        TaskContinuationOptions.ExecuteSynchronously);
+                        CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
                 else
                     _triggerCommitRequested();
             }
@@ -205,7 +206,7 @@ namespace Avalonia.Rendering.Composition
                         if (_pendingBatch.Processed == t)
                             _pendingBatch = null;
                     }
-                }, TaskContinuationOptions.ExecuteSynchronously);
+                }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
                 _nextCommit = null;
                 
                 return commit;

--- a/src/Avalonia.Base/Rendering/Composition/Compositor.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Compositor.cs
@@ -203,7 +203,7 @@ namespace Avalonia.Rendering.Composition
                 {
                     lock (_pendingBatchLock)
                     {
-                        if (_pendingBatch.Processed == t)
+                        if (_pendingBatch?.Processed == t)
                             _pendingBatch = null;
                     }
                 }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Makes all `Task.ContinueWith` calls in rendering-related code to use `TaskScheduler.Default`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

When `Compositor.CommitCore()` is called indirectly from task (for example via`Dispatcher.Invoke` or `Dispatcher.PushFrame` methods) started with TaskScheduler, that scheduler will be used by`ContinueWith` to continuation scheduling.

[See #19710 for reproducible sample](https://github.com/AvaloniaUI/Avalonia/issues/19170)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

All continuations in rendering-related code now use `TaskScheduler.Default`.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #19710 
