### PR TITLE
Fix validation error not being cleared on valid input

### DIFF
--- a/src/Avalonia.Base/Data/Core/BindingExpression.cs
+++ b/src/Avalonia.Base/Data/Core/BindingExpression.cs
@@ -355,8 +355,9 @@ internal partial class BindingExpression : UntypedBindingExpressionBase, IDescri
             }
         }
 
-        // Don't set the value if it's unchanged.
-        if (TypeUtilities.IdentityEquals(LeafNode.Value, value, type))
+        // Don't set the value if it's unchanged. If there is a binding error, we still have to set the value
+        // in order to clear the error.
+        if (TypeUtilities.IdentityEquals(LeafNode.Value, value, type) && ErrorType == BindingErrorType.None)
             return true;
 
         try

--- a/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.DataValidation.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.DataValidation.cs
@@ -305,6 +305,26 @@ public partial class BindingExpressionTests
             BindingErrorType.DataValidationError);
     }
 
+    [Fact]
+    public void Setting_Valid_Value_Should_Clear_Binding_Error()
+    {
+        var data = new ViewModel { DoubleValue = 5.6 };
+        var target = CreateTargetWithSource(
+            data,
+            o => o.DoubleValue,
+            enableDataValidation: true,
+            mode: BindingMode.TwoWay,
+            targetProperty: TargetClass.StringProperty);
+
+        target.String = "5.6";
+        target.String = "5.6a";
+        target.String = "5.6";
+
+        AssertNoError(target, TargetClass.StringProperty);
+
+        GC.KeepAlive(data);
+    }
+
     public class ExceptionViewModel : NotifyingBase
     {
         private int _mustBePositive;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Validation errors are not being cleared, if underlying bound value doesn't change
<img width="1154" height="234" alt="Persisting invalid cast demonstration" src="https://github.com/user-attachments/assets/d544052f-2c27-4c5a-b23c-9d67c1b472a4" />

This PR fixes that.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
1) Have data binding using data validation for example TextBox TextProperty bound to double value
2) Input some correct value (5.6)
3) Input invalid value - this raises data validation error (5.6a)
4) Input same value as in step 2 - this should clear the validation error, but it doesn't.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Validation error is cleared once data validation error should no longer be raised.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
