### PR TITLE
Fix SplitView incorrectly closing when the user changes DisplayMode to inline when IsPaneOpen is already true

### DIFF
--- a/src/Avalonia.Controls/SplitView/SplitView.cs
+++ b/src/Avalonia.Controls/SplitView/SplitView.cs
@@ -314,6 +314,7 @@ namespace Avalonia.Controls
         {
             base.OnDetachedFromVisualTree(e);
             _pointerDisposable?.Dispose();
+            _pointerDisposable = null;
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/SplitView/SplitView.cs
+++ b/src/Avalonia.Controls/SplitView/SplitView.cs
@@ -423,7 +423,7 @@ namespace Avalonia.Controls
 
         protected virtual void OnPaneOpened(RoutedEventArgs args)
         {
-            EnableLightDismiss();
+            InvalidateLightDismissSubscription();
             RaiseEvent(args);
         }
 
@@ -528,6 +528,8 @@ namespace Avalonia.Controls
             };
             TemplateSettings.ClosedPaneWidth = closedPaneWidth;
             TemplateSettings.PaneColumnGridLength = paneColumnGridLength;
+            
+            InvalidateLightDismissSubscription();
         }
 
         private void UpdateVisualStateForPanePlacementProperty(SplitViewPanePlacement newValue)
@@ -541,7 +543,7 @@ namespace Avalonia.Controls
             PseudoClasses.Add(_lastPlacementPseudoclass);
         }
 
-        private void EnableLightDismiss()
+        private void InvalidateLightDismissSubscription()
         {
             if (_pane == null)
                 return;
@@ -549,19 +551,26 @@ namespace Avalonia.Controls
             // If this returns false, we're not in Overlay or CompactOverlay DisplayMode
             // and don't need the light dismiss behavior
             if (!IsInOverlayMode())
-                return;
-
-            var topLevel = TopLevel.GetTopLevel(this);
-            if (topLevel != null)
             {
-                _pointerDisposable = Disposable.Create(() =>
-                {
-                    topLevel.PointerReleased -= PointerReleasedOutside;
-                    topLevel.BackRequested -= TopLevelBackRequested;
-                });
+                _pointerDisposable?.Dispose();
+                _pointerDisposable = null;
+                return;
+            }
 
-                topLevel.PointerReleased += PointerReleasedOutside;
-                topLevel.BackRequested += TopLevelBackRequested;
+            if (_pointerDisposable == null)
+            {
+                var topLevel = TopLevel.GetTopLevel(this);
+                if (topLevel != null)
+                {
+                    _pointerDisposable = Disposable.Create(() =>
+                    {
+                        topLevel.PointerReleased -= PointerReleasedOutside;
+                        topLevel.BackRequested -= TopLevelBackRequested;
+                    });
+
+                    topLevel.PointerReleased += PointerReleasedOutside;
+                    topLevel.BackRequested += TopLevelBackRequested;
+                }
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/SplitViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SplitViewTests.cs
@@ -303,5 +303,45 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.Contains(splitView.Classes, ":closed".Equals);
         }
+        
+        [Fact]
+        public void SplitView_Shouldnt_Close_Panel_When_IsPaneOpen_True_Then_Display_Mode_Changed()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow
+                .With(globalClock: new MockGlobalClock()));
+            var wnd = new Window
+            {
+                Width = 1280,
+                Height = 720
+            };
+            var splitView = new SplitView();
+            splitView.DisplayMode = SplitViewDisplayMode.CompactOverlay;
+            wnd.Content = splitView;
+            wnd.Show();
+
+            splitView.IsPaneOpen = true;
+
+            splitView.RaiseEvent(new PointerReleasedEventArgs(splitView,
+                null, wnd, new Point(1270, 30), 0,
+                new PointerPointProperties(),
+                KeyModifiers.None,
+                MouseButton.Left));
+
+            Assert.False(splitView.IsPaneOpen);
+
+            // Inline shouldn't close the pane
+            splitView.IsPaneOpen = true;
+            
+            // Change the display mode once the pane is already open.
+            splitView.DisplayMode = SplitViewDisplayMode.Inline;
+
+            splitView.RaiseEvent(new PointerReleasedEventArgs(splitView,
+                null, wnd, new Point(1270, 30), 0,
+                new PointerPointProperties(),
+                KeyModifiers.None,
+                MouseButton.Left));
+
+            Assert.True(splitView.IsPaneOpen);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Fixes the SplitView which will close the panel when it shouldnt if the user sets properties in the wrong order.

## What is the current behavior?
If you set IsPaneOpen to true, then change the displayMode from an Overlay to an Inline, when the user clicks outside the pane it will be closed

## What is the updated/expected behavior with this PR?
The pane will no longer close when in an inline displaymode, no matter which order IsPaneOpen or DisplayMode properties are set.

## How was the solution implemented (if it's not obvious)?
Dispose the existing subscription when EnableLightDismiss() is called, and call it also whenever displaymode is changed.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
none

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #19457 
