### PR TITLE
Fix typo in XML documentation for ExtendClientAreaChromeHints enum

### DIFF
--- a/src/Avalonia.Controls/Platform/ExtendClientAreaChromeHints.cs
+++ b/src/Avalonia.Controls/Platform/ExtendClientAreaChromeHints.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Platform
     public enum ExtendClientAreaChromeHints
     {
         /// <summary>
-        /// The will be no chrome at all.
+        /// There will be no chrome at all.
         /// </summary>
         NoChrome,
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes the typo in the XML documentation for `ExtendClientAreaChromeHints` enum.
The typo was:
> **The** will be no chrome at all.

## How was the solution implemented
Fixed "The" → "There" in the XML documentation comment.
No functional code changes.