### PR TITLE
Use captured element if available as source for tap gestures

### DIFF
--- a/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
@@ -89,6 +89,40 @@ namespace Avalonia.Base.UnitTests.Input
         }
 
         [Fact]
+        public void Tapped_Should_Be_Raised_From_Captured_Control()
+        {
+            Border inner = new Border()
+            {
+                Focusable = true,
+                Name = "Inner"
+            };
+            Border border = new Border()
+            {
+                Focusable = true,
+                Child = inner,
+                Name = "Parent"
+            };
+            var root = new TestRoot
+            {
+                Child = border
+            };
+            var raised = false;
+
+            border.PointerPressed += (s, e) =>
+            {
+                e.Pointer.Capture(inner);
+            };
+            _mouse.Click(border, MouseButton.Left);
+
+            root.AddHandler(Gestures.TappedEvent, (_, _) => raised = true);
+
+            _mouse.Click(border, MouseButton.Left);
+
+
+            Assert.True(raised);
+        }
+
+        [Fact]
         public void RightTapped_Should_Be_Raised_For_Right_Button()
         {
             Border border = new Border();

--- a/tests/Avalonia.UnitTests/MouseTestHelper.cs
+++ b/tests/Avalonia.UnitTests/MouseTestHelper.cs
@@ -104,7 +104,8 @@ namespace Avalonia.UnitTests
             Point position = default, KeyModifiers modifiers = default)
         {
             Down(target, source, button, position, modifiers);
-            Up(target, source, button, position, modifiers);
+            var captured = (_pointer.Captured as Interactive) ?? source;
+            Up(captured, captured, button, position, modifiers);
         }
 
         public void DoubleClick(Interactive target, MouseButton button = MouseButton.Left, Point position = default,
@@ -115,7 +116,8 @@ namespace Avalonia.UnitTests
             Point position = default, KeyModifiers modifiers = default)
         {
             Down(target, source, button, position, modifiers, clickCount: 1);
-            Up(target, source, button, position, modifiers);
+            var captured = (_pointer.Captured as Interactive) ?? source;
+            Up(captured, captured, button, position, modifiers);
             Down(target, source, button, position, modifiers, clickCount: 2);
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
If a pointer is captured by an element, use that element instead of event source for Tap gestures.


## What is the current behavior?
Controls which sets the pointer's captured element to a child element aren't triggering tap events. An example is Textbox. The pointer event source is `TextBox`, but at the end of the PointerPressed handler in `TextBox`, the child `TextPresenter` is explicitly captured. Tap events currently use the event source of the PointerPressed, which will always be `TextBox` while successive pointer events will use the captured element as source, which is `TextPresenter` in this case. Because gesture code checks that the original source is the same as the current source, Tap event will not be triggered.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
