### PR TITLE
Unify selection event handling for all `SelectingItemsControl` types plus `TreeView`

### DIFF
--- a/src/Avalonia.Base/Input/DragEventArgs.cs
+++ b/src/Avalonia.Base/Input/DragEventArgs.cs
@@ -5,7 +5,7 @@ using Avalonia.Metadata;
 
 namespace Avalonia.Input
 {
-    public class DragEventArgs : RoutedEventArgs
+    public class DragEventArgs : RoutedEventArgs, IKeyModifiersEventArgs
     {
         private readonly Interactive _target;
         private readonly Point _targetLocation;

--- a/src/Avalonia.Base/Input/FocusChangingEventArgs.cs
+++ b/src/Avalonia.Base/Input/FocusChangingEventArgs.cs
@@ -7,7 +7,7 @@ using Avalonia.Interactivity;
 
 namespace Avalonia.Input
 {
-    public class FocusChangingEventArgs : RoutedEventArgs
+    public class FocusChangingEventArgs : RoutedEventArgs, IKeyModifiersEventArgs
     {
         /// <summary>
         /// Provides data for focus changing.

--- a/src/Avalonia.Base/Input/GotFocusEventArgs.cs
+++ b/src/Avalonia.Base/Input/GotFocusEventArgs.cs
@@ -5,7 +5,7 @@ namespace Avalonia.Input
     /// <summary>
     /// Holds arguments for a <see cref="InputElement.GotFocusEvent"/>.
     /// </summary>
-    public class GotFocusEventArgs : RoutedEventArgs
+    public class GotFocusEventArgs : RoutedEventArgs, IKeyModifiersEventArgs
     {
         public GotFocusEventArgs() : base(InputElement.GotFocusEvent)
         {

--- a/src/Avalonia.Base/Input/IKeyModifiersEventArgs.cs
+++ b/src/Avalonia.Base/Input/IKeyModifiersEventArgs.cs
@@ -1,8 +1,11 @@
-﻿namespace Avalonia.Input;
+﻿using Avalonia.Metadata;
+
+namespace Avalonia.Input;
 
 /// <summary>
 /// Represents an event associated with a set of <see cref="Input.KeyModifiers"/>.
 /// </summary>
+[NotClientImplementable]
 public interface IKeyModifiersEventArgs
 {
     /// <summary>

--- a/src/Avalonia.Base/Input/IKeyModifiersEventArgs.cs
+++ b/src/Avalonia.Base/Input/IKeyModifiersEventArgs.cs
@@ -1,0 +1,12 @@
+﻿namespace Avalonia.Input;
+
+/// <summary>
+/// Represents an event associated with a set of <see cref="Input.KeyModifiers"/>.
+/// </summary>
+public interface IKeyModifiersEventArgs
+{
+    /// <summary>
+    /// Gets the key modifiers associated with this event.
+    /// </summary>
+    KeyModifiers KeyModifiers { get; }
+}

--- a/src/Avalonia.Base/Input/KeyEventArgs.cs
+++ b/src/Avalonia.Base/Input/KeyEventArgs.cs
@@ -5,7 +5,7 @@ namespace Avalonia.Input;
 /// <summary>
 /// Provides information specific to a keyboard event.
 /// </summary>
-public class KeyEventArgs : RoutedEventArgs
+public class KeyEventArgs : RoutedEventArgs, IKeyModifiersEventArgs
 {
     /// <summary>
     /// <para>
@@ -33,9 +33,6 @@ public class KeyEventArgs : RoutedEventArgs
     /// <seealso cref="KeySymbol"/>
     public Key Key { get; init; }
 
-    /// <summary>
-    /// Gets the key modifiers for the associated event.
-    /// </summary>
     public KeyModifiers KeyModifiers { get; init; }
 
     /// <summary>

--- a/src/Avalonia.Base/Input/PointerEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerEventArgs.cs
@@ -7,7 +7,7 @@ using Avalonia.VisualTree;
 
 namespace Avalonia.Input
 {
-    public class PointerEventArgs : RoutedEventArgs
+    public class PointerEventArgs : RoutedEventArgs, IKeyModifiersEventArgs
     {
         private readonly Visual? _rootVisual;
         private readonly Point _rootVisualPosition;

--- a/src/Avalonia.Base/Input/TappedEventArgs.cs
+++ b/src/Avalonia.Base/Input/TappedEventArgs.cs
@@ -4,7 +4,7 @@ using Avalonia.VisualTree;
 
 namespace Avalonia.Input
 {
-    public class TappedEventArgs : RoutedEventArgs
+    public class TappedEventArgs : RoutedEventArgs, IKeyModifiersEventArgs
     {
         private readonly PointerEventArgs lastPointerEventArgs;
 

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -383,15 +383,10 @@ namespace Avalonia.Controls
             return false;
         }
 
-        protected override InputSelectionTrigger EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs)
-        {
-            return base.EventSelectionTrigger(selectable, eventArgs) switch
-            {
-                InputSelectionTrigger.None => InputSelectionTrigger.None,
-                InputSelectionTrigger.Press or InputSelectionTrigger.Release => InputSelectionTrigger.Release, // never select on press
-                _ => throw new NotImplementedException(),
-            };
-        }
+        protected override bool EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs) =>
+            ItemSelectionEventTriggers.IsPointerEventWithinBounds(selectable, eventArgs) &&
+            eventArgs is { Properties.PointerUpdateKind: PointerUpdateKind.LeftButtonReleased or PointerUpdateKind.RightButtonReleased } &&
+            eventArgs.RoutedEvent == PointerReleasedEvent;
 
         /// <inheritdoc/>
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -383,7 +383,7 @@ namespace Avalonia.Controls
             return false;
         }
 
-        protected override bool EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs) =>
+        protected override bool ShouldTriggerSelection(Visual selectable, PointerEventArgs eventArgs) =>
             ItemSelectionEventTriggers.IsPointerEventWithinBounds(selectable, eventArgs) &&
             eventArgs is { Properties.PointerUpdateKind: PointerUpdateKind.LeftButtonReleased or PointerUpdateKind.RightButtonReleased } &&
             eventArgs.RoutedEvent == PointerReleasedEvent;

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -146,14 +146,6 @@ namespace Avalonia.Controls
                 Selection.SelectAll();
                 e.Handled = true;
             }
-            else if (e.Key == Key.Space || e.Key == Key.Enter)
-            {
-                UpdateSelectionFromEventSource(
-                    e.Source,
-                    true,
-                    e.KeyModifiers.HasFlag(KeyModifiers.Shift),
-                    ctrl);
-            }
 
             base.OnKeyDown(e);
         }
@@ -162,20 +154,6 @@ namespace Avalonia.Controls
         {
             base.OnApplyTemplate(e);
             Scroll = e.NameScope.Find<IScrollable>("PART_ScrollViewer");
-        }
-
-        internal bool UpdateSelectionFromPointerEvent(Control source, PointerEventArgs e)
-        {
-            // TODO: use TopLevel.PlatformSettings here, but first need to update our tests to use TopLevels. 
-            var hotkeys = Application.Current!.PlatformSettings?.HotkeyConfiguration;
-            var toggle = hotkeys is not null && e.KeyModifiers.HasAllFlags(hotkeys.CommandModifiers);
-
-            return UpdateSelectionFromEventSource(
-                source,
-                true,
-                e.KeyModifiers.HasAllFlags(KeyModifiers.Shift),
-                toggle,
-                e.GetCurrentPoint(source).Properties.IsRightButtonPressed);
         }
     }
 }

--- a/src/Avalonia.Controls/ListBoxItem.cs
+++ b/src/Avalonia.Controls/ListBoxItem.cs
@@ -4,7 +4,7 @@ using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Mixins;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
-using Avalonia.Platform;
+using Avalonia.Interactivity;
 
 namespace Avalonia.Controls
 {
@@ -19,9 +19,6 @@ namespace Avalonia.Controls
         /// </summary>
         public static readonly StyledProperty<bool> IsSelectedProperty =
             SelectingItemsControl.IsSelectedProperty.AddOwner<ListBoxItem>();
-
-        private static readonly Point s_invalidPoint = new Point(double.NaN, double.NaN);
-        private Point _pointerDownPoint = s_invalidPoint;
 
         /// <summary>
         /// Initializes static members of the <see cref="ListBoxItem"/> class.
@@ -51,76 +48,21 @@ namespace Avalonia.Controls
         protected override void OnPointerPressed(PointerPressedEventArgs e)
         {
             base.OnPointerPressed(e);
-
-            _pointerDownPoint = s_invalidPoint;
-
-            if (e.Handled)
-                return;
-
-            if (!e.Handled && ItemsControl.ItemsControlFromItemContainer(this) is ListBox owner)
-            {
-                var p = e.GetCurrentPoint(this);
-
-                if (p.Properties.PointerUpdateKind is PointerUpdateKind.LeftButtonPressed or 
-                    PointerUpdateKind.RightButtonPressed)
-                {
-                    if (p.Pointer.Type == PointerType.Mouse
-                        || (p.Pointer.Type == PointerType.Pen && p.Properties.IsRightButtonPressed))
-                    {
-                        // If the pressed point comes from a mouse or right-click pen, perform the selection immediately.
-                        // In case of pen, only right-click is accepted, as left click (a tip touch) is used for scrolling. 
-                        e.Handled = owner.UpdateSelectionFromPointerEvent(this, e);
-                    }
-                    else
-                    {
-                        // Otherwise perform the selection when the pointer is released as to not
-                        // interfere with gestures.
-                        _pointerDownPoint = p.Position;
-
-                        // Ideally we'd set handled here, but that would prevent the scroll gesture
-                        // recognizer from working.
-                        ////e.Handled = true;
-                    }
-                }
-            }
+            UpdateSelectionFromEvent(e);
         }
 
         protected override void OnPointerReleased(PointerReleasedEventArgs e)
         {
             base.OnPointerReleased(e);
-
-            if (!e.Handled && 
-                !double.IsNaN(_pointerDownPoint.X) &&
-                e.InitialPressMouseButton is MouseButton.Left or MouseButton.Right)
-            {
-                var point = e.GetCurrentPoint(this);
-                var settings = TopLevel.GetTopLevel(e.Source as Visual)?.PlatformSettings;
-                var tapSize = settings?.GetTapSize(point.Pointer.Type) ?? new Size(4, 4);
-                var tapRect = new Rect(_pointerDownPoint, new Size())
-                    .Inflate(new Thickness(tapSize.Width, tapSize.Height));
-
-                if (new Rect(Bounds.Size).ContainsExclusive(point.Position) &&
-                    tapRect.ContainsExclusive(point.Position) &&
-                    ItemsControl.ItemsControlFromItemContainer(this) is ListBox owner)
-                {
-                    if (owner.UpdateSelectionFromPointerEvent(this, e))
-                    {
-                        // As we only update selection from touch/pen on pointer release, we need to raise
-                        // the pointer event on the owner to trigger a commit.
-                        if (e.Pointer.Type != PointerType.Mouse)
-                        {
-                            var sourceBackup = e.Source;
-                            owner.RaiseEvent(e);
-                            e.Source = sourceBackup;
-                        }
-
-                        e.Handled = true;
-                    }
-                }
-            }
-
-            _pointerDownPoint = s_invalidPoint;
+            UpdateSelectionFromEvent(e);
         }
 
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            base.OnKeyDown(e);
+            UpdateSelectionFromEvent(e);
+        }
+
+        protected bool UpdateSelectionFromEvent(RoutedEventArgs e) => SelectingItemsControl.ItemsControlFromItemContainer(this)?.UpdateSelectionFromEvent(this, e) ?? false;
     }
 }

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -484,7 +484,7 @@ namespace Avalonia.Controls
         protected override void OnGotFocus(GotFocusEventArgs e)
         {
             base.OnGotFocus(e);
-            e.Handled = UpdateSelectionFromEventSource(e.Source, true);
+            ItemsControlFromItemContainer(this)?.UpdateSelectionFromEvent(this, e);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/Primitives/ItemSelectionEventTriggers.cs
+++ b/src/Avalonia.Controls/Primitives/ItemSelectionEventTriggers.cs
@@ -14,7 +14,7 @@ public static class ItemSelectionEventTriggers
     /// </summary>
     /// <param name="selectable">The selectable element which is processing the event.</param>
     /// <param name="eventArgs">The event to analyse.</param>
-    public static bool EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs)
+    public static bool ShouldTriggerSelection(Visual selectable, PointerEventArgs eventArgs)
     {
         if (!IsPointerEventWithinBounds(selectable, eventArgs))
         {
@@ -48,13 +48,13 @@ public static class ItemSelectionEventTriggers
         };
     }
 
-    public static bool IsPointerEventWithinBounds(InputElement selectable, PointerEventArgs eventArgs) =>
+    internal static bool IsPointerEventWithinBounds(Visual selectable, PointerEventArgs eventArgs) =>
         new Rect(selectable.Bounds.Size).Contains(eventArgs.GetPosition(selectable));
 
-    /// <inheritdoc cref="EventSelectionTrigger(InputElement, PointerEventArgs)"/>
-    public static bool EventSelectionTrigger(InputElement selectable, KeyEventArgs eventArgs)
+    /// <inheritdoc cref="ShouldTriggerSelection(Visual, PointerEventArgs)"/>
+    public static bool ShouldTriggerSelection(Visual selectable, KeyEventArgs eventArgs)
     {
-        // Only accept space/enter key presses directly from the selectable
+        // Only accept space/enter key presses directly from the selectable, otherwise key input can become unpredictable
         return eventArgs.Source == selectable && eventArgs.Key is Key.Space or Key.Enter ? eventArgs.RoutedEvent == InputElement.KeyDownEvent : false;
     }
 
@@ -64,7 +64,7 @@ public static class ItemSelectionEventTriggers
     /// <param name="selectable">The selectable element which is processing the event.</param>
     /// <param name="eventArgs">The event to analyse.</param>
     /// <seealso cref="PlatformHotkeyConfiguration.SelectionModifiers"/>
-    public static bool HasRangeSelectionModifier(InputElement selectable, RoutedEventArgs eventArgs) => HasModifiers(eventArgs, Hotkeys(selectable)?.SelectionModifiers);
+    public static bool HasRangeSelectionModifier(Visual selectable, RoutedEventArgs eventArgs) => HasModifiers(eventArgs, Hotkeys(selectable)?.SelectionModifiers);
 
     /// <summary>
     /// Analyses an input event received by a selectable element, and determines whether the action should trigger toggle selection.
@@ -72,9 +72,9 @@ public static class ItemSelectionEventTriggers
     /// <param name="selectable">The selectable element which is processing the event.</param>
     /// <param name="eventArgs">The event to analyse.</param>
     /// <seealso cref="PlatformHotkeyConfiguration.CommandModifiers"/>
-    public static bool HasToggleSelectionModifier(InputElement selectable, RoutedEventArgs eventArgs) => HasModifiers(eventArgs, Hotkeys(selectable)?.CommandModifiers);
+    public static bool HasToggleSelectionModifier(Visual selectable, RoutedEventArgs eventArgs) => HasModifiers(eventArgs, Hotkeys(selectable)?.CommandModifiers);
 
-    private static PlatformHotkeyConfiguration? Hotkeys(InputElement element) =>
+    private static PlatformHotkeyConfiguration? Hotkeys(Visual element) =>
         (TopLevel.GetTopLevel(element)?.PlatformSettings ?? Application.Current?.PlatformSettings)?.HotkeyConfiguration;
 
     private static bool HasModifiers(RoutedEventArgs eventArgs, KeyModifiers? modifiers) =>

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -865,20 +865,20 @@ namespace Avalonia.Controls.Primitives
             return false;
         }
         
