### PR TITLE
Limit InlineUIContainer to available width

### DIFF
--- a/src/Avalonia.Controls/Documents/Inline.cs
+++ b/src/Avalonia.Controls/Documents/Inline.cs
@@ -66,7 +66,7 @@ namespace Avalonia.Controls.Documents
             control.SetValue(TextDecorationsProperty, value);
         }
         
-        internal abstract void BuildTextRun(IList<TextRun> textRuns);
+        internal abstract void BuildTextRun(IList<TextRun> textRuns, Size blockSize);
 
         internal abstract void AppendText(StringBuilder stringBuilder);
 

--- a/src/Avalonia.Controls/Documents/InlineCollection.cs
+++ b/src/Avalonia.Controls/Documents/InlineCollection.cs
@@ -160,15 +160,6 @@ namespace Avalonia.Controls.Documents
             foreach (var child in this)
             {
                 child.InlineHost = newValue;
-
-                if (child is not InlineUIContainer container)
-                {
-                    continue;
-                }
-
-                oldValue?.VisualChildren.Remove(container.Child);
-
-                newValue?.VisualChildren.Add(container.Child);
             }
 
             Invalidate();

--- a/src/Avalonia.Controls/Documents/InlineCollection.cs
+++ b/src/Avalonia.Controls/Documents/InlineCollection.cs
@@ -180,22 +180,12 @@ namespace Avalonia.Controls.Documents
 
             LogicalChildren?.Add(inline);
 
-            if (inline is InlineUIContainer container)
-            {
-                InlineHost?.VisualChildren.Add(container.Child);
-            }
-
             Invalidate();
         }
 
         private void OnRemove(TextElement inline)
         {
             LogicalChildren?.Remove(inline);
-
-            if (inline is InlineUIContainer container)
-            {
-                InlineHost?.VisualChildren.Remove(container.Child);
-            }
 
             inline.InlineHost = null;
 

--- a/src/Avalonia.Controls/Documents/InlineUIContainer.cs
+++ b/src/Avalonia.Controls/Documents/InlineUIContainer.cs
@@ -77,12 +77,15 @@ namespace Avalonia.Controls.Documents
                 if(change.OldValue is Control oldChild)
                 {
                     LogicalChildren.Remove(oldChild);
+                    InlineHost?.VisualChildren.Remove(oldChild);
                 }
 
                 if(change.NewValue is Control newChild)
                 {
                     LogicalChildren.Add(newChild);
                 }
+
+                InlineHost?.Invalidate();
             }
         }
     }

--- a/src/Avalonia.Controls/Documents/InlineUIContainer.cs
+++ b/src/Avalonia.Controls/Documents/InlineUIContainer.cs
@@ -83,10 +83,18 @@ namespace Avalonia.Controls.Documents
                 if(change.NewValue is Control newChild)
                 {
                     LogicalChildren.Add(newChild);
+                    InlineHost?.VisualChildren.Add(newChild);
                 }
 
                 InlineHost?.Invalidate();
             }
+        }
+
+        internal override void OnInlineHostChanged(IInlineHost? oldValue, IInlineHost? newValue)
+        {
+            var child = Child;
+            oldValue?.VisualChildren.Remove(child);
+            newValue?.VisualChildren.Add(child);
         }
     }
 }

--- a/src/Avalonia.Controls/Documents/InlineUIContainer.cs
+++ b/src/Avalonia.Controls/Documents/InlineUIContainer.cs
@@ -18,6 +18,8 @@ namespace Avalonia.Controls.Documents
         public static readonly StyledProperty<Control> ChildProperty =
             AvaloniaProperty.Register<InlineUIContainer, Control>(nameof(Child));
 
+        private double _measuredWidth = double.NaN;
+
         /// <summary>
         /// Initializes a new instance of InlineUIContainer element.
         /// </summary>
@@ -51,11 +53,12 @@ namespace Avalonia.Controls.Documents
             set => SetValue(ChildProperty, value);
         }
 
