### PR TITLE
Revert 15603, add InputPaneActivationRequested in TextInputMethodClient

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
@@ -72,6 +72,13 @@ namespace Avalonia.Android.Platform.Input
 
         public void SetClient(TextInputMethodClient? client)
         {
+            if(_client != null)
+            {
+                _client.SurroundingTextChanged -= _client_SurroundingTextChanged;
+                _client.SelectionChanged -= _client_SelectionChanged;
+                _client.InputPaneActivationRequested -= _client_InputPaneActivationRequested;
+            }
+
             _client = client;
 
             if (IsActive)
@@ -86,13 +93,21 @@ namespace Avalonia.Android.Platform.Input
 
                 _client.SurroundingTextChanged += _client_SurroundingTextChanged;
                 _client.SelectionChanged += _client_SelectionChanged;
+                _client.InputPaneActivationRequested += _client_InputPaneActivationRequested;
             }
             else
             {
-                _host.ClearFocus();
                 _imm.RestartInput(View);
                 _inputConnection = null;
                 _imm.HideSoftInputFromWindow(_host.WindowToken, HideSoftInputFlags.ImplicitOnly);
+            }
+        }
+
+        private void _client_InputPaneActivationRequested(object? sender, EventArgs e)
+        {
+            if(IsActive)
+            {
+                _imm.ShowSoftInput(_host, ShowFlags.Implicit);
             }
         }
 

--- a/src/Avalonia.Base/Input/TextInput/TextInputMethodClient.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextInputMethodClient.cs
@@ -28,6 +28,11 @@ namespace Avalonia.Input.TextInput
         /// Fires when client wants to reset IME state
         /// </summary>
         public event EventHandler? ResetRequested;
+        
+        /// <summary>
+        /// Fires when client requests the input panel be opened.
+        /// </summary>
+        public event EventHandler? InputPaneActivationRequested;
 
         /// <summary>
         /// The visual that's showing the text
@@ -78,6 +83,7 @@ namespace Avalonia.Input.TextInput
             SetPreeditText(preeditText);
         }
 
+        [Obsolete]
         public virtual void ShowInputPanel() { }
         
         protected virtual void RaiseTextViewVisualChanged()
@@ -98,6 +104,11 @@ namespace Avalonia.Input.TextInput
         protected virtual void RaiseSelectionChanged()
         {
             SelectionChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        protected virtual void RaiseInputPaneActivationRequested()
+        {
+            InputPaneActivationRequested?.Invoke(this, EventArgs.Empty);
         }
         
         protected virtual void RequestReset()

--- a/src/Avalonia.Base/Input/TextInput/TextInputMethodClient.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextInputMethodClient.cs
@@ -83,8 +83,12 @@ namespace Avalonia.Input.TextInput
             SetPreeditText(preeditText);
         }
 
+        //TODO12: remove
         [Obsolete]
-        public virtual void ShowInputPanel() { }
+        public virtual void ShowInputPanel()
+        {
+            RaiseInputPaneActivationRequested();
+        }
         
         protected virtual void RaiseTextViewVisualChanged()
         {

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1791,8 +1791,6 @@ namespace Avalonia.Controls
 
             if (e.Pointer.Type != PointerType.Mouse && !_isDoubleTapped)
             {
-                _imClient.ShowInputPanel();
-
                 var text = Text;
                 var clickInfo = e.GetCurrentPoint(this);
                 if (text != null && !(clickInfo.Pointer?.Captured is Border))

--- a/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
+++ b/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
@@ -13,7 +13,6 @@ namespace Avalonia.Controls
         private TextPresenter? _presenter;
         private bool _selectionChanged;
         private bool _isInChange;
-        private ITextInputMethodImpl? _im;
 
         public override Visual TextViewVisual => _presenter!;
 
@@ -119,6 +118,7 @@ namespace Avalonia.Controls
             if (_parent != null)
             {
                 _parent.PropertyChanged -= OnParentPropertyChanged;
+                _parent.Tapped -= OnParentTapped;
             }
 
             _parent = parent;
@@ -126,11 +126,7 @@ namespace Avalonia.Controls
             if (_parent != null)
             {
                 _parent.PropertyChanged += OnParentPropertyChanged;
-                _im = (_parent.VisualRoot as ITextInputMethodRoot)?.InputMethod;
-            }
-            else
-            {
-                _im = null;
+                _parent.Tapped += OnParentTapped;
             }
 
             var oldPresenter = _presenter;
@@ -154,6 +150,11 @@ namespace Avalonia.Controls
             RaiseCursorRectangleChanged();
         }
 
+        private void OnParentTapped(object? sender, Input.TappedEventArgs e)
+        {
+            RaiseInputPaneActivationRequested();
+        }
+
         public override void SetPreeditText(string? preeditText) => SetPreeditText(preeditText, null);
 
         public override void SetPreeditText(string? preeditText, int? cursorPos)
@@ -165,17 +166,6 @@ namespace Avalonia.Controls
 
             _presenter.SetCurrentValue(TextPresenter.PreeditTextProperty, preeditText);
             _presenter.SetCurrentValue(TextPresenter.PreeditTextCursorPositionProperty, cursorPos);
-        }
-
-        public override void ShowInputPanel()
-        {
-            base.ShowInputPanel();
-
-            if (_parent is { } && _im is { })
-            {
-                _im.SetOptions(TextInputOptions.FromStyledElement(_parent));
-                _im.SetClient(this);
-            }
         }
 
         private static string GetTextLineText(TextLine textLine)

