### PR TITLE
Remove non implemented message AvnView.resetPressedMouseButtons

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.h
+++ b/native/Avalonia.Native/src/OSX/AvnView.h
@@ -19,7 +19,6 @@
 -(AvnPoint) translateLocalPoint:(AvnPoint)pt;
 -(void) onClosed;
 -(void) setModifiers:(NSEventModifierFlags)modifierFlags;
--(void) resetPressedMouseButtons;
 
 -(AvnPlatformResizeReason) getResizeReason;
 -(void) setResizeReason:(AvnPlatformResizeReason)reason;

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -450,7 +450,6 @@ HRESULT WindowBaseImpl::BeginDragAndDropOperation(AvnDragDropEffects effects, Av
         op |= NSDragOperationLink;
     if ((ieffects & (int) AvnDragDropEffects::Move) != 0)
         op |= NSDragOperationMove;
-    [View resetPressedMouseButtons];
     [View beginDraggingSessionWithItems:@[dragItem] event:nsevent
                                  source:CreateDraggingSource((NSDragOperation) op, cb, sourceHandle)];
     return S_OK;


### PR DESCRIPTION
## What does the pull request do?
The implementation of `AvnView.resetPressedMouseButtons` has been removed in #19101 but the calls weren't.
This caused assertion failures in debug builds. This PR fixes that.

