### PR TITLE
Added HeadingLevel to AutomationProperties

### DIFF
--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -122,7 +122,7 @@
         case AutomationSplitButton: return NSAccessibilityPopUpButtonRole;
         case AutomationWindow: return NSAccessibilityWindowRole;
         case AutomationPane: return NSAccessibilityGroupRole;
-        case AutomationHeader: return NSAccessibilityGroupRole;
+        case AutomationHeader: return @"AXHeading";
         case AutomationHeaderItem:  return NSAccessibilityButtonRole;
         case AutomationTable: return NSAccessibilityTableRole;
         case AutomationTitleBar: return NSAccessibilityGroupRole;
@@ -175,6 +175,10 @@
     else if (_peer->GetAutomationControlType() == AutomationText)
     {
         return GetNSStringAndRelease(_peer->GetName());
+    }
+    else if (_peer->GetAutomationControlType() == AutomationHeader)
+    {
+        return [NSNumber numberWithInt:_peer->GetHeadingLevel()];
     }
 
     return [super accessibilityValue];

--- a/samples/IntegrationTestApp/Pages/AutomationPage.axaml
+++ b/samples/IntegrationTestApp/Pages/AutomationPage.axaml
@@ -13,5 +13,14 @@
     <TextBox Name="LabeledByTextBox" AutomationProperties.LabeledBy="{Binding #TextBlockAsLabel}">
       Foo
     </TextBox>
+    <TextBlock Name="TextBlockWithHeader1" AutomationProperties.ControlTypeOverride="Header" AutomationProperties.HeadingLevel="1">
+      Header 1
+    </TextBlock>
+    <TextBlock Name="TextBlockWithHeader2" AutomationProperties.ControlTypeOverride="Header" AutomationProperties.HeadingLevel="2">
+      Header 2
+    </TextBlock>
+    <TextBlock Name="TextBlockWithoutHeader">
+      Header None
+    </TextBlock>
   </StackPanel>
 </UserControl>

--- a/src/Avalonia.Controls/Automation/AutomationElementIdentifiers.cs
+++ b/src/Avalonia.Controls/Automation/AutomationElementIdentifiers.cs
@@ -30,5 +30,11 @@ namespace Avalonia.Automation
         /// by the <see cref="AutomationPeer.GetHelpText"/> method.
         /// </summary>
         public static AutomationProperty HelpTextProperty { get; } = new AutomationProperty();
+
+        /// <summary>
+        /// Identifiers the heading level automation property. The class name property value is returned
+        /// by the <see cref="AutomationPeer.GetHeadingLevel"/> method.
+        /// </summary>
+        public static AutomationProperty HeadingLevelProperty { get; } = new AutomationProperty();
     }
 }

--- a/src/Avalonia.Controls/Automation/AutomationProperties.cs
+++ b/src/Avalonia.Controls/Automation/AutomationProperties.cs
@@ -105,6 +105,17 @@ namespace Avalonia.Automation
                 typeof(AutomationProperties));
 
         /// <summary>
+        /// Defines the AutomationProperties.HeadingLevel attached property.
+        /// </summary>
+        /// <remarks>
+        /// This property affects the default value for <see cref="AutomationPeer.GetHeadingLevel"/>.
+        /// </remarks>
+        public static readonly AttachedProperty<int> HeadingLevelProperty =
+            AvaloniaProperty.RegisterAttached<StyledElement, int>(
+                "HeadingLevel",
+                typeof(AutomationProperties));
+
+        /// <summary>
         /// Defines the AutomationProperties.IsColumnHeader attached property.
         /// </summary>
         /// <remarks>
