### PR TITLE
Fix tooltip hit test following a dirtyRect invalidation not respecting `IsHitTestVisible`

### DIFF
--- a/src/Avalonia.Base/Rendering/IRenderer.cs
+++ b/src/Avalonia.Base/Rendering/IRenderer.cs
@@ -80,6 +80,10 @@ namespace Avalonia.Rendering
         /// <summary>
         /// Hit tests a location to find the visuals at the specified point.
         /// </summary>
+        /// <remarks>
+        /// <para>⚠️ This method is low-level and <b>DOES NOT respect <see cref="Input.InputElement.IsHitTestVisible"/></b>.</para>
+        /// <para>Use  <see cref="Input.InputExtensions"/> to perform input hit testing, or provide your own <paramref name="filter"/> function.</para>
+        /// </remarks>
         /// <param name="p">The point, in client coordinates.</param>
         /// <param name="root">The root of the subtree to search.</param>
         /// <param name="filter">
@@ -92,12 +96,7 @@ namespace Avalonia.Rendering
         /// <summary>
         /// Hit tests a location to find first visual at the specified point.
         /// </summary>
-        /// <param name="p">The point, in client coordinates.</param>
-        /// <param name="root">The root of the subtree to search.</param>
-        /// <param name="filter">
-        /// A filter predicate. If the predicate returns false then the visual and all its
-        /// children will be excluded from the results.
-        /// </param>
+        /// <inheritdoc cref="HitTest(Point, Visual, Func{Visual, bool}?)"/>
         /// <returns>The visual at the specified point, topmost first.</returns>
         Visual? HitTestFirst(Point p, Visual root, Func<Visual, bool>? filter);
     }

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -952,7 +952,7 @@ namespace Avalonia.Controls
                 var clientPoint = this.PointToClient(lastPos);
                 if (dirtyRect.Contains(clientPoint))
                 {
-                    _tooltipService.Update(this, HitTester.HitTestFirst(clientPoint, this, null));
+                    _tooltipService.Update(this, this.InputHitTest(clientPoint, enabledElementsOnly: false) as Visual);
                 }
             }
         }


### PR DESCRIPTION
See #18515 for repro steps. The key is to have an element with `IsHitTestVisible=false` above the element with a tooltip, and then to trigger a redraw without moving the pointer.

The problem is that `HitTester` confusingly sees controls with `IsHitTestVisible=false` unless you specifically filter them out. This sounds insane, but is actually a requirement because the type is also used for rendering. The name collision is the problem.

As well as replacing direct use of `HitTester` with a proper `InputExtensions` input hit test, I added an XML doc warning for others.

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #18515