### PR TITLE
Adjust macOS Tray/Menu icons scaling

### DIFF
--- a/native/Avalonia.Native/src/OSX/menu.mm
+++ b/native/Avalonia.Native/src/OSX/menu.mm
@@ -262,10 +262,10 @@ HRESULT AvnAppMenuItem::SetIcon(void *data, size_t length)
             NSSize originalSize = [image size];
              
             NSSize size;
-            size.height = [[NSFont menuFontOfSize:0] pointSize] * 1.333333;
+            size.height = floor([[NSFont menuFontOfSize:0] pointSize] * 1.333333);
             
             auto scaleFactor = size.height / originalSize.height;
-            size.width = originalSize.width * scaleFactor;
+            size.width = floor(originalSize.width * scaleFactor);
             
             [image setSize: size];
             [_native setImage:image];

--- a/native/Avalonia.Native/src/OSX/trayicon.mm
+++ b/native/Avalonia.Native/src/OSX/trayicon.mm
@@ -13,7 +13,6 @@ extern IAvnTrayIcon* CreateTrayIcon()
 AvnTrayIcon::AvnTrayIcon()
 {
     _native = [[NSStatusBar systemStatusBar] statusItemWithLength: NSSquareStatusItemLength];
-    
 }
 
 AvnTrayIcon::~AvnTrayIcon()
@@ -35,16 +34,8 @@ HRESULT AvnTrayIcon::SetIcon (void* data, size_t length)
         {
             NSData *imageData = [NSData dataWithBytes:data length:length];
             NSImage *image = [[NSImage alloc] initWithData:imageData];
+            [image setSize:NSMakeSize(17, 17)];
             
-            NSSize originalSize = [image size];
-             
-            NSSize size;
-            size.height = [[NSFont menuFontOfSize:0] pointSize] * 1.333333;
-            
-            auto scaleFactor = size.height / originalSize.height;
-            size.width = originalSize.width * scaleFactor;
-            
-            [image setSize: size];
             [image setTemplate: _isTemplateIcon];
             [_native setImage:image];
         }

--- a/native/Avalonia.Native/src/OSX/trayicon.mm
+++ b/native/Avalonia.Native/src/OSX/trayicon.mm
@@ -13,6 +13,7 @@ extern IAvnTrayIcon* CreateTrayIcon()
 AvnTrayIcon::AvnTrayIcon()
 {
     _native = [[NSStatusBar systemStatusBar] statusItemWithLength: NSSquareStatusItemLength];
+    
 }
 
 AvnTrayIcon::~AvnTrayIcon()
@@ -34,8 +35,16 @@ HRESULT AvnTrayIcon::SetIcon (void* data, size_t length)
         {
             NSData *imageData = [NSData dataWithBytes:data length:length];
             NSImage *image = [[NSImage alloc] initWithData:imageData];
-            [image setSize:NSMakeSize(17, 17)];
             
+            NSSize originalSize = [image size];
+             
+            NSSize size;
+            size.height = floor([[NSFont menuFontOfSize:0] pointSize] * 1.333333);
+
+            auto scaleFactor = size.height / originalSize.height;
+            size.width = floor(originalSize.width * scaleFactor);
+            
+            [image setSize: size];
             [image setTemplate: _isTemplateIcon];
             [_native setImage:image];
         }


### PR DESCRIPTION
Fixes #18896 

## What does the pull request do?
This PR adjusts the scaling behavior for macOS Tray and Menu images to round down the scaling to a whole number. 

## What is the current behavior?
The logic in menu.mm and tray icon.mm tries to set the height and width of the menu image based on the menu font size. This would, generally, over-scale the image, both cutting it off and making it blurry.

## What is the updated/expected behavior with this PR?
I've added a floor to it so now it will scale down to a whole number. This keeps the existing-ish logic and should fix it so it won't be blurry and cut off.

- Without the change
<img width="371" height="28" alt="Without" src="https://github.com/user-attachments/assets/cf31ee15-7245-4b6f-aa64-1d805e25894c" />
<img width="251" height="66" alt="Without-Menu" src="https://github.com/user-attachments/assets/f9a05e59-7631-431b-aabd-080bbe7efa61" />

- With the change
<img width="371" height="28" alt="With" src="https://github.com/user-attachments/assets/50903601-30a1-40e0-b5dc-a023500a0a41" />
<img width="251" height="66" alt="With-Menu" src="https://github.com/user-attachments/assets/7537dc8b-152c-4d1f-aa2a-b9683e8fad08" />

The scaling logic can't be fully removed because that would be a breaking change. NSStatusBar does allow for variable size icons [that are not square](https://developer.apple.com/documentation/appkit/nsstatusitem/variablelength?language=objc) and more could be done to allow for directly setting sizes, but I feel this is the least destructive way to handle it for now that should fix the general issue.
