### PR TITLE
Implement focus change only on release when using touch or pen input

### DIFF
--- a/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
+++ b/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
@@ -276,7 +276,6 @@ namespace Avalonia.Controls.Primitives
             {
                 _textBox.RemoveHandler(TextBox.TextChangingEvent, TextChanged);
                 _textBox.RemoveHandler(KeyDownEvent, TextBoxKeyDown);
-                _textBox.RemoveHandler(PointerReleasedEvent, TextBoxPointerReleased);
 
                 _textBox.PropertyChanged -= TextBoxPropertyChanged;
                 _textBox.EffectiveViewportChanged -= TextBoxEffectiveViewportChanged;
@@ -294,7 +293,6 @@ namespace Avalonia.Controls.Primitives
                 {
                     _textBox.AddHandler(TextBox.TextChangingEvent, TextChanged, handledEventsToo: true);
                     _textBox.AddHandler(KeyDownEvent, TextBoxKeyDown, handledEventsToo: true);
-                    _textBox.AddHandler(PointerReleasedEvent, TextBoxPointerReleased, handledEventsToo: true);
 
                     _textBox.PropertyChanged += TextBoxPropertyChanged;
                     _textBox.EffectiveViewportChanged += TextBoxEffectiveViewportChanged;
@@ -371,15 +369,12 @@ namespace Avalonia.Controls.Primitives
             return false;
         }
 
-        private void TextBoxPointerReleased(object? sender, PointerReleasedEventArgs e)
+        internal void Show()
         {
-            if (e.Pointer.Type != PointerType.Mouse)
-            {
-                ShowHandles = true;
+            ShowHandles = true;
 
-                MoveHandlesToSelection();
-                EnsureVisible();
-            }
+            MoveHandlesToSelection();
+            EnsureVisible();
         }
 
         private void TextBoxPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)

--- a/src/Avalonia.Controls/Primitives/TextSelectionHandle.cs
+++ b/src/Avalonia.Controls/Primitives/TextSelectionHandle.cs
@@ -151,11 +151,6 @@ namespace Avalonia.Controls.Primitives
             {
                 var vector = e.GetPosition(VisualRoot as Visual) - _lastPoint.Value;
 
-                var tapSize = TopLevel.GetTopLevel(this)?.PlatformSettings?.GetTapSize(PointerType.Touch) ?? new Size(10, 10);
-
-                if (Math.Abs(vector.X) < tapSize.Width && Math.Abs(vector.Y) < tapSize.Height)
-                    return;
-
                 ev = new VectorEventArgs
                 {
                     RoutedEvent = DragDeltaEvent,

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1868,6 +1868,8 @@ namespace Avalonia.Controls
                     SetCurrentValue(SelectionEndProperty, caretIndex);
                 }
 
+                _presenter.TextSelectionHandleCanvas?.Show();
+
                 if (SelectionStart != SelectionEnd)
                 {
                     _presenter.TextSelectionHandleCanvas?.ShowContextMenu();


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR updates focus behavior when using touch input. Controls will only get or lose focus on pointer release when using touch or pen input

## What is the current behavior?
Mobile focus behaves the same as desktop. This causes issues with navigating with touch when you just want to scroll, but buttons and textboxes take focus on pointer press and triggers undesirable effects, like showing the input panel with textboxes.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
