### PR TITLE
TextLine.GetTextBounds zero width run fixes

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
@@ -1104,22 +1104,28 @@ namespace Avalonia.Media.TextFormatting
             var startOffset = currentRun.GlyphRun.GetDistanceFromCharacterHit(new CharacterHit(startIndex));
             var endOffset = currentRun.GlyphRun.GetDistanceFromCharacterHit(new CharacterHit(endIndex));
 
-            // Preserve non-zero width for zero-advance ranges
-            if (startOffset == endOffset && startIndex != endIndex)
-            {
-                //We need to make sure a zero width text line is hit test at the end so we add some delta
-                endOffset += MathUtilities.DoubleEpsilon;
-            }
-
             var endX = startX + endOffset;
             startX += startOffset;
 
             //Hit test against visual positions
             var startHit = currentRun.GlyphRun.GetCharacterHitFromDistance(startOffset, out _);
-            var endHit = currentRun.GlyphRun.GetCharacterHitFromDistance(endOffset, out _);
-
             var startHitIndex = startHit.FirstCharacterIndex + startHit.TrailingLength;
-            var endHitIndex = endHit.FirstCharacterIndex + endHit.TrailingLength;
+
+            int endHitIndex;
+
+            //Find the next possible position that contains the endIndex
+            var nearestCharacterHit = currentRun.GlyphRun.FindNearestCharacterHit(endIndex, out _);
+
+            if (nearestCharacterHit.FirstCharacterIndex < endIndex)
+            {
+                //The hit is inside or at the trailing edge
+                endHitIndex = nearestCharacterHit.FirstCharacterIndex + nearestCharacterHit.TrailingLength;
+            }
+            else
+            {
+                //The hit is at the leading edge
+                endHitIndex = nearestCharacterHit.FirstCharacterIndex;
+            }
           
             //Adjust characterLength by the cluster offset to only cover the remaining length of the cluster.
             var characterLength = Math.Max(0, Math.Abs(startHitIndex - endHitIndex) - clusterOffset);
@@ -1154,6 +1160,7 @@ namespace Avalonia.Media.TextFormatting
 
             //Current position is a text source index and first cluster is relative to the GlyphRun's buffer.
             var textSourceOffset = currentPosition - firstCluster;
+
             Debug.Assert(textSourceOffset >= 0);
 
             var clusterOffset = 0;
@@ -1185,20 +1192,27 @@ namespace Avalonia.Media.TextFormatting
             startX -= currentRun.Size.Width - startOffset;
             endX -= currentRun.Size.Width - endOffset;
 
-            // Preserve non-zero width for zero-advance ranges
-            if (startOffset == endOffset && startIndex != endIndex)
-            {
-                //We need to make sure a zero width text line is hit test at the end so we add some delta
-                endOffset += MathUtilities.DoubleEpsilon;
-            }
-
             //Hit test against visual positions
             var startHit = currentRun.GlyphRun.GetCharacterHitFromDistance(startOffset, out _);
-            var endHit = currentRun.GlyphRun.GetCharacterHitFromDistance(endOffset, out _);
-
             var startHitIndex = startHit.FirstCharacterIndex + startHit.TrailingLength;
-            var endHitIndex = endHit.FirstCharacterIndex + endHit.TrailingLength;
 
+            int endHitIndex;
+
+            //Find the next possible position that contains the endIndex
+            var nearestCharacterHit = currentRun.GlyphRun.FindNearestCharacterHit(endIndex, out _);
+
+            if (nearestCharacterHit.FirstCharacterIndex < endIndex)
+            {
+                //The hit is inside or at the trailing edge
+                endHitIndex = nearestCharacterHit.FirstCharacterIndex + nearestCharacterHit.TrailingLength;
+            }
+            else
+            {
+                //The hit is at the leading edge
+                endHitIndex = nearestCharacterHit.FirstCharacterIndex;
+            }
+
+            //Adjust characterLength by the cluster offset to only cover the remaining length of the cluster.
             var characterLength = Math.Max(0, Math.Abs(startHitIndex - endHitIndex) - clusterOffset);
 
             // Normalize bounds

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
@@ -2012,6 +2012,42 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
         }
 
         [Fact]
+        public void Should_Get_TextBounds_With_Glue()
+        {
+            using (Start())
+            {
+                var typeface = Typeface.Default;
+
+                var defaultProperties = new GenericTextRunProperties(typeface);
+                var text = "a‬‬‬‬b";
+                var shaperOption = new TextShaperOptions(typeface.GlyphTypeface);
+
+                var textSource = new SingleBufferTextSource(text, defaultProperties);
+
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, double.PositiveInfinity,
+                        new GenericTextParagraphProperties(defaultProperties));
+
+                Assert.NotNull(textLine);
+
+                var textBounds = textLine.GetTextBounds(1, 1);
+
+                Assert.NotEmpty(textBounds);
+
+                var firstTextBounds = textBounds[0];
+
+                Assert.NotEmpty(firstTextBounds.TextRunBounds);
+
+                var firstRunBounds = firstTextBounds.TextRunBounds[0];
+
+                Assert.Equal(1, firstRunBounds.TextSourceCharacterIndex);
+                Assert.Equal(1, firstRunBounds.Length);
+            }
+        }
+
+        [Fact]
         public void Should_Get_TextBounds_Tamil()
         {
             var text = "எடுத்துக்காட்டு வழி வினவல்";

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
@@ -2019,7 +2019,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                 var typeface = Typeface.Default;
 
                 var defaultProperties = new GenericTextRunProperties(typeface);
-                var text = "a‬‬‬‬b";
+                var text = "a\u202C\u202C\u202C\u202Cb";
                 var shaperOption = new TextShaperOptions(typeface.GlyphTypeface);
 
                 var textSource = new SingleBufferTextSource(text, defaultProperties);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR adjusts the TextLineImpl.GetTextBounds implementation so it handles zero-width characters that do not belong to a cluster.
This also reduces code duplication by introducing a unified GetTextRunBounds implementation

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Text that has a standalone control character produces a crash

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
The previous implementation was using visual distances to calculate the end hit of the requested text range. This is no longer the case, and instead, we try to find the end character hit with logical units.
This allows us to find the end hit without requiring the containing character to occupy any space.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
