### PR TITLE
Remove Microsoft.SourceLink.GitHub PackageReference

### DIFF
--- a/build/SourceLink.props
+++ b/build/SourceLink.props
@@ -14,10 +14,6 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
   
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-  </ItemGroup>
-
   <!-- Workaround for https://github.com/dotnet/sdk/issues/11105 -->
   <ItemGroup>
     <SourceRoot Include="$([MSBuild]::EnsureTrailingSlash($(NuGetPackageRoot)))" Condition="'$(NuGetPackageRoot)' != ''" />


### PR DESCRIPTION
SourceLink comes with the SDK now, and having the old package has an incremental build bug, see: https://github.com/dotnet/sdk/issues/36666#issuecomment-2162173453

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Remove the custom reference to SourceLink which is no longer required and has a build incrementality bug:
https://github.com/dotnet/sdk/issues/36666

## What is the current behavior?
The fast up-to-date check in the IDE is broken and it rebuilds every time even if nothing has changed, because regular build writes `System.Reflection.AssemblyInformationalVersionAttribute12.0.999+a24b1e355a9d65a6cc7e383c1886ff79aaadf6b2` and design-time build writes `System.Reflection.AssemblyInformationalVersionAttribute12.0.999` because SourceLink doesn't run during design-time build due to the bug.


## What is the updated/expected behavior with this PR?
Building the solution twice in a row in the IDE should do nothing because it was built the first time already.

## How was the solution implemented (if it's not obvious)?

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes


## Obsoletions / Deprecations

## Fixed issues
