### PR TITLE
Avoid processing frameworks in parallel in ValidateApiDiff

### DIFF
--- a/nukebuild/ApiDiffHelper.cs
+++ b/nukebuild/ApiDiffHelper.cs
@@ -47,20 +47,13 @@ public static class ApiDiffHelper
 
         var allErrors = new List<string>();
 
-        Parallel.ForEach(
-            packageDiff.Frameworks,
-            framework =>
-            {
-                var args = $""" -l="{framework.BaselineFolderPath}" -r="{framework.CurrentFolderPath}" {suppressionArgs}""";
+        foreach (var framework in packageDiff.Frameworks)
+        {
+            var args = $""" -l="{framework.BaselineFolderPath}" -r="{framework.CurrentFolderPath}" {suppressionArgs}""";
 
-                var localErrors = GetErrors(apiCompatTool(args));
-
-                if (localErrors.Length > 0)
-                {
-                    lock (allErrors)
-                        allErrors.AddRange(localErrors);
-                }
-            });
+            var localErrors = GetErrors(apiCompatTool(args));
+            allErrors.AddRange(localErrors);
+        }
 
         ThrowOnErrors(allErrors, packageDiff.PackageId, "ValidateApiDiff");
     }


### PR DESCRIPTION
## What does the pull request do?
#19490 made packages and frameworks be processed in parallel inside the `OutputApiDiff` task because the API diff generation is quite slow (50s on a good machine). The same improvement was applied to `ValidateApiDiff`.

However, `ValidateApiDiff` uses common suppression files for all frameworks. Having the validation happen in parallel caused the file to be overwritten, missing some suppressions. This PR reverts back to a standard loop for this task.

`ValidateApiDiff` being much faster (a few seconds) than `OutputApiDiff`, this optimization wasn't really needed here anyway.
