### PR TITLE
WeakEvent subscription management thread race condition fix

### DIFF
--- a/src/Avalonia.Base/Utilities/WeakEvent.cs
+++ b/src/Avalonia.Base/Utilities/WeakEvent.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using Avalonia.Collections.Pooled;
 using Avalonia.Threading;
 
 namespace Avalonia.Utilities;
@@ -23,22 +25,27 @@ public sealed class WeakEvent<TSender, TEventArgs> : WeakEvent where TSender : c
             return () => unsubscribe(t, s);
         };
     }
-    
+
     internal WeakEvent(Func<TSender, EventHandler<TEventArgs>, Action> subscribe)
     {
         _subscribe = subscribe;
     }
-    
+
     public void Subscribe(TSender target, IWeakEventSubscriber<TEventArgs> subscriber)
     {
-        if (!_subscriptions.TryGetValue(target, out var subscription))
-            _subscriptions.Add(target, subscription = new Subscription(this, target));
-        subscription.Add(subscriber);
+        var spinWait = default(SpinWait);
+        while (true)
+        {
+            var subscription = _subscriptions.GetValue(target, _ => new Subscription(this, target));
+            if (subscription.Add(subscriber))
+                break;
+            spinWait.SpinOnce();
+        }
     }
 
     public void Unsubscribe(TSender target, IWeakEventSubscriber<TEventArgs> subscriber)
     {
-        if (_subscriptions.TryGetValue(target, out var subscription)) 
+        if (_subscriptions.TryGetValue(target, out var subscription))
             subscription.Remove(subscriber);
     }
 
@@ -47,8 +54,9 @@ public sealed class WeakEvent<TSender, TEventArgs> : WeakEvent where TSender : c
         private readonly WeakEvent<TSender, TEventArgs> _ev;
         private readonly TSender _target;
         private readonly Action _compact;
-        private readonly Action _unsubscribe;
         private readonly WeakHashList<IWeakEventSubscriber<TEventArgs>> _list = new();
+        private readonly object _lock = new();
+        private Action? _unsubscribe;
         private bool _compactScheduled;
         private bool _destroyed;
 
@@ -57,7 +65,6 @@ public sealed class WeakEvent<TSender, TEventArgs> : WeakEvent where TSender : c
             _ev = ev;
             _target = target;
             _compact = Compact;
-            _unsubscribe = ev._subscribe(target, OnEvent);
         }
 
         private void Destroy()
@@ -65,19 +72,42 @@ public sealed class WeakEvent<TSender, TEventArgs> : WeakEvent where TSender : c
             if(_destroyed)
                 return;
             _destroyed = true;
-            _unsubscribe();
+            _unsubscribe?.Invoke();
             _ev._subscriptions.Remove(_target);
         }
 
-        public void Add(IWeakEventSubscriber<TEventArgs> s) => _list.Add(s);
+        public bool Add(IWeakEventSubscriber<TEventArgs> s)
+        {
+            if (_destroyed)
+                return false;
+
+            lock (_lock)
+            {
+                if (_destroyed)
+                    return false;
+
+                _unsubscribe ??= _ev._subscribe(_target, OnEvent);
+                _list.Add(s);
+                return true;
+            }
+        }
 
         public void Remove(IWeakEventSubscriber<TEventArgs> s)
         {
-            _list.Remove(s);
-            if(_list.IsEmpty)
-                Destroy();
-            else if(_list.NeedCompact && _compactScheduled)
-                ScheduleCompact();
+            if (_destroyed)
+                return;
+
+            lock (_lock)
+            {
+                if (_destroyed)
+                    return;
+
+                _list.Remove(s);
+                if(_list.IsEmpty)
+                    Destroy();
+                else if(_list.NeedCompact && _compactScheduled)
+                    ScheduleCompact();
+            }
         }
 
         private void ScheduleCompact()
@@ -90,23 +120,40 @@ public sealed class WeakEvent<TSender, TEventArgs> : WeakEvent where TSender : c
 
         private void Compact()
         {
-            if(!_compactScheduled)
+            if (_destroyed)
                 return;
-            _compactScheduled = false;
-            _list.Compact();
-            if (_list.IsEmpty)
-                Destroy();
+
+            lock (_lock)
+            {
+                if (_destroyed)
+                    return;
+                if(!_compactScheduled)
+                    return;
+                _compactScheduled = false;
+                _list.Compact();
+                if (_list.IsEmpty)
+                    Destroy();
+            }
         }
 
         private void OnEvent(object? sender, TEventArgs eventArgs)
         {
-            var alive = _list.GetAlive();
-            if(alive == null)
-                Destroy();
-            else
+            PooledList<IWeakEventSubscriber<TEventArgs>>? alive;
+            lock (_lock)
             {
-                foreach(var item in alive.Span)
-                    item.OnEvent(_target, _ev, eventArgs);
+                alive = _list.GetAlive();
+                if (alive == null)
+                {
+                    Destroy();
+                    return;
+                }
+            }
+
+            foreach(var item in alive.Span)
+                item.OnEvent(_target, _ev, eventArgs);
+
+            lock (_lock)
+            {
                 WeakHashList<IWeakEventSubscriber<TEventArgs>>.ReturnToSharedPool(alive);
                 if(_list.NeedCompact && !_compactScheduled)
                     ScheduleCompact();
@@ -124,13 +171,13 @@ public class WeakEvent
     {
         return new WeakEvent<TSender, TEventArgs>(subscribe, unsubscribe);
     }
-    
+
     public static WeakEvent<TSender, TEventArgs> Register<TSender, TEventArgs>(
         Func<TSender, EventHandler<TEventArgs>, Action> subscribe) where TSender : class where TEventArgs : EventArgs
     {
         return new WeakEvent<TSender, TEventArgs>(subscribe);
     }
-    
+
     public static WeakEvent<TSender, EventArgs> Register<TSender>(
         Action<TSender, EventHandler> subscribe,
         Action<TSender, EventHandler> unsubscribe) where TSender : class

--- a/src/Avalonia.Controls/Utils/CollectionChangedEventManager.cs
+++ b/src/Avalonia.Controls/Utils/CollectionChangedEventManager.cs
@@ -132,16 +132,20 @@ namespace Avalonia.Controls.Utils
                     }
                 }
 
-                var l = Listeners.ToArray();
-
                 if (Dispatcher.UIThread.CheckAccess())
                 {
+                    var l = Listeners.ToArray();
                     Notify(_collection, e, l);
                 }
                 else
                 {
                     var eCapture = e;
-                    Dispatcher.UIThread.Post(() => Notify(_collection, eCapture, l), DispatcherPriority.Send);
+                    Dispatcher.UIThread.Post(() =>
+                        {
+                            var l = Listeners.ToArray();
+                            Notify(_collection, eCapture, l);
+                        },
+                        DispatcherPriority.Send);
                 }
             }
         }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
The INotifyCollectionChanged events can be fired on a non-UI thread. Avalonia, at some point, checks if the current thread is the UI thread and posts execution to the UI thread if it is not. However, some logic is still executed on the background thread, which is why you might get NullReferenceException and some other issues caused by a thread-race condition. This PR introduces several fixes to this issue.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
NullReferenceException might fire when INotifyCollectionChanged is fired on non-UI thread


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Behaviour remains intact. Thread-safety is added only.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
This PR introduces 2 fixes:
1. src/Avalonia.Controls/Utils/CollectionChangedEventManager.cs resolves Listeners on UI thread (current implementation can enumerate Listeners collection on background thread, while it might be modified on UI thread) 
2. src/Avalonia.Base/Utilities/WeakEvent.cs thread-safe logic