-        /// <inheritdoc cref="ItemSelectionEventTriggers.EventSelectionTrigger(InputElement, PointerEventArgs)"/>
+        /// <inheritdoc cref="ItemSelectionEventTriggers.ShouldTriggerSelection(Visual, PointerEventArgs)"/>
         /// <seealso cref="UpdateSelectionFromEvent"/>
-        protected virtual bool EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs) => ItemSelectionEventTriggers.EventSelectionTrigger(selectable, eventArgs);
+        protected virtual bool ShouldTriggerSelection(Visual selectable, PointerEventArgs eventArgs) => ItemSelectionEventTriggers.ShouldTriggerSelection(selectable, eventArgs);
         
-        /// <inheritdoc cref="ItemSelectionEventTriggers.EventSelectionTrigger(InputElement, KeyEventArgs)"/>
-        protected virtual bool EventSelectionTrigger(InputElement selectable, KeyEventArgs eventArgs) => ItemSelectionEventTriggers.EventSelectionTrigger(selectable, eventArgs);
+        /// <inheritdoc cref="ItemSelectionEventTriggers.ShouldTriggerSelection(Visual, KeyEventArgs)"/>
+        protected virtual bool ShouldTriggerSelection(Visual selectable, KeyEventArgs eventArgs) => ItemSelectionEventTriggers.ShouldTriggerSelection(selectable, eventArgs);
 
         /// <summary>
         /// Updates the selection based on an event that may have originated in a container that
         /// belongs to the control.
         /// </summary>
         /// <returns>True if the event was accepted and handled, otherwise false.</returns>
