### PR TITLE
WIP: Fix window cannot be transparent when using EGL.

### DIFF
--- a/src/Avalonia.OpenGL/Egl/EglConsts.cs
+++ b/src/Avalonia.OpenGL/Egl/EglConsts.cs
@@ -35,7 +35,7 @@ namespace Avalonia.OpenGL.Egl
 //        public const int  EGL_MAX_PBUFFER_PIXELS = 0x302B;
 //        public const int  EGL_MAX_PBUFFER_WIDTH = 0x302C;
 //        public const int  EGL_NATIVE_RENDERABLE = 0x302D;
-//        public const int  EGL_NATIVE_VISUAL_ID = 0x302E;
+        public const int  EGL_NATIVE_VISUAL_ID = 0x302E;
 //        public const int  EGL_NATIVE_VISUAL_TYPE = 0x302F;
         public const int  EGL_NONE = 0x3038;
 //        public const int  EGL_NON_CONFORMANT_CONFIG = 0x3051;

--- a/src/Avalonia.OpenGL/Egl/EglDisplay.cs
+++ b/src/Avalonia.OpenGL/Egl/EglDisplay.cs
@@ -20,6 +20,7 @@ namespace Avalonia.OpenGL.Egl
 
         public IntPtr Handle => _display;
         public IntPtr Config => _config.Config;
+        public int NativeVisualId { get; }
         internal bool SingleContext => !_options.SupportsMultipleContexts;
         private readonly List<EglContext> _contexts = new();
         
@@ -45,7 +46,9 @@ namespace Avalonia.OpenGL.Egl
             if(_display == IntPtr.Zero)
                 throw new ArgumentException();
 
-            _config = EglDisplayUtils.InitializeAndGetConfig(_egl, display, options.GlVersions);
+            _config = EglDisplayUtils.InitializeAndGetConfig(_egl, display, options);
+            _egl.GetConfigAttrib(_display, _config.Config, EGL_NATIVE_VISUAL_ID, out var id);
+            NativeVisualId = id;
         }
         
         public EglInterface EglInterface => _egl;

--- a/src/Avalonia.OpenGL/Egl/EglDisplayOptions.cs
+++ b/src/Avalonia.OpenGL/Egl/EglDisplayOptions.cs
@@ -12,6 +12,7 @@ public class EglDisplayOptions
     public Func<bool>? DeviceLostCheckCallback { get; set; }
     public Action? DisposeCallback { get; set; }
     public IEnumerable<GlVersion>? GlVersions { get; set; }
+    public Func<EglInterface, nint, nint[], nint>? ChooseConfigCallback { get; set; }
 }
 
 public class EglContextOptions

--- a/src/Avalonia.OpenGL/Egl/EglInterface.cs
+++ b/src/Avalonia.OpenGL/Egl/EglInterface.cs
@@ -64,8 +64,8 @@ namespace Avalonia.OpenGL.Egl
 
         [GetProcAddress("eglChooseConfig")]
         public partial bool ChooseConfig(IntPtr display, int[] attribs,
-            out IntPtr surfaceConfig, int numConfigs, out int choosenConfig);
-        
+            IntPtr[]? configs, int numConfigs, out int choosenConfig);
+
         [GetProcAddress("eglCreateContext")]
         public partial IntPtr CreateContext(IntPtr display, IntPtr config,
             IntPtr share, int[] attrs);

--- a/src/Avalonia.OpenGL/Egl/EglPlatformGraphics.cs
+++ b/src/Avalonia.OpenGL/Egl/EglPlatformGraphics.cs
@@ -6,14 +6,14 @@ namespace Avalonia.OpenGL.Egl
 {
     public sealed class EglPlatformGraphics : IPlatformGraphics
     {
-        private readonly EglDisplay _display;
+        public EglDisplay Display { get; }
         public bool UsesSharedContext => false;
-        public IPlatformGraphicsContext CreateContext() => _display.CreateContext(null);
+        public IPlatformGraphicsContext CreateContext() => Display.CreateContext(null);
         public IPlatformGraphicsContext GetSharedContext() => throw new NotSupportedException();
         
         public EglPlatformGraphics(EglDisplay display)
         {
-            _display = display;
+            Display = display;
         }
         
         public static EglPlatformGraphics? TryCreate() => TryCreate(() => new EglDisplay(new EglDisplayCreationOptions
@@ -23,7 +23,7 @@ namespace Avalonia.OpenGL.Egl
             SupportsMultipleContexts = true,
             SupportsContextSharing = true
         }));
-        
+
         public static EglPlatformGraphics? TryCreate(Func<EglDisplay> displayFactory)
         {
             try

--- a/src/Avalonia.X11/X11Structs.cs
+++ b/src/Avalonia.X11/X11Structs.cs
@@ -1786,6 +1786,22 @@ namespace Avalonia.X11 {
         public ulong blue_mask;
         private fixed byte funcs[128];
     }
+
+    [Flags]
+    internal enum VisualInfoMasks : long
+    {
+        VisualNoMask = 0x0,
+        VisualIDMask = 0x1,
+        VisualScreenMask = 0x2,
+        VisualDepthMask = 0x4,
+        VisualClassMask = 0x8,
+        VisualRedMaskMask = 0x10,
+        VisualGreenMaskMask = 0x20,
+        VisualBlueMaskMask = 0x40,
+        VisualColormapSizeMask = 0x80,
+        VisualBitsPerRGBMask = 0x100,
+        VisualAllMask = 0x1FF,
+    }
     
     [StructLayout(LayoutKind.Sequential)]
     internal struct XVisualInfo

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -130,8 +130,11 @@ namespace Avalonia.X11
                 // the target sufrace currently is
                 _useCompositorDrivenRenderWindowResize = true;
             }
-            else if (glfeature == null)
+            else
+            {
+                // Egl or software (no glfeature)
                 visualInfo = _x11.TransparentVisualInfo;
+            }
 
             var egl = glfeature as EglPlatformGraphics;
             

--- a/src/Avalonia.X11/XLib.cs
+++ b/src/Avalonia.X11/XLib.cs
@@ -749,5 +749,8 @@ namespace Avalonia.X11
 
         public static int XkbSetGroupForCoreState(int state, int newGroup)
             => (state & ~(0x3 << 13)) | ((newGroup & 0x3) << 13);
+
+        [DllImport(libX11)]
+        public static extern IntPtr XGetVisualInfo(IntPtr display, VisualInfoMasks vinfo_mask, in XVisualInfo vinfo_template, out int nitems_return);
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Fix window cannot be transparent when using EGL.


## What is the current behavior?
If using EGL, `visualInfo` will be null. Then the window will be 24-bit depth, so it cannot be transparent.


## What is the updated/expected behavior with this PR?
Window can be transparent when using EGL.


## How was the solution implemented (if it's not obvious)?
Using `_x11.TransparentVisualInfo`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes


## Obsoletions / Deprecations


## Fixed issues

