### PR TITLE
Use hard links for build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,5 +9,9 @@
       <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
       <RunApiCompat>False</RunApiCompat>
       <LangVersion>12</LangVersion>
+      <CreateHardLinksForCopyAdditionalFilesIfPossible>true</CreateHardLinksForCopyAdditionalFilesIfPossible>
+      <CreateHardLinksForCopyFilesToOutputDirectoryIfPossible>true</CreateHardLinksForCopyFilesToOutputDirectoryIfPossible>
+      <CreateHardLinksForCopyLocalIfPossible>true</CreateHardLinksForCopyLocalIfPossible>
+      <CreateHardLinksForPublishFilesIfPossible>true</CreateHardLinksForPublishFilesIfPossible>
   </PropertyGroup>
 </Project>

--- a/tests/BuildTests/Directory.Build.props
+++ b/tests/BuildTests/Directory.Build.props
@@ -3,6 +3,10 @@
   <PropertyGroup>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <CreateHardLinksForCopyAdditionalFilesIfPossible>true</CreateHardLinksForCopyAdditionalFilesIfPossible>
+    <CreateHardLinksForCopyFilesToOutputDirectoryIfPossible>true</CreateHardLinksForCopyFilesToOutputDirectoryIfPossible>
+    <CreateHardLinksForCopyLocalIfPossible>true</CreateHardLinksForCopyLocalIfPossible>
+    <CreateHardLinksForPublishFilesIfPossible>true</CreateHardLinksForPublishFilesIfPossible>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## What does the pull request do?
This PR enables the use of hard links when building and publishing projects.

Since the merge of #18981, we're starting to hit the storage limit of the the Windows agent on Azure DevOps.
This should alleviate the problem.

(As a bonus, this speeds up a full rebuild by ≈10% on my machine.)