### PR TITLE
Add AllowTapRangeSelection for Calendar

### DIFF
--- a/samples/ControlCatalog/Pages/CalendarPage.xaml
+++ b/samples/ControlCatalog/Pages/CalendarPage.xaml
@@ -33,6 +33,11 @@
         <Calendar SelectionMode="MultipleRange" />
       </StackPanel>
       <StackPanel>
+        <TextBlock Text="Tap Range Selection" />
+        <Calendar SelectionMode="SingleRange"
+                  AllowTapRangeSelection="True" />
+      </StackPanel>
+      <StackPanel>
         <TextBlock Text="DisplayDates"/>
         <Calendar Name="DisplayDatesCalendar"
                   SelectionMode="SingleDate" />

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -442,7 +442,7 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<bool> AllowTapRangeSelectionProperty =
             AvaloniaProperty.Register<Calendar, bool>(
                 nameof(AllowTapRangeSelection),
-                defaultValue: false);
+                defaultValue: true);
 
         /// <summary>
         /// Gets or sets a value that indicates what kind of selections are

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -237,6 +237,8 @@ namespace Avalonia.Controls
 
         private bool _isShiftPressed;
         private bool _displayDateIsChanging;
+        private bool _isTapRangeSelectionActive;
+        private DateTime? _tapRangeStart;
 
         internal CalendarDayButton? FocusButton { get; set; }
         internal CalendarButton? FocusCalendarButton { get; set; }
@@ -437,6 +439,11 @@ namespace Avalonia.Controls
                 nameof(SelectionMode),
                 defaultValue: CalendarSelectionMode.SingleDate);
 
+        public static readonly StyledProperty<bool> AllowTapRangeSelectionProperty =
+            AvaloniaProperty.Register<Calendar, bool>(
+                nameof(AllowTapRangeSelection),
+                defaultValue: false);
+
         /// <summary>
         /// Gets or sets a value that indicates what kind of selections are
         /// allowed.
@@ -462,6 +469,24 @@ namespace Avalonia.Controls
             set => SetValue(SelectionModeProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether tap-to-select range mode is enabled.
+        /// When enabled, users can tap a start date and then tap an end date to select a range.
+        /// </summary>
+        /// <value>
+        /// True to enable tap range selection; otherwise, false. The default is false.
+        /// </value>
+        /// <remarks>
+        /// This feature only works when SelectionMode is set to SingleRange.
+        /// When enabled, the first tap selects the start date, and the second tap selects 
+        /// the end date to complete the range. Tapping a third date starts a new range.
+        /// </remarks>
+        public bool AllowTapRangeSelection
+        {
+            get => GetValue(AllowTapRangeSelectionProperty);
+            set => SetValue(AllowTapRangeSelectionProperty, value);
+        }
+
         private void OnSelectionModeChanged(AvaloniaPropertyChangedEventArgs e)
         {
             if (IsValidSelectionMode(e.NewValue!))
@@ -470,11 +495,21 @@ namespace Avalonia.Controls
                 SetCurrentValue(SelectedDateProperty, null);
                 _displayDateIsChanging = false;
                 SelectedDates.Clear();
+                
+                // Reset tap range selection state when mode changes
+                _isTapRangeSelectionActive = false;
+                _tapRangeStart = null;
             }
             else
             {
                 throw new ArgumentOutOfRangeException(nameof(e), "Invalid SelectionMode");
             }
+        }
+
+        private void OnAllowTapRangeSelectionChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            _isTapRangeSelectionActive = false;
+            _tapRangeStart = null;
         }
 
         /// <summary>
@@ -1450,6 +1485,94 @@ namespace Avalonia.Controls
                 SelectedDates.AddRange(HoverStart.Value, HoverEnd.Value);
             }
         }
