### PR TITLE
Add AdditionalFiles XAML to samples

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -8,6 +8,10 @@
     <NoWarn>$(NoWarn);CS8002</NoWarn> <!-- ignore signing warnings for samples -->
   </PropertyGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="**\*.xaml" SourceItemGroup="AvaloniaXaml" />
+  </ItemGroup>
+
   <Import Project="..\build\SharedVersion.props"/>
   <Import Project="..\build\DevAnalyzers.props"/>
   <Import Project="$(MSBuildThisFileDirectory)\..\Directory.Build.props" />


### PR DESCRIPTION
This adds an `AdditionalFiles` include for XAML files listed in the samples directory, so the designers can pick them up and resolve them.

This isn't something a normal user would have to do, as it's resolved by the Nuget targets and automatically handled, but because of the age of these projects and that it's built from source, it needs a little handholding.