### PR TITLE
Add Add/Remove event handler methods to DragDrop.

### DIFF
--- a/src/Avalonia.Base/Input/DragDrop.cs
+++ b/src/Avalonia.Base/Input/DragDrop.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 
@@ -39,6 +40,86 @@ namespace Avalonia.Input
         public static void SetAllowDrop(Interactive interactive, bool value)
         {
             interactive.SetValue(AllowDropProperty, value);
+        }
+
+        /// <summary>
+        /// Adds a handler for the DragEnter attached event.
+        /// </summary>
+        /// <param name="element">The element to attach the handler to.</param>
+        /// <param name="handler">The handler for the event.</param>
+        public static void AddDragEnterHandler(Interactive element, EventHandler<DragEventArgs> handler)
+        {
+            element.AddHandler(DragEnterEvent, handler);
+        }
+
+        /// <summary>
+        /// Removes a handler for the DragEnter attached event.
+        /// </summary>
+        /// <param name="element">The element to remove the handler from.</param>
+        /// <param name="handler">The handler to remove.</param>
+        public static void RemoveDragEnterHandler(Interactive element, EventHandler<DragEventArgs> handler)
+        {
+            element.RemoveHandler(DragEnterEvent, handler);
+        }
+
+        /// <summary>
+        /// Adds a handler for the DragLeave attached event.
+        /// </summary>
+        /// <param name="element">The element to attach the handler to.</param>
+        /// <param name="handler">The handler for the event.</param>
+        public static void AddDragLeaveHandler(Interactive element, EventHandler<DragEventArgs> handler)
+        {
+            element.AddHandler(DragLeaveEvent, handler);
+        }
+
+        /// <summary>
+        /// Removes a handler for the DragLeave attached event.
+        /// </summary>
+        /// <param name="element">The element to remove the handler from.</param>
+        /// <param name="handler">The handler to remove.</param>
+        public static void RemoveDragLeaveHandler(Interactive element, EventHandler<DragEventArgs> handler)
+        {
+            element.RemoveHandler(DragLeaveEvent, handler);
+        }
+
+        /// <summary>
+        /// Adds a handler for the DragOver attached event.
+        /// </summary>
+        /// <param name="element">The element to attach the handler to.</param>
+        /// <param name="handler">The handler for the event.</param>
+        public static void AddDragOverHandler(Interactive element, EventHandler<DragEventArgs> handler)
+        {
+            element.AddHandler(DragOverEvent, handler);
+        }
+
+        /// <summary>
+        /// Removes a handler for the DragOver attached event.
+        /// </summary>
+        /// <param name="element">The element to remove the handler from.</param>
+        /// <param name="handler">The handler to remove.</param>
+        public static void RemoveDragOverHandler(Interactive element, EventHandler<DragEventArgs> handler)
+        {
+            element.RemoveHandler(DragOverEvent, handler);
+        }
+
+        /// <summary>
+        /// Adds a handler for the Drop attached event.
+        /// </summary>
+        /// <param name="element">The element to attach the handler to.</param>
+        /// <param name="handler">The handler for the event.</param>
+        public static void AddDropHandler(Interactive element, EventHandler<DragEventArgs> handler)
+        {
+            element.AddHandler(DropEvent, handler);
+        }
+
+        /// <summary>
+        /// Removes a handler for the Drop attached event.
+        /// </summary>
+        /// <param name="element">The element to remove the handler from.</param>
+        /// <param name="handler">The handler to remove.</param>
+        public static void RemoveDropHandler(Interactive element, EventHandler<DragEventArgs> handler)
+        {
+            element.RemoveHandler(DropEvent, handler);
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?

Attached events [should follow the pattern](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/events/attached-events-overview#define-a-custom-attached-event) of providing static `Add<event-name>Handler` and `Remove<event-name>Handler` methods, but `DragDrop` did not provide these - it only provided the static `RoutedEvent` fields.

This PR adds these missing methods:

- `public static void AddDragEnterHandler(Interactive element, EventHandler<DragEventArgs> handler)`
- `public static void RemoveDragEnterHandler(Interactive element, EventHandler<DragEventArgs> handler)`
- `public static void AddDragLeaveHandler(Interactive element, EventHandler<DragEventArgs> handler)`
- `public static void RemoveDragLeaveHandler(Interactive element, EventHandler<DragEventArgs> handler)`
- `public static void AddDragOverHandler(Interactive element, EventHandler<DragEventArgs> handler)`
- `public static void RemoveDragOverHandler(Interactive element, EventHandler<DragEventArgs> handler)`
- `public static void AddDropHandler(Interactive element, EventHandler<DragEventArgs> handler)`
- `public static void RemoveDropHandler(Interactive element, EventHandler<DragEventArgs> handler)`

## What is the current behavior?

One must call `AddHandler` or `RemoveHandler` manually with the relevant `RoutedEvent` field.

## What is the updated/expected behavior with this PR?

There are convivence methods for adding/removing these attached events.