@@ -346,6 +357,25 @@ namespace Avalonia.Automation
         {
             _ = element ?? throw new ArgumentNullException(nameof(element));
             return element.GetValue(HelpTextProperty);
+        }
+
+        /// <summary>
+        /// Helper for setting the value of the <see cref="HeadingLevelProperty"/> on a StyledElement.
+        /// </summary>
+        public static void SetHeadingLevel(StyledElement element, int value)
+        {
+            _ = element ?? throw new ArgumentNullException(nameof(element));
+            element.SetValue(HeadingLevelProperty, value);
+        }
+
+        /// <summary>
+        /// Helper for reading the value of the <see cref="HeadingLevelProperty"/> on a StyledElement.
+        /// </summary>
+        /// <returns></returns>
+        public static int GetHeadingLevel(StyledElement element)
+        {
+            _ = element ?? throw new ArgumentNullException(nameof(element));
+            return element.GetValue(HeadingLevelProperty);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
@@ -271,6 +271,23 @@ namespace Avalonia.Automation.Peers
         public string GetHelpText() => GetHelpTextCore() ?? string.Empty;
 
         /// <summary>
+        /// Gets the heading level that is associated with this automation peer.
+        /// </summary>
+        /// <remarks>
+        /// <list type="table">
+        ///   <item>
+        ///     <term>Windows</term>
+        ///     <description><c>UIA_HeadingLevelPropertyId</c></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>macOS</term>
+        ///     <description>Not supported</description>
+        ///   </item>
+        /// </list>
+        /// </remarks>
+        public int GetHeadingLevel() => GetHeadingLevelCore();
+
+        /// <summary>
         /// Gets the <see cref="AutomationPeer"/> that is the parent of this <see cref="AutomationPeer"/>.
         /// </summary>
         /// <remarks>
@@ -503,6 +520,7 @@ namespace Avalonia.Automation.Peers
         protected abstract AutomationPeer? GetLabeledByCore();
         protected abstract string? GetNameCore();
         protected virtual string? GetHelpTextCore() => null;
+        protected virtual int GetHeadingLevelCore() => 0;
         protected abstract AutomationPeer? GetParentCore();
         protected abstract bool HasKeyboardFocusCore();
         protected abstract bool IsContentElementCore();

--- a/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
@@ -281,7 +281,7 @@ namespace Avalonia.Automation.Peers
         ///   </item>
         ///   <item>
         ///     <term>macOS</term>
-        ///     <description>Not supported</description>
+        ///     <description><c>NSAccessibilityProtocol.accessibilityValue</c></description>
         ///   </item>
         /// </list>
         /// </remarks>

--- a/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
@@ -134,6 +134,7 @@ namespace Avalonia.Automation.Peers
 
             return result;
         }
+        protected override int GetHeadingLevelCore() => AutomationProperties.GetHeadingLevel(Owner);
         protected override AutomationPeer? GetParentCore()
         {
             EnsureConnected();

--- a/src/Avalonia.Native/AvnAutomationPeer.cs
+++ b/src/Avalonia.Native/AvnAutomationPeer.cs
@@ -40,6 +40,7 @@ namespace Avalonia.Native
         public IAvnAutomationPeer? LabeledBy => Wrap(_inner.GetLabeledBy());
         public IAvnString Name => _inner.GetName().ToAvnString();
         public IAvnString HelpText => _inner.GetHelpText().ToAvnString();
+        public int HeadingLevel => _inner.GetHeadingLevel();
         public IAvnAutomationPeer? Parent => Wrap(_inner.GetParent());
         public IAvnAutomationPeer? VisualRoot => Wrap(_inner.GetVisualRoot());
 

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -1238,6 +1238,7 @@ interface IAvnAutomationPeer : IUnknown
      void ValueProvider_SetValue(char* value);
 
      IAvnString* GetHelpText();
+     int GetHeadingLevel();
 }
 
 [uuid(b00af5da-78af-4b33-bfff-4ce13a6239a9)]

--- a/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
+++ b/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
@@ -37,6 +37,7 @@ namespace Avalonia.Win32.Automation
             { AutomationElementIdentifiers.ClassNameProperty, UiaPropertyId.ClassName },
             { AutomationElementIdentifiers.NameProperty, UiaPropertyId.Name },
             { AutomationElementIdentifiers.HelpTextProperty, UiaPropertyId.HelpText },
+            { AutomationElementIdentifiers.HeadingLevelProperty, UiaPropertyId.HeadingLevel },
             { ExpandCollapsePatternIdentifiers.ExpandCollapseStateProperty, UiaPropertyId.ExpandCollapseExpandCollapseState },
             { RangeValuePatternIdentifiers.IsReadOnlyProperty, UiaPropertyId.RangeValueIsReadOnly},
             { RangeValuePatternIdentifiers.MaximumProperty, UiaPropertyId.RangeValueMaximum },
