### PR TITLE
Fix: RelativePanel calculation error with extensible and aligned child

### DIFF
--- a/src/Avalonia.Controls/RelativePanel.cs
+++ b/src/Avalonia.Controls/RelativePanel.cs
@@ -333,6 +333,22 @@ namespace Avalonia.Controls
                         : node.AlignBottomWithNode.Bottom * 0.5;
                 }
 
+                if (node.BelowNode != null)
+                {
+                    if (node.Top.IsNaN())
+                    {
+                        node.Top = AvailableSize.Height - node.BelowNode.Bottom;
+                    }
+                }
+                
+                if (node.RightOfNode != null)
+                {
+                    if (node.Left.IsNaN())
+                    {
+                        node.Left = AvailableSize.Width - node.RightOfNode.Right;
+                    }
+                }
+                
                 var availableHeight = AvailableSize.Height - node.Top - node.Bottom;
                 if (availableHeight.IsNaN())
                 {
@@ -383,10 +399,6 @@ namespace Avalonia.Controls
                         node.Right = node.RightOfNode.Right - childSize.Width;
                     }
 
-                    if (node.Left.IsNaN())
-                    {
-                        node.Left = AvailableSize.Width - node.RightOfNode.Right;
-                    }
                 }
 
                 if (node.BelowNode != null)
@@ -396,10 +408,6 @@ namespace Avalonia.Controls
                         node.Bottom = node.BelowNode.Bottom - childSize.Height;
                     }
 
