### PR TITLE
Run Avalonia.LeakTests on CI

### DIFF
--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -28,7 +28,7 @@ using Xunit.Abstractions;
 
 namespace Avalonia.LeakTests
 {
-    [DotMemoryUnit(FailIfRunWithoutSupport = true)]
+    [DotMemoryUnit(FailIfRunWithoutSupport = false)]
     public class ControlTests
     {
         // Need to have the collection as field, so GC will not free it

--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -28,7 +28,7 @@ using Xunit.Abstractions;
 
 namespace Avalonia.LeakTests
 {
-    [DotMemoryUnit(FailIfRunWithoutSupport = false)]
+    [DotMemoryUnit(FailIfRunWithoutSupport = true)]
     public class ControlTests
     {
         // Need to have the collection as field, so GC will not free it

--- a/tests/Avalonia.LeakTests/TransitionTests.cs
+++ b/tests/Avalonia.LeakTests/TransitionTests.cs
@@ -3,6 +3,7 @@ using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Styling;
+using Avalonia.Threading;
 using Avalonia.UnitTests;
 using JetBrains.dotMemoryUnit;
 using Xunit;
@@ -99,6 +100,9 @@ namespace Avalonia.LeakTests
 
                 var result = run();
 
+                // Process all Loaded events to free control reference(s)
+                Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
+
                 dotMemory.Check(memory =>
                     Assert.Equal(0, memory.GetObjects(where => where.Type.Is<Button>()).ObjectsCount));
             }
@@ -140,6 +144,9 @@ namespace Avalonia.LeakTests
                 };
 
                 var result = run();
+
+                // Process all Loaded events to free control reference(s)
+                Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
 
                 dotMemory.Check(memory =>
                     Assert.Equal(0, memory.GetObjects(where => where.Type.Is<Button>()).ObjectsCount));


### PR DESCRIPTION
## What does the pull request do?
Run Avalonia.LeakTests via DotMemoryUnit on CI


## What is the current behavior?
Avalonia.LeakTests always succeeds because DotMemoryUnit is not used


## What is the updated/expected behavior with this PR?
Avalonia.LeakTests signals a memory leak