### PR TITLE
Do not recapture already captured element

### DIFF
--- a/src/Avalonia.Base/Input/Pointer.cs
+++ b/src/Avalonia.Base/Input/Pointer.cs
@@ -46,9 +46,12 @@ namespace Avalonia.Input
 
         private void Capture(IInputElement? control, bool platformInitiated)
         {
-            if (Captured is Visual v1)
-                v1.DetachedFromVisualTree -= OnCaptureDetached;
             var oldCapture = Captured;
+            if (oldCapture == control)
+                return;
+
+            if (oldCapture is Visual v1)
+                v1.DetachedFromVisualTree -= OnCaptureDetached;
             Captured = control;
             
             if (!platformInitiated)

--- a/tests/Avalonia.Base.UnitTests/Input/PointerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/PointerTests.cs
@@ -36,5 +36,22 @@ namespace Avalonia.Base.UnitTests.Input
             pointer.Capture(null);
             Assert.True(receivers.SequenceEqual(new object[] { newCapture, newParent, el, root }));
         }
+
+        [Fact]
+        public void Capture_Captured_ShouldNot_Call_Platform()
+        {
+            var pointer = new TestPointer(Pointer.GetNextFreeId(), PointerType.Mouse, true);
+
+            Border capture = new Border();
+            pointer.Capture(capture);
+            pointer.Capture(capture);
+
+            Assert.Equal(1, pointer.PlatformCaptureCalled);
+
+            pointer.Capture(null);
+            pointer.Capture(null);
+
+            Assert.Equal(2, pointer.PlatformCaptureCalled);
+        }
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Input/PointerTestsBase.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/PointerTestsBase.cs
@@ -16,6 +16,18 @@ namespace Avalonia.Base.UnitTests.Input;
 
 public abstract class PointerTestsBase : ScopedTestBase
 {
+    protected class TestPointer : Pointer
+    {
+        internal int PlatformCaptureCalled = 0;
+
+        internal TestPointer(int id, PointerType type, bool isPrimary) : base(id, type, isPrimary) { }
+
+        protected override void PlatformCapture(IInputElement? element)
+        {
+            PlatformCaptureCalled++;
+        }
+    }
+
     private protected static void SetHit(Mock<IHitTester> renderer, Control? hit)
     {
         renderer.Setup(x => x.HitTest(It.IsAny<Point>(), It.IsAny<Visual>(), It.IsAny<Func<Visual, bool>>()))


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This fixes a bug where `MouseDevice.MouseUp` sets capture to `null`

https://github.com/AvaloniaUI/Avalonia/blob/d7f417017db23bd46094caed392f83b82f96bfee/src/Avalonia.Base/Input/MouseDevice.cs#L209

at a time when it does not have a capture anymore.

## What is the current behavior?
When a context menu opens and captures mouse, the mouse up event on the owner window will cancel the capture, either dismissing the menu or making it indismissable.

## What is the updated/expected behavior with this PR?
When the captured element is already the one to be captured (in this case `null`), do nothing, and especially don't tell the platform capture has changed.

## How was the solution implemented (if it's not obvious)?
`Pointer.Capture` is a no-op if element already captured.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
Code calling `Capture(element)` when the `element` is already captured will no longer go through losing and gaining capture and associated events.
