### PR TITLE
Pass app delegate to the default UseiOS call

### DIFF
--- a/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
@@ -33,7 +33,7 @@ namespace Avalonia.iOS
             remove { _onDeactivated -= value; }
         }
 
-        protected virtual AppBuilder CreateAppBuilder() => AppBuilder.Configure<TApp>().UseiOS();
+        protected virtual AppBuilder CreateAppBuilder() => AppBuilder.Configure<TApp>().UseiOS(this);
         protected virtual AppBuilder CustomizeAppBuilder(AppBuilder builder) => builder;
 
         [Export("window")]


### PR DESCRIPTION
## What does the pull request do?

Deep link activation was added with https://github.com/AvaloniaUI/Avalonia/pull/14556
And it was somewhat broken in https://github.com/AvaloniaUI/Avalonia/pull/15158, requiring hacks to pass app current delegate

## What is the updated/expected behavior with this PR?

Default CreateAppBuilder call should pass app delegate to the iOS backend registration.
Without that, developers need to add `.UseiOS(this)` in their code
