### PR TITLE
Fixes duplicate class property registration

### DIFF
--- a/src/Avalonia.Base/ClassBindingManager.cs
+++ b/src/Avalonia.Base/ClassBindingManager.cs
@@ -33,10 +33,13 @@ namespace Avalonia
         }
 
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-        public static AvaloniaProperty GetClassProperty(string className) =>
-            s_RegisteredProperties.TryGetValue(ClassPropertyPrefix + className, out var property)
-                ? property 
-                : s_RegisteredProperties[className] = RegisterClassProxyProperty(className);
+        public static AvaloniaProperty GetClassProperty(string className)
+        {
+            var prefixedClassName = ClassPropertyPrefix + className;
+            return s_RegisteredProperties.TryGetValue(prefixedClassName, out var property)
+                ? property
+                : s_RegisteredProperties[prefixedClassName] = RegisterClassProxyProperty(className);
+        }
 
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static bool IsClassesBindingProperty(AvaloniaProperty property, [NotNullWhen(true)] out string? classPropertyName)

--- a/tests/Avalonia.Base.UnitTests/ClassBindingManagerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/ClassBindingManagerTests.cs
@@ -1,0 +1,24 @@
+﻿using Xunit;
+
+namespace Avalonia.Base.UnitTests
+{
+    public class ClassBindingManagerTests
+    {
+
+        [Fact]
+        public void GetClassProperty_Should_Return_Same_Instance_For_Same_Class()
+        {
+            var property1 = ClassBindingManager.GetClassProperty("Foo");
+            var property2 = ClassBindingManager.GetClassProperty("Foo");
+            Assert.Same(property1, property2);
+        }
+
+        [Fact]
+        public void GetClassProperty_Should_Return_Different_Instances_For_Different_Classes()
+        {
+            var property1 = ClassBindingManager.GetClassProperty("Foo");
+            var property2 = ClassBindingManager.GetClassProperty("Bar");
+            Assert.NotSame(property1, property2);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
Fixes the registered property dictionary insert in ClassBindingManager to use the correct key.

## What is the current behavior?
An incorrect dictionary key causes a duplicate `AvaloniaProperty` to be registered on each call of `ClassBindingManager.GetClassProperty()`, leading to increased memory usage.

<img width="1293" height="416" alt="482087737-599007f5-f2c8-40ec-a861-1edadc83764b" src="https://github.com/user-attachments/assets/c3936660-b58d-4d88-a723-0cd7f164c626" />

## What is the updated/expected behavior with this PR?
A single `AvaloniaProperty` is registered and inserted into `s_RegisteredProperties` using the correct key, allowing for reuse of the property.

<img width="876" height="148" alt="image" src="https://github.com/user-attachments/assets/624fdc97-103a-41d7-9722-803411d1e089" />

## How was the solution implemented (if it's not obvious)?

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

## Obsoletions / Deprecations


## Fixed issues
Fixes #19551