### PR TITLE
Remove textbox holding handler in text selection handle

### DIFF
--- a/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
+++ b/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
@@ -70,6 +70,10 @@ namespace Avalonia.Controls.Primitives
             _caretHandle.PointerReleased += Handle_PointerReleased;
             _endHandle.PointerReleased += Handle_PointerReleased;
 
+            _startHandle.Holding += Caret_Holding;
+            _caretHandle.Holding += Caret_Holding;
+            _endHandle.Holding += Caret_Holding;
+
             IsVisible = ShowHandles;
 
             ClipToBounds = false;
@@ -214,7 +218,12 @@ namespace Avalonia.Controls.Primitives
 
         public void MoveHandlesToSelection()
         {
-            if (_presenter == null || _textBox == null || _startHandle.IsDragging || _endHandle.IsDragging)
+            if (_presenter == null
+                || _textBox == null
+                || _startHandle.IsDragging
+                || _endHandle.IsDragging
+                || _textBox.ContextFlyout?.IsOpen == true
+                || _textBox.ContextMenu?.IsOpen == true)
             {
                 return;
             }
@@ -268,7 +277,6 @@ namespace Avalonia.Controls.Primitives
                 _textBox.RemoveHandler(TextBox.TextChangingEvent, TextChanged);
                 _textBox.RemoveHandler(KeyDownEvent, TextBoxKeyDown);
                 _textBox.RemoveHandler(PointerReleasedEvent, TextBoxPointerReleased);
-                _textBox.RemoveHandler(Gestures.HoldingEvent, TextBoxHolding);
 
                 _textBox.PropertyChanged -= TextBoxPropertyChanged;
                 _textBox.EffectiveViewportChanged -= TextBoxEffectiveViewportChanged;
@@ -287,7 +295,6 @@ namespace Avalonia.Controls.Primitives
                     _textBox.AddHandler(TextBox.TextChangingEvent, TextChanged, handledEventsToo: true);
                     _textBox.AddHandler(KeyDownEvent, TextBoxKeyDown, handledEventsToo: true);
                     _textBox.AddHandler(PointerReleasedEvent, TextBoxPointerReleased, handledEventsToo: true);
-                    _textBox.AddHandler(Gestures.HoldingEvent, TextBoxHolding, handledEventsToo: true);
 
                     _textBox.PropertyChanged += TextBoxPropertyChanged;
                     _textBox.EffectiveViewportChanged += TextBoxEffectiveViewportChanged;
@@ -310,7 +317,7 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
-        private void TextBoxHolding(object? sender, HoldingRoutedEventArgs e)
+        private void Caret_Holding(object? sender, HoldingRoutedEventArgs e)
         {
             if (ShowContextMenu())
                 e.Handled = true;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
A little fixup in TextSelectionHandle. Controls by default trigger context menu when Holding event is invoked, so it isn't necessary to handle that in TextSelectionHandle if the event is from the textbox and not the handles.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
