### PR TITLE
[iOS] Enable Pointer/Trackpad scrolling

### DIFF
--- a/src/iOS/Avalonia.iOS/AvaloniaView.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaView.cs
@@ -76,6 +76,17 @@ namespace Avalonia.iOS
             {
 #if !TVOS
                 MultipleTouchEnabled = true;
+                
+                if (OperatingSystem.IsIOSVersionAtLeast(13, 4) || OperatingSystem.IsMacCatalyst())
+                {
+                    var scrollGestureRecognizer = new UIPanGestureRecognizer(_input.HandleScrollWheel)
+                    {
+                        // Only respond to scroll events, not touches
+                        MaximumNumberOfTouches = 0,
+                        AllowedScrollTypesMask = UIScrollTypeMask.Discrete | UIScrollTypeMask.Continuous
+                    };
+                    AddGestureRecognizer(scrollGestureRecognizer);
+                }
 #endif
             }
         }

--- a/src/iOS/Avalonia.iOS/InputHandler.cs
+++ b/src/iOS/Avalonia.iOS/InputHandler.cs
@@ -370,14 +370,17 @@ internal sealed class InputHandler
         // even though the pointer on screen is not moving.
         // We can cache the location when we start scrolling and keep it static
         // until the inertia stops.
-        _tl.Input?.Invoke(new RawMouseWheelEventArgs(
+        if (_cachedScrollLocation is not null)
+        {
+            _tl.Input?.Invoke(new RawMouseWheelEventArgs(
             _mouseDevice, 
             (ulong)(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()), 
             Root,
-            _cachedScrollLocation ?? new Point(0, 0),
+            _cachedScrollLocation.Value,
             new Vector(_momentumVelocityX, _momentumVelocityY),
             RawInputModifiers.None
         ));
+        }
 #endif
     }
 

--- a/src/iOS/Avalonia.iOS/InputHandler.cs
+++ b/src/iOS/Avalonia.iOS/InputHandler.cs
@@ -6,6 +6,9 @@ using Avalonia.Input.Raw;
 using Avalonia.Platform;
 using Foundation;
 using UIKit;
+#if !TVOS
+using CoreAnimation;
+#endif
 
 namespace Avalonia.iOS;
 
@@ -20,6 +23,14 @@ internal sealed class InputHandler
     private readonly PenDevice _penDevice = new(releasePointerOnPenUp: true);
     private static long _nextTouchPointId = 1;
     private readonly Dictionary<UITouch, long> _knownTouches = new();
+    private Point? _cachedScrollLocation;
+    
+    #if !TVOS
+    private CADisplayLink? _momentumDisplayLink;
+    private double _momentumVelocityX;
+    private double _momentumVelocityY;
+    private const double DecelerationRate = 0.95;
+    #endif
 
     public InputHandler(AvaloniaView view, ITopLevelImpl tl)
     {
@@ -247,6 +258,117 @@ internal sealed class InputHandler
         }
 
         return modifier;
+    }
+
+    public void HandleScrollWheel(UIPanGestureRecognizer recognizer)
+    {
+        switch (recognizer.State)
+        {
+            case UIGestureRecognizerState.Began:
+                StopMomentumScrolling();
+                _cachedScrollLocation = recognizer.LocationInView(_view).ToAvalonia();
+                return;
+            case UIGestureRecognizerState.Changed:
+                SendActiveScrollEvent(recognizer);
+                return;
+            case UIGestureRecognizerState.Ended:
+                StartInertiaScrolling(recognizer);
+                return;
+            case UIGestureRecognizerState.Cancelled:
+            case UIGestureRecognizerState.Failed:
+                StopMomentumScrolling();
+                return;
+            default:
+                return;
+        }
+    }
+
+    private void SendActiveScrollEvent(UIPanGestureRecognizer recognizer)
+    {
+#if !TVOS
+        // iOS 13.4+ and Catalyst support scroll wheel events
+        if (!OperatingSystem.IsIOSVersionAtLeast(13, 4) && !OperatingSystem.IsMacCatalyst())
+            return;
+
+        var velocity = recognizer.VelocityInView(_view);
+        
+        // Use much more sensitive scaling for active scrolling to match AppKit.
+        // macOS uses small deltas, so we need much larger divisors
+        var scaleFactor = 3000.0;
+        
+        var deltaX = velocity.X / scaleFactor;
+        var deltaY = velocity.Y / scaleFactor;
+            
+        var location = _cachedScrollLocation ?? new Point(0, 0);
+        var timestamp = (ulong)(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        
+        var scrollEvent = new RawMouseWheelEventArgs(
+            _mouseDevice, 
+            timestamp, 
+            Root,
+            location,
+            new Vector(deltaX, deltaY),
+            RawInputModifiers.None
+        );
+        
+        _tl.Input?.Invoke(scrollEvent);
+#endif
+    }
+
+    private void StartInertiaScrolling(UIPanGestureRecognizer recognizer)
+    {
+#if !TVOS
+        // iOS 13.4+ and Catalyst support scroll wheel events
+        if (!OperatingSystem.IsIOSVersionAtLeast(13, 4) && !OperatingSystem.IsMacCatalyst())
+            return;
+
+        var velocity = recognizer.VelocityInView(_view);
+        
+        var scaleFactor = 800.0;
+        _momentumVelocityX = velocity.X / scaleFactor;
+        _momentumVelocityY = velocity.Y / scaleFactor;
+        _momentumDisplayLink = CADisplayLink.Create(UpdateInertiaScrolling);
+        _momentumDisplayLink.AddToRunLoop(NSRunLoop.Main, NSRunLoopMode.Common);
+#endif
+    }
+
+    private void StopMomentumScrolling()
+    {
+#if !TVOS
+        if (_momentumDisplayLink != null)
+        {
+            // Invalidate removes it from all run loops
+            // https://developer.apple.com/documentation/quartzcore/cadisplaylink
+            _momentumDisplayLink.Invalidate();
+            _momentumDisplayLink = null;
+        }
+        
+        _momentumVelocityX = 0;
+        _momentumVelocityY = 0;
+        _cachedScrollLocation = null;
+#endif
+    }
+
+    private void UpdateInertiaScrolling()
+    {
+#if !TVOS
+        _momentumVelocityX *= DecelerationRate;
+        _momentumVelocityY *= DecelerationRate;
+        
+        // UIPanGestureRecognizer will continue to upload the location of the pointer,
+        // to where it would be if it was moving with the current velocity,
+        // even though the pointer on screen is not moving.
+        // We can cache the location when we start scrolling and keep it static
+        // until the inertia stops.
+        _tl.Input?.Invoke(new RawMouseWheelEventArgs(
+            _mouseDevice, 
+            (ulong)(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()), 
+            Root,
+            _cachedScrollLocation ?? new Point(0, 0),
+            new Vector(_momentumVelocityX, _momentumVelocityY),
+            RawInputModifiers.None
+        ));
+#endif
     }
 
 #pragma warning disable CA1416

--- a/src/iOS/Avalonia.iOS/InputHandler.cs
+++ b/src/iOS/Avalonia.iOS/InputHandler.cs
@@ -298,20 +298,15 @@ internal sealed class InputHandler
         
         var deltaX = velocity.X / scaleFactor;
         var deltaY = velocity.Y / scaleFactor;
-            
-        var location = _cachedScrollLocation ?? new Point(0, 0);
-        var timestamp = (ulong)(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
         
-        var scrollEvent = new RawMouseWheelEventArgs(
+        _tl.Input?.Invoke(new RawMouseWheelEventArgs(
             _mouseDevice, 
-            timestamp, 
+            (ulong)(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()), 
             Root,
-            location,
+            _cachedScrollLocation ?? new Point(0, 0),
             new Vector(deltaX, deltaY),
             RawInputModifiers.None
-        );
-        
-        _tl.Input?.Invoke(scrollEvent);
+        ));
 #endif
     }
 

--- a/src/iOS/Avalonia.iOS/InputHandler.cs
+++ b/src/iOS/Avalonia.iOS/InputHandler.cs
@@ -359,7 +359,7 @@ internal sealed class InputHandler
 
         var currentMagnitude = Math.Sqrt(_momentumVelocityX * _momentumVelocityX + _momentumVelocityY * _momentumVelocityY);
 
-        if (currentMagnitude < 0.0001)
+        if (currentMagnitude < 0.0001 || _cachedScrollLocation is null)
         {
             StopMomentumScrolling();
             return;
@@ -370,9 +370,7 @@ internal sealed class InputHandler
         // even though the pointer on screen is not moving.
         // We can cache the location when we start scrolling and keep it static
         // until the inertia stops.
-        if (_cachedScrollLocation is not null)
-        {
-            _tl.Input?.Invoke(new RawMouseWheelEventArgs(
+        _tl.Input?.Invoke(new RawMouseWheelEventArgs(
             _mouseDevice, 
             (ulong)(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()), 
             Root,
@@ -380,7 +378,6 @@ internal sealed class InputHandler
             new Vector(_momentumVelocityX, _momentumVelocityY),
             RawInputModifiers.None
         ));
-        }
 #endif
     }
 


### PR DESCRIPTION
## What does the pull request do?
Enables the iPadOS Trackpad and Mouse support for scrolling and panning.

## What is the current behavior?
If you use Avalonia.iOS, either as an app or embedded within a view, and use a trackpad or mouse for navigation, scrolling does not work. This is because iOS/iPadOS does not treat scroll events with a device as a touch event. So currently, scrolling or panning within a view does nothing, The only thing that works is clicks.


## What is the updated/expected behavior with this PR?
Scroll events should be handled correctly and should match what they are on AppKit. What's done here will also work for Mac Catalyst, if and when support for that is enabled.

## How was the solution implemented (if it's not obvious)?
Scroll events can be implemented using a UIPanGestureRecognizer. This contains the two finger gesture used for scrolling and mouse scroll wheels, and works on iOS and Mac Catalyst. It handles sending the correct values for natural scrolling so we only need to care about the values returned.

We calculate the momentum caused by the gesture event. This should map to the similar logic used for macOS, where if you hold down the gesture for scrolling you'll get exact movement, and once you lift or flick you'll get momentum.

The calculations for momentum are done with a CADisplayLink Runloop that gets added or removed when the gesture is done.

The location of the cursor when the gesture starts is cached. As far as I can tell, the position of the pointer within the view moves during the scroll gesture, even when it's not moving on screen, which can cause the pointer to move to another area and cause unrelated elements to start scrolling. Caching the position of the pointer fixes this.

If you're using the simulator for testing, be sure to enable the pointer. If you try scrolling with touch mode, it won't do anything, which is expected.