-        /// <seealso cref="EventSelectionTrigger(InputElement, PointerEventArgs)"/>
-        /// <seealso cref="EventSelectionTrigger(InputElement, KeyEventArgs)"/>
+        /// <seealso cref="ShouldTriggerSelection(Visual, PointerEventArgs)"/>
+        /// <seealso cref="ShouldTriggerSelection(Visual, KeyEventArgs)"/>
         public virtual bool UpdateSelectionFromEvent(Control container, RoutedEventArgs eventArgs)
         {
             if (eventArgs.Handled)
@@ -894,8 +894,8 @@ namespace Avalonia.Controls.Primitives
 
             switch (eventArgs)
             {
-                case PointerEventArgs pointerEvent when EventSelectionTrigger(container, pointerEvent):
-                case KeyEventArgs keyEvent when EventSelectionTrigger(container, keyEvent):
+                case PointerEventArgs pointerEvent when ShouldTriggerSelection(container, pointerEvent):
+                case KeyEventArgs keyEvent when ShouldTriggerSelection(container, keyEvent):
                 case GotFocusEventArgs:
                     UpdateSelection(containerIndex, true,
                         ItemSelectionEventTriggers.HasRangeSelectionModifier(container, eventArgs),

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls.Selection;
 using Avalonia.Controls.Utils;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Metadata;
 using Avalonia.Threading;
@@ -115,7 +116,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public static readonly StyledProperty<bool> IsTextSearchEnabledProperty =
             AvaloniaProperty.Register<SelectingItemsControl, bool>(nameof(IsTextSearchEnabled), false);
-        
+
         /// <summary>
         /// Event that should be raised by containers when their selection state changes to notify
         /// the parent <see cref="SelectingItemsControl"/> that their selection state has changed.
@@ -445,6 +446,9 @@ namespace Avalonia.Controls.Primitives
             return null;
         }
 
+        /// <inheritdoc cref="ItemsControl.ItemsControlFromItemContainer(Control)"/>
+        public new static SelectingItemsControl? ItemsControlFromItemContainer(Control container) => ItemsControl.ItemsControlFromItemContainer(container) as SelectingItemsControl;
+
         private protected override void OnItemsViewCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             base.OnItemsViewCollectionChanged(sender!, e);
@@ -594,7 +598,7 @@ namespace Avalonia.Controls.Primitives
                 {
                     SelectedIndex = newIndex;
                 }
-                
+
                 StartTextSearchTimer();
 
                 e.Handled = true;
@@ -813,6 +817,7 @@ namespace Avalonia.Controls.Primitives
         /// <param name="toggleModifier">Whether the toggle modifier is enabled (i.e. ctrl key).</param>
         /// <param name="rightButton">Whether the event is a right-click.</param>
         /// <param name="fromFocus">Wheter the event is a focus event</param>
+        [Obsolete($"Call {nameof(UpdateSelectionFromEvent)} instead.")]
         protected void UpdateSelection(
             Control container,
             bool select = true,
@@ -829,10 +834,7 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
-        /// <summary>
-        /// Updates the selection based on an event that may have originated in a container that
-        /// belongs to the control.
-        /// </summary>
+        /// <inheritdoc cref="UpdateSelectionFromEvent"/>
         /// <param name="eventSource">The control that raised the event.</param>
         /// <param name="select">Whether the container should be selected or unselected.</param>
         /// <param name="rangeModifier">Whether the range modifier is enabled (i.e. shift key).</param>
@@ -843,6 +845,7 @@ namespace Avalonia.Controls.Primitives
         /// True if the event originated from a container that belongs to the control; otherwise
         /// false.
         /// </returns>
+        [Obsolete($"Call {nameof(UpdateSelectionFromEvent)} instead.")]
         protected bool UpdateSelectionFromEventSource(
             object? eventSource,
             bool select = true,
@@ -860,6 +863,56 @@ namespace Avalonia.Controls.Primitives
             }
 
             return false;
+        }
+        
+        /// <inheritdoc cref="SelectionEventLogic.EventSelectionTrigger(InputElement, PointerEventArgs)"/>
+        /// <seealso cref="UpdateSelectionFromEvent"/>
+        protected virtual InputSelectionTrigger EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs) => SelectionEventLogic.EventSelectionTrigger(selectable, eventArgs);
+        
+        /// <inheritdoc cref="SelectionEventLogic.EventSelectionTrigger(InputElement, KeyEventArgs)"/>
+        protected virtual InputSelectionTrigger EventSelectionTrigger(InputElement selectable, KeyEventArgs eventArgs) => SelectionEventLogic.EventSelectionTrigger(selectable, eventArgs);
+
+        /// <summary>
+        /// Updates the selection based on an event that may have originated in a container that
+        /// belongs to the control.
+        /// </summary>
+        /// <returns>True if the event was accepted and handled, otherwise false.</returns>
+        /// <seealso cref="EventSelectionTrigger(InputElement, PointerEventArgs)"/>
+        /// <seealso cref="EventSelectionTrigger(InputElement, KeyEventArgs)"/>
+        public virtual bool UpdateSelectionFromEvent(Control container, RoutedEventArgs eventArgs)
+        {
+            if (eventArgs.Handled)
+            {
+                return false;
+            }
+
+            var containerIndex = IndexFromContainer(container);
+            if (containerIndex == -1)
+            {
+                return false;
+            }
+
+            switch (eventArgs)
+            {
+                case PointerPressedEventArgs pointerPressedEvent when EventSelectionTrigger(container, pointerPressedEvent) == InputSelectionTrigger.Press:
+                case PointerReleasedEventArgs pointerReleasedEvent when EventSelectionTrigger(container, pointerReleasedEvent) == InputSelectionTrigger.Release:
+                
+                case KeyEventArgs keyDownEvent when keyDownEvent.RoutedEvent == KeyDownEvent && EventSelectionTrigger(container, keyDownEvent) == InputSelectionTrigger.Press:
+                case KeyEventArgs keyUpEvent when keyUpEvent.RoutedEvent == KeyUpEvent && EventSelectionTrigger(container, keyUpEvent) == InputSelectionTrigger.Release:
+
+                case GotFocusEventArgs:
+                    UpdateSelection(containerIndex, true,
+                        SelectionEventLogic.HasRangeSelectionModifier(container, eventArgs),
+                        SelectionEventLogic.HasToggleSelectionModifier(container, eventArgs),
+                        eventArgs is PointerEventArgs { Properties.IsRightButtonPressed: true },
+                        eventArgs is GotFocusEventArgs);
+
+                    eventArgs.Handled = true;
+                    return true;
+
+                default:
+                    return false;
+            }
         }
 
         private ISelectionModel GetOrCreateSelectionModel()

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -865,12 +865,12 @@ namespace Avalonia.Controls.Primitives
             return false;
         }
         
