### PR TITLE
Fix SelectedItems clearing when selecting folders

### DIFF
--- a/src/Avalonia.Dialogs/Internal/ManagedFileChooserViewModel.cs
+++ b/src/Avalonia.Dialogs/Internal/ManagedFileChooserViewModel.cs
@@ -212,11 +212,7 @@ namespace Avalonia.Dialogs.Internal
             {
                 try
                 {
-                    if (_selectingDirectory)
-                    {
-                        SelectedItems.Clear();
-                    }
-                    else
+                    if (!_selectingDirectory)
                     {
                         if (!_options.AllowDirectorySelection)
                         {
@@ -226,14 +222,11 @@ namespace Avalonia.Dialogs.Internal
                                 SelectedItems.Remove(item);
                         }
 
-                        if (!_selectingDirectory)
-                        {
-                            var selectedItem = SelectedItems.FirstOrDefault();
+                        var selectedItem = SelectedItems.FirstOrDefault();
 
-                            if (selectedItem != null)
-                            {
-                                FileName = selectedItem.DisplayName;
-                            }
+                        if (selectedItem != null)
+                        {
+                            FileName = selectedItem.DisplayName;
                         }
                     }
                     RaisePropertyChanged(nameof(SelectedItems));


### PR DESCRIPTION
## What does the pull request do?
Corrects incorrect display of selected folders

## What is the current behavior?
When selecting folders, the selection indication is displayed and immediately disappears

## What is the updated/expected behavior with this PR?
The folder selection indicator is displayed after selecting it, as well as until it is deselected.

## Fixed issues
Fixes #19541