+
+        /// <summary>
+        /// Handles tap range selection logic for date range selection.
+        /// </summary>
+        /// <param name="selectedDate">The date that was tapped.</param>
+        /// <returns>True if the tap was handled as part of range selection; otherwise, false.</returns>
+        internal bool ProcessTapRangeSelection(DateTime selectedDate)
+        {
+            if (!AllowTapRangeSelection || 
+                (SelectionMode != CalendarSelectionMode.SingleRange && SelectionMode != CalendarSelectionMode.MultipleRange))
+            {
+                return false;
+            }
+
+            if (!IsValidDateSelection(this, selectedDate))
+            {
+                return false;
+            }
+
+            if (!_isTapRangeSelectionActive || !_tapRangeStart.HasValue)
+            {
+                _isTapRangeSelectionActive = true;
+                _tapRangeStart = selectedDate;
+                
+                if (SelectionMode == CalendarSelectionMode.SingleRange)
+                {
+                    foreach (DateTime item in SelectedDates)
+                    {
+                        RemovedItems.Add(item);
+                    }
+                    SelectedDates.ClearInternal();
+                }
+
+                if (!SelectedDates.Contains(selectedDate))
+                {
+                    SelectedDates.Add(selectedDate);
+                }
+
+                return true;
+            }
+            else
+            {
+                DateTime startDate = _tapRangeStart.Value;
+                DateTime endDate = selectedDate;
+
+                if (DateTime.Compare(startDate, endDate) > 0)
+                {
+                    (startDate, endDate) = (endDate, startDate);
+                }
+
+                CalendarDateRange range = new CalendarDateRange(startDate, endDate);
+                if (BlackoutDates.ContainsAny(range))
+                {
+                    _tapRangeStart = selectedDate;
+                    
+                    if (SelectionMode == CalendarSelectionMode.SingleRange)
+                    {
+                        foreach (DateTime item in SelectedDates)
+                        {
+                            RemovedItems.Add(item);
+                        }
+                        SelectedDates.ClearInternal();
+                    }
+                    
+                    if (!SelectedDates.Contains(selectedDate))
+                    {
+                        SelectedDates.Add(selectedDate);
+                    }
+                    return true;
+                }
+
+                if (SelectionMode == CalendarSelectionMode.SingleRange)
+                {
+                    foreach (DateTime item in SelectedDates)
+                    {
+                        RemovedItems.Add(item);
+                    }
+                    SelectedDates.ClearInternal();
+                }
+
+                SelectedDates.AddRange(startDate, endDate);
+
+                _isTapRangeSelectionActive = false;
+                _tapRangeStart = null;
+
+                return true;
+            }
+        }
         private void ProcessSelection(bool shift, DateTime? lastSelectedDate, int? index)
         {
             if (SelectionMode == CalendarSelectionMode.None && lastSelectedDate != null)
@@ -1457,6 +1580,17 @@ namespace Avalonia.Controls
                 OnDayClick(lastSelectedDate.Value);
                 return;
             }
