### PR TITLE
Clarify the CenterX and CenterY properties in Avalonia.Media.RotateTransform

### DIFF
--- a/src/Avalonia.Base/Media/RotateTransform.cs
+++ b/src/Avalonia.Base/Media/RotateTransform.cs
@@ -5,7 +5,7 @@ using Avalonia.VisualTree;
 namespace Avalonia.Media
 {
     /// <summary>
-    /// Rotates an <see cref="Visual"/>.
+    /// Rotates a <see cref="Visual"/>.
     /// </summary>
     public sealed class RotateTransform : Transform
     {
@@ -49,8 +49,8 @@ namespace Avalonia.Media
         /// Initializes a new instance of the <see cref="RotateTransform"/> class.
         /// </summary>
         /// <param name="angle">The angle, in degrees.</param>
-        /// <param name="centerX">The x-coordinate of the center point for the rotation.</param>
-        /// <param name="centerY">The y-coordinate of the center point for the rotation.</param>
+        /// <param name="centerX">The x-coordinate of the center point for the rotation with 0 being the RenderTransformOrigin point (center by default).</param>
+        /// <param name="centerY">The y-coordinate of the center point for the rotation with 0 being the RenderTransformOrigin point (center by default).</param>
         public RotateTransform(double angle, double centerX, double centerY)
             : this()
         {
@@ -69,7 +69,7 @@ namespace Avalonia.Media
         }
 
         /// <summary>
-        /// Gets or sets the x-coordinate of the rotation center point. The default is 0.
+        /// Gets or sets the x-coordinate of the rotation center point. The default is 0 which is the RenderTransformOrigin point (center by default).
         /// </summary>
         public double CenterX
         {
@@ -78,7 +78,7 @@ namespace Avalonia.Media
         }
 
         /// <summary>
-        /// Gets or sets the y-coordinate of the rotation center point. The default is 0.
+        /// Gets or sets the y-coordinate of the rotation center point. The default is 0 which is the RenderTransformOrigin point (center by default).
         /// </summary>
         public double CenterY
         {

--- a/src/Avalonia.Base/Media/RotateTransform.cs
+++ b/src/Avalonia.Base/Media/RotateTransform.cs
@@ -49,8 +49,8 @@ namespace Avalonia.Media
         /// Initializes a new instance of the <see cref="RotateTransform"/> class.
         /// </summary>
         /// <param name="angle">The angle, in degrees.</param>
-        /// <param name="centerX">The x-coordinate of the center point for the rotation with 0 being the RenderTransformOrigin point (center by default).</param>
-        /// <param name="centerY">The y-coordinate of the center point for the rotation with 0 being the RenderTransformOrigin point (center by default).</param>
+        /// <param name="centerX">The x-coordinate of the center point for the rotation with 0 being the <see cref="Visual.RenderTransformOrigin"/> point (center by default).</param>
+        /// <param name="centerY">The y-coordinate of the center point for the rotation with 0 being the <see cref="Visual.RenderTransformOrigin"/> point (center by default).</param>
         public RotateTransform(double angle, double centerX, double centerY)
             : this()
         {
@@ -69,7 +69,7 @@ namespace Avalonia.Media
         }
 
         /// <summary>
-        /// Gets or sets the x-coordinate of the rotation center point. The default is 0 which is the RenderTransformOrigin point (center by default).
+        /// Gets or sets the x-coordinate of the rotation center point. The default is 0 which is the <see cref="Visual.RenderTransformOrigin"/> point (center by default).
         /// </summary>
         public double CenterX
         {
@@ -78,7 +78,7 @@ namespace Avalonia.Media
         }
 
         /// <summary>
-        /// Gets or sets the y-coordinate of the rotation center point. The default is 0 which is the RenderTransformOrigin point (center by default).
+        /// Gets or sets the y-coordinate of the rotation center point. The default is 0 which is the <see cref="Visual.RenderTransformOrigin"/> point (center by default).
         /// </summary>
         public double CenterY
         {


### PR DESCRIPTION
From the property's summary, it isn't obvious how the CenterX and CenterY property works. I assumed 0 would be the left edge but it's actually the center of the visual. I believe this should be mentioned in the summary of the property so that it's obvious for a developer what values should be used to achieve what you need.

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Adds clarification to RotateTransform.CenterX and RotateTransform.CenterY summary about how they work.

## What is the updated/expected behavior with this PR?

Nothing should change, as this PR only modifies the summaries not the code itself.

## How was the solution implemented (if it's not obvious)?
Should be obvious


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
This change only modifies the properties summary, so it shouldn't break anything.

## Obsoletions / Deprecations
None

## Fixed issues
None
