### PR TITLE
Fix a typo error of X11Window ClientMessageEvent.ptr5

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -1245,10 +1245,10 @@ namespace Avalonia.X11
                     ptr1 = l0,
                     ptr2 = l1 ?? IntPtr.Zero,
                     ptr3 = l2 ?? IntPtr.Zero,
-                    ptr4 = l3 ?? IntPtr.Zero
+                    ptr4 = l3 ?? IntPtr.Zero,
+                    ptr5 = l4 ?? IntPtr.Zero
                 }
             };
-            xev.ClientMessageEvent.ptr4 = l4 ?? IntPtr.Zero;
             XSendEvent(_x11.Display, _x11.RootWindow, false,
                 new IntPtr((int)(EventMask.SubstructureRedirectMask | EventMask.SubstructureNotifyMask)), ref xev);
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Fix a typo in X11Window.cs: in SendNetWMMessage the 5th payload value (l4) must be assigned to ptr5 (data.l[4], source indication) instead of ptr4 (data.l[3], button). This aligns the `_NET_WM_MOVERESIZE` client message with the EWMH spec.

Reference: https://specifications.freedesktop.org/wm-spec/1.4/ar01s04.html

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Previously, l4 was mistakenly written to ptr4, overwriting data.l[3] (button) and leaving data.l[4] (source indication) unset.

The only code uses `data.l[4]` is in the BeginMoveResize method:

```csharp
private void BeginMoveResize(NetWmMoveResize side, PointerPressedEventArgs e)
{
    var pos = GetCursorPos(_x11);
    XUngrabPointer(_x11.Display, new IntPtr(0));
    SendNetWMMessage (_x11.Atoms._NET_WM_MOVERESIZE, (IntPtr) pos.x, (IntPtr) pos.y,
        (IntPtr) side,
        (IntPtr) 1, (IntPtr)1); // left button
        
    e.Pointer.Capture(null);
}
```

> ```c
> _NET_WM_MOVERESIZE
>   window = window to be moved or resized
>   message_type = _NET_WM_MOVERESIZE
>   format = 32
>   data.l[0] = x_root 
>   data.l[1] = y_root
>   data.l[2] = direction
>   data.l[3] = button
>   data.l[4] = source indication
> ```

In practice, many window managers ignore `data.l[4]` for `_NET_WM_MOVERESIZE`, so this likely had no user‑visible effect. Thanks to @kkwpsv, he read the code of kwin and confirmed this behavior.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

No functional change is expected. The client message payload now strictly matches the official specification.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Assign ptr5 = l4 during event initialization and remove the stray reassignment of ptr4.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
