### PR TITLE
Respond to WM_CAPTURECHANGED

### DIFF
--- a/src/Avalonia.Base/Input/MouseDevice.cs
+++ b/src/Avalonia.Base/Input/MouseDevice.cs
@@ -311,7 +311,7 @@ namespace Avalonia.Input
 
         internal void PlatformCaptureLost()
         {
-            _pointer.Capture(null);
+            _pointer.PlatformCaptureLost();
         }
     }
 }

--- a/src/Avalonia.Base/Input/MouseDevice.cs
+++ b/src/Avalonia.Base/Input/MouseDevice.cs
@@ -104,6 +104,9 @@ namespace Avalonia.Input
                 case RawPointerEventType.Swipe:
                     e.Handled = GestureSwipe(mouse, e.Timestamp, e.Root, e.Position, props, ((RawPointerGestureEventArgs)e).Delta, keyModifiers, e.InputHitTestResult.firstEnabledAncestor);
                     break;
+                case RawPointerEventType.CancelCapture:
+                    PlatformCaptureLost();
+                    break;
             }
         }
 

--- a/src/Avalonia.Base/Input/Pointer.cs
+++ b/src/Avalonia.Base/Input/Pointer.cs
@@ -32,14 +32,28 @@ namespace Avalonia.Input
         {
             
         }
-        
+
+        internal void PlatformCaptureLost()
+        {
+            if (Captured != null)
+                Capture(null, platformInitiated: true);
+        }
+
         public void Capture(IInputElement? control)
+        {
+            Capture(control, platformInitiated: false);
+        }
+
+        private void Capture(IInputElement? control, bool platformInitiated)
         {
             if (Captured is Visual v1)
                 v1.DetachedFromVisualTree -= OnCaptureDetached;
             var oldCapture = Captured;
             Captured = control;
-            PlatformCapture(control);
+            
+            if (!platformInitiated)
+                PlatformCapture(control);
+
             if (oldCapture is Visual v2)
             {
                 var commonParent = FindCommonParent(control, oldCapture);

--- a/src/Avalonia.Base/Input/Raw/RawPointerEventArgs.cs
+++ b/src/Avalonia.Base/Input/Raw/RawPointerEventArgs.cs
@@ -26,7 +26,8 @@ namespace Avalonia.Input.Raw
         TouchCancel,
         Magnify,
         Rotate,
-        Swipe
+        Swipe,
+        CancelCapture
     }
 
     /// <summary>

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -114,8 +114,7 @@ namespace Avalonia.Win32
                         //Window doesn't exist anymore
                         _hwnd = IntPtr.Zero;
                         //Remove root reference to this class, so unmanaged delegate can be collected
-                        lock (s_instances)
-                            s_instances.Remove(this);
+                        s_instances.Remove(this);
 
                         _mouseDevice.Dispose();
                         _touchDevice.Dispose();
@@ -401,7 +400,7 @@ namespace Avalonia.Win32
                         {
                             break;
                         }
-                        if (!IsOurWindow(lParam))
+                        if (_hwnd != lParam)
                         {
                             _trackingMouse = false;
                             e = new RawPointerEventArgs(

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -114,7 +114,8 @@ namespace Avalonia.Win32
                         //Window doesn't exist anymore
                         _hwnd = IntPtr.Zero;
                         //Remove root reference to this class, so unmanaged delegate can be collected
-                        s_instances.Remove(this);
+                        lock (s_instances)
+                            s_instances.Remove(this);
 
                         _mouseDevice.Dispose();
                         _touchDevice.Dispose();
@@ -391,6 +392,26 @@ namespace Avalonia.Win32
                             RawPointerEventType.LeaveWindow,
                             new Point(-1, -1),
                             WindowsKeyboardDevice.Instance.Modifiers);
+                        break;
+                    }
+
+                case WindowsMessage.WM_CAPTURECHANGED:
+                    {
+                        if (IsMouseInPointerEnabled)
+                        {
+                            break;
+                        }
+                        if (!IsOurWindow(lParam))
+                        {
+                            _trackingMouse = false;
+                            e = new RawPointerEventArgs(
+                                _mouseDevice,
+                                timestamp,
+                                Owner,
+                                RawPointerEventType.CancelCapture,
+                                new Point(-1, -1),
+                                WindowsKeyboardDevice.Instance.Modifiers);
+                        }
                         break;
                     }
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -177,9 +177,7 @@ namespace Avalonia.Win32
             _nativeControlHost = new Win32NativeControlHost(this, !UseRedirectionBitmap);
             _defaultTransparencyLevel = UseRedirectionBitmap ? WindowTransparencyLevel.None : WindowTransparencyLevel.Transparent;
             _transparencyLevel = _defaultTransparencyLevel;
-
-            lock (s_instances)
-                s_instances.Add(this);
+            s_instances.Add(this);
         }
 
         internal IInputRoot Owner