@@ -138,6 +139,7 @@ namespace Avalonia.Win32.Automation
                 UiaPropertyId.LocalizedControlType => InvokeSync(() => Peer.GetLocalizedControlType()),
                 UiaPropertyId.Name => InvokeSync(() => Peer.GetName()),
                 UiaPropertyId.HelpText => InvokeSync(() => Peer.GetHelpText()),
+                UiaPropertyId.HeadingLevel => InvokeSync(() => ToUiaHeadingLevel(Peer.GetHeadingLevel())),
                 UiaPropertyId.ProcessId => s_pid,
                 UiaPropertyId.RuntimeId => _runtimeId,
                 _ => null,
@@ -355,6 +357,23 @@ namespace Avalonia.Win32.Automation
                 AutomationControlType.TitleBar => UiaControlTypeId.TitleBar,
                 AutomationControlType.Separator => UiaControlTypeId.Separator,
                 _ => UiaControlTypeId.Custom,
+            };
+        }
+
+        private static UiaHeadingLevel ToUiaHeadingLevel(int level)
+        {
+            return level switch
+            {
+                1 => UiaHeadingLevel.Level1,
+                2 => UiaHeadingLevel.Level2,
+                3 => UiaHeadingLevel.Level3,
+                4 => UiaHeadingLevel.Level4,
+                5 => UiaHeadingLevel.Level5,
+                6 => UiaHeadingLevel.Level6,
+                7 => UiaHeadingLevel.Level7,
+                8 => UiaHeadingLevel.Level8,
+                9 => UiaHeadingLevel.Level9,
+                _ => UiaHeadingLevel.None,
             };
         }
 

--- a/src/Windows/Avalonia.Win32.Automation/Interop/IRawElementProviderSimple.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Interop/IRawElementProviderSimple.cs
@@ -184,7 +184,14 @@ internal enum UiaPropertyId
     OutlineThickness,
     CenterPoint,
     Rotatation,
-    Size
+    Size,
+    IsSelectionPattern2Available,
+    Selection2FirstSelectedItem,
+    Selection2LastSelectedItem,
+    Selection2CurrentSelectedItem,
+    Selection2ItemCount,
+    HeadingLevel,
+    IsDialog
 }
 
 internal enum UiaPatternId
@@ -268,6 +275,20 @@ internal enum UiaControlTypeId
     Separator,
     SemanticZoom,
     AppBar
+};
+
+internal enum UiaHeadingLevel
+{
+    None = 80050,
+    Level1,
+    Level2,
+    Level3,
+    Level4,
+    Level5,
+    Level6,
+    Level7,
+    Level8,
+    Level9
 };
 
 #if NET8_0_OR_GREATER


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This adds the `HeadingLevel` property to `AutomationProperties` so that client accessibility tools on Windows and Mac can know what level a header is.

This was mentioned in #5177 but as far as I can tell not actually implemented after it was mentioned. Possibly forgotten about?

I might also still add support for `LandmarkType`. Should this be in a separate PR, or would you be okay if I commit that with this PR too?

## What is the updated/expected behavior with this PR?
This adds the ability to add `AutomationProperties.HeadingLevel="1"` to controls in order to set their heading level property.

In the `IntegrationTestApp`, I have added 3 text blocks: "Header 1", "Header 2", and "Header None". If you use [Accessibility Insights for Windows](https://accessibilityinsights.io/) you can see that the heading level is set:

<img width="916" height="847" alt="image" src="https://github.com/user-attachments/assets/17befb78-475b-4fe7-bf9a-09f54255594c" />

And this works on Mac, too:

<img width="879" height="301" alt="image" src="https://github.com/user-attachments/assets/f0bbd2f7-026f-4098-9535-b80e8e8231c7" />

## How was the solution implemented (if it's not obvious)?
This property is implemented as an integer which then gets converted to `UiaHeadingLevel` on Windows, and an `NSNumber` on Mac for header type elements.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

I don't see any existing integration tests for automation properties, so I didn't add any, but I'd be happy to if needed.

There's also no current documentation for `AutomationProperties`, so I don't think a PR to the docs repo makes sense right now.

## Breaking changes
Not sure how breaking this really is, but this changes the header role on Mac from `AXGroup` to its proper role `AXHeading`.

## Obsoletions / Deprecations
n/a

## Fixed issues
n/a