### PR TITLE
Backport GRContext bugfix from 12.0 branch

### DIFF
--- a/src/iOS/Avalonia.iOS/Metal/MetalPlatformGraphics.cs
+++ b/src/iOS/Avalonia.iOS/Metal/MetalPlatformGraphics.cs
@@ -33,17 +33,6 @@ internal class MetalPlatformGraphics : IPlatformGraphics
             return null;
         }
 
-#if !TVOS
-        using var queue = device.CreateCommandQueue();
-        using var context = GRContext.CreateMetal(new GRMtlBackendContext { Device = device, Queue = queue });
-        if (context is null)
-        {
-            // Can be null on macCatalyst because of older Skia bug.
-            // Fixed in SkiaSharp 3.0
-            return null;
-        }
-#endif
-
         return new MetalPlatformGraphics(device);
     }
 }


### PR DESCRIPTION
This bug was fixed in main branch already, while dropping 2.88 skia support.
See https://github.com/AvaloniaUI/Avalonia/pull/18981#issuecomment-2948702708 and https://github.com/AvaloniaUI/Avalonia/pull/18981#issuecomment-3037501095

Closes https://github.com/AvaloniaUI/Avalonia/issues/19308 (for 11.3 too)