### PR TITLE
[iOS] Implement Save File Picker Support

### DIFF
--- a/samples/ControlCatalog.iOS/Info.plist
+++ b/samples/ControlCatalog.iOS/Info.plist
@@ -16,7 +16,6 @@
 	<array>
 		<integer>1</integer>
 		<integer>2</integer>
-        <integer>3</integer>
 	</array>
     <key>UIRequiredDeviceCapabilities</key>
     <array>
@@ -38,5 +37,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>

--- a/src/iOS/Avalonia.iOS/Storage/IOSStorageProvider.cs
+++ b/src/iOS/Avalonia.iOS/Storage/IOSStorageProvider.cs
@@ -195,7 +195,7 @@ internal class IOSStorageProvider : IStorageProvider
         var tempFileUrl = tempDir.Append(tempFileName, false);
         
         // Create an empty file at the temp location
-        NSData.FromString("").Save(tempFileUrl, false);
+        NSData.FromBytes(0, 0).Save(tempFileUrl, false);
         
         UIDocumentPickerViewController documentPicker;
         if (OperatingSystem.IsIOSVersionAtLeast(14))

--- a/src/iOS/Avalonia.iOS/Storage/IOSStorageProvider.cs
+++ b/src/iOS/Avalonia.iOS/Storage/IOSStorageProvider.cs
@@ -226,9 +226,9 @@ internal class IOSStorageProvider : IStorageProvider
             var tcs = new TaskCompletionSource<NSUrl[]>();
             documentPicker.Delegate = new PickerDelegate(urls => tcs.TrySetResult(urls));
             var urls = await ShowPicker(documentPicker, tcs);
-            
-            // Clean up the temporary file
-            NSFileManager.DefaultManager.Remove(tempFileUrl, out _);
+
+            // Clean up the temporary directory
+            NSFileManager.DefaultManager.Remove(tempDir, out _);
             
             return urls.FirstOrDefault() is { } url ? new IOSStorageFile(url) : null;
         }

--- a/src/iOS/Avalonia.iOS/Storage/IOSStorageProvider.cs
+++ b/src/iOS/Avalonia.iOS/Storage/IOSStorageProvider.cs
@@ -175,15 +175,10 @@ internal class IOSStorageProvider : IStorageProvider
         */
 
         // Create a temporary file to use with the document picker
-        var tempFileName = options.SuggestedFileName ?? "document";
-        if (!string.IsNullOrEmpty(options.DefaultExtension))
-        {
-            var extension = options.DefaultExtension.StartsWith('.') ? options.DefaultExtension : "." + options.DefaultExtension;
-            if (!tempFileName.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
-            {
-                tempFileName += extension;
-            }
-        }
+        var tempFileName = StorageProviderHelpers.NameWithExtension(
+            options.SuggestedFileName ?? "document", 
+            options.DefaultExtension, 
+            options.FileTypeChoices?.FirstOrDefault());
         
         var tempDir = NSFileManager.DefaultManager.GetTemporaryDirectory().Append(Guid.NewGuid().ToString(), true);
         if (tempDir == null)

--- a/src/iOS/Avalonia.iOS/Storage/IOSStorageProvider.cs
+++ b/src/iOS/Avalonia.iOS/Storage/IOSStorageProvider.cs
@@ -26,7 +26,7 @@ internal class IOSStorageProvider : IStorageProvider
 
     public bool CanOpen => true;
 
-    public bool CanSave => false;
+    public bool CanSave => true;
 
     public bool CanPickFolder => true;
 
@@ -161,10 +161,77 @@ internal class IOSStorageProvider : IStorageProvider
         return Task.FromResult<IStorageFolder?>(new IOSStorageFolder(uri, wellKnownFolder));
     }
 
