### PR TITLE
Set IsKeyboardFocusWithin to false when control is detached from visual tree

### DIFF
--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -566,6 +566,8 @@ namespace Avalonia.Input
             {
                 FocusManager.GetFocusManager(this)?.ClearFocusOnElementRemoved(this, e.Parent);
             }
+
+            IsKeyboardFocusWithin = false;
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -670,6 +670,51 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void Popup_Should_Clear_Keyboard_Focus_From_Children_When_Closed()
+        {
+            using (CreateServicesWithFocus())
+            {
+                var winButton = new Button();
+                var window = PreparedWindow(new Panel { Children = { winButton }});
+
+                var border1 = new Border();
+                var border2 = new Border();
+                var button = new Button();
+                border1.Child = border2;
+                border2.Child = button;
+                var popup = new Popup
+                {
+                    PlacementTarget = window,
+                    Child = new StackPanel
+                    {
+                        Children =
+                        {
+                            border1
+                        }
+                    }
+                };
+
+                ((ISetLogicalParent)popup).SetParent(popup.PlacementTarget);
+                window.Show();
+                winButton.Focus();
+                popup.Open();
+
+                button.Focus();
+
+                var inputRoot = Assert.IsAssignableFrom<IInputRoot>(popup.Host);
+
+                var focusManager = inputRoot.FocusManager!;
+                Assert.Same(button, focusManager.GetFocusedElement());
+
+                border1.Child = null;
+
+                winButton.Focus();
+
+                Assert.False(border2.IsKeyboardFocusWithin);
+            }
+        }
+
+        [Fact]
         public void Closing_Popup_Sets_Focus_On_PlacementTarget()
         {
             using (CreateServicesWithFocus())


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Supercedes https://github.com/AvaloniaUI/Avalonia/pull/19325
When a control is detached from visual tree, it can't have keyboard focus, thus we set IsKeyboardWithin to false. The detached event moves down the tree from the detached visual so all descendants also set the property to false.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/19299
