### PR TITLE
Switch the `BackgroundSizing` default to `InnerBorderEdge`

### DIFF
--- a/src/Avalonia.Controls/Border.cs
+++ b/src/Avalonia.Controls/Border.cs
@@ -26,7 +26,7 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<BackgroundSizing> BackgroundSizingProperty =
             AvaloniaProperty.Register<Border, BackgroundSizing>(
                 nameof(BackgroundSizing),
-                BackgroundSizing.CenterBorder);
+                BackgroundSizing.InnerBorderEdge);
 
         /// <summary>
         /// Defines the <see cref="BorderBrush"/> property.


### PR DESCRIPTION
## What does the pull request do?

Switches the default value of `BackgroundSizing` from `CenterBorder` to `InnerBorderEdge`. This aligns Avalonia with the implicit behavior of WPF and the explicit behavior of UWP/WinUI. From a design standpoint it also looks a lot better as the default than `CenterBorder`.

 * https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.control.backgroundsizing?view=winrt-26100
 * https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.border.backgroundsizing?view=winrt-26100

The reason(s) this wasn't done in #14048 are:

 1. Backwards compatibility, even with the rendering errors at the time this was the least breaking change for 11.1 compared to 11.0. In 11.0 `CenterBorder` was the implicit behavior of the simple rendering path.
 2. The `BoxShadow` on Border only works with the simple rendering path, which in turn only works with `CenterBorder`: 
     * #15602
     * #11517
     * #16387
     * etc.

Now that we are preparing for 12.0 and allowing some breaking changes, it is time to improve the default value and align with other XAML frameworks.

Yes, I expect this to open up a debate.

## What is the current behavior?

The current default value is `CenterBorder`:

## What is the updated/expected behavior with this PR?

The default value of `BackgroundSizing` is now `InnerBorderEdge` aligning with WPF, UWP and WinUI.

## How was the solution implemented (if it's not obvious)?

Obvious.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

Yes

## Obsoletions / Deprecations

None

## Fixed issues

None, related to #9946 and #14048