-    public Task<IStorageFile?> SaveFilePickerAsync(FilePickerSaveOptions options)
+    public async Task<IStorageFile?> SaveFilePickerAsync(FilePickerSaveOptions options)
     {
-        return Task.FromException<IStorageFile?>(
-            new PlatformNotSupportedException("Save file picker is not supported by iOS"));
+        /* 
+            This requires a bit of dialog here...
+            To save a file, we need to present the user with a document picker
+            This requires a temp file to be created and used to "export" the file to.
+            When the user picks the file location and name, UIDocumentPickerViewController
+            will give back the URI to the real file location, which we can then use 
+            to give back as an IStorageFile.
+            https://developer.apple.com/documentation/uikit/uidocumentpickerviewcontroller
+            Yes, it is weird, but without the temp file it will explode.
+        */
+
+        // Create a temporary file to use with the document picker
+        var tempFileName = options.SuggestedFileName ?? "document";
+        if (!string.IsNullOrEmpty(options.DefaultExtension))
+        {
+            var extension = options.DefaultExtension.StartsWith('.') ? options.DefaultExtension : "." + options.DefaultExtension;
+            if (!tempFileName.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+            {
+                tempFileName += extension;
+            }
+        }
+        
+        var tempDir = NSFileManager.DefaultManager.GetTemporaryDirectory().Append(Guid.NewGuid().ToString(), true);
+        if (tempDir == null)
+        {
+            throw new InvalidOperationException("Failed to get temporary directory for save file picker");
+        }
+
+        var isDirectoryCreated = NSFileManager.DefaultManager.CreateDirectory(tempDir, true, null, out var error);
+        if (!isDirectoryCreated)
+        {
+            throw new InvalidOperationException("Failed to create temporary directory for save file picker");
+        }
+        
+        var tempFileUrl = tempDir.Append(tempFileName, false);
+        
+        // Create an empty file at the temp location
+        NSData.FromString("").Save(tempFileUrl, false);
+        
+        UIDocumentPickerViewController documentPicker;
+        if (OperatingSystem.IsIOSVersionAtLeast(14))
+        {
+            documentPicker = new UIDocumentPickerViewController(new[] { tempFileUrl }, asCopy: true);
+        }
+        else
+        {
+#pragma warning disable CA1422
+            documentPicker = new UIDocumentPickerViewController(tempFileUrl, UIDocumentPickerMode.ExportToService);
+#pragma warning restore CA1422
+        }
+        
+        using (documentPicker)
+        {
+            if (OperatingSystem.IsIOSVersionAtLeast(13))
+            {
+                documentPicker.DirectoryUrl = GetUrlFromFolder(options.SuggestedStartLocation);
+            }
+            
+            documentPicker.Title = options.Title;
+            
+            var tcs = new TaskCompletionSource<NSUrl[]>();
+            documentPicker.Delegate = new PickerDelegate(urls => tcs.TrySetResult(urls));
+            var urls = await ShowPicker(documentPicker, tcs);
+            
+            // Clean up the temporary file
+            NSFileManager.DefaultManager.Remove(tempFileUrl, out _);
+            
+            return urls.FirstOrDefault() is { } url ? new IOSStorageFile(url) : null;
+        }
     }
 
     public async Task<IReadOnlyList<IStorageFolder>> OpenFolderPickerAsync(FolderPickerOpenOptions options)


### PR DESCRIPTION
https://github.com/user-attachments/assets/73483437-4a77-41bb-952d-a61a658a289c

<img width="724" height="374" alt="image" src="https://github.com/user-attachments/assets/0b9ddc57-e36d-4ea7-ac75-f4fd17d9a2d3" />

## What does the pull request do?
Implements SaveFilePickerAsync for Avalonia.iOS

## What is the current behavior?
Throws an exception saying that Saving Files is unsupported.


## What is the updated/expected behavior with this PR?
Allows for saving files on iOS and Mac Catalyst.

## How was the solution implemented (if it's not obvious)?
UIDocumentPickerViewController can "export" and "copy" files to a user's device. For it to work, you need to create a temp file that is passed into the picker, set as a copy. The user picks the file name and location to save to. If they follow through, you get an IStorageFile with a URI that can be written to. 

It's similar in approach to the [MAUI CommunityToolkit](https://github.com/CommunityToolkit/Maui/blob/main/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverImplementation.macios.cs) implementation, except the file is written to after the fact.

Note that for Read/Write access from outside the App Sandbox, you need to enable

```
<key>com.apple.security.files.user-selected.read-write</key>
<true/>
```

in the info.plist.