### PR TITLE
Fix font memory leak in tests

### DIFF
--- a/src/Avalonia.Base/Media/FontManager.cs
+++ b/src/Avalonia.Base/Media/FontManager.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Media
     ///     The font manager is used to query the system's installed fonts and is responsible for caching loaded fonts.
     ///     It is also responsible for the font fallback.
     /// </summary>
-    public sealed class FontManager
+    public sealed class FontManager : IDisposable
     {
         internal static Uri SystemFontsKey = new Uri("fonts:SystemFonts", UriKind.Absolute);
 
@@ -367,6 +367,15 @@ namespace Avalonia.Media
             }
 
             return defaultFontFamilyName;
+        }
+
+        void IDisposable.Dispose()
+        {
+            foreach (var pair in _fontCollections)
+                pair.Value.Dispose();
+
+            _fontCollections.Clear();
+            (PlatformImpl as IDisposable)?.Dispose();
         }
     }
 }

--- a/tests/Avalonia.Skia.UnitTests/Media/CustomFontManagerImpl.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/CustomFontManagerImpl.cs
@@ -10,7 +10,7 @@ using System.IO;
 
 namespace Avalonia.Skia.UnitTests.Media
 {
-    public class CustomFontManagerImpl : IFontManagerImpl
+    public class CustomFontManagerImpl : IFontManagerImpl, IDisposable
     {
         private readonly string _defaultFamilyName;
         private readonly IFontCollection _customFonts;
@@ -93,6 +93,11 @@ namespace Avalonia.Skia.UnitTests.Media
             glyphTypeface = new GlyphTypefaceImpl(skTypeface, fontSimulations);
 
             return true;
+        }
+
+        public void Dispose()
+        {
+            _customFonts.Dispose();
         }
     }
 }

--- a/tests/Avalonia.UnitTests/UnitTestApplication.cs
+++ b/tests/Avalonia.UnitTests/UnitTestApplication.cs
@@ -51,7 +51,8 @@ namespace Avalonia.UnitTests
                 }
 
                 ((ToolTipService)AvaloniaLocator.Current.GetService<IToolTipService>())?.Dispose();
-                
+                (AvaloniaLocator.Current.GetService<FontManager>() as IDisposable)?.Dispose();
+
                 Dispatcher.ResetForUnitTests();
                 scope.Dispose();
                 Dispatcher.ResetBeforeUnitTests();


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a memory leak occurring in our unit tests. Each call to `UnitTestApplication.Start()` creates a new `FontManager` which loads and holds several fonts used by tests. Harfbuzz keeps a reference to those fonts in a static field so these are never collected unless they're disposed first.

With more and more tests added, the issue became more visible, and out of memory warnings [started to be logged by the CI runner](https://dev.azure.com/AvaloniaUI/AvaloniaUI/_build/results?buildId=58513&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=5b4cc83a-7bb0-5664-5bb1-588f7e4dc05b&l=982), causing failures.

This PR implements `IDisposable` on `FontManager` and disposes of every font loaded so far.