### PR TITLE
Fix: ChoreographerTimer should check for Android version correctly.

### DIFF
--- a/src/Android/Avalonia.Android/ChoreographerTimer.cs
+++ b/src/Android/Avalonia.Android/ChoreographerTimer.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Android
 {
     internal sealed class ChoreographerTimer : IRenderTimer
     {
-        private static readonly bool s_supports64Callback = OperatingSystem.IsAndroidVersionAtLeast(10);
+        private static readonly bool s_supports64Callback = OperatingSystem.IsAndroidVersionAtLeast(29);
         private readonly object _lock = new();
         private readonly TaskCompletionSource<IntPtr> _choreographer = new();
         private readonly AutoResetEvent _event = new(false);

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/AndroidFramebuffer.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/AndroidFramebuffer.cs
@@ -65,12 +65,12 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         internal static extern IntPtr AChoreographer_getInstance();
 
         [DllImport("android")]
-        [UnsupportedOSPlatform("android10.0")]
+        [UnsupportedOSPlatform("android29.0")]
         internal static extern void AChoreographer_postFrameCallback(
             IntPtr choreographer, delegate* unmanaged<int, IntPtr, void> callback, IntPtr data);
 
         [DllImport("android")]
-        [SupportedOSPlatform("android10.0")]
+        [SupportedOSPlatform("android29.0")]
         internal static extern void AChoreographer_postFrameCallback64(
             IntPtr choreographer, delegate* unmanaged<long, IntPtr, void> callback, IntPtr data);
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This pull request fixes faulty code in the Android implementation of `ChoreographerTimer` which incorrectly checks for Android 10 devices. The issue comes from an incorrect assumption that the API level number matches the official release number. 


## What is the current behavior?
The current behavior checks for Android "10" by incorrectly querying the `OperatingSystem` API with the literal constant `10`. This causes crashes on older OS versions.


## What is the updated/expected behavior with this PR?
The new behavior (described below) fixes the issue for older OS versions and no longer crashes at startup.

## How was the solution implemented (if it's not obvious)?
This constant now instead reflects the correct API level number corresponding to Android 10, which is API 29+


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
