### PR TITLE
Make ScreenBase impl more reliable

### DIFF
--- a/src/Avalonia.Controls/Platform/IScreenImpl.cs
+++ b/src/Avalonia.Controls/Platform/IScreenImpl.cs
@@ -135,6 +135,9 @@ namespace Avalonia.Platform
             if (_allScreens is not null)
                 return;
 
+            // We don't synchronize this method, as it is expected to be called on UI thread only.
+            Dispatcher.UIThread.VerifyAccess();
+
             var screens = GetAllScreenKeys();
             var screensSet = new HashSet<TKey>(screens, screenKeyComparer);
 

--- a/src/Avalonia.Controls/Platform/IScreenImpl.cs
+++ b/src/Avalonia.Controls/Platform/IScreenImpl.cs
@@ -43,7 +43,7 @@ namespace Avalonia.Platform
         private readonly Dictionary<TKey, TScreen> _allScreensByKey = screenKeyComparer is not null ?
             new Dictionary<TKey, TScreen>(screenKeyComparer) :
             new Dictionary<TKey, TScreen>();
-        private TScreen[]? _allScreens;
+        private IReadOnlyList<TScreen>? _allScreens;
         private int? _screenCount;
         private bool? _screenDetailsRequestGranted;
         private DispatcherOperation? _onChangeOperation;
@@ -158,24 +158,21 @@ namespace Avalonia.Platform
                 }
             }
 
-            var tempScreens = new TScreen[screens.Count];
-            int i = 0;
+            var tempScreens = new List<TScreen>(screens.Count);
             foreach (var newScreenKey in screens)
             {
                 if (_allScreensByKey.TryGetValue(newScreenKey, out var oldScreen))
                 {
                     ScreenChanged(oldScreen);
-                    tempScreens[i] = oldScreen;
+                    tempScreens.Add(oldScreen);
                 }
                 else
                 {
                     var newScreen = CreateScreenFromKey(newScreenKey);
                     ScreenAdded(newScreen);
                     _allScreensByKey[newScreenKey] = newScreen;
-                    tempScreens[i] = newScreen;
+                    tempScreens.Add(newScreen);
                 }
-
-                i++;
             }
 
             _allScreens = tempScreens;

--- a/src/Avalonia.Controls/Platform/IScreenImpl.cs
+++ b/src/Avalonia.Controls/Platform/IScreenImpl.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Metadata;
 using Avalonia.Threading;
@@ -138,7 +139,11 @@ namespace Avalonia.Platform
             var screensSet = new HashSet<TKey>(screens, screenKeyComparer);
 
             // .ToList() is only necessary for .NET Framework apps.
+#if NET
+            foreach (var oldScreenKey in _allScreensByKey.Keys)
+#else
             foreach (var oldScreenKey in _allScreensByKey.Keys.ToList())
+#endif
             {
                 if (!screensSet.Contains(oldScreenKey))
                 {

--- a/src/Avalonia.Controls/Platform/IScreenImpl.cs
+++ b/src/Avalonia.Controls/Platform/IScreenImpl.cs
@@ -137,9 +137,8 @@ namespace Avalonia.Platform
             var screens = GetAllScreenKeys();
             var screensSet = new HashSet<TKey>(screens, screenKeyComparer);
 
-            _allScreens = new TScreen[screens.Count];
-
-            foreach (var oldScreenKey in _allScreensByKey.Keys)
+            // .ToList() is only necessary for .NET Framework apps.
+            foreach (var oldScreenKey in _allScreensByKey.Keys.ToList())
             {
                 if (!screensSet.Contains(oldScreenKey))
                 {
@@ -151,24 +150,27 @@ namespace Avalonia.Platform
                 }
             }
 
+            var tempScreens = new TScreen[screens.Count];
             int i = 0;
             foreach (var newScreenKey in screens)
             {
                 if (_allScreensByKey.TryGetValue(newScreenKey, out var oldScreen))
                 {
                     ScreenChanged(oldScreen);
-                    _allScreens[i] = oldScreen;
+                    tempScreens[i] = oldScreen;
                 }
                 else
                 {
                     var newScreen = CreateScreenFromKey(newScreenKey);
                     ScreenAdded(newScreen);
                     _allScreensByKey[newScreenKey] = newScreen;
-                    _allScreens[i] = newScreen;
+                    tempScreens[i] = newScreen;
                 }
 
                 i++;
             }
+
+            _allScreens = tempScreens;
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

1. Don't expose unfilled array, for the case if another thread reads it mid-initialization.
2. Use list instead of array, no reason not to.
3. Adds Dispatcher.UIThread.VerifyAccess, as we don't synchronize threads otherwise 
4. Fix potential but on .NET Framework with dictionary modification during iteration

## Fixed issues

Probably fixes https://github.com/AvaloniaUI/Avalonia/issues/19758