-        /// <inheritdoc cref="SelectionEventLogic.EventSelectionTrigger(InputElement, PointerEventArgs)"/>
+        /// <inheritdoc cref="ItemSelectionEventTriggers.EventSelectionTrigger(InputElement, PointerEventArgs)"/>
         /// <seealso cref="UpdateSelectionFromEvent"/>
-        protected virtual InputSelectionTrigger EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs) => SelectionEventLogic.EventSelectionTrigger(selectable, eventArgs);
+        protected virtual bool EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs) => ItemSelectionEventTriggers.EventSelectionTrigger(selectable, eventArgs);
         
-        /// <inheritdoc cref="SelectionEventLogic.EventSelectionTrigger(InputElement, KeyEventArgs)"/>
-        protected virtual InputSelectionTrigger EventSelectionTrigger(InputElement selectable, KeyEventArgs eventArgs) => SelectionEventLogic.EventSelectionTrigger(selectable, eventArgs);
+        /// <inheritdoc cref="ItemSelectionEventTriggers.EventSelectionTrigger(InputElement, KeyEventArgs)"/>
+        protected virtual bool EventSelectionTrigger(InputElement selectable, KeyEventArgs eventArgs) => ItemSelectionEventTriggers.EventSelectionTrigger(selectable, eventArgs);
 
         /// <summary>
         /// Updates the selection based on an event that may have originated in a container that
