### PR TITLE
feat: Add SpaceBetween alignment to WrapPanel

### DIFF
--- a/tests/Avalonia.Controls.UnitTests/WrapPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WrapPanelTests.cs
@@ -99,6 +99,8 @@ namespace Avalonia.Controls.UnitTests
                 (Orientation.Vertical, WrapPanelItemsAlignment.Center) => new(0, 50),
                 (Orientation.Horizontal, WrapPanelItemsAlignment.End) => new(100, 0),
                 (Orientation.Vertical, WrapPanelItemsAlignment.End) => new(0, 100),
+                (Orientation.Horizontal, WrapPanelItemsAlignment.SpaceBetween) => new(0, 0),
+                (Orientation.Vertical, WrapPanelItemsAlignment.SpaceBetween) => new(0, 0),
                 _ => throw new NotImplementedException(),
             }, rowBounds.Position);
         }


### PR DESCRIPTION
## What does the pull request do?
This pull request introduces a new `SpaceBetween` alignment option to the `WrapPanel` control. This alignment mode arranges child elements with equal spacing between them within each row, providing a new way to distribute content evenly.

## What is the current behavior?
The current `WrapPanel` offers `Start`, `Center`, and `End` alignments. The `Center` alignment centers the entire group of children as a single block within each line. This can lead to uneven visual gaps, especially when the items don't fill the entire width of the line.

## What is the updated/expected behavior with this PR?
With this PR, users can set `ItemsAlignment="SpaceBetween"` to achieve a justified layout. In this mode, the `WrapPanel` will calculate the remaining horizontal space in each line and distribute it evenly as gaps between the child elements.

<img width="1354" height="1140" alt="image" src="https://github.com/user-attachments/assets/0a2ec2b7-31e0-4402-b3fc-7b936f9e8163" />


The expected behavior for `SpaceBetween` is:
- **`ItemsAlignment="SpaceBetween"`**: Child items are arranged from the start of the line, with equal spacing injected between each item to fill the remaining space. This creates a visually balanced, "justified" look for each row.

To test this, create a `WrapPanel` with `ItemsAlignment="SpaceBetween"` and add several child controls. Observe how the spacing between the children changes as you resize the window.

## How was the solution implemented (if it's not obvious)?
The solution was implemented by extending the `WrapPanelItemsAlignment` enum with a new `SpaceBetween` value. The core layout logic was modified within the `ArrangeLine` local function in `ArrangeOverride`. A new `case` was added to the `ItemsAlignment` `switch` statement that calculates the spacing required for the `SpaceBetween` behavior and arranges the children accordingly.

## Checklist

- [x] Added unit tests?
  - A new `case` has been added to the `Lays_Out_With_Items_Alignment` test to verify the behavior of `SpaceBetween`.
- [x] Added XML documentation to any related classes?
  - XML documentation has been added to the `WrapPanelItemsAlignment.SpaceBetween` enum value.
- [ ] Consider submitting a PR to [https://github.com/AvaloniaUI/avalonia-docs](https://github.com/AvaloniaUI/avalonia-docs) with user documentation

## Breaking changes
No breaking changes. This is an additive change to an existing public API.

## Obsoletions / Deprecations
No APIs have been obsoleted or deprecated.

## Fixed issues
