### PR TITLE
Track current focus tree with dictionary for updating IsKeyboardFocusWithin

### DIFF
--- a/src/Avalonia.Base/ElementTreeState.cs
+++ b/src/Avalonia.Base/ElementTreeState.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+
+namespace Avalonia
+{
+    internal class ElementTreeState
+    {
+        private Dictionary<Visual, Visual?> _visualParents = new Dictionary<Visual, Visual?>();
+
+        public void SetVisualParent(Visual visual, Visual? parent)
+        {
+            if (!_visualParents.ContainsKey(visual))
+                _visualParents[visual] = parent;
+        }
+
+        public Visual? GetVisualParent(Visual? visual)
+        {
+            if (visual != null && _visualParents.TryGetValue(visual, out var parent))
+                return parent;
+
+            return null;
+        }
+
+        public void RemoveVisualParent(Visual? visual)
+        {
+            if(visual != null && _visualParents.ContainsKey(visual))
+                _visualParents.Remove(visual);
+        }
+
+        public void Clear()
+        {
+            _visualParents.Clear();
+        }
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -670,6 +670,51 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void Popup_Should_Clear_Keyboard_Focus_From_Children_When_Closed()
+        {
+            using (CreateServicesWithFocus())
+            {
+                var winButton = new Button();
+                var window = PreparedWindow(new Panel { Children = { winButton }});
+
+                var border1 = new Border();
+                var border2 = new Border();
+                var button = new Button();
+                border1.Child = border2;
+                border2.Child = button;
+                var popup = new Popup
+                {
+                    PlacementTarget = window,
+                    Child = new StackPanel
+                    {
+                        Children =
+                        {
+                            border1
+                        }
+                    }
+                };
+
+                ((ISetLogicalParent)popup).SetParent(popup.PlacementTarget);
+                window.Show();
+                winButton.Focus();
+                popup.Open();
+
+                button.Focus();
+
+                var inputRoot = Assert.IsAssignableFrom<IInputRoot>(popup.Host);
+
+                var focusManager = inputRoot.FocusManager!;
+                Assert.Same(button, focusManager.GetFocusedElement());
+
+                border1.Child = null;
+
+                winButton.Focus();
+
+                Assert.False(border2.IsKeyboardFocusWithin);
+            }
+        }
+
+        [Fact]
         public void Closing_Popup_Sets_Focus_On_PlacementTarget()
         {
             using (CreateServicesWithFocus())


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Instead of going up the visual tree when clearing `IsKeyboardFocusWithin`, this pr stores the all elements with focus within in a dictionary and searches that instead when clearing the property. This fixes issues where orphaned visual elements don't reset the `IsKeyboardFocusWithin` property when focus switches between visual roots(see test commit).

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [X] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/19299