### PR TITLE
Fix typeface exception when created with empty font family name

### DIFF
--- a/src/Avalonia.Base/Media/Typeface.cs
+++ b/src/Avalonia.Base/Media/Typeface.cs
@@ -48,7 +48,8 @@ namespace Avalonia.Media
             FontStyle style = FontStyle.Normal,
             FontWeight weight = FontWeight.Normal,
             FontStretch stretch = FontStretch.Normal)
-            : this(fontFamilyName == null ? FontFamily.Default : new FontFamily(fontFamilyName), style, weight, stretch)
+            : this(string.IsNullOrEmpty(fontFamilyName) ? FontFamily.Default : new FontFamily(fontFamilyName),
+                  style, weight, stretch)
         {
         }
 

--- a/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
@@ -427,5 +427,19 @@ namespace Avalonia.Skia.UnitTests.Media
                 }
             }
         }
+
+        [Fact]
+        public void Should_Fallback_When_Font_Family_Is_Empty()
+        {
+            using (UnitTestApplication.Start(
+                TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl())))
+            {
+                using (AvaloniaLocator.EnterScope())
+                {
+                    var typeface = new Typeface(string.Empty);
+                    Assert.NotNull(typeface.FontFamily);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix an endless exception when rendering some texts which are loaded in wrong encoding (occur on some Windows PC). For example:
    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
    var encoding = Encoding.GetEncoding(936); // simplified chinese
    someTextBlock.Text = encoding.GetString(Encoding.UTF8.GetBytes("中文"));

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The fontFamilyName pass to Typeface constructor may be empty, but not null, which will raise exception in FontFamily's constructor as below.
public FontFamily(Uri? baseUri, string name)
{
    if (string.IsNullOrEmpty(name))
    {
        throw new ArgumentNullException(nameof(name));
    }
}

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Exception should not throw when create Typeface with empty family name.
See the Should_Fallback_When_Font_Family_Is_Empty test case in FontManagerTests.cs

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Just check if the fontFamilyName is empty and fallback to default one.

## Checklist

- [x] Added unit tests (if possible)?
Yes.
- [ ] Added XML documentation to any related classes?
No.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
N/A.

## Breaking changes
<!--- List any breaking changes here. -->
N/A

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
N/A

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Not reported.