+
+            // Handle tap range selection.
+            if (lastSelectedDate != null && index == null && !shift)
+            {
+                if (ProcessTapRangeSelection(lastSelectedDate.Value))
+                {
+                    OnDayClick(lastSelectedDate.Value);
+                    return;
+                }
+            }
+
             if (lastSelectedDate != null && IsValidKeyboardSelection(this, lastSelectedDate.Value))
             {
                 if (SelectionMode == CalendarSelectionMode.SingleRange || SelectionMode == CalendarSelectionMode.MultipleRange)
@@ -2069,6 +2203,7 @@ namespace Avalonia.Controls
             IsTodayHighlightedProperty.Changed.AddClassHandler<Calendar>((x, e) => x.OnIsTodayHighlightedChanged(e));
             DisplayModeProperty.Changed.AddClassHandler<Calendar>((x, e) => x.OnDisplayModePropertyChanged(e));
             SelectionModeProperty.Changed.AddClassHandler<Calendar>((x, e) => x.OnSelectionModeChanged(e));
+            AllowTapRangeSelectionProperty.Changed.AddClassHandler<Calendar>((x, e) => x.OnAllowTapRangeSelectionChanged(e));
             SelectedDateProperty.Changed.AddClassHandler<Calendar>((x, e) => x.OnSelectedDateChanged(e));
             DisplayDateProperty.Changed.AddClassHandler<Calendar>((x, e) => x.OnDisplayDateChanged(e));
             DisplayDateStartProperty.Changed.AddClassHandler<Calendar>((x, e) => x.OnDisplayDateStartChanged(e));

--- a/src/Avalonia.Controls/Calendar/CalendarItem.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarItem.cs
@@ -19,11 +19,11 @@ namespace Avalonia.Controls.Primitives
     /// Represents the currently displayed month or year on a
     /// <see cref="T:Avalonia.Controls.Calendar" />.
     /// </summary>
-    [TemplatePart(PART_ElementHeaderButton,   typeof(Button))]
-    [TemplatePart(PART_ElementMonthView,      typeof(Grid))]
-    [TemplatePart(PART_ElementNextButton,     typeof(Button))]
+    [TemplatePart(PART_ElementHeaderButton, typeof(Button))]
+    [TemplatePart(PART_ElementMonthView, typeof(Grid))]
+    [TemplatePart(PART_ElementNextButton, typeof(Button))]
     [TemplatePart(PART_ElementPreviousButton, typeof(Button))]
-    [TemplatePart(PART_ElementYearView,       typeof(Grid))]
+    [TemplatePart(PART_ElementYearView, typeof(Grid))]
     [PseudoClasses(":calendardisabled")]
     public sealed class CalendarItem : TemplatedControl
     {
@@ -41,7 +41,7 @@ namespace Avalonia.Controls.Primitives
         private Button? _headerButton;
         private Button? _nextButton;
         private Button? _previousButton;
-        
+
         private DateTime _currentMonth;
         private bool _isMouseLeftButtonDown;
         private bool _isMouseLeftButtonDownYearView;
@@ -163,7 +163,7 @@ namespace Avalonia.Controls.Primitives
         /// Gets the Grid that hosts the content when in year or decade mode.
         /// </summary>
         internal Grid? YearView { get; set; }
-        
+
         private void PopulateGrids()
         {
             if (MonthView != null)
@@ -206,7 +206,7 @@ namespace Avalonia.Controls.Primitives
                         children.Add(cell);
                     }
                 }
-                
+
                 MonthView.Children.AddRange(children);
             }
 
@@ -254,7 +254,7 @@ namespace Avalonia.Controls.Primitives
             NextButton = e.NameScope.Find<Button>(PART_ElementNextButton);
             MonthView = e.NameScope.Find<Grid>(PART_ElementMonthView);
             YearView = e.NameScope.Find<Grid>(PART_ElementYearView);
-            
+
             if (Owner != null)
             {
                 UpdateDisabled(Owner.IsEnabled);
@@ -886,7 +886,7 @@ namespace Avalonia.Controls.Primitives
                 }
             }
         }
