### PR TITLE
Add Boxshadow(s) Documentation Comments

### DIFF
--- a/src/Avalonia.Base/Media/BoxShadow.cs
+++ b/src/Avalonia.Base/Media/BoxShadow.cs
@@ -55,16 +55,23 @@ namespace Avalonia.Media
             {
                 s = null;
                 if (_index >= _arr.Length)
+                {
                     return false;
+                }
+
                 s = _arr[_index];
                 _index++;
+
                 return true;
             }
 
             public string ReadString()
             {
-                if(!TryReadString(out var rv))
+                if (!TryReadString(out var rv))
+                {
                     throw new FormatException();
+                }
+
                 return rv;
             }
         }
@@ -108,18 +115,27 @@ namespace Avalonia.Media
 
         public static unsafe BoxShadow Parse(string s)
         {
-            if(s == null)
+            if (s == null)
+            {
                 throw new ArgumentNullException();
+            }
+
             if (s.Length == 0)
+            {
                 throw new FormatException();
+            }
 
             var p = s.Split(s_Separator, StringSplitOptions.RemoveEmptyEntries);
             if (p.Length == 1 && p[0] == "none")
+            {
                 return default;
-            
+            }
+
             if (p.Length < 3 || p.Length > 6)
+            {
                 throw new FormatException();
-            
+            }
+
             bool inset = false;
 
             var tokenizer = new ArrayReader(p);
@@ -135,16 +151,20 @@ namespace Avalonia.Media
             var offsetY = double.Parse(tokenizer.ReadString(), CultureInfo.InvariantCulture);
             double blur = 0;
             double spread = 0;
-            
 
             tokenizer.TryReadString(out var token3);
             tokenizer.TryReadString(out var token4);
             tokenizer.TryReadString(out var token5);
 
-            if (token4 != null) 
+            if (token4 != null)
+            {
                 blur = double.Parse(token3!, CultureInfo.InvariantCulture);
+            }
+
             if (token5 != null)
+            {
                 spread = double.Parse(token4!, CultureInfo.InvariantCulture);
+            }
 
             var color = Color.Parse(token5 ?? token4 ?? token3!);
             return new BoxShadow

--- a/src/Avalonia.Base/Media/BoxShadow.cs
+++ b/src/Avalonia.Base/Media/BoxShadow.cs
@@ -6,25 +6,90 @@ using Avalonia.Utilities;
 
 namespace Avalonia.Media
 {
+    /// <summary>
+    /// Represents a box shadow which can be attached to an element or control.
+    /// </summary>
     public struct BoxShadow
     {
+        private readonly static char[] s_Separator = new char[] { ' ', '\t' };
+
+        /// <summary>
+        /// Gets or sets the horizontal offset (distance) of the shadow.
+        /// </summary>
+        /// <remarks>
+        /// Positive values place the shadow to the right of the element while
+        /// negative values place the shadow to the left.
+        /// </remarks>
         public double OffsetX { get; set; }
+
+        /// <summary>
+        /// Gets or sets the vertical offset (distance) of the shadow.
+        /// </summary>
+        /// <remarks>
+        /// Positive values place the shadow below the element while
+        /// negative values place the shadow above.
+        /// </remarks>
         public double OffsetY { get; set; }
+
+        /// <summary>
+        /// Gets or sets the blur radius.
+        /// This is used to control the amount of blurring.
+        /// </summary>
+        /// <remarks>
+        /// The larger this value, the bigger the blur effect, so the shadow becomes larger and more transparent.
+        /// Negative values are not allowed. If not specified, the default (zero) is used and the shadow edge is sharp.
+        /// </remarks>
         public double Blur { get; set; }
+
+        /// <summary>
+        /// Gets or sets the spread radius.
+        /// This is used to control the overall size of the shadow.
+        /// </summary>
+        /// <remarks>
+        /// Positive values will cause the shadow to expand and grow larger, negative values will cause the shadow to shrink.
+        /// If not specified, the default (zero) is used and the shadow will be the same size as the element.
+        /// </remarks>
         public double Spread { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color of the shadow.
+        /// </summary>
         public Color Color { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the shadow is inset and drawn within the element rather than outside of it.
+        /// </summary>
+        /// <remarks>
+        /// Inset changes the shadow to inside the element (as if the content was depressed inside the box).
+        /// If false (the default), the shadow is assumed to be a drop shadow (as if the box were raised above the content).
+        /// <br/><br/>
+        /// Inset shadows are drawn inside the element, above the background (even when it's transparent), but below any content.
+        /// </remarks>
         public bool IsInset { get; set; }
 
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// <c>true</c> if the current object is equal to the other parameter; otherwise, <c>false</c>.
+        /// </returns>
         public bool Equals(in BoxShadow other)
         {
-            return OffsetX.Equals(other.OffsetX) && OffsetY.Equals(other.OffsetY) && Blur.Equals(other.Blur) && Spread.Equals(other.Spread) && Color.Equals(other.Color);
+            return OffsetX.Equals(other.OffsetX)
+                && OffsetY.Equals(other.OffsetY)
+                && Blur.Equals(other.Blur)
+                && Spread.Equals(other.Spread)
+                && Color.Equals(other.Color);
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             return obj is BoxShadow other && Equals(other);
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked
@@ -37,8 +102,6 @@ namespace Avalonia.Media
                 return hashCode;
             }
         }
-
-        private readonly static char[] s_Separator = new char[] { ' ', '\t' };
 
         struct ArrayReader
         {
@@ -76,6 +139,7 @@ namespace Avalonia.Media
             }
         }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             var sb = StringBuilderCache.Acquire();
@@ -113,6 +177,22 @@ namespace Avalonia.Media
             Color.ToString(sb);
         }
 
+        /// <summary>
+        /// Parses a <see cref="BoxShadow"/> string.
+        /// </summary>
+        /// <remarks>
+        /// A box shadow may be specified in multiple formats with separate components:
+        ///   <list type="bullet">
+        ///     <item>Two, three, or four length values.</item>
+        ///     <item>A color value.</item>
+        ///     <item>An optional inset keyword.</item>
+        ///   </list>
+        /// If only two length values are given they will be interpreted as <see cref="OffsetX"/> and <see cref="OffsetY"/>.
+        /// If a third value is given, it is interpreted as a <see cref="Blur"/>, and if a fourth value is given,
+        /// it is interpreted as <see cref="Spread"/>.
+        /// </remarks>
+        /// <param name="s">The input string to parse.</param>
+        /// <returns>A new <see cref="BoxShadow"/></returns>
         public static unsafe BoxShadow Parse(string s)
         {
             if (s == null)
@@ -178,12 +258,36 @@ namespace Avalonia.Media
             };
         }
 
+        /// <summary>
+        /// Transforms the specified bounding rectangle to account for the shadow's offset, spread, and blur.
+        /// </summary>
+        /// <param name="rect">The original bounding <see cref="Rect"/> to transform.</param>
+        /// <returns>
+        /// A new <see cref="Rect"/> that includes the shadow's offset, spread, and blur if the shadow is not inset;
+        /// otherwise, the original rectangle.
+        /// </returns>
         public Rect TransformBounds(in Rect rect)
             => IsInset ? rect : rect.Translate(new Vector(OffsetX, OffsetY)).Inflate(Spread + Blur);
 
+        /// <summary>
+        /// Determines whether two <see cref="BoxShadow"/> values are equal.
+        /// </summary>
+        /// <param name="left">The first <see cref="BoxShadow"/> to compare.</param>
+        /// <param name="right">The second <see cref="BoxShadow"/> to compare.</param>
+        /// <returns>
+        /// <c>true</c> if the two <see cref="BoxShadow"/> values are equal; otherwise, <c>false</c>.
+        /// </returns>
         public static bool operator ==(BoxShadow left, BoxShadow right) =>
             left.Equals(right);
 
+        /// <summary>
+        /// Determines whether two <see cref="BoxShadow"/> values are not equal.
+        /// </summary>
+        /// <param name="left">The first <see cref="BoxShadow"/> to compare.</param>
+        /// <param name="right">The second <see cref="BoxShadow"/> to compare.</param>
+        /// <returns>
+        /// <c>true</c> if the two <see cref="BoxShadow"/> values are not equal; otherwise, <c>false</c>.
+        /// </returns>
         public static bool operator !=(BoxShadow left, BoxShadow right) => 
             !(left == right);
     }

