### PR TITLE
Fix X11Screen info update incorrectly when screen changed.

### DIFF
--- a/src/Avalonia.X11/Screens/X11Screens.cs
+++ b/src/Avalonia.X11/Screens/X11Screens.cs
@@ -15,7 +15,7 @@ namespace Avalonia.X11.Screens
             _impl = (info.RandrVersion != null && info.RandrVersion >= new Version(1, 5))
                 ? new Randr15ScreensImpl(platform)
                 : (IX11RawScreenInfoProvider)new FallbackScreensImpl(platform);
-            _impl.Changed += () => Changed?.Invoke();
+            _impl.Changed += OnChanged;
         }
 
         protected override int GetScreenCount() => _impl.ScreenKeys.Length;
@@ -24,6 +24,13 @@ namespace Avalonia.X11.Screens
 
         protected override X11Screen CreateScreenFromKey(nint key) => _impl.CreateScreenFromKey(key);
 
-        protected override void ScreenChanged(X11Screen screen) => screen.Refresh();
+        protected override void ScreenChanged(X11Screen screen)
+        {
+            var handle = screen.TryGetPlatformHandle()?.Handle;
+            if (handle != null)
+            {
+                screen.Refresh(_impl.GetMonitorInfoByKey(handle.Value));
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix bug.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
On Linux，when TopLevel.Screens.Changed invoke（change the resolution or dpi of the screen in system settings），use Screens.ScreenFromWindow to get current screen of the window.The screen return with wrong info（resolution or dpi）.