--- a/src/Browser/Avalonia.Browser/BrowserTextInputMethod.cs
+++ b/src/Browser/Avalonia.Browser/BrowserTextInputMethod.cs
@@ -29,11 +29,13 @@ internal class BrowserTextInputMethod(
         if (_client != null)
         {
             _client.SurroundingTextChanged -= SurroundingTextChanged;
+            _client.InputPaneActivationRequested -= InputPaneActivationRequested;
         }
 
         if (client != null)
         {
             client.SurroundingTextChanged += SurroundingTextChanged;
+            client.InputPaneActivationRequested += InputPaneActivationRequested;
         }
 
         InputHelper.ClearInputElement(_inputElement);
@@ -42,8 +44,7 @@ internal class BrowserTextInputMethod(
 
         if (_client != null)
         {
-            InputHelper.ShowElement(_inputElement);
-            InputHelper.FocusElement(_inputElement);
+            ShowIme();
 
             var surroundingText = _client.SurroundingText ?? "";
             var selection = _client.Selection;
@@ -54,6 +55,20 @@ internal class BrowserTextInputMethod(
         {
             HideIme();
         }
+    }
+
+    private void InputPaneActivationRequested(object? sender, EventArgs e)
+    {
+        if (_client != null)
+        {
+            ShowIme();
+        }
+    }
+
+    private void ShowIme()
+    {
+        InputHelper.ShowElement(_inputElement);
+        InputHelper.FocusElement(_inputElement);
     }
 
     private void SurroundingTextChanged(object? sender, EventArgs e)

--- a/src/Tizen/Avalonia.Tizen/NuiAvaloniaViewTextEditable.cs
+++ b/src/Tizen/Avalonia.Tizen/NuiAvaloniaViewTextEditable.cs
@@ -118,11 +118,18 @@ internal class NuiAvaloniaViewTextEditable
             client.TextViewVisualChanged += OnTextViewVisualChanged;
             client.SurroundingTextChanged += OnSurroundingTextChanged;
             client.SelectionChanged += OnClientSelectionChanged;
+            client.InputPaneActivationRequested += OnInputPaneActivationRequested;
 
             TextInput.SelectWholeText();
             OnClientSelectionChanged(this, EventArgs.Empty);
         }
         finally { _updating = false; }
+    }
+
+    private void OnInputPaneActivationRequested(object? sender, EventArgs e)
+    {
+        var inputContext = TextInput.GetInputMethodContext();
+        inputContext.ShowInputPanel();
     }
 
     private void OnClientSelectionChanged(object? sender, EventArgs e) => InvokeUpdate(client =>
@@ -152,6 +159,7 @@ internal class NuiAvaloniaViewTextEditable
             _client!.TextViewVisualChanged -= OnTextViewVisualChanged;
             _client!.SurroundingTextChanged -= OnSurroundingTextChanged;
             _client!.SelectionChanged -= OnClientSelectionChanged;
+            _client!.InputPaneActivationRequested -= OnInputPaneActivationRequested;
         }
 
         if (Window.Instance.GetDefaultLayer().Children.Contains((View)TextInput))


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Reverts https://github.com/AvaloniaUI/Avalonia/pull/15603 , and introduced a proper fix fir the linked issue. Textbox should not directly interact with input panel or OS ime. 
Instead, listen to Tap event from textbox and request input panel to be shown through an event.
Requires this pr to be merged due to a bug preventing Textboxes from raising Tap events. https://github.com/AvaloniaUI/Avalonia/pull/19222

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
