### PR TITLE
[OSX] Move Drag and Drop logic to TopLevelImpl

### DIFF
--- a/native/Avalonia.Native/src/OSX/TopLevelImpl.h
+++ b/native/Avalonia.Native/src/OSX/TopLevelImpl.h
@@ -60,6 +60,9 @@ public:
     virtual HRESULT SetTransparencyMode(AvnWindowTransparencyMode mode) override;
 
     virtual HRESULT GetCurrentDisplayId (CGDirectDisplayID* ret) override;
+
+    virtual HRESULT BeginDragAndDropOperation(AvnDragDropEffects effects, AvnPoint point,
+                                             IAvnClipboard* clipboard, IAvnDndResultCallback* cb, void* sourceHandle) override;
 protected:
     NSCursor *cursor;
     virtual void UpdateAppearance();

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
@@ -69,10 +69,6 @@ public:
 
     virtual HRESULT SetFrameThemeVariant(AvnPlatformThemeVariant variant) override;
 
-    virtual HRESULT BeginDragAndDropOperation(AvnDragDropEffects effects, AvnPoint point,
-            IAvnClipboard *clipboard, IAvnDndResultCallback *cb,
-            void *sourceHandle) override;
-
     virtual HRESULT SetTransparencyMode(AvnWindowTransparencyMode mode) override;
                            
     virtual bool IsModal();

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -411,50 +411,6 @@ HRESULT WindowBaseImpl::SetFrameThemeVariant(AvnPlatformThemeVariant variant) {
     return S_OK;
 }
 
-HRESULT WindowBaseImpl::BeginDragAndDropOperation(AvnDragDropEffects effects, AvnPoint point, IAvnClipboard *clipboard, IAvnDndResultCallback *cb, void *sourceHandle) {
-    START_COM_CALL;
-
-    auto item = TryGetPasteboardItem(clipboard);
-    [item setString:@"" forType:GetAvnCustomDataType()];
-    if (item == nil)
-        return E_INVALIDARG;
-    if (View == NULL)
-        return E_FAIL;
-
-    auto nsevent = [NSApp currentEvent];
-    auto nseventType = [nsevent type];
-
-    // If current event isn't a mouse one (probably due to malfunctioning user app)
-    // attempt to forge a new one
-    if (!((nseventType >= NSEventTypeLeftMouseDown && nseventType <= NSEventTypeMouseExited)
-            || (nseventType >= NSEventTypeOtherMouseDown && nseventType <= NSEventTypeOtherMouseDragged))) {
-        NSRect convertRect = [Window convertRectToScreen:NSMakeRect(point.X, point.Y, 0.0, 0.0)];
-        auto nspoint = NSMakePoint(convertRect.origin.x, convertRect.origin.y);
-        CGPoint cgpoint = NSPointToCGPoint(nspoint);
-        auto cgevent = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown, cgpoint, kCGMouseButtonLeft);
-        nsevent = [NSEvent eventWithCGEvent:cgevent];
-        CFRelease(cgevent);
-    }
-
-    auto dragItem = [[NSDraggingItem alloc] initWithPasteboardWriter:item];
-
-    auto dragItemImage = [NSImage imageNamed:NSImageNameMultipleDocuments];
-    NSRect dragItemRect = {(float) point.X, (float) point.Y, [dragItemImage size].width, [dragItemImage size].height};
-    [dragItem setDraggingFrame:dragItemRect contents:dragItemImage];
-
-    int op = 0;
-    int ieffects = (int) effects;
-    if ((ieffects & (int) AvnDragDropEffects::Copy) != 0)
-        op |= NSDragOperationCopy;
-    if ((ieffects & (int) AvnDragDropEffects::Link) != 0)
-        op |= NSDragOperationLink;
-    if ((ieffects & (int) AvnDragDropEffects::Move) != 0)
-        op |= NSDragOperationMove;
-    [View beginDraggingSessionWithItems:@[dragItem] event:nsevent
-                                 source:CreateDraggingSource((NSDragOperation) op, cb, sourceHandle)];
-    return S_OK;
-}
-
 bool WindowBaseImpl::IsModal() {
     return false;
 }