-        
+
         internal void Cell_MouseLeftButtonDown(object? sender, PointerPressedEventArgs e)
         {
             if (Owner != null)
@@ -1029,6 +1029,17 @@ namespace Avalonia.Controls.Primitives
                     {
                         Owner.OnDayClick(selectedDate);
                         return;
+                    }
+
+                    if (Owner.AllowTapRangeSelection &&
+                        (Owner.SelectionMode == CalendarSelectionMode.SingleRange
+                            || Owner.SelectionMode == CalendarSelectionMode.MultipleRange))
+                    {
+                        if (Owner.ProcessTapRangeSelection(selectedDate))
+                        {
+                            Owner.OnDayClick(selectedDate);
+                            return;
+                        }
                     }
                     if (Owner.HoverStart.HasValue)
                     {

--- a/src/Avalonia.Controls/Calendar/CalendarItem.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarItem.cs
@@ -19,11 +19,11 @@ namespace Avalonia.Controls.Primitives
     /// Represents the currently displayed month or year on a
     /// <see cref="T:Avalonia.Controls.Calendar" />.
     /// </summary>
-    [TemplatePart(PART_ElementHeaderButton, typeof(Button))]
-    [TemplatePart(PART_ElementMonthView, typeof(Grid))]
-    [TemplatePart(PART_ElementNextButton, typeof(Button))]
+    [TemplatePart(PART_ElementHeaderButton,   typeof(Button))]
+    [TemplatePart(PART_ElementMonthView,      typeof(Grid))]
+    [TemplatePart(PART_ElementNextButton,     typeof(Button))]
     [TemplatePart(PART_ElementPreviousButton, typeof(Button))]
-    [TemplatePart(PART_ElementYearView, typeof(Grid))]
+    [TemplatePart(PART_ElementYearView,       typeof(Grid))]
     [PseudoClasses(":calendardisabled")]
     public sealed class CalendarItem : TemplatedControl
     {
@@ -41,7 +41,7 @@ namespace Avalonia.Controls.Primitives
         private Button? _headerButton;
         private Button? _nextButton;
         private Button? _previousButton;
-
+        
         private DateTime _currentMonth;
         private bool _isMouseLeftButtonDown;
         private bool _isMouseLeftButtonDownYearView;
@@ -163,7 +163,7 @@ namespace Avalonia.Controls.Primitives
         /// Gets the Grid that hosts the content when in year or decade mode.
         /// </summary>
         internal Grid? YearView { get; set; }
-
+        
         private void PopulateGrids()
         {
             if (MonthView != null)
@@ -206,7 +206,7 @@ namespace Avalonia.Controls.Primitives
                         children.Add(cell);
                     }
                 }
-
+                
                 MonthView.Children.AddRange(children);
             }
 
@@ -254,7 +254,7 @@ namespace Avalonia.Controls.Primitives
             NextButton = e.NameScope.Find<Button>(PART_ElementNextButton);
             MonthView = e.NameScope.Find<Grid>(PART_ElementMonthView);
             YearView = e.NameScope.Find<Grid>(PART_ElementYearView);
-
+            
             if (Owner != null)
             {
                 UpdateDisabled(Owner.IsEnabled);
@@ -886,7 +886,7 @@ namespace Avalonia.Controls.Primitives
                 }
             }
         }
-
+        
         internal void Cell_MouseLeftButtonDown(object? sender, PointerPressedEventArgs e)
         {
             if (Owner != null)
@@ -1030,10 +1030,8 @@ namespace Avalonia.Controls.Primitives
                         Owner.OnDayClick(selectedDate);
                         return;
                     }
-
                     if (Owner.AllowTapRangeSelection &&
-                        (Owner.SelectionMode == CalendarSelectionMode.SingleRange
-                            || Owner.SelectionMode == CalendarSelectionMode.MultipleRange))
+                        (Owner.SelectionMode == CalendarSelectionMode.SingleRange || Owner.SelectionMode == CalendarSelectionMode.MultipleRange))
                     {
                         if (Owner.ProcessTapRangeSelection(selectedDate))
                         {

--- a/tests/Avalonia.Controls.UnitTests/CalendarTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CalendarTests.cs
@@ -273,13 +273,13 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
-        public void AllowTapRangeSelection_Should_Enable_TapToSelectRange()
+        public void AllowTapRangeSelection_Should_Disable_TapToSelectRange()
         {
             var calendar = new Calendar();
-            Assert.False(calendar.AllowTapRangeSelection); // Default should be false
+            Assert.True(calendar.AllowTapRangeSelection); // Default should be true
             
-            calendar.AllowTapRangeSelection = true;
-            Assert.True(calendar.AllowTapRangeSelection);
+            calendar.AllowTapRangeSelection = false;
+            Assert.False(calendar.AllowTapRangeSelection);
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?
Adds a new API to Calendar to allow tapping twice to select a range of dates.

## What is the current behavior?
Date selection ranges are done using keyboard shortcuts, which does not work on mobile.

## What is the updated/expected behavior with this PR?
This PR introduces a new `AllowTapRangeSelection` feature, enabling users to tap once to select an initial date and tap again to choose the second. It only works for `SingleRange` mode. If you have `MultipleRange` selected, it will work for the first range, then reset for the second. 

I've added the boolean to preserve the existing keyboard functions for users who expect a new start date when clicking, ensuring the original functions remain intact. This is intended as a stopgap measure while we research different ways of handling more advance features in the future.

