### PR TITLE
Fixes TextLineImpl.GetTextBounds with trailing zero width

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
@@ -1118,23 +1118,29 @@ namespace Avalonia.Media.TextFormatting
             }
 
             // Find the start of the hit
-            var startHit = currentRun.GlyphRun.GetCharacterHitFromDistance(startOffset, out _);
-            var startHitIndex = startHit.FirstCharacterIndex + startHit.TrailingLength;
+            var startHit = currentRun.GlyphRun.FindNearestCharacterHit(startIndex, out _);
+            var startHitIndex = startHit.FirstCharacterIndex;
+
+            //If the requested text range starts at the trailing edge we need to move at the end of the hit
+            if(startHitIndex < startIndex)
+            {
+                startHitIndex += startHit.TrailingLength;
+            }
 
             //Find the next possible position that contains the endIndex
-            var nearestCharacterHit = currentRun.GlyphRun.FindNearestCharacterHit(endIndex, out _);
+            var nearestEndHit = currentRun.GlyphRun.FindNearestCharacterHit(endIndex, out _);
 
             int endHitIndex;
 
-            if (nearestCharacterHit.FirstCharacterIndex < endIndex)
+            if (nearestEndHit.FirstCharacterIndex < endIndex)
             {
                 //The hit is inside or at the trailing edge
-                endHitIndex = nearestCharacterHit.FirstCharacterIndex + nearestCharacterHit.TrailingLength;
+                endHitIndex = nearestEndHit.FirstCharacterIndex + nearestEndHit.TrailingLength;
             }
             else
             {
                 //The hit is at the leading edge
-                endHitIndex = nearestCharacterHit.FirstCharacterIndex;
+                endHitIndex = nearestEndHit.FirstCharacterIndex;
             }
 
             var coveredLength = Math.Max(0, Math.Abs(startHitIndex - endHitIndex) - clusterOffset);

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
@@ -2135,6 +2135,32 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
             }
         }
 
+        [Fact]
+        public void Should_GetTextBounds_Trailing_ZeroWidth()
+        {
+            var text = "dasdsad\r\n";
+
+            using (Start())
+            {
+                var typeface = Typeface.Default;
+
+                var defaultProperties = new GenericTextRunProperties(typeface);
+                var shaperOption = new TextShaperOptions(typeface.GlyphTypeface);
+
+                var textSource = new SingleBufferTextSource(text, defaultProperties);
+
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, double.PositiveInfinity,
+                        new GenericTextParagraphProperties(defaultProperties));
+
+                Assert.NotNull(textLine);
+
+                var textBounds = textLine.GetTextBounds(7, 3);
+            }
+        }
+
         private class FixedRunsTextSource : ITextSource
         {
             private readonly IReadOnlyList<TextRun> _textRuns;

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
@@ -2158,6 +2158,18 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                 Assert.NotNull(textLine);
 
                 var textBounds = textLine.GetTextBounds(7, 3);
+
+                Assert.NotEmpty(textBounds);
+
+                var firstBounds = textBounds[0];
+
+                Assert.NotEmpty(firstBounds.TextRunBounds);
+
+                var firstRunBounds = firstBounds.TextRunBounds[0];
+
+                Assert.Equal(7, firstRunBounds.TextSourceCharacterIndex);
+
+                Assert.Equal(2, firstRunBounds.Length);
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR fixes the GetRunBounds implementation when a run has a zero-width character at the trailing edge.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Trailing zero-width regions produce a crash.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
The GetRunBounds implementation now uses GetNearestCharacterHit to determine the start index of the covered text range, rather than GetCharacterHitFromDistance. This ensures that zero-width regions of the current run are properly hit-tested.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes: #19614