@@ -894,16 +894,12 @@ namespace Avalonia.Controls.Primitives
 
             switch (eventArgs)
             {
-                case PointerPressedEventArgs pointerPressedEvent when EventSelectionTrigger(container, pointerPressedEvent) == InputSelectionTrigger.Press:
-                case PointerReleasedEventArgs pointerReleasedEvent when EventSelectionTrigger(container, pointerReleasedEvent) == InputSelectionTrigger.Release:
-                
-                case KeyEventArgs keyDownEvent when keyDownEvent.RoutedEvent == KeyDownEvent && EventSelectionTrigger(container, keyDownEvent) == InputSelectionTrigger.Press:
-                case KeyEventArgs keyUpEvent when keyUpEvent.RoutedEvent == KeyUpEvent && EventSelectionTrigger(container, keyUpEvent) == InputSelectionTrigger.Release:
-
+                case PointerEventArgs pointerEvent when EventSelectionTrigger(container, pointerEvent):
+                case KeyEventArgs keyEvent when EventSelectionTrigger(container, keyEvent):
                 case GotFocusEventArgs:
                     UpdateSelection(containerIndex, true,
-                        SelectionEventLogic.HasRangeSelectionModifier(container, eventArgs),
-                        SelectionEventLogic.HasToggleSelectionModifier(container, eventArgs),
+                        ItemSelectionEventTriggers.HasRangeSelectionModifier(container, eventArgs),
+                        ItemSelectionEventTriggers.HasToggleSelectionModifier(container, eventArgs),
                         eventArgs is PointerEventArgs { Properties.IsRightButtonPressed: true },
                         eventArgs is GotFocusEventArgs);
 

--- a/src/Avalonia.Controls/Primitives/SelectionEventLogic.cs
+++ b/src/Avalonia.Controls/Primitives/SelectionEventLogic.cs
@@ -1,0 +1,94 @@
+﻿using Avalonia.Input;
+using Avalonia.Input.Platform;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Controls.Primitives;
+
+public enum InputSelectionTrigger
+{
+    /// <summary>
+    /// Do not select in response to this input.
+    /// </summary>
+    None,
+    /// <summary>
+    /// Select when this input begins.
+    /// </summary>
+    Press,
+    /// <summary>
+    /// Select when this input ends.
+    /// </summary>
+    Release,
+}
+
+/// <summary>
+/// Defines standard logic for selecting items via user input. Behaviour differs between input devices.
+/// </summary>
+public static class SelectionEventLogic
+{
+    /// <summary>
+    /// Analyses an input event received by a selectable element, and determines whether the action should trigger selection on press, on release, or not at all.
+    /// </summary>
+    /// <remarks>
+    /// While this method could also check whether the event actually was a press or release and return <see cref="bool"/>, it 
+    /// instead provides a more detailed result which can be better integrated into the caller's selection logic.
+    /// </remarks>
+    /// <param name="selectable">The selectable element which is processing the event.</param>
+    /// <param name="eventArgs">The event to analyse.</param>
+    public static InputSelectionTrigger EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs)
+    {
+        if (!new Rect(selectable.Bounds.Size).Contains(eventArgs.GetPosition(selectable)))
+        {
+            return InputSelectionTrigger.None; // don't select if the pointer has moved away from the element since being pressed
+        }
+
+        return eventArgs switch
+        {
+            // Only select for left/right button events
+            { Properties.PointerUpdateKind: not (PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.RightButtonPressed or
+                PointerUpdateKind.LeftButtonReleased or PointerUpdateKind.RightButtonReleased) } => InputSelectionTrigger.None,
+
+            // Select on mouse press, unless the mouse can generate gestures
+            { Pointer.Type: PointerType.Mouse } => Gestures.GetIsHoldWithMouseEnabled(selectable) ? InputSelectionTrigger.Release : InputSelectionTrigger.Press,
+
+            // Pen "right clicks" are used for context menus, and gestures are only processed for primary input
+            { Pointer.Type: PointerType.Pen, Properties.PointerUpdateKind: PointerUpdateKind.RightButtonPressed or PointerUpdateKind.RightButtonReleased } => InputSelectionTrigger.Press,
+            // For all other pen input, select on release
+            { Pointer.Type: PointerType.Pen } => InputSelectionTrigger.Release,
+
+            // Select on touch release
+            { Pointer.Type: PointerType.Touch } => InputSelectionTrigger.Release,
+
+            // Don't select in any other case
+            _ => InputSelectionTrigger.None,
+        };
+    }
+
+    /// <inheritdoc cref="EventSelectionTrigger(InputElement, PointerEventArgs)"/>
+    public static InputSelectionTrigger EventSelectionTrigger(InputElement selectable, KeyEventArgs eventArgs)
+    {
+        // Only accept space/enter key presses directly from the selectable
+        return eventArgs.Source == selectable && eventArgs.Key is Key.Space or Key.Enter ? InputSelectionTrigger.Press : InputSelectionTrigger.None;
+    }
+
+    /// <summary>
+    /// Analyses an input event received by a selectable element, and determines whether the action should trigger range selection.
+    /// </summary>
+    /// <param name="selectable">The selectable element which is processing the event.</param>
+    /// <param name="eventArgs">The event to analyse.</param>
+    /// <seealso cref="PlatformHotkeyConfiguration.SelectionModifiers"/>
+    public static bool HasRangeSelectionModifier(InputElement selectable, RoutedEventArgs eventArgs) => HasModifiers(eventArgs, Hotkeys(selectable)?.SelectionModifiers);
+
+    /// <summary>
+    /// Analyses an input event received by a selectable element, and determines whether the action should trigger toggle selection.
+    /// </summary>
+    /// <param name="selectable">The selectable element which is processing the event.</param>
+    /// <param name="eventArgs">The event to analyse.</param>
+    /// <seealso cref="PlatformHotkeyConfiguration.CommandModifiers"/>
+    public static bool HasToggleSelectionModifier(InputElement selectable, RoutedEventArgs eventArgs) => HasModifiers(eventArgs, Hotkeys(selectable)?.CommandModifiers);
+
+    private static PlatformHotkeyConfiguration? Hotkeys(InputElement element) =>
+        (TopLevel.GetTopLevel(element)?.PlatformSettings ?? Application.Current?.PlatformSettings)?.HotkeyConfiguration;
+
+    private static bool HasModifiers(RoutedEventArgs eventArgs, KeyModifiers? modifiers) =>
+        modifiers != null && eventArgs is IKeyModifiersEventArgs { KeyModifiers: { } eventModifiers } && eventModifiers.HasAllFlags(modifiers.Value);
+}

--- a/src/Avalonia.Controls/Primitives/TabStrip.cs
+++ b/src/Avalonia.Controls/Primitives/TabStrip.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 
 namespace Avalonia.Controls.Primitives
@@ -26,31 +27,24 @@ namespace Avalonia.Controls.Primitives
             return NeedsContainer<TabStripItem>(item, out recycleKey);
         }
 
-        /// <inheritdoc/>
-        protected override void OnGotFocus(GotFocusEventArgs e)
+        protected override InputSelectionTrigger EventSelectionTrigger(InputElement selectable, PointerEventArgs e)
         {
-            base.OnGotFocus(e);
-
-            if (e.NavigationMethod == NavigationMethod.Directional)
+            if (e.Properties.PointerUpdateKind is not (PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.LeftButtonReleased))
             {
-                e.Handled = UpdateSelectionFromEventSource(e.Source);
+                return InputSelectionTrigger.None;
             }
+
+            return base.EventSelectionTrigger(selectable, e);
         }
 
-        /// <inheritdoc/>
-        protected override void OnPointerPressed(PointerPressedEventArgs e)
+        public override bool UpdateSelectionFromEvent(Control container, RoutedEventArgs eventArgs)
         {
-            base.OnPointerPressed(e);
-
-            if (e.Source is Visual source)
+            if (eventArgs is GotFocusEventArgs { NavigationMethod: not NavigationMethod.Directional })
             {
-                var point = e.GetCurrentPoint(source);
-
-                if (point.Properties.IsLeftButtonPressed)
-                {
-                    e.Handled = UpdateSelectionFromEventSource(e.Source);
-                }
+                return false;
             }
+
+            return base.UpdateSelectionFromEvent(container, eventArgs);
         }
     }
 }

--- a/src/Avalonia.Controls/Primitives/TabStrip.cs
+++ b/src/Avalonia.Controls/Primitives/TabStrip.cs
@@ -27,15 +27,8 @@ namespace Avalonia.Controls.Primitives
             return NeedsContainer<TabStripItem>(item, out recycleKey);
         }
 
-        protected override InputSelectionTrigger EventSelectionTrigger(InputElement selectable, PointerEventArgs e)
-        {
-            if (e.Properties.PointerUpdateKind is not (PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.LeftButtonReleased))
-            {
-                return InputSelectionTrigger.None;
-            }
-
-            return base.EventSelectionTrigger(selectable, e);
-        }
+        protected override bool EventSelectionTrigger(InputElement selectable, PointerEventArgs e) =>
+            e.Properties.PointerUpdateKind is PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.LeftButtonReleased && base.EventSelectionTrigger(selectable, e);
 
         public override bool UpdateSelectionFromEvent(Control container, RoutedEventArgs eventArgs)
         {

--- a/src/Avalonia.Controls/Primitives/TabStrip.cs
+++ b/src/Avalonia.Controls/Primitives/TabStrip.cs
@@ -27,8 +27,8 @@ namespace Avalonia.Controls.Primitives
             return NeedsContainer<TabStripItem>(item, out recycleKey);
         }
 