--- a/src/Avalonia.Base/Media/BoxShadows.cs
+++ b/src/Avalonia.Base/Media/BoxShadows.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Media
         private readonly BoxShadow _first;
         private readonly BoxShadow[]? _list;
         public int Count { get; }
-        
+
         public BoxShadows(BoxShadow shadow)
         {
             _first = shadow;
@@ -30,9 +30,15 @@ namespace Avalonia.Media
             get
             {
                 if (c< 0 || c >= Count)
+                {
                     throw new IndexOutOfRangeException();
+                }
+
                 if (c == 0)
+                {
                     return _first;
+                }
+
                 return _list![c - 1];
             }
         }
@@ -89,15 +95,22 @@ namespace Avalonia.Media
                 || (sp.Length == 1 &&
                     (string.IsNullOrWhiteSpace(sp[0])
                      || sp[0] == "none")))
+            {
                 return new BoxShadows();
+            }
 
             var first = BoxShadow.Parse(sp[0]);
             if (sp.Length == 1)
+            {
                 return new BoxShadows(first);
+            }
 
             var rest = new BoxShadow[sp.Length - 1];
             for (var c = 0; c < rest.Length; c++)
+            {
                 rest[c] = BoxShadow.Parse(sp[c + 1]);
+            }
+
             return new BoxShadows(first, rest);
         }
 
