### PR TITLE
Fix BringDescendantIntoView with respect to margins

### DIFF
--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -258,7 +258,7 @@ namespace Avalonia.Controls.Presenters
                 return false;
             }
 
-            var rectangle = targetRect.TransformToAABB(transform.Value).Deflate(new Thickness(Child.Margin.Left, Child.Margin.Top, 0, 0));
+            var rectangle = targetRect.TransformToAABB(transform.Value);
             Rect viewport = new Rect(Offset.X, Offset.Y, Viewport.Width, Viewport.Height);
 
             double minX = ComputeScrollOffsetWithMinimalScroll(viewport.Left, viewport.Right, rectangle.Left, rectangle.Right);

--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -251,12 +251,14 @@ namespace Avalonia.Controls.Presenters
                 return scrollable.BringIntoView(control, targetRect);
             }
 
-            var transform = target.TransformToVisual(Child);
+            var transform = target.TransformToVisual(this);
 
             if (transform == null)
             {
                 return false;
             }
+
+            transform *= Matrix.CreateTranslation(Offset);
 
             var rectangle = targetRect.TransformToAABB(transform.Value);
             Rect viewport = new Rect(Offset.X, Offset.Y, Viewport.Width, Viewport.Height);

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -1561,7 +1561,7 @@ namespace Avalonia.Controls.UnitTests
         [InlineData(0.5d,
             0, 7,
             0, 7,
-            0, 9)]
+            7, 17)]
         public void Focused_Container_Is_Positioned_Correctly_when_Container_Size_Change_Causes_It_To_Be_Moved_Into_Visible_Viewport(double bufferFactor, 
             int firstIndex1, int lastIndex1,
             int firstIndex2, int lastIndex2,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Remove incorrect margin deflation when calculating the transformed Rect in BringDescendantIntoView. Also changes the transform to use the presenter instead of `Child`. Tests have been updated to test both content with margins and without.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