-                    if (node.Top.IsNaN())
-                    {
-                        node.Top = AvailableSize.Height - node.BelowNode.Bottom;
-                    }
                 }
 
                 if (node.AlignHorizontalCenterWith != null)

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/RelativePanelTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/RelativePanelTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using Avalonia.Controls;
+using Avalonia.Data.Converters;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Markup.Xaml.UnitTests.Xaml
+{
+    public class RelativePanelTests : XamlTestBase
+    {
+        [Fact]
+        public void ScrollViewer_Viewport_Small_Than_Bounds()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'
+        Height='800'
+        Width='1000'
+>
+  <RelativePanel x:Name=""TestRelativePanel"">
+    <Panel
+          x:Name=""Area1""
+          RelativePanel.AlignTopWithPanel=""True""
+          RelativePanel.AlignLeftWithPanel=""True""
+          RelativePanel.AlignRightWithPanel=""True""
+          Height=""100""
+          Background=""LightSkyBlue"">
+      <TextBlock
+          Text=""Area1""
+          HorizontalAlignment=""Center""
+          VerticalAlignment=""Center""
+          />
+      <!-- <Button Click=""Button_OnClick"">Second</Button> -->
+    </Panel>
+    <Panel
+      x:Name=""Area2""
+      RelativePanel.Below=""Area1""
+      RelativePanel.AlignLeftWithPanel=""True""
+      RelativePanel.AlignBottomWithPanel=""True""
+      Background=""DeepSkyBlue""
+        Width=""100""
+      >
+      <TextBlock
+        Text=""Area2""
+        HorizontalAlignment=""Center""
+        VerticalAlignment=""Center""
+        Height=""100""
+      />
+    </Panel>
+    <ScrollViewer
+        x:Name=""TestArea""
+        Background=""Aqua""
+        RelativePanel.Below=""Area1""
+        RelativePanel.RightOf=""Area2""
+        RelativePanel.AlignRightWithPanel=""True""
+        RelativePanel.AlignBottomWithPanel=""True""
+        HorizontalScrollBarVisibility=""Visible""
+        Margin=""0 0 0 0""
+        >
+      <ItemsControl
+        ItemsSource=""{Binding DataExample}""
+        >
+        <ItemsControl.ItemsPanel>
+          <ItemsPanelTemplate>
+            <StackPanel></StackPanel>
+          </ItemsPanelTemplate>
+        </ItemsControl.ItemsPanel>
+        <ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <StackPanel Orientation=""Horizontal"">
+              <TextBlock Width=""100"" Text=""{Binding Id}""></TextBlock>
+              <TextBlock Width=""100"" Text=""{Binding Id}""></TextBlock>
+              <TextBlock Width=""100"" Text=""{Binding Id}""></TextBlock>
+              <TextBlock Width=""100"" Text=""{Binding Id}""></TextBlock>
+              <TextBlock Width=""100"" Text=""{Binding Id}""></TextBlock>
+              <TextBlock Width=""100"" Text=""{Binding Id}""></TextBlock>
+              <TextBlock Width=""100"" Text=""{Binding Id}""></TextBlock>
+              <TextBlock Width=""100"" Text=""{Binding Id}""></TextBlock>
+              <TextBlock Width=""100"" Text=""{Binding Id}""></TextBlock>
+              <TextBlock Width=""100"" Text=""{Binding Id}""></TextBlock>
+            </StackPanel>
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+    </ScrollViewer>
+  </RelativePanel>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                {
+                    var panel = window.FindControl<RelativePanel>("TestRelativePanel");
+
+                    panel.DataContext = new
+                    {
+                        DataExample = Enumerable.Range(1001, 100).Select(e => new { Id = $"{e}" })
+                    };
+                }
+                window.ApplyTemplate();
+                window.Show();
+                    
+                var sv = window.FindControl<ScrollViewer>("TestArea");
+                Assert.True(sv.Viewport.Width < sv.Bounds.Width);
+                Assert.True(sv.Viewport.Height < sv.Bounds.Height);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Fix the problem:

The DataGrid's scroll bar does not display correctly.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

### Can not see the last item of DataGrid and horizontal scrollbar.

<img width="2218" height="1299" alt="image" src="https://github.com/user-attachments/assets/f6d294fe-56b8-4c9c-957f-e58f6667932a" />

### Decrease width, all scroll bar are lost.

<img width="1618" height="1228" alt="image" src="https://github.com/user-attachments/assets/30571872-ef57-49cb-bd72-b430c6f6a132" />

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

1. Create a MVVM sample
2. Modify `MainWindow.axaml` and `MainWindowViewModel.cs` as follwing code:

```xml
<Window xmlns="https://github.com/avaloniaui"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:vm="using:AvaloniaBugDemo.ViewModels"
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
        mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
        x:Class="AvaloniaBugDemo.Views.MainWindow"
        x:DataType="vm:MainWindowViewModel"
        Icon="/Assets/avalonia-logo.ico"
        Title="AvaloniaBugDemo">
    <Design.DataContext>
        <!-- This only sets the DataContext for the previewer in an IDE,
             to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
        <vm:MainWindowViewModel/>
    </Design.DataContext>
  <RelativePanel x:Name="TestRelativePanel">
    <Panel
          x:Name="Area1"
          RelativePanel.AlignTopWithPanel="True"
          RelativePanel.AlignLeftWithPanel="True"
          RelativePanel.AlignRightWithPanel="True"
          Height="100"
          Background="LightSkyBlue">
      <TextBlock
          Text="Area1"
          HorizontalAlignment="Center"
          VerticalAlignment="Center"
          />
      <!-- <Button Click="Button_OnClick">Second</Button> -->
    </Panel>
    <Panel
      x:Name="Area2"
      RelativePanel.Below="Area1"
      RelativePanel.AlignLeftWithPanel="True"
      RelativePanel.AlignBottomWithPanel="True"
      Background="DeepSkyBlue"
        Width="100"
      >
      <TextBlock
        Text="Area2"
        HorizontalAlignment="Center"
        VerticalAlignment="Center"
        Height="100"
      />
    </Panel>
    <DataGrid
        x:Name="TestGrid"
        Background="Aqua"
        ItemsSource="{Binding DataGridExample}"
        RelativePanel.Below="Area1"
        RelativePanel.RightOf="Area2"
        RelativePanel.AlignRightWithPanel="True"
        RelativePanel.AlignBottomWithPanel="True"
        IsReadOnly="True"
        Margin="0 0 0 0"
        >
      <DataGrid.Columns>
        <DataGridTextColumn Header="Id1" Width="100" Binding="{Binding Id}"></DataGridTextColumn>
        <DataGridTextColumn Header="Id2" Width="100" Binding="{Binding Id}"></DataGridTextColumn>
        <DataGridTextColumn Header="Id3" Width="100" Binding="{Binding Id}"></DataGridTextColumn>
        <DataGridTextColumn Header="Id4" Width="100" Binding="{Binding Id}"></DataGridTextColumn>
        <DataGridTextColumn Header="Id5" Width="100" Binding="{Binding Id}"></DataGridTextColumn>
        <DataGridTextColumn Header="Id6" Width="100" Binding="{Binding Id}"></DataGridTextColumn>
        <DataGridTextColumn Header="Id7" Width="100" Binding="{Binding Id}"></DataGridTextColumn>
        <DataGridTextColumn Header="Id8" Width="100" Binding="{Binding Id}"></DataGridTextColumn>
        <DataGridTextColumn Header="Id9" Width="100" Binding="{Binding Id}"></DataGridTextColumn>
        <DataGridTextColumn Header="Id10" Width="100" Binding="{Binding Id}"></DataGridTextColumn>
      </DataGrid.Columns>
    </DataGrid>
  </RelativePanel>
</Window>
```

```C#
using System;
using System.Linq;
using Avalonia.Collections;

namespace AvaloniaBugDemo.ViewModels;

public partial class MainWindowViewModel : ViewModelBase
{
    public string Greeting { get; } = "Welcome to Avalonia!";
    public AvaloniaList<TestItem> DataGridExample { get; } = new (Enumerable.Range(1001, 100).Select(e => new TestItem($"{e}")));

    public MainWindowViewModel()
    {
        Console.WriteLine($"Count: {DataGridExample.Count}");
    }

}

public class TestItem(string id)
{
    public string Id { get; set; } = id;
}
```

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

### Original logic

1. Measure the size of DataGrid; 
     In this step, `availableHeight`'s value is wrong. `availableHeight` = `TotalHeight` = `Area1.Height + RemainArea.Height`
2. Calculate DataGrid's position.

### Midified logic

1. Calculate DataGrid's position; 
     `availableHeight`'s value is right. `availableHeight` = `TotalHeight - Area1.Height` = `RemainArea.Height`
2. Measure the size of DataGrid.

### Other thing

I modified the code in the branch `release/11.3.4` and cherry-picked the commit to the `master` branch;

because I can not run a program on master branch, I do not know how to solve the compile exception.

### Result

<img width="1824" height="1297" alt="image" src="https://github.com/user-attachments/assets/fe8191ff-ada2-45f7-95e6-86a38a3b7c32" />

## Checklist

- [ ] Added unit tests (if possible)?  ***I tried, but failed. Due to DataGrid package build exception.***
- [ ] Added XML documentation to any related classes? (I don't think it's necessary)
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation (I don't think it's necessary)

## Breaking changes
<!--- List any breaking changes here. -->

No.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

No.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
