### PR TITLE
fix os timer interval calculation in windows dispatcher

### DIFF
--- a/src/Windows/Avalonia.Win32/Win32DispatcherImpl.cs
+++ b/src/Windows/Avalonia.Win32/Win32DispatcherImpl.cs
@@ -46,7 +46,7 @@ internal class Win32DispatcherImpl : IControlledDispatcherImpl
         }
         else
         {
-            var interval = (uint)Math.Min(int.MaxValue - 10, Math.Max(1, Now - dueTimeInMs.Value));
+            var interval = (uint)Math.Min(int.MaxValue - 10, Math.Max(1, dueTimeInMs.Value - Now));
             SetTimer(
                 _messageWindow,
                 (IntPtr)Win32Platform.TIMERID_DISPATCHER,


### PR DESCRIPTION
## What does the pull request do?

Fixes the calculation of the next OS timer interval in the Windows dispatcher implementation. The previous formula produce a negative delay that was then clamped to 1, effectively flooding the message queue with WM_TIMER messages.

## What is the current behavior?

The interval is computed as:

`var interval = (uint)Math.Min(int.MaxValue - 10, Math.Max(1, Now - dueTimeInMs.Value));`

In almost all cases Now - dueTimeInMs.Value is negative, so it is clamped to 1. As a result, Windows is asked to deliver a WM_TIMER roughly every millisecond, which can overload the application’s message queue and degrade system responsiveness.

## What is the updated/expected behavior with this PR?

Compute the delay as time until the due time:

`var interval = (uint)Math.Min(int.MaxValue - 10, Math.Max(1, dueTimeInMs.Value - Now));`

This prevents unnecessary wakeups and aligns the behavior with the macOS dispatcher implementation.

## How was the solution implemented (if it's not obvious)?

Swap the operands in Avalonia.Win32.Win32DispatcherImpl.UpdateTimer to use dueTimeInMs.Value - Now (matching the macOS variant).

## Fixed issues

not 100% sure, but it might fixes #19082