@@ -105,28 +118,44 @@ namespace Avalonia.Media
         {
             var final = rect;
             foreach (var shadow in this)
+            {
                 final = final.Union(shadow.TransformBounds(rect));
+            }
+
             return final;
         }
-        
+
         public bool HasInsetShadows
         {
             get
             {
                 foreach(var boxShadow in this)
+                {
                     if (boxShadow != default && boxShadow.IsInset)
+                    {
                         return true;
+                    }
+                }
+
                 return false;
             }
         }
-        
+
         public bool Equals(BoxShadows other)
         {
             if (other.Count != Count)
+            {
                 return false;
-            for(var c=0; c<Count ; c++)
+            }
+
+            for (var c = 0; c < Count; c++)
+            {
                 if (!this[c].Equals(other[c]))
+                {
                     return false;
+                }
+            }
+
             return true;
         }
 
@@ -141,7 +170,10 @@ namespace Avalonia.Media
             {
                 int hashCode = 0;
                 foreach (var s in this)
+                {
                     hashCode = (hashCode * 397) ^ s.GetHashCode();
+                }
+
                 return hashCode;
             }
         }

--- a/src/Avalonia.Base/Media/BoxShadows.cs
+++ b/src/Avalonia.Base/Media/BoxShadows.cs
@@ -1,16 +1,28 @@
 using System;
 using System.ComponentModel;
