### PR TITLE
Fix: Browser StorageItem methods not working and handle conversion issue

### DIFF
--- a/src/Browser/Avalonia.Browser/Interop/StorageHelper.cs
+++ b/src/Browser/Avalonia.Browser/Interop/StorageHelper.cs
@@ -56,16 +56,16 @@ internal static partial class StorageHelper
     [JSImport("StorageProvider.createAcceptType", AvaloniaModule.StorageModuleName)]
     public static partial JSObject CreateAcceptType(string description, string[] mimeTypes, string[]? extensions);
 
-    [JSImport("StorageProvider.deleteAsync", AvaloniaModule.StorageModuleName)]
+    [JSImport("StorageItem.deleteAsync", AvaloniaModule.StorageModuleName)]
     public static partial Task DeleteAsync(JSObject fileHandle);
     
-    [JSImport("StorageProvider.moveAsync", AvaloniaModule.StorageModuleName)]
+    [JSImport("StorageItem.moveAsync", AvaloniaModule.StorageModuleName)]
     public static partial Task<JSObject?> MoveAsync(JSObject fileHandle, JSObject destinationFolder);
     
-    [JSImport("StorageProvider.createFile", AvaloniaModule.StorageModuleName)]
+    [JSImport("StorageItem.createFile", AvaloniaModule.StorageModuleName)]
     public static partial Task<JSObject?> CreateFile(JSObject folderHandle, string name);
     
-    [JSImport("StorageProvider.createFolder", AvaloniaModule.StorageModuleName)]
+    [JSImport("StorageItem.createFolder", AvaloniaModule.StorageModuleName)]
     public static partial Task<JSObject?> CreateFolder(JSObject folderHandle, string name);
 
     [JSImport("StorageItem.getFile", AvaloniaModule.StorageModuleName)]

--- a/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
+++ b/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
@@ -235,11 +235,13 @@ internal abstract class JSStorageItem : IStorageBookmarkItem
             throw new InvalidOperationException("Destination folder must be initialized the StorageProvider API.");
         }
 
-        var storageItem = await StorageHelper.MoveAsync(FileHandle, folder.FileHandle);
-        if (storageItem is null)
+        var itemHandle = await StorageHelper.MoveAsync(FileHandle, folder.FileHandle);
+        if (itemHandle is null)
         {
             return null;
         }
+        
+        var storageItem = StorageHelper.StorageItemFromHandle(itemHandle)!;
 
         var kind = storageItem.GetPropertyAsString("kind");
         return kind switch
@@ -394,13 +396,15 @@ internal class JSStorageFolder : JSStorageItem, IStorageBookmarkFolder
     {
         try
         {
-            var storageFile = await StorageHelper.GetFolder(FileHandle, name);
-            if (storageFile is null)
+            var folderHandle = await StorageHelper.GetFolder(FileHandle, name);
+            if (folderHandle is null)
             {
                 return null;
             }
+            
+            var storageFolder = StorageHelper.StorageItemFromHandle(folderHandle)!;
 
-            return new JSStorageFolder(storageFile);
+            return new JSStorageFolder(storageFolder);
         }
         catch (JSException ex) when (ShouldSupressErrorOnFileAccess(ex))
         {
@@ -412,11 +416,13 @@ internal class JSStorageFolder : JSStorageItem, IStorageBookmarkFolder
     {
         try
         {
-            var storageFile = await StorageHelper.GetFile(FileHandle, name);
-            if (storageFile is null)
+            var fileHandle = await StorageHelper.GetFile(FileHandle, name);
+            if (fileHandle is null)
             {
                 return null;
             }
+            
+            var storageFile = StorageHelper.StorageItemFromHandle(fileHandle)!;
 
             return new JSStorageFile(storageFile);
         }

--- a/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
+++ b/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
@@ -356,12 +356,13 @@ internal class JSStorageFolder : JSStorageItem, IStorageBookmarkFolder
     {
         try
         {
-            var storageFile = await StorageHelper.CreateFile(FileHandle, name);
-            if (storageFile is null)
+            var fileHandle = await StorageHelper.CreateFile(FileHandle, name);
+            if (fileHandle is null)
             {
                 return null;
             }
-
+            
+            var storageFile = StorageHelper.StorageItemFromHandle(fileHandle)!;
             return new JSStorageFile(storageFile);
         }
         catch (JSException ex) when (ex.Message == BrowserStorageProvider.NoPermissionsMessage)
@@ -374,13 +375,14 @@ internal class JSStorageFolder : JSStorageItem, IStorageBookmarkFolder
     {
         try
         {
-            var storageFile = await StorageHelper.CreateFolder(FileHandle, name);
-            if (storageFile is null)
+            var folderHandler = await StorageHelper.CreateFolder(FileHandle, name);
+            if (folderHandler is null)
             {
                 return null;
             }
-
-            return new JSStorageFolder(storageFile);
+            
+            var storageFolder = StorageHelper.StorageItemFromHandle(folderHandler)!;
+            return new JSStorageFolder(storageFolder);
         }
         catch (JSException ex) when (ex.Message == BrowserStorageProvider.NoPermissionsMessage)
         {


### PR DESCRIPTION
## What does the pull request do?  
This pull request resolves an issue with `JSImport` definitions that prevented methods from being invoked on newly created folders and files.  

## What is the current behavior?  
Invoking `MoveAsync`, `DeleteAsync`, `CreateFile`, or `CreateFolder` in a browser environment fails. The following error is logged to the console:  
`StorageProvider.moveAsync must be a Function but was undefined`.  

Additionally, the `CreateFile` and `CreateFolder` methods return raw handles instead of fully constructed storage items. This results in failed checks such as `item.handle != null` in `storageItem.cs` and prevents further operations on the newly created files or folders.  

## What is the updated/expected behavior with this PR?  
After applying this change:  
- The methods `MoveAsync`, `DeleteAsync`, `CreateFile`, and `CreateFolder` now execute correctly in the browser.  
- Newly created files and folders are returned as proper `StorageItem` instances instead of raw handles, allowing validation checks (e.g., `item.handle != null`) to succeed.  
- Methods of newly created items can now be invoked without errors.  

## How was the solution implemented (if it's not obvious)?  
- Replaced the incorrect reference from `StorageProvider` to `StorageItem` in `storageItem.cs`.  
- Introduced calls to `StorageItemFromHandle` within `CreateFile` and `CreateFolder` to ensure that valid storage items are returned instead of raw handles.  

## Checklist  
- [ ] Added unit tests (where applicable).  
- [ ] Provided XML documentation for any related classes.  
- [ ] Consider submitting a companion PR to [https://github.com/AvaloniaUI/avalonia-docs](https://github.com/AvaloniaUI/avalonia-docs) with updated user documentation.  

## Breaking changes  

## Obsoletions / Deprecations  

## Fixed issues  

## Related conversations  
[https://github.com/AvaloniaUI/Avalonia/discussions/19150](https://github.com/AvaloniaUI/Avalonia/discussions/19150) 