--- a/src/Avalonia.Native/AvaloniaNativeDragSource.cs
+++ b/src/Avalonia.Native/AvaloniaNativeDragSource.cs
@@ -36,7 +36,7 @@ namespace Avalonia.Native
         {
             // Sanity check
             var tl = TopLevel.GetTopLevel(triggerEvent.Source as Visual);
-            var view = tl?.PlatformImpl as WindowBaseImpl;
+            var view = tl?.PlatformImpl as TopLevelImpl;
             if (view == null)
                 throw new ArgumentException();
 

--- a/src/Avalonia.Native/TopLevelImpl.cs
+++ b/src/Avalonia.Native/TopLevelImpl.cs
@@ -52,7 +52,7 @@ internal class MacOSTopLevelHandle : IPlatformHandle, IMacOSTopLevelPlatformHand
     {
         return Native.ObtainNSViewHandleRetained();
     }
-    
+
     public IntPtr NSWindow => (Native as IAvnWindowBase)?.ObtainNSWindowHandle() ?? IntPtr.Zero;
 
     public IntPtr GetNSWindowRetained()
@@ -98,11 +98,17 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
     {
         _handle = handle;
         _savedLogicalSize = ClientSize;
-        _savedScaling = Native?.Scaling ?? 1;;
+        _savedScaling = Native?.Scaling ?? 1;
+        ;
         _nativeControlHost = new NativeControlHostImpl(Native!.CreateNativeControlHost());
         _platformBehaviorInhibition = new PlatformBehaviorInhibition(Factory.CreatePlatformBehaviorInhibition());
         _surfaces = new object[] { new GlPlatformSurface(Native), new MetalPlatformSurface(Native), this };
         InputMethod = new AvaloniaNativeTextInputMethod(Native);
+    }
+
+    internal void BeginDraggingSession(AvnDragDropEffects effects, AvnPoint point, IAvnClipboard clipboard, IAvnDndResultCallback callback, IntPtr sourceHandle)
+    {
+        Native?.BeginDragAndDropOperation(effects, point, clipboard, callback, sourceHandle);
     }
 
     public double DesktopScaling => 1;
@@ -118,7 +124,7 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
             {
                 return default;
             }
-            
+
             var s = Native.ClientSize;
             return new Size(s.Width, s.Height);
 
@@ -135,7 +141,7 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
     public Compositor Compositor => AvaloniaNativePlatform.Compositor;
     public Action? Closed { get; set; }
     public Action? LostFocus { get; set; }
-    
+
     public WindowTransparencyLevel TransparencyLevel
     {
         get => _transparencyLevel;
@@ -397,7 +403,7 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
         {
             throw new RenderTargetNotReadyException();
         }
-        
+
         return new FramebufferRenderTarget(this, nativeRenderTarget);
     }
 
@@ -439,7 +445,7 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
             {
                 return;
             }
-            
+
             var s = new Size(size->Width, size->Height);
             _parent._savedLogicalSize = s;
             _parent.Resized?.Invoke(s, (WindowResizeReason)reason);
@@ -492,7 +498,7 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
             {
                 return AvnDragDropEffects.None;
             }
-            
+
             IDataObject? dataObject = null;
             if (dataObjectHandle != IntPtr.Zero)
                 dataObject = GCHandle.FromIntPtr(dataObjectHandle).Target as IDataObject;

--- a/src/Avalonia.Native/TopLevelImpl.cs
+++ b/src/Avalonia.Native/TopLevelImpl.cs
@@ -99,7 +99,6 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
         _handle = handle;
         _savedLogicalSize = ClientSize;
         _savedScaling = Native?.Scaling ?? 1;
-        ;
         _nativeControlHost = new NativeControlHostImpl(Native!.CreateNativeControlHost());
         _platformBehaviorInhibition = new PlatformBehaviorInhibition(Factory.CreatePlatformBehaviorInhibition());
         _surfaces = new object[] { new GlPlatformSurface(Native), new MetalPlatformSurface(Native), this };

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -116,12 +116,6 @@ namespace Avalonia.Native
             Native?.SetMinMaxSize(minSize.ToAvnSize(), maxSize.ToAvnSize());
         }
 
-        internal void BeginDraggingSession(AvnDragDropEffects effects, AvnPoint point, IAvnClipboard clipboard,
-            IAvnDndResultCallback callback, IntPtr sourceHandle)
-        {
-            Native?.BeginDragAndDropOperation(effects, point, clipboard, callback, sourceHandle);
-        }
-
         protected class WindowBaseEvents : TopLevelEvents, IAvnWindowBaseEvents
         {
             private readonly WindowBaseImpl _parent;

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -735,6 +735,9 @@ interface IAvnTopLevel : IUnknown
      HRESULT SetTransparencyMode(AvnWindowTransparencyMode mode);
      
      HRESULT GetCurrentDisplayId(uint* ret);
+
+     HRESULT BeginDragAndDropOperation(AvnDragDropEffects effects, AvnPoint point,
+                                              IAvnClipboard* clipboard, IAvnDndResultCallback* cb, [intptr]void* sourceHandle);
 }
 
 [uuid(e5aca675-02b7-4129-aa79-d6e417210bda), cpp-virtual-inherits]
@@ -757,8 +760,6 @@ interface IAvnWindowBase : IAvnTopLevel
      HRESULT SetMainMenu(IAvnMenu* menu);
      HRESULT ObtainNSWindowHandle([intptr]void** retOut);
      HRESULT ObtainNSWindowHandleRetained([intptr]void** retOut);
-     HRESULT BeginDragAndDropOperation(AvnDragDropEffects effects, AvnPoint point,
-                                              IAvnClipboard* clipboard, IAvnDndResultCallback* cb, [intptr]void* sourceHandle);
 }
 
 [uuid(83e588f3-6981-4e48-9ea0-e1e569f79a91), cpp-virtual-inherits]


### PR DESCRIPTION
Fixes #19704 

## What does the pull request do?
The PR moves the drag and drop logic from WindowBaseImpl to TopLevelImpl, allowing for embedded NSView's to be able to handle drag and drop.

## What is the current behavior?
Currently, WindowBaseImpl has native methods for dealing with drag and drop within an Avalonia macOS View. This depends on the NSWindow. This breaks drag and drop for embedded NSView Avalonia Views, since it assumes that it's being run within an Avalonia Window.

## What is the updated/expected behavior with this PR?
Now the same internal drag and drop actions should apply to both Avalonia app and embedded views.

## How was the solution implemented (if it's not obvious)?
This moves the logic up to the shared TopLevelImpl. An NSView can call on itself to get its NSWindow (Or itself), so the same logic applies to both implementations, it just needed to be moved up so both could access it.