@@ -1022,22 +1020,6 @@ namespace Avalonia.Win32
                 return ret;
 
             return WndProc(hWnd, msg, wParam, lParam);
-        }
-
-        private bool IsOurWindow(IntPtr hwnd)
-        {
-            if (hwnd == IntPtr.Zero)
-                return false;
-
-            if (hwnd == _hwnd)
-                return true;
-
-            lock (s_instances)
-                for (int i = 0; i < s_instances.Count; i++)
-                    if (s_instances[i]._hwnd == hwnd)
-                        return true;
-
-            return false;
         }
 
         private void CreateDropTarget(IInputRoot inputRoot)

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -177,7 +177,9 @@ namespace Avalonia.Win32
             _nativeControlHost = new Win32NativeControlHost(this, !UseRedirectionBitmap);
             _defaultTransparencyLevel = UseRedirectionBitmap ? WindowTransparencyLevel.None : WindowTransparencyLevel.Transparent;
             _transparencyLevel = _defaultTransparencyLevel;
-            s_instances.Add(this);
+
+            lock (s_instances)
+                s_instances.Add(this);
         }
 
         internal IInputRoot Owner
@@ -1020,6 +1022,22 @@ namespace Avalonia.Win32
                 return ret;
 
             return WndProc(hWnd, msg, wParam, lParam);
+        }
+
+        private bool IsOurWindow(IntPtr hwnd)
+        {
+            if (hwnd == IntPtr.Zero)
+                return false;
+
+            if (hwnd == _hwnd)
+                return true;
+
+            lock (s_instances)
+                for (int i = 0; i < s_instances.Count; i++)
+                    if (s_instances[i]._hwnd == hwnd)
+                        return true;
+
+            return false;
         }
 
         private void CreateDropTarget(IInputRoot inputRoot)


### PR DESCRIPTION
## What does the pull request do?

On windows, WM_CAPTURECHANGED is received when someone else steals capture from us. This PR informs the element thinking it has a capture that it lost it.

## What is the current behavior?
The message is ignored, leaving the element thinking it still has capture. It doesn't receive any more events though, including mouse up that should cancel the capture.

## What is the updated/expected behavior with this PR?
Elements lose capture as soon as someone else grabs it (e.g. using SetCapture native API).

## How was the solution implemented (if it's not obvious)?
The message raises raw input event that calls `MouseDevice.PlatformCaptureLost()`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
Should not be breaking, applications should not rely on the current behavior and handle capture loss as usual.

## Public API changes

```diff
namespace Avalonia.Input.Raw
{
    public enum RawPointerEventType
    {
        LeaveWindow,
        LeftButtonDown,
        LeftButtonUp,
        RightButtonDown,
        RightButtonUp,
        MiddleButtonDown,
        MiddleButtonUp,
        XButton1Down,
        XButton1Up,
        XButton2Down,
        XButton2Up,
        Move,
        Wheel,
        NonClientLeftButtonDown,
        TouchBegin,
        TouchUpdate,
        TouchEnd,
        TouchCancel,
        Magnify,
        Rotate,
        Swipe,
+       CancelCapture
    }
```

similar to WPF's `RawMouseActions.CancelCapture`

## Fixed issues
Fixes #13490