### PR TITLE
Fix multiline selection crash

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Input/AvaloniaInputConnection.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AvaloniaInputConnection.cs
@@ -285,14 +285,14 @@ namespace Avalonia.Android.Platform.Input
         public ICharSequence? GetTextAfterCursorFormatted(int n, [GeneratedEnum] GetTextFlags flags)
         {
             var end = Math.Min(_editBuffer.Selection.End, _editBuffer.Text.Length);
-            return new Java.Lang.String(_editBuffer.Text.Substring(end, Math.Min(n, _editBuffer.Text.Length - end)));
+            return SafeSubstring(_editBuffer.Text, end, Math.Min(n, _editBuffer.Text.Length - end));
         }
 
         public ICharSequence? GetTextBeforeCursorFormatted(int n, [GeneratedEnum] GetTextFlags flags)
         {
             var start = Math.Max(0, _editBuffer.Selection.Start - n);
             var length = _editBuffer.Selection.Start - start;
-            return _editBuffer.Text == null ? null : new Java.Lang.String(_editBuffer.Text.Substring(start, length));
+            return SafeSubstring(_editBuffer.Text, start, length);
         }
 
         public bool PerformPrivateCommand(string? action, Bundle? data)
@@ -329,6 +329,14 @@ namespace Avalonia.Android.Platform.Input
             {
                 EndBatchEdit();
             }
+        }
+
+        private static ICharSequence? SafeSubstring(string? text, int start, int length)
+        {
+            if (text == null || text.Length < start + length)
+                return null;
+            else
+                return new Java.Lang.String(text.Substring(start, length));
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Fixes #19336.

## What is the current behavior?

Crash.

## What is the updated/expected behavior with this PR?

No crash.

## How was the solution implemented (if it's not obvious)?

Returns `null` when the text is shorter than start index + length in `GetTextBeforeCursorFormatted`. `_editBuffer.Text` only returns the current line, which is why the character counts in multiline selection don't add up. A proper solution would probably involve working with the entire content of the textbox, but that's beyond my understanding of Avalonia text handling works, and this is still better than crashing.