### PR TITLE
Enable tray icon creation in all circumstances when running as an admin

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.302",
+    "version": "8.0.411",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.411",
+    "version": "9.0.302",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1502,6 +1502,14 @@ namespace Avalonia.Win32.Interop
         [DllImport("shell32", CharSet = CharSet.Auto)]
         public static extern int Shell_NotifyIcon(NIM dwMessage, NOTIFYICONDATA lpData);
 
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern nint ChangeWindowMessageFilter(uint message, MessageFilterFlag dwFlag);
+        public enum MessageFilterFlag
+        {
+            MSGFLT_ADD = 1,
+            MSGFLT_REMOVE = 2,
+        }
+
         [DllImport("shell32", CharSet = CharSet.Auto)]
         public static extern nint SHAppBarMessage(AppBarMessage dwMessage, ref APPBARDATA lpData);
 

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1509,6 +1509,7 @@ namespace Avalonia.Win32.Interop
             MessageFilterFlag action,
             IntPtr pChangeFilterStruct
         );
+
         public enum MessageFilterFlag
         {
             MSGFLT_RESET = 0,

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1502,8 +1502,13 @@ namespace Avalonia.Win32.Interop
         [DllImport("shell32", CharSet = CharSet.Auto)]
         public static extern int Shell_NotifyIcon(NIM dwMessage, NOTIFYICONDATA lpData);
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        public static extern nint ChangeWindowMessageFilter(uint message, MessageFilterFlag dwFlag);
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool ChangeWindowMessageFilterEx(
+            IntPtr hWnd,
+            uint message,
+            MessageFilterFlag action,
+            IntPtr pChangeFilterStruct
+        );
         public enum MessageFilterFlag
         {
             MSGFLT_ADD = 1,

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1511,8 +1511,9 @@ namespace Avalonia.Win32.Interop
         );
         public enum MessageFilterFlag
         {
-            MSGFLT_ADD = 1,
-            MSGFLT_REMOVE = 2,
+            MSGFLT_RESET = 0,
+            MSGFLT_ALLOW = 1,
+            MSGFLT_DISALLOW = 2,
         }
 
         [DllImport("shell32", CharSet = CharSet.Auto)]

--- a/src/Windows/Avalonia.Win32/TrayIconImpl.cs
+++ b/src/Windows/Avalonia.Win32/TrayIconImpl.cs
@@ -40,7 +40,7 @@ namespace Avalonia.Win32
 
         internal static void ChangeWindowMessageFilter(IntPtr hWnd)
         {
-            ChangeWindowMessageFilterEx(hWnd, WM_TASKBARCREATED, MessageFilterFlag.MSGFLT_ADD, IntPtr.Zero);
+            ChangeWindowMessageFilterEx(hWnd, WM_TASKBARCREATED, MessageFilterFlag.MSGFLT_ALLOW, IntPtr.Zero);
         }
 
         public TrayIconImpl()

--- a/src/Windows/Avalonia.Win32/TrayIconImpl.cs
+++ b/src/Windows/Avalonia.Win32/TrayIconImpl.cs
@@ -33,6 +33,7 @@ namespace Avalonia.Win32
 
         static TrayIconImpl()
         {
+            ChangeWindowMessageFilter(WM_TASKBARCREATED, MessageFilterFlag.MSGFLT_ADD);
             using var bitmap = new WriteableBitmap(
                 new PixelSize(32, 32), new Vector(96, 96), PixelFormats.Bgra8888, AlphaFormat.Unpremul);
             s_emptyIcon = new Win32Icon(bitmap);

--- a/src/Windows/Avalonia.Win32/TrayIconImpl.cs
+++ b/src/Windows/Avalonia.Win32/TrayIconImpl.cs
@@ -40,7 +40,7 @@ namespace Avalonia.Win32
 
         internal static void ChangeWindowMessageFilter(IntPtr hWnd)
         {
-            ChangeWindowMessageFilterEx(hWnd, WM_TASKBARCREATED,MessageFilterFlag.MSGFLT_ADD, IntPtr.Zero);
+            ChangeWindowMessageFilterEx(hWnd, WM_TASKBARCREATED, MessageFilterFlag.MSGFLT_ADD, IntPtr.Zero);
         }
 
         public TrayIconImpl()

--- a/src/Windows/Avalonia.Win32/TrayIconImpl.cs
+++ b/src/Windows/Avalonia.Win32/TrayIconImpl.cs
@@ -33,12 +33,16 @@ namespace Avalonia.Win32
 
         static TrayIconImpl()
         {
-            ChangeWindowMessageFilter(WM_TASKBARCREATED, MessageFilterFlag.MSGFLT_ADD);
             using var bitmap = new WriteableBitmap(
                 new PixelSize(32, 32), new Vector(96, 96), PixelFormats.Bgra8888, AlphaFormat.Unpremul);
             s_emptyIcon = new Win32Icon(bitmap);
         }
-        
+
+        internal static void ChangeWindowMessageFilter(IntPtr hWnd)
+        {
+            ChangeWindowMessageFilterEx(hWnd, WM_TASKBARCREATED,MessageFilterFlag.MSGFLT_ADD, IntPtr.Zero);
+        }
+
         public TrayIconImpl()
         {
             FindTaskBarMonitor();

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -218,6 +218,8 @@ namespace Avalonia.Win32
             {
                 throw new Win32Exception();
             }
+
+            TrayIconImpl.ChangeWindowMessageFilter(_hwnd);
         }
 
         public ITrayIconImpl CreateTrayIcon()


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix trayicon cannot be created

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When running the program with administrator privileges and the explorer.exe  has not been created,, the WM_TASKBARCREATED message cannot be obtained, resulting in the tray icon being unable to be created

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Set ChangeWindowmessageFilter to add listeners to WM_TASKBARCREATED 