### PR TITLE
Fix selected files filename

### DIFF
--- a/src/Avalonia.Dialogs/Internal/ManagedFileChooserViewModel.cs
+++ b/src/Avalonia.Dialogs/Internal/ManagedFileChooserViewModel.cs
@@ -9,6 +9,7 @@ using Avalonia.Controls.Platform;
 using Avalonia.Platform.Storage;
 using Avalonia.Reactive;
 using Avalonia.Threading;
+using Avalonia.Utilities;
 
 namespace Avalonia.Dialogs.Internal
 {
@@ -228,11 +229,29 @@ namespace Avalonia.Dialogs.Internal
 
                         if (!_selectingDirectory)
                         {
-                            var selectedItem = SelectedItems.FirstOrDefault();
-
-                            if (selectedItem != null)
+                            if (SelectedItems.Count > 1)
                             {
-                                FileName = selectedItem.DisplayName;
+                                var sb = StringBuilderCache.Acquire();
+
+                                for (var i = 0; i < SelectedItems.Count; i++)
+                                {
+                                    var item = SelectedItems[i];
+                                    sb.Append('"');
+                                    sb.Append(item.DisplayName);
+                                    sb.Append('"');
+                                    if (i + 1 < SelectedItems.Count)
+                                    {
+                                        sb.Append(' ');
+                                    }
+                                }
+
+                                FileName = sb.ToString();
+                                
+                                StringBuilderCache.Release(sb);
+                            }
+                            else
+                            {
+                                FileName = SelectedItems.FirstOrDefault()?.DisplayName;
                             }
                         }
                     }


### PR DESCRIPTION
## What does the pull request do?
Corrects incorrect behavior when selecting multiple files

## What is the current behavior?
When selecting multiple files, only the name of the first one is displayed

## What is the updated/expected behavior with this PR?
Now a string like `"<file name>" "<second file name>"` is displayed

Fixes #19539