### PR TITLE
Fix the issue that setting SelectedIndex before color picker initialize will not retain the selection

### DIFF
--- a/src/Avalonia.Controls.ColorPicker/ColorView/ColorView.cs
+++ b/src/Avalonia.Controls.ColorPicker/ColorView/ColorView.cs
@@ -77,7 +77,7 @@ namespace Avalonia.Controls
         /// Derived controls may re-implement this based on their default style / control template
         /// and any specialized selection needs.
         /// </remarks>
-        protected virtual void ValidateSelection()
+        protected virtual void ValidateSelection(bool initial = false)
         {
             if (_tabControl != null &&
                 _tabControl.Items != null)
@@ -98,19 +98,26 @@ namespace Avalonia.Controls
                 {
                     object? selectedItem = null;
 
-                    if (_tabControl.SelectedItem == null &&
-                        _tabControl.ItemCount > 0)
+                    if (initial && SelectedIndex >= 0 && SelectedIndex < numVisibleItems)
                     {
-                        // As a failsafe, forcefully select the first item
-                        foreach (var item in _tabControl.Items)
-                        {
-                            selectedItem = item;
-                            break;
-                        }
+                        selectedItem = _tabControl.Items[SelectedIndex];
                     }
                     else
                     {
-                        selectedItem = _tabControl.SelectedItem;
+                        if (_tabControl.SelectedItem == null &&
+                            _tabControl.ItemCount > 0)
+                        {
+                            // As a failsafe, forcefully select the first item
+                            foreach (var item in _tabControl.Items)
+                            {
+                                selectedItem = item;
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            selectedItem = _tabControl.SelectedItem;
+                        }
                     }
 
                     if (selectedItem is Control selectedControl &&
@@ -193,7 +200,7 @@ namespace Avalonia.Controls
             }
 
             base.OnApplyTemplate(e);
-            ValidateSelection();
+            ValidateSelection(true);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls.ColorPicker/ColorView/ColorView.cs
+++ b/src/Avalonia.Controls.ColorPicker/ColorView/ColorView.cs
@@ -77,7 +77,12 @@ namespace Avalonia.Controls
         /// Derived controls may re-implement this based on their default style / control template
         /// and any specialized selection needs.
         /// </remarks>
-        protected virtual void ValidateSelection(bool initial = false)
+        protected virtual void ValidateSelection()
+        {
+            ValidateSelection(false);
+        }
+
+        private void ValidateSelection(bool initial)
         {
             if (_tabControl != null &&
                 _tabControl.Items != null)

--- a/tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj
+++ b/tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj
@@ -14,6 +14,7 @@
   <Import Project="..\..\build\SharedVersion.props" />
   <Import Project="..\..\build\HarfBuzzSharp.props" />
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Avalonia.Controls.ColorPicker\Avalonia.Controls.ColorPicker.csproj" />
     <ProjectReference Include="..\..\src\Markup\Avalonia.Markup.Xaml.Loader\Avalonia.Markup.Xaml.Loader.csproj" />
     <ProjectReference Include="..\..\src\Markup\Avalonia.Markup.Xaml\Avalonia.Markup.Xaml.csproj" />
     <ProjectReference Include="..\..\src\Markup\Avalonia.Markup\Avalonia.Markup.csproj" />

--- a/tests/Avalonia.Controls.UnitTests/ColorPickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ColorPickerTests.cs
@@ -1,0 +1,50 @@
+﻿using Avalonia.Controls.Templates;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests
+{
+    public class ColorPickerTests : ScopedTestBase
+    {
+        private static FuncControlTemplate GetTemplate()
+        {
+            var tabCtrl = new TabControl
+            {
+                Name = "PART_TabControl",
+            };
+            tabCtrl.Items.Add(new TabItem() { Header = "ColorSpectrum" });
+            tabCtrl.Items.Add(new TabItem() { Header = "ColorPalette" });
+            tabCtrl.Items.Add(new TabItem() { Header = "ColorComponents" });
+
+            return new FuncControlTemplate<ColorPicker>((parent, scope) =>
+            {
+                return new DropDownButton
+                {
+                    Flyout = new Flyout
+                    {
+                        Content = tabCtrl.RegisterInNameScope(scope)
+                    }
+                };
+            });
+        }
+
+        [Fact]
+        public void Setting_SelectedIndex_Before_Initialize_Should_Retain_Selection()
+        {
+            var colorPicker = new ColorPicker
+            {
+                SelectedIndex = 1,
+                Template = GetTemplate()
+            };
+
+            colorPicker.BeginInit();
+
+            var root = new TestRoot(colorPicker);
+            colorPicker.ApplyTemplate();
+
+            colorPicker.EndInit();
+
+            Assert.Equal(1, colorPicker.SelectedIndex);
+        }
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix the issue that setting SelectedIndex before color picker initialize will not retain the selection.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Setting or binding SelectedIndex (e.g. 1) to color picker when it's not open, the result selection will always be the first tab (i.e. SelectedIndex == 0) after the color picker is open.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Setting SelectedIndex before color picker initialize should retain the selection.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Take the SelectedIndex into account when the color picker call ValidateSelection for the first time (after OnApplyTemplate).

## Checklist

- [ ] Added unit tests (if possible)?
Yes.
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
N/A.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
N/A.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Not reported.