### PR TITLE
Add optional feature to move tooltip with mouse

### DIFF
--- a/samples/ControlCatalog/Pages/ToolTipPage.xaml
+++ b/samples/ControlCatalog/Pages/ToolTipPage.xaml
@@ -19,8 +19,9 @@
             <Border Background="{DynamicResource SystemAccentColor}"
                     Margin="5"
                     Padding="50"
-                    ToolTip.Tip="This is a ToolTip">
-                <TextBlock>Hover Here</TextBlock>
+                    ToolTip.Tip="This is a ToolTip"
+                    ToolTip.MoveWithPointer="True">
+                <TextBlock>Hover Here, Tip moves with cursor</TextBlock>
             </Border>
             <Border Name="Border"
                     Background="{DynamicResource SystemAccentColor}"

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -766,6 +766,8 @@ namespace Avalonia.Controls.Primitives
                 UpdateHostPosition(_openState.PopupHost, _openState.PlacementTarget);
             }
         }
+        
+        internal void UpdatePositionToPointer() => HandlePositionChange();
 
         /// <inheritdoc />
         protected override AutomationPeer OnCreateAutomationPeer()

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -38,7 +38,8 @@ namespace Avalonia.Controls
             if (e is RawPointerEventArgs pointerEvent)
             {
                 bool isTooltipEvent = false;
-                if (_tipControl?.GetValue(ToolTip.ToolTipProperty) is { } currentTip && e.Root == currentTip.PopupHost)
+                ToolTip? currentTip = _tipControl?.GetValue(ToolTip.ToolTipProperty);
+                if (currentTip != null && e.Root == currentTip.PopupHost)
                 {
                     isTooltipEvent = true;
                     _lastTipEventTime = pointerEvent.Timestamp;
@@ -52,6 +53,7 @@ namespace Avalonia.Controls
                 {
                     case RawPointerEventType.Move:
                         Update(pointerEvent.Root, pointerEvent.InputHitTestResult.element as Visual);
+                        currentTip?.TryUpdatePositionForPointerMove();
                         break;
                     case RawPointerEventType.LeaveWindow when (e.Root == _tipControl?.VisualRoot && _lastTipEventTime != e.Timestamp) || (isTooltipEvent && _lastWindowEventTime != e.Timestamp):
                         ClearTip();


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR adds a property `ToolTip.MoveWithPointerProperty` which, when true, and also when `ToolTip.PlacementProperty` is `PlacementMode.Pointer`, will cause the position of the tooltip's popup position to be updated when the pointer moves within a `TopLevel`

The `ControlCatalog.NetCore` project has a demo of this in the `ToolTipPage`