### PR TITLE
LayoutTransformControl - fix memory leak due to Transform.Changed event subscription

### DIFF
--- a/src/Avalonia.Controls/LayoutTransformControl.cs
+++ b/src/Avalonia.Controls/LayoutTransformControl.cs
@@ -150,6 +150,7 @@ namespace Avalonia.Controls
         {
             base.OnAttachedToVisualTree(e);
             SubscribeLayoutTransform(LayoutTransform as Transform);
+            ApplyLayoutTransform();
         }
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)

--- a/tests/Avalonia.Controls.UnitTests/LayoutTransformControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/LayoutTransformControlTests.cs
@@ -306,6 +306,35 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(m.M31, res.M31, 3);
             Assert.Equal(m.M32, res.M32, 3);
         }
+        
+        [Fact]
+        public void Should_Apply_Transform_On_Attach_To_VisualTree()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var transform = new SkewTransform() { AngleX = -45, AngleY = -45 };
+                
+                LayoutTransformControl lt = CreateWithChildAndMeasureAndTransform(
+                    100,
+                    100,
+                    transform);
+
+                transform.AngleX = 45;
+                transform.AngleY = 45;
+                
+                var window = new Window { Content = lt };
+                window.Show();
+
+                Matrix actual = lt.TransformRoot.RenderTransform.Value;
+                Matrix expected = Matrix.CreateSkew(Matrix.ToRadians(45), Matrix.ToRadians(45));
+                Assert.Equal(expected.M11, actual.M11, 3);
+                Assert.Equal(expected.M12, actual.M12, 3);
+                Assert.Equal(expected.M21, actual.M21, 3);
+                Assert.Equal(expected.M22, actual.M22, 3);
+                Assert.Equal(expected.M31, actual.M31, 3);
+                Assert.Equal(expected.M32, actual.M32, 3);
+            }
+        }
 
         private static void TransformMeasureSizeTest(Size size, Transform transform, Size expectedSize)
         {

--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -13,6 +13,7 @@ using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Diagnostics;
 using Avalonia.Input;
+using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Rendering;
@@ -1000,6 +1001,54 @@ namespace Avalonia.LeakTests
             }
         }
         
+        [Fact]
+        public void LayoutTransformControl_Is_Freed()
+        {
+            using (Start())
+            {
+                var transform = new RotateTransform { Angle = 90 };
+
+                Func<Window> run = () =>
+                {
+                    var window = new Window
+                    {
+                        Content = new LayoutTransformControl
+                        {
+                            LayoutTransform = transform,
+                            Child = new Canvas()
+                        }
+                    };
+
+                    window.Show();
+
+                    // Do a layout and make sure that LayoutTransformControl gets added to visual tree
+                    window.LayoutManager.ExecuteInitialLayoutPass();
+                    Assert.IsType<LayoutTransformControl>(window.Presenter.Child);
+                    Assert.NotEmpty(window.Presenter.Child.GetVisualChildren());
+
+                    // Clear the content and ensure the LayoutTransformControl is removed.
+                    window.Content = null;
+                    window.LayoutManager.ExecuteLayoutPass();
+                    Assert.Null(window.Presenter.Child);
+
+                    return window;
+                };
+
+                var result = run();
+
+                // Process all Loaded events to free control reference(s)
+                Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
+
+                dotMemory.Check(memory =>
+                    Assert.Equal(0, memory.GetObjects(where => where.Type.Is<LayoutTransformControl>()).ObjectsCount));
+                dotMemory.Check(memory =>
+                    Assert.Equal(0, memory.GetObjects(where => where.Type.Is<Canvas>()).ObjectsCount));
+
+                // We are keeping transform alive to simulate a resource that outlives the control.
+                GC.KeepAlive(transform);
+            }
+        }
+
         private FuncControlTemplate CreateWindowTemplate()
         {
             return new FuncControlTemplate<Window>((parent, scope) =>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
The subscription to the Transform.Changed event was changed from Observable.FromEventPattern to WeakEventHandlerManager.Subscribe (see #19698)

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Memory leak observed after LayoutTransformControl is remove from the visual tree.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Memory doesn`t leak, LayoutTransformControl is correctly collected

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
#19698