-using Avalonia.Animation.Animators;
 using Avalonia.Utilities;
 
 namespace Avalonia.Media
 {
+    /// <summary>
+    /// Represents a collection of <see cref="BoxShadow"/>s.
+    /// </summary>
     public struct BoxShadows
     {
+        private static readonly char[] s_Separators = new[] { ',' };
+
         private readonly BoxShadow _first;
         private readonly BoxShadow[]? _list;
+
+        /// <summary>
+        /// Gets the number of <see cref="BoxShadow"/>s in the collection.
+        /// </summary>
         public int Count { get; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BoxShadows"/> struct.
+        /// </summary>
+        /// <param name="shadow">The first <see cref="BoxShadow"/> to add to the collection.</param>
         public BoxShadows(BoxShadow shadow)
         {
             _first = shadow;
@@ -18,6 +30,11 @@ namespace Avalonia.Media
             Count = _first == default ? 0 : 1;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BoxShadows"/> struct.
+        /// </summary>
+        /// <param name="first">The first <see cref="BoxShadow"/> to add to the collection.</param>
+        /// <param name="rest">All remaining <see cref="BoxShadow"/>s to add to the collection.</param>
         public BoxShadows(BoxShadow first, BoxShadow[] rest)
         {
             _first = first;
@@ -25,24 +42,33 @@ namespace Avalonia.Media
             Count = 1 + (rest?.Length ?? 0);
         }
 
-        public BoxShadow this[int c]
+        /// <summary>
+        /// Gets the <see cref="BoxShadow"/> at the specified index.
+        /// </summary>
+        /// <param name="index">The index of the <see cref="BoxShadow"/> to return.</param>
+        /// <returns>The <see cref="BoxShadow"/> at the specified index.</returns>
+        /// <exception cref="IndexOutOfRangeException">
+        /// Thrown when index less than 0 or index greater than or equal to <see cref="Count"/>.
+        /// </exception>
+        public BoxShadow this[int index]
         {
             get
             {
-                if (c< 0 || c >= Count)
+                if (index < 0 || index >= Count)
                 {
                     throw new IndexOutOfRangeException();
                 }
 
-                if (c == 0)
+                if (index == 0)
                 {
                     return _first;
                 }
 
-                return _list![c - 1];
+                return _list![index - 1];
             }
         }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             if (Count == 0)
@@ -87,7 +113,11 @@ namespace Avalonia.Media
         [EditorBrowsable(EditorBrowsableState.Never)]
         public BoxShadowsEnumerator GetEnumerator() => new BoxShadowsEnumerator(this);
 
-        private static readonly char[] s_Separators = new[] { ',' };
+        /// <summary>
+        /// Parses a <see cref="BoxShadows"/> string representing one or more <see cref="BoxShadow"/>s.
+        /// </summary>
+        /// <param name="s">The input string to parse.</param>
+        /// <returns>A new <see cref="BoxShadows"/> collection.</returns>
         public static BoxShadows Parse(string s)
         {
             var sp = s.Split(s_Separators, StringSplitOptions.RemoveEmptyEntries);
@@ -114,6 +144,13 @@ namespace Avalonia.Media
             return new BoxShadows(first, rest);
         }
 
+        /// <summary>
+        /// Transforms the specified bounding rectangle to account for all shadow's offset, spread, and blur.
+        /// </summary>
+        /// <param name="rect">The original bounding <see cref="Rect"/> to transform.</param>
+        /// <returns>
+        /// A new <see cref="Rect"/> that includes all shadow's offset, spread, and blur in the collection.
+        /// </returns>
         public Rect TransformBounds(in Rect rect)
         {
             var final = rect;
@@ -125,6 +162,10 @@ namespace Avalonia.Media
             return final;
         }
 
+        /// <summary>
+        /// Gets a value indicating whether any <see cref="BoxShadow"/> in the collection has
+        /// <see cref="BoxShadow.IsInset"/> set to <c>true</c>.
+        /// </summary>
         public bool HasInsetShadows
         {
             get
@@ -141,6 +182,13 @@ namespace Avalonia.Media
             }
         }
 
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// <c>true</c> if the current object is equal to the other parameter; otherwise, <c>false</c>.
+        /// </returns>
         public bool Equals(BoxShadows other)
         {
             if (other.Count != Count)
@@ -159,11 +207,13 @@ namespace Avalonia.Media
             return true;
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             return obj is BoxShadows other && Equals(other);
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked
@@ -178,9 +228,25 @@ namespace Avalonia.Media
             }
         }
 
+        /// <summary>
+        /// Determines whether two <see cref="BoxShadows"/> collections are equal.
+        /// </summary>
+        /// <param name="left">The first <see cref="BoxShadows"/> collection to compare.</param>
+        /// <param name="right">The second <see cref="BoxShadows"/> collection to compare.</param>
+        /// <returns>
+        /// <c>true</c> if the two <see cref="BoxShadows"/> collections are equal; otherwise, <c>false</c>.
+        /// </returns>
         public static bool operator ==(BoxShadows left, BoxShadows right) => 
             left.Equals(right);
 
+        /// <summary>
+        /// Determines whether two <see cref="BoxShadows"/> collections are not equal.
+        /// </summary>
+        /// <param name="left">The first <see cref="BoxShadows"/> collection to compare.</param>
+        /// <param name="right">The second <see cref="BoxShadows"/> collection to compare.</param>
+        /// <returns>
+        /// <c>true</c> if the two <see cref="BoxShadows"/> collections are not equal; otherwise, <c>false</c>.
+        /// </returns>
         public static bool operator !=(BoxShadows left, BoxShadows right) =>
             !(left == right);
     }


### PR DESCRIPTION
## What does the pull request do?

Fully documents all public members of `BoxShadow` and `BoxShadows`. This helps in understanding the code for other purposes.

I also reformatted a few things and added braces to get rid of IDE warnings.

A few other comments:

 1. Unlike the vast majority of other structs in Avalonia, these are mutable. That seems like something to cleanup later with the animation system rework.
 2. We really need a system that can generate public Avalonia documentation sections from in-code comments. It would help a ton and we shouldn't have multiple sources of truth for things like property documentation. This should just come from source code (where it's already needed for devs).

## What is the current behavior?

These structs are completely undocumented.

## What is the updated/expected behavior with this PR?

They are now documented.

## How was the solution implemented (if it's not obvious)?

Obvious.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

I did change the parameter name below to index which is the proper term. But this cannot be a breaking change as I don't believe indexers support a syntax like `collection[c:0]`.

**Before**
`public BoxShadow this[int c]`

**After**
`public BoxShadow this[int index]`

## Obsoletions / Deprecations

None

## Fixed issues

None