### PR TITLE
Schedule a full render pass on CompositionBatchCompletion to prevent tearing

### DIFF
--- a/src/Avalonia.Base/Media/MediaContext.Compositor.cs
+++ b/src/Avalonia.Base/Media/MediaContext.Compositor.cs
@@ -49,24 +49,12 @@ partial class MediaContext
         {
             _animationsAreWaitingForComposition = false;
 
-            // Check if we have uncommited changes
-            if (_requestedCommits.Count != 0)
-            {
-                if (!CommitCompositorsWithThrottling())
-                    ScheduleRenderForAnimationsIfNeeded();
-
-            }
-            // Check if there are active animations and schedule the next render
-            else
-                ScheduleRenderForAnimationsIfNeeded();
+            // Check if we have requested commits or active animations and schedule a new render pass 
+            if (_requestedCommits.Count != 0 || _clock.HasSubscriptions)
+                ScheduleRender(false);
         }
     }
 
-    void ScheduleRenderForAnimationsIfNeeded()
-    {
-        if (_clock.HasSubscriptions) 
-            ScheduleRender(false);
-    }
 
     /// <summary>
     /// Triggers a composition commit if any batches are waiting to be sent,


### PR DESCRIPTION
This was causing a flickering issue in some cases caused by some updates being included into composition commit and some being scheduled for the next one.

Future work - https://github.com/AvaloniaUI/Avalonia/issues/19485