### PR TITLE
Fix: Unable to input numbers, symbols, and English letters in Avalonia on X11 with fcitx5 ForwardKey messages

### DIFF
--- a/src/Avalonia.FreeDesktop/DBusIme/Fcitx/FcitxX11TextInputMethod.cs
+++ b/src/Avalonia.FreeDesktop/DBusIme/Fcitx/FcitxX11TextInputMethod.cs
@@ -180,13 +180,15 @@ namespace Avalonia.FreeDesktop.DBusIme.Fcitx
                 mods |= KeyModifiers.Shift;
             if (state.HasAllFlags(FcitxKeyState.FcitxKeyState_Super))
                 mods |= KeyModifiers.Meta;
+            var isPressKey = ev.type == (int)FcitxKeyEventType.FCITX_PRESS_KEY;
             FireForward(new X11InputMethodForwardedKey
             {
                 Modifiers = mods,
                 KeyVal = (int)ev.keyval,
-                Type = ev.type == (int)FcitxKeyEventType.FCITX_PRESS_KEY ?
+                Type = isPressKey ?
                     RawKeyEventType.KeyDown :
-                    RawKeyEventType.KeyUp
+                    RawKeyEventType.KeyUp,
+                WithText = isPressKey,
             });
         }
 

--- a/src/Avalonia.FreeDesktop/IX11InputMethod.cs
+++ b/src/Avalonia.FreeDesktop/IX11InputMethod.cs
@@ -18,6 +18,7 @@ namespace Avalonia.FreeDesktop
         public int KeyVal { get; set; }
         public KeyModifiers Modifiers { get; set; }
         public RawKeyEventType Type { get; set; }
+        public bool WithText { get; set; }
     }
     
     internal interface IX11InputMethodControl : IDisposable

--- a/src/Avalonia.X11/X11Window.Ime.cs
+++ b/src/Avalonia.X11/X11Window.Ime.cs
@@ -88,15 +88,26 @@ namespace Avalonia.X11
             var x11Key = (X11Key)forwardedKey.KeyVal;
             var keySymbol = _x11.HasXkb ? GetKeySymbolXkb(x11Key) : GetKeySymbolXCore(x11Key);
 
-            ScheduleInput(new RawKeyEventArgs(
-                _keyboard,
-                (ulong)_x11.LastActivityTimestamp.ToInt64(),
-                InputRoot,
-                forwardedKey.Type,
-                X11KeyTransform.KeyFromX11Key(x11Key),
-                (RawInputModifiers)forwardedKey.Modifiers,
-                PhysicalKey.None,
-                keySymbol));
+            ScheduleInput(forwardedKey.WithText ?
+                new RawKeyEventArgsWithText(
+                    _keyboard,
+                    (ulong)_x11.LastActivityTimestamp.ToInt64(),
+                    InputRoot,
+                    forwardedKey.Type,
+                    X11KeyTransform.KeyFromX11Key(x11Key),
+                    (RawInputModifiers)forwardedKey.Modifiers,
+                    PhysicalKey.None,
+                    keySymbol,
+                    keySymbol) :
+                new RawKeyEventArgs(
+                    _keyboard,
+                    (ulong)_x11.LastActivityTimestamp.ToInt64(),
+                    InputRoot,
+                    forwardedKey.Type,
+                    X11KeyTransform.KeyFromX11Key(x11Key),
+                    (RawInputModifiers)forwardedKey.Modifiers,
+                    PhysicalKey.None,
+                    keySymbol));
         }
 
         private void UpdateImePosition() => _imeControl?.UpdateWindowInfo(_position ?? default, RenderScaling);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

This PR fixes an issue where TextBox controls in Avalonia applications on Linux cannot receive input from fcitx5-based virtual keyboards when using ForwardKey messages to simulate key presses for numbers, symbols, or English letters.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

When using fcitx5-based virtual keyboards on Linux, TextBox controls in Avalonia applications do not respond to simulated key presses for numbers, symbols, or English letters sent via ForwardKey messages.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

After this fix, TextBox controls will correctly receive and display input from fcitx5-based virtual keyboards on Linux. When users press keys on the virtual keyboard, the corresponding characters (numbers, symbols, English letters) will be properly entered into the focused TextBox.

**Testing:**

1. Set up a Linux system with fcitx5 input method
2. Use a virtual keyboard that integrates with fcitx5 (For example: [kylin-virtual-keyboard](https://gitee.com/openkylin/kylin-virtual-keyboard)), or manually send ForwardKey messages to simulate the issue
3. Create an Avalonia application with a TextBox
4. Focus the TextBox and press keys on the virtual keyboard
5. Verify that the characters appear in the TextBox as expected

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

The fix modifies the `ProcessForwardedKey` method in `X11Window.Ime.cs` to create `RawKeyEventArgsWithText` for KeyDown events instead of plain `RawKeyEventArgs`. This ensures that the text content of the key press is properly passed to the input system.

The key change is:

- For KeyDown events: Use `RawKeyEventArgsWithText` with the key symbol as both the key and text parameter
- For KeyUp events: Continue using the existing `RawKeyEventArgs` since text input is only needed for KeyDown events

see:

* [fcitx5-gtk gtk3 _fcitx_im_context_forward_key_cb](https://github.com/fcitx/fcitx5-gtk/blob/5.1.4/gtk3/fcitximcontext.cpp#L1293C0-L1300C1)
* [fcitx5 VirtualKeyboardBackend processKeyEvent](https://github.com/fcitx/fcitx5/blob/5.1.4/src/ui/virtualkeyboard/virtualkeyboard.cpp#L142)

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to [avalonia-docs](https://github.com/AvaloniaUI/avalonia-docs) with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

If an input method sends both ForwardKey and CommitString events for the same character simultaneously, this could result in duplicate input. However, this is not expected behavior for fcitx5-based virtual keyboards, which typically rely on ForwardKey messages for basic character input. 

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

None.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #19078