-        protected override bool EventSelectionTrigger(InputElement selectable, PointerEventArgs e) =>
-            e.Properties.PointerUpdateKind is PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.LeftButtonReleased && base.EventSelectionTrigger(selectable, e);
+        protected override bool ShouldTriggerSelection(Visual selectable, PointerEventArgs e) =>
+            e.Properties.PointerUpdateKind is PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.LeftButtonReleased && base.ShouldTriggerSelection(selectable, e);
 
         public override bool UpdateSelectionFromEvent(Control container, RoutedEventArgs eventArgs)
         {

--- a/src/Avalonia.Controls/Primitives/TabStripItem.cs
+++ b/src/Avalonia.Controls/Primitives/TabStripItem.cs
@@ -1,3 +1,5 @@
+using Avalonia.Input;
+
 namespace Avalonia.Controls.Primitives
 {
     /// <summary>
@@ -5,5 +7,10 @@ namespace Avalonia.Controls.Primitives
     /// </summary>
     public class TabStripItem : ListBoxItem
     {
+        protected override void OnGotFocus(GotFocusEventArgs e)
+        {
+            base.OnGotFocus(e);
+            UpdateSelectionFromEvent(e);
+        }
     }
 }

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -194,8 +194,8 @@ namespace Avalonia.Controls
             UpdateSelectedContent();
         }
 
-        protected override bool EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs) =>
-            eventArgs.Properties.PointerUpdateKind is PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.LeftButtonReleased && base.EventSelectionTrigger(selectable, eventArgs);
+        protected override bool ShouldTriggerSelection(Visual selectable, PointerEventArgs eventArgs) =>
+            eventArgs.Properties.PointerUpdateKind is PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.LeftButtonReleased && base.ShouldTriggerSelection(selectable, eventArgs);
 
         public override bool UpdateSelectionFromEvent(Control container, RoutedEventArgs eventArgs)
         {

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -194,15 +194,8 @@ namespace Avalonia.Controls
             UpdateSelectedContent();
         }
 
-        protected override InputSelectionTrigger EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs)
-        {
-            if (eventArgs.Properties.PointerUpdateKind is not (PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.LeftButtonReleased))
-            {
-                return InputSelectionTrigger.None;
-            }
-
-            return base.EventSelectionTrigger(selectable, eventArgs);
-        }
+        protected override bool EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs) =>
+            eventArgs.Properties.PointerUpdateKind is PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.LeftButtonReleased && base.EventSelectionTrigger(selectable, eventArgs);
 
         public override bool UpdateSelectionFromEvent(Control container, RoutedEventArgs eventArgs)
         {

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -11,6 +11,7 @@ using Avalonia.VisualTree;
 using Avalonia.Automation;
 using Avalonia.Controls.Metadata;
 using Avalonia.Reactive;
+using Avalonia.Interactivity;
 
 namespace Avalonia.Controls
 {
@@ -193,6 +194,26 @@ namespace Avalonia.Controls
             UpdateSelectedContent();
         }
 
+        protected override InputSelectionTrigger EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs)
+        {
+            if (eventArgs.Properties.PointerUpdateKind is not (PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.LeftButtonReleased))
+            {
+                return InputSelectionTrigger.None;
+            }
+
+            return base.EventSelectionTrigger(selectable, eventArgs);
+        }
+
+        public override bool UpdateSelectionFromEvent(Control container, RoutedEventArgs eventArgs)
+        {
+            if (eventArgs is GotFocusEventArgs { NavigationMethod: not NavigationMethod.Directional })
+            {
+                return false;
+            }
+
+            return base.UpdateSelectionFromEvent(container, eventArgs);
+        }
+
         private void UpdateSelectedContent(Control? container = null)
         {
             _selectedItemSubscriptions?.Dispose();
@@ -259,42 +280,6 @@ namespace Avalonia.Controls
                 KeyboardNavigation.SetTabOnceActiveElement(
                     panel,
                     KeyboardNavigation.GetTabOnceActiveElement(this));
-            }
-        }
-
-        /// <inheritdoc/>
-        protected override void OnGotFocus(GotFocusEventArgs e)
-        {
-            base.OnGotFocus(e);
-
-            if (e.NavigationMethod == NavigationMethod.Directional && e.Source is TabItem)
-            {
-                e.Handled = UpdateSelectionFromEventSource(e.Source);
-            }
-        }
-
-        /// <inheritdoc/>
-        protected override void OnPointerPressed(PointerPressedEventArgs e)
-        {
-            base.OnPointerPressed(e);
-
-            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed && e.Pointer.Type == PointerType.Mouse)
-            {
-                e.Handled = UpdateSelectionFromEventSource(e.Source);
-            }
-        }
-
-        protected override void OnPointerReleased(PointerReleasedEventArgs e)
-        {
-            if (e.InitialPressMouseButton == MouseButton.Left && e.Pointer.Type != PointerType.Mouse)
-            {
-                var container = GetContainerFromEventSource(e.Source);
-                if (container != null
-                    && container.GetVisualsAt(e.GetPosition(container))
-                        .Any(c => container == c || container.IsVisualAncestorOf(c)))
-                {
-                    e.Handled = UpdateSelectionFromEventSource(e.Source);
-                }
             }
         }
 

--- a/src/Avalonia.Controls/TabItem.cs
+++ b/src/Avalonia.Controls/TabItem.cs
@@ -71,7 +71,6 @@ namespace Avalonia.Controls
 
         protected override AutomationPeer OnCreateAutomationPeer() => new ListItemAutomationPeer(this);
 
-        
         [Obsolete("Owner manages its children properties by itself")]
         protected void SubscribeToOwnerProperties(AvaloniaObject owner)
         {
@@ -79,12 +78,32 @@ namespace Avalonia.Controls
 
         private static void OnAccessKeyPressed(TabItem tabItem, AccessKeyPressedEventArgs e)
         {
-            if (e.Handled || (e.Target != null && tabItem.IsSelected)) 
+            if (e.Handled || (e.Target != null && tabItem.IsSelected))
                 return;
-            
+
             e.Target = tabItem;
             e.Handled = true;
         }
+
+        protected override void OnGotFocus(GotFocusEventArgs e)
+        {
+            base.OnGotFocus(e);
+            UpdateSelectionFromEvent(e);
+        }
+
+        protected override void OnPointerPressed(PointerPressedEventArgs e)
+        {
+            base.OnPointerPressed(e);
+            UpdateSelectionFromEvent(e);
+        }
+
+        protected override void OnPointerReleased(PointerReleasedEventArgs e)
+        {
+            base.OnPointerReleased(e);
+            UpdateSelectionFromEvent(e);
+        }
+
+        protected bool UpdateSelectionFromEvent(RoutedEventArgs e) => SelectingItemsControl.ItemsControlFromItemContainer(this)?.UpdateSelectionFromEvent(this, e) ?? false;
 
         private void UpdateHeader(AvaloniaPropertyChangedEventArgs obj)
         {

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -663,12 +663,12 @@ namespace Avalonia.Controls
             return result;
         }
 
-        /// <inheritdoc cref="ItemSelectionEventTriggers.EventSelectionTrigger(InputElement, PointerEventArgs)"/>
+        /// <inheritdoc cref="ItemSelectionEventTriggers.ShouldTriggerSelection(Visual, PointerEventArgs)"/>
         /// <seealso cref="UpdateSelectionFromEvent"/>
-        protected virtual bool EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs) => ItemSelectionEventTriggers.EventSelectionTrigger(selectable, eventArgs);
+        protected virtual bool ShouldTriggerSelection(Visual selectable, PointerEventArgs eventArgs) => ItemSelectionEventTriggers.ShouldTriggerSelection(selectable, eventArgs);
 
