### PR TITLE
[Grid] Fix inner size calculation when Row/ColumnDefinition is not set but spacing is set

### DIFF
--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -448,8 +448,8 @@ namespace Avalonia.Controls
                     MeasureCellsGroup(extData.CellGroup1, false, false);
                     double rowSpacing = RowSpacing;
                     double columnSpacing = ColumnSpacing;
-                    double combinedRowSpacing = RowSpacing * (RowDefinitions.Count - 1);
-                    double combinedColumnSpacing = ColumnSpacing * (ColumnDefinitions.Count - 1);
+                    double combinedRowSpacing = RowSpacing * (DefinitionsV.Count - 1);
+                    double combinedColumnSpacing = ColumnSpacing * (DefinitionsU.Count - 1);
                     Size innerAvailableSize = new Size(constraint.Width - combinedColumnSpacing, constraint.Height - combinedRowSpacing);
                     {
                         //  after Group1 is measured,  only Group3 may have cells belonging to Auto rows.
@@ -551,8 +551,8 @@ namespace Avalonia.Controls
                     Debug.Assert(DefinitionsU.Count > 0 && DefinitionsV.Count > 0);
                     double rowSpacing = RowSpacing;
                     double columnSpacing = ColumnSpacing;
-                    double combinedRowSpacing = rowSpacing * (RowDefinitions.Count - 1);
-                    double combinedColumnSpacing = columnSpacing * (ColumnDefinitions.Count - 1);
+                    double combinedRowSpacing = rowSpacing * (DefinitionsV.Count - 1);
+                    double combinedColumnSpacing = columnSpacing * (DefinitionsU.Count - 1);
                     SetFinalSize(DefinitionsU, arrangeSize.Width - combinedColumnSpacing, true);
                     SetFinalSize(DefinitionsV, arrangeSize.Height - combinedRowSpacing, false);
 

--- a/tests/Avalonia.Controls.UnitTests/GridTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/GridTests.cs
@@ -1900,6 +1900,36 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(grid1.Children[4].Bounds.Width, grid2.Children[0].Bounds.Width);
         }
 
+
+        [Fact]
+        public void Grid_With_ColumnSpacing_And_ColumnDefinitions_Unset()
+        {
+            var target = new Grid
+            {
+                Height = 300,
+                Width = 100,
+                ColumnSpacing = 10,
+                RowDefinitions = RowDefinitions.Parse("Auto,*"),//Set RowDefinitions to avoid 
+                Children =
+                {
+                    new Border
+                    {
+                        [Grid.RowProperty] = 0,
+                        Height = 80,
+                        Margin = new Thickness(10),
+                    },
+                    new Border
+                    {
+                        [Grid.RowProperty] = 1,
+                        Margin = new Thickness(20),
+                    },
+                },
+            };
+            target.Measure(new Size(100, 300));
+            target.Arrange(new Rect(target.DesiredSize));
+            Assert.Equal(new Rect(10, 10, 80, 80), target.Children[0].Bounds);
+            Assert.Equal(new Rect(20, 120, 60, 160),target.Children[1].Bounds);
+        }
         private class TestControl : Control
         {
             public Size MeasureSize { get; set; }


### PR DESCRIPTION

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fix inner size calculation when Row/ColumnDefinition is not set but spacing is set

## What is the current behavior?
```
<Grid RowDefinitions="Auto,*" ColumnSpacing="12">
  <Border Grid.Row="0" Height="256" Background="Aqua"/>
  <Border Grid.Row="1" Margin="12" Background="Red"/>
</Grid>
```
![d0f89b773d4f0526835f5f69f6b37caa](https://github.com/user-attachments/assets/12149e58-b823-410d-9f84-06e063bc9a51)
When ColumnSpacing is set but ColumnDefinition is not set, the inner size is not correct, leading to wrong calculation of the width of two borders.

## What is the updated/expected behavior with this PR?
The inner size is correctly calculated.

## How was the solution implemented (if it's not obvious)?
Replace Row/ColumnDefinitions with DefinitionsV/U, which ensure at least one definition, thereby preventing the calculation of negative combined spacings.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
