### PR TITLE
Fix headless FontManager leak

### DIFF
--- a/tests/Avalonia.Headless.UnitTests/LeakTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/LeakTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+
+namespace Avalonia.Headless.UnitTests;
+
+public class LeakTests
+{
+    public static IEnumerable<object[]> TestData { get; } =
+        Enumerable.Range(0, 50).Select(i => new object[] { i.ToString() });
+
+    private static WeakReference s_previousFontManager;
+
+#if NUNIT
+    [TestCaseSource(nameof(TestData))]
+    [AvaloniaTest, Timeout(10000)]
+#elif XUNIT
+    [MemberData(nameof(TestData))]
+    [AvaloniaTheory]
+#endif
+    public void Previous_FontManager_Should_Be_Collected(string data)
+    {
+        // Arrange
+        var fontManager = new WeakReference(FontManager.Current);
+        var button = new Button { Content = data };
+        var window = new Window
+        {
+            Content = button
+        };
+
+        // Act, just some interaction, to make sure the FontManager is actually used
+        window.Show();
+        button.Focus();
+        window.MouseDown(new Point(1,1), MouseButton.Left);
+        window.Close();
+
+        // Assert
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        if (s_previousFontManager is not null)
+        {
+            Assert.False(s_previousFontManager.IsAlive);
+        }
+
+        s_previousFontManager = fontManager;
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

For each test executed we recreate application services, isolating them. Including font manager. But we do not dispose these, keeping all the native memory alive.

There are really two options to solve it:
1. Do explicit dispose (done in this PR). I went this direction, because we already did it for [UnitTestApplication](https://github.com/AvaloniaUI/Avalonia/blob/22f3c026dfb16f68808235cee01176f590ca4cf8/tests/Avalonia.UnitTests/UnitTestApplication.cs#L40-L61) exactly the same way.
2. Make sure each skia object has a finalizer, and somehow break `managed holds native, native holds managed` reference loop in [GlyphTypefaceImpl.Face GetTable delegate](https://github.com/AvaloniaUI/Avalonia/blob/22f3c026dfb16f68808235cee01176f590ca4cf8/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs#L29).

While #2 sounds reasonable to do, FontManager is practically a singleton in normal (non-unit test) applications, and won't do much there. And we still have to properly dispose AvaloniaLocator services after we don't use them.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation


I hope `LeakTests` won't be flaky one. But also can't use dotMemory extensions properly there, as FontManager is allocated and destroyed _outside_ of the test method itself.