-        /// <inheritdoc cref="ItemSelectionEventTriggers.EventSelectionTrigger(InputElement, PointerEventArgs)"/>
-        protected virtual bool EventSelectionTrigger(InputElement selectable, KeyEventArgs eventArgs) => ItemSelectionEventTriggers.EventSelectionTrigger(selectable, eventArgs);
+        /// <inheritdoc cref="ItemSelectionEventTriggers.ShouldTriggerSelection(Visual, PointerEventArgs)"/>
+        protected virtual bool ShouldTriggerSelection(Visual selectable, KeyEventArgs eventArgs) => ItemSelectionEventTriggers.ShouldTriggerSelection(selectable, eventArgs);
 
         /// <inheritdoc cref="SelectingItemsControl.UpdateSelectionFromEvent"/>
         /// <seealso cref="SelectingItemsControl.UpdateSelectionFromEvent"/>
@@ -681,8 +681,8 @@ namespace Avalonia.Controls
 
             switch (eventArgs)
             {
-                case PointerEventArgs pointerEvent when EventSelectionTrigger(container, pointerEvent):
-                case KeyEventArgs keyEvent when EventSelectionTrigger(container, keyEvent):
+                case PointerEventArgs pointerEvent when ShouldTriggerSelection(container, pointerEvent):
+                case KeyEventArgs keyEvent when ShouldTriggerSelection(container, keyEvent):
                     UpdateSelectionFromContainer(container, true,
                         ItemSelectionEventTriggers.HasRangeSelectionModifier(container, eventArgs),
                         ItemSelectionEventTriggers.HasToggleSelectionModifier(container, eventArgs),

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -663,12 +663,12 @@ namespace Avalonia.Controls
             return result;
         }
 
-        /// <inheritdoc cref="SelectionEventLogic.EventSelectionTrigger(InputElement, PointerEventArgs)"/>
+        /// <inheritdoc cref="ItemSelectionEventTriggers.EventSelectionTrigger(InputElement, PointerEventArgs)"/>
         /// <seealso cref="UpdateSelectionFromEvent"/>
-        protected virtual InputSelectionTrigger EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs) => SelectionEventLogic.EventSelectionTrigger(selectable, eventArgs);
+        protected virtual bool EventSelectionTrigger(InputElement selectable, PointerEventArgs eventArgs) => ItemSelectionEventTriggers.EventSelectionTrigger(selectable, eventArgs);
 
-        /// <inheritdoc cref="SelectionEventLogic.EventSelectionTrigger(InputElement, PointerEventArgs)"/>
-        protected virtual InputSelectionTrigger EventSelectionTrigger(InputElement selectable, KeyEventArgs eventArgs) => SelectionEventLogic.EventSelectionTrigger(selectable, eventArgs);
+        /// <inheritdoc cref="ItemSelectionEventTriggers.EventSelectionTrigger(InputElement, PointerEventArgs)"/>
+        protected virtual bool EventSelectionTrigger(InputElement selectable, KeyEventArgs eventArgs) => ItemSelectionEventTriggers.EventSelectionTrigger(selectable, eventArgs);
 
         /// <inheritdoc cref="SelectingItemsControl.UpdateSelectionFromEvent"/>
         /// <seealso cref="SelectingItemsControl.UpdateSelectionFromEvent"/>
@@ -681,15 +681,11 @@ namespace Avalonia.Controls
 
             switch (eventArgs)
             {
-                case PointerPressedEventArgs pointerPressedEvent when EventSelectionTrigger(container, pointerPressedEvent) == InputSelectionTrigger.Press:
-                case PointerReleasedEventArgs pointerReleasedEvent when EventSelectionTrigger(container, pointerReleasedEvent) == InputSelectionTrigger.Release:
-
-                case KeyEventArgs keyDownEvent when keyDownEvent.RoutedEvent == KeyDownEvent && EventSelectionTrigger(container, keyDownEvent) == InputSelectionTrigger.Press:
-                case KeyEventArgs keyUpEvent when keyUpEvent.RoutedEvent == KeyUpEvent && EventSelectionTrigger(container, keyUpEvent) == InputSelectionTrigger.Release:
-
+                case PointerEventArgs pointerEvent when EventSelectionTrigger(container, pointerEvent):
+                case KeyEventArgs keyEvent when EventSelectionTrigger(container, keyEvent):
                     UpdateSelectionFromContainer(container, true,
-                        SelectionEventLogic.HasRangeSelectionModifier(container, eventArgs),
-                        SelectionEventLogic.HasToggleSelectionModifier(container, eventArgs),
+                        ItemSelectionEventTriggers.HasRangeSelectionModifier(container, eventArgs),
+                        ItemSelectionEventTriggers.HasToggleSelectionModifier(container, eventArgs),
                         eventArgs is PointerEventArgs { Properties.IsRightButtonPressed: true });
 
                     eventArgs.Handled = true;

--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -229,6 +229,10 @@ namespace Avalonia.Controls
                 {
                     e.Handled = handler(this);
                 }
+                else
+                {
+                    TreeViewOwner?.UpdateSelectionFromEvent(this, e);
+                }
 
                 // NOTE: these local functions do not use the TreeView.Expand/CollapseSubtree
                 // function because we want to know if any items were in fact expanded to set the
@@ -302,6 +306,18 @@ namespace Avalonia.Controls
             }
 
             // Don't call base.OnKeyDown - let events bubble up to containing TreeView.
+        }
+
+        protected override void OnPointerPressed(PointerPressedEventArgs e)
+        {
+            base.OnPointerPressed(e);
+            TreeViewOwner?.UpdateSelectionFromEvent(this, e);
+        }
+
+        protected override void OnPointerReleased(PointerReleasedEventArgs e)
+        {
+            base.OnPointerReleased(e);
+            TreeViewOwner?.UpdateSelectionFromEvent(this, e);
         }
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)

--- a/tests/Avalonia.UnitTests/MouseTestHelper.cs
+++ b/tests/Avalonia.UnitTests/MouseTestHelper.cs
@@ -38,14 +38,14 @@ namespace Avalonia.UnitTests
 
         private MouseButton _pressedButton;
 