-        internal override void BuildTextRun(IList<TextRun> textRuns)
+        internal override void BuildTextRun(IList<TextRun> textRuns, Size blockSize)
         {
-            if(!Child.IsMeasureValid)
+            if (_measuredWidth != blockSize.Width || !Child.IsMeasureValid)
             {
-                Child.Measure(Size.Infinity);
+                Child.Measure(new Size(blockSize.Width, double.PositiveInfinity));
+                _measuredWidth = blockSize.Width;
             }
 
             textRuns.Add(new EmbeddedControlRun(Child, CreateTextRunProperties()));

--- a/src/Avalonia.Controls/Documents/LineBreak.cs
+++ b/src/Avalonia.Controls/Documents/LineBreak.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Controls.Documents
         {
         }
 
-        internal override void BuildTextRun(IList<TextRun> textRuns)
+        internal override void BuildTextRun(IList<TextRun> textRuns, Size blockSize)
         {
             var text = Environment.NewLine;
 

--- a/src/Avalonia.Controls/Documents/Run.cs
+++ b/src/Avalonia.Controls/Documents/Run.cs
@@ -50,7 +50,7 @@ namespace Avalonia.Controls.Documents
             set => SetValue(TextProperty, value);
         }
 
-        internal override void BuildTextRun(IList<TextRun> textRuns)
+        internal override void BuildTextRun(IList<TextRun> textRuns, Size blockSize)
         {
             var text = Text ?? "";
 
@@ -59,7 +59,7 @@ namespace Avalonia.Controls.Documents
                 return;
             }
 
-            var textRunProperties = CreateTextRunProperties();           
+            var textRunProperties = CreateTextRunProperties();
 
             var textCharacters = new TextCharacters(text, textRunProperties);
 

--- a/src/Avalonia.Controls/Documents/Span.cs
+++ b/src/Avalonia.Controls/Documents/Span.cs
@@ -38,11 +38,11 @@ namespace Avalonia.Controls.Documents
             set => SetValue(InlinesProperty, value);
         }
 
-        internal override void BuildTextRun(IList<TextRun> textRuns)
+        internal override void BuildTextRun(IList<TextRun> textRuns, Size blockSize)
         {
             foreach (var inline in Inlines)
             {
-                inline.BuildTextRun(textRuns);
+                inline.BuildTextRun(textRuns, blockSize);
             }
         }
 

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -730,7 +730,7 @@ namespace Avalonia.Controls
                 _textLayout = null;
                 _constraint = deflatedSize;
 
-                //Force arrange so text will be properly alligned.
+                //Force arrange so text will be properly aligned.
                 InvalidateArrange();
             }
            
@@ -742,7 +742,7 @@ namespace Avalonia.Controls
 
                 foreach (var inline in inlines!)
                 {
-                    inline.BuildTextRun(textRuns);
+                    inline.BuildTextRun(textRuns, deflatedSize);
                 }
 
                 _textRuns = textRuns;

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -348,7 +348,7 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
-        public void InlineUIContainer_Child_Schould_Be_Arranged()
+        public void InlineUIContainer_Child_Should_Be_Arranged()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
@@ -379,6 +379,31 @@ namespace Avalonia.Controls.UnitTests
                 Assert.True(button.IsArrangeValid);
 
                 Assert.Equal(60, button.Bounds.Left);
+            }
+        }
+
+        [Fact]
+        public void InlineUIContainer_Child_Should_Be_Constrained()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var target = new TextBlock();
+
+                GeometryDrawing drawing = new GeometryDrawing();
+                drawing.Geometry = new RectangleGeometry(new Rect(0, 0, 500, 500));
+                DrawingImage image = new DrawingImage(drawing);
+
+                Image imageControl = new Image { Source = image };
+                InlineUIContainer container = new InlineUIContainer(imageControl);
+
+                target.Inlines.Add(new Run("The child should not be limited by position on line."));
+                target.Inlines.Add(container);
+
+                target.Measure(new Size(100, 100));
+                target.Arrange(new Rect(target.DesiredSize));
+
+                Assert.True(imageControl.IsMeasureValid);
+                Assert.Equal(100, imageControl.Bounds.Width);
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
In alignment with WPF, measures the `InlineUIContainer` with the constraint of the parent block.


## What is the current behavior?
`InlineUIContainer` is measured without constraint.


## What is the updated/expected behavior with this PR?
`InlineUIContainer` will have maximum width of the parent `TextBlock`


## How was the solution implemented (if it's not obvious)?
`Inline` types have the size passed in `BuildTextRun`, `TextBlock` provides it.


## Checklist

- [x] Added unit tests
- [ ] XML documentation: internal
- [ ] Avalonia Docs: internal

## Breaking changes
Inline UI elements larger than the TextBlock will get less space and if noncompliant clipped.

## Obsoletions / Deprecations
N/A

## Fixed issues
