### PR TITLE
Fix OSXThickTitleBar event handling

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -491,6 +491,12 @@
                 AvnView* view = parent->View;
                 NSPoint windowPoint = [event locationInWindow];
                 NSPoint viewPoint = [view convertPoint:windowPoint fromView:nil];
+
+                NSRect bounds = view.bounds;
+                if ([self getExtendedTitleBarHeight] > 0)
+                {
+                    bounds.size.height += [self getExtendedTitleBarHeight];
+                }
                 
                 auto targetView = [[self findRootView:view] hitTest: windowPoint];
                 if(targetView)
@@ -500,7 +506,7 @@
                         return;
                 }
                 
-                if (!NSPointInRect(viewPoint, view.bounds))
+                if (!NSPointInRect(viewPoint, bounds))
                 {
                     auto avnPoint = ToAvnPoint(windowPoint);
                     auto point = [self translateLocalPoint:avnPoint];


### PR DESCRIPTION
Adjusted macOS event handling to include the extended title bar height when determining whether pointer events occur inside the client area. This prevents pointer events from being misclassified as non-client when the thick title bar is enabled

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes https://github.com/AvaloniaUI/Avalonia/issues/15696