-        public void Down(Interactive target, MouseButton mouseButton = MouseButton.Left, Point position = default,
+        public void Down(Interactive target, MouseButton mouseButton = MouseButton.Left, Point? position = null,
             KeyModifiers modifiers = default, int clickCount = 1)
         {
             Down(target, target, mouseButton, position, modifiers, clickCount);
         }
 
         public void Down(Interactive target, Interactive source, MouseButton mouseButton = MouseButton.Left, 
-            Point position = default, KeyModifiers modifiers = default, int clickCount = 1)
+            Point? position = null, KeyModifiers modifiers = default, int clickCount = 1)
         {
             _pressedButtons |= Convert(mouseButton);
             var props = new PointerPointProperties((RawInputModifiers)_pressedButtons,
@@ -54,12 +54,12 @@ namespace Avalonia.UnitTests
                 : mouseButton == MouseButton.Right ? PointerUpdateKind.RightButtonPressed : PointerUpdateKind.Other
             );
             if (ButtonCount(props) > 1)
-                Move(target, source, position);
+                Move(target, source, position ?? default);
             else
             {
                 _pressedButton = mouseButton;
                 _pointer.Capture((IInputElement)target);
-                source.RaiseEvent(new PointerPressedEventArgs(source, _pointer, GetRoot(target), position, Timestamp(), props,
+                source.RaiseEvent(new PointerPressedEventArgs(source, _pointer, GetRoot(target), position ?? MidpointRelativeToRoot(target), Timestamp(), props,
                     modifiers, clickCount));
             }
         }
@@ -72,12 +72,12 @@ namespace Avalonia.UnitTests
                 Timestamp(), new PointerPointProperties((RawInputModifiers)_pressedButtons, PointerUpdateKind.Other), modifiers));
         }
 
-        public void Up(Interactive target, MouseButton mouseButton = MouseButton.Left, Point position = default,
+        public void Up(Interactive target, MouseButton mouseButton = MouseButton.Left, Point? position = null,
             KeyModifiers modifiers = default)
             => Up(target, target, mouseButton, position, modifiers);
         
         public void Up(Interactive target, Interactive source, MouseButton mouseButton = MouseButton.Left,
-            Point position = default, KeyModifiers modifiers = default)
+            Point? position = null, KeyModifiers modifiers = default)
         {
             var conv = Convert(mouseButton);
             _pressedButtons = (_pressedButtons | conv) ^ conv;
@@ -88,32 +88,32 @@ namespace Avalonia.UnitTests
             );
             if (ButtonCount(props) == 0)
             {
-                target.RaiseEvent(new PointerReleasedEventArgs(source, _pointer, GetRoot(target), position,
+                target.RaiseEvent(new PointerReleasedEventArgs(source, _pointer, GetRoot(target), position ?? MidpointRelativeToRoot(target),
                     Timestamp(), props, modifiers, _pressedButton));
                 _pointer.Capture(null);
             }
             else
-                Move(target, source, position);
+                Move(target, source, position ?? default);
         }
 
-        public void Click(Interactive target, MouseButton button = MouseButton.Left, Point position = default,
+        public void Click(Interactive target, MouseButton button = MouseButton.Left, Point? position = null,
             KeyModifiers modifiers = default)
             => Click(target, target, button, position, modifiers);
 
         public void Click(Interactive target, Interactive source, MouseButton button = MouseButton.Left, 
-            Point position = default, KeyModifiers modifiers = default)
+            Point? position = null, KeyModifiers modifiers = default)
         {
             Down(target, source, button, position, modifiers);
             var captured = (_pointer.Captured as Interactive) ?? source;
             Up(captured, captured, button, position, modifiers);
         }
 
-        public void DoubleClick(Interactive target, MouseButton button = MouseButton.Left, Point position = default,
+        public void DoubleClick(Interactive target, MouseButton button = MouseButton.Left, Point? position = null,
             KeyModifiers modifiers = default)
             => DoubleClick(target, target, button, position, modifiers);
 
         public void DoubleClick(Interactive target, Interactive source, MouseButton button = MouseButton.Left,
-            Point position = default, KeyModifiers modifiers = default)
+            Point? position = null, KeyModifiers modifiers = default)
         {
             Down(target, source, button, position, modifiers, clickCount: 1);
             var captured = (_pointer.Captured as Interactive) ?? source;
@@ -136,6 +136,12 @@ namespace Avalonia.UnitTests
         private Visual GetRoot(Interactive source)
         {
             return ((source as Visual)?.GetVisualRoot() as Visual) ?? (Visual)source;
+        }
+
+        private Point MidpointRelativeToRoot(Interactive element)
+        {
+            var root = GetRoot(element);
+            return element.TranslatePoint(new(element.Bounds.Width / 2, element.Bounds.Height / 2), root).Value;
         }
     }
 }


### PR DESCRIPTION
This PR substantially refactors selection logic to achieve a consistent experience which adapts to user expectations on different input devices. Behaviour is unchanged for standard mouse input, but touch and pen input have both been altered to fix bugs and bring Avalonia into line with native UI behaviours on relevant devices.

## What is the current behavior?

The current state of selection logic is outlined in #18902.

## What is the updated/expected behavior with this PR?

User facing:

* `ListBox` no longer cares if you swipe before releasing touch, unless a gesture is triggered or you swipe off the item entirely
*  `TreeViewItem` is now selected on touch/pen release
* If `Gestures.IsHoldWithMouseEnabled` is true for a container, then mouse input selects on release instead of press

API:

* Container types now always handle selection input, instead of letting the event bubble up to their `ItemsControl`. Previously some did this and others did not. This is of particular relevance to `TreeViewItem`, which can be nested.
* However, when handling the events containers privately call `UpdateSelectionFromEvent` on their `ItemsControl`, a virtual method which contains shared selection logic for all containers of that control. This is where behaviour is customised.
* The default implementation of `UpdateSelectionFromEvent` calls `EventSelectionTrigger`, an overloaded virtual method which determines whether the state of the device calls for selection on press or release. Tweaking the return value is enough to implement correct behaviour for all `SelectingItemsControl` types defined in Avalonia.
* `TopLevel.PlatformSettings.HotkeyConfiguration` is now used, with a fallback to `Application.Current.PlatformSettings.HotkeyConfiguration` if null. This resolves a TODO comment I found in the codebase.

## How was the solution implemented (if it's not obvious)?
Because `TreeView` does not inherit from `SelectingItemsControl`, I defined the standard selection logic in `public static` methods which both of these types call in their virtual methods.

I moved event handling to container types because this is the sane way to ensure that the event actually came from a container. Previously all events that reached the `SelectingItemsControl`/`TreeView` were handled, and the visual tree needed to be searched or hit tested to tell which container each one came from, if it came from one at all. This is no longer necessary.

I originally aimed to have selection behaviour customisable via properties, but this proved impractical. It's instead achieved with method overrides.

## Breaking changes
 An `ItemsControl` no longer sees the original events which cause its selection to change. This could disrupt existing custom event processing. To adapt to the new system, relevant code must be moved to an override of the new `UpdateSelectionFromEvent` method(s). An example of this happening can be seen in the changes to `ComboBox` in this PR.

The switch from selecting on touch press to touch release on some controls may break existing event handling.

## Obsoletions / Deprecations

* `SelectingItemsControl.UpdateSelection`
* `SelectingItemsControl.UpdateSelectionFromEventSource`

Calls to either of these methods should be replaced with a call to `SelectingItemsControl.UpdateSelectionFromEvent`.

## Fixed issues
Fixes #18902

## Future work

* Add a `TreeViewItem:pressed` style to the `Avalonia.Themes.Simple`
* Fix bug I noticed where `TreeViewItem:pressed` style from `Avalonia.Themes.Fluent` doesn't activate on iOS, but does on Mac and Windows
* Integrate selection changes into `Calendar`