### PR TITLE
Win32 - Fix margins and nc hit test for caption buttons in  extend to client windows

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.CustomCaptionProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.CustomCaptionProc.cs
@@ -17,13 +17,34 @@ namespace Avalonia.Win32
             // Get the window rectangle.
             GetWindowRect(hWnd, out var rcWindow);
 
+            var scaling = (uint)(RenderScaling * StandardDpi);
+            var relativeScaling = RenderScaling / PrimaryScreenRenderScaling;
+
             // Get the frame rectangle, adjusted for the style without a caption.
             var rcFrame = new RECT();
-            AdjustWindowRectEx(ref rcFrame, (uint)(WindowStyles.WS_OVERLAPPEDWINDOW & ~WindowStyles.WS_CAPTION), false, 0);
-
             var borderThickness = new RECT();
-            
-            AdjustWindowRectEx(ref borderThickness, (uint)GetStyle(), false, 0);
+            if (Win32Platform.WindowsVersion < PlatformConstants.Windows10_1607)
+            {
+                AdjustWindowRectEx(ref rcFrame, (uint)(WindowStyles.WS_OVERLAPPEDWINDOW & ~WindowStyles.WS_CAPTION), false, 0);
+
+                rcFrame.top = (int)(rcFrame.top * relativeScaling);
+                rcFrame.right = (int)(rcFrame.right * relativeScaling);
+                rcFrame.left = (int)(rcFrame.left * relativeScaling);
+                rcFrame.bottom = (int)(rcFrame.bottom * relativeScaling);
+
+                AdjustWindowRectEx(ref borderThickness, (uint)GetStyle(), false, 0);
+
+                borderThickness.top = (int)(borderThickness.top * relativeScaling);
+                borderThickness.right = (int)(borderThickness.right * relativeScaling);
+                borderThickness.left = (int)(borderThickness.left * relativeScaling);
+                borderThickness.bottom = (int)(borderThickness.bottom * relativeScaling);
+            }
+            else
+            {
+                AdjustWindowRectExForDpi(ref rcFrame, WindowStyles.WS_OVERLAPPEDWINDOW & ~WindowStyles.WS_CAPTION, false, 0, scaling);
+                AdjustWindowRectExForDpi(ref borderThickness, GetStyle(), false, 0, scaling);
+            }
+
             borderThickness.left *= -1;
             borderThickness.top *= -1;
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1100,8 +1100,30 @@ namespace Avalonia.Win32
             RECT borderThickness = new RECT();
             RECT borderCaptionThickness = new RECT();
 
-            AdjustWindowRectEx(ref borderCaptionThickness, (uint)(GetStyle()), false, 0);
-            AdjustWindowRectEx(ref borderThickness, (uint)(GetStyle() & ~WindowStyles.WS_CAPTION), false, 0);
+            var scaling = (uint)(RenderScaling * StandardDpi);
+            var relativeScaling = RenderScaling / PrimaryScreenRenderScaling;
+
+            if (Win32Platform.WindowsVersion < PlatformConstants.Windows10_1607)
+            {
+                AdjustWindowRectEx(ref borderCaptionThickness, (uint)GetStyle(), false, 0);
+                AdjustWindowRectEx(ref borderThickness, (uint)(GetStyle() & ~WindowStyles.WS_CAPTION), false, 0);
+
+                borderCaptionThickness.top = (int)(borderCaptionThickness.top * relativeScaling);
+                borderCaptionThickness.right = (int)(borderCaptionThickness.right * relativeScaling);
+                borderCaptionThickness.left = (int)(borderCaptionThickness.left * relativeScaling);
+                borderCaptionThickness.bottom = (int)(borderCaptionThickness.bottom * relativeScaling);
+
+                borderThickness.top = (int)(borderThickness.top * relativeScaling);
+                borderThickness.right = (int)(borderThickness.right * relativeScaling);
+                borderThickness.left = (int)(borderThickness.left * relativeScaling);
+                borderThickness.bottom = (int)(borderThickness.bottom * relativeScaling);
+            }
+            else
+            {
+                AdjustWindowRectExForDpi(ref borderCaptionThickness, GetStyle(), false, 0, (uint)(RenderScaling * StandardDpi));
+                AdjustWindowRectExForDpi(ref borderThickness, GetStyle() & ~WindowStyles.WS_CAPTION, false, 0, (uint)(RenderScaling * StandardDpi));
+            }
+
             borderThickness.left *= -1;
             borderThickness.top *= -1;
             borderCaptionThickness.left *= -1;
@@ -1132,7 +1154,7 @@ namespace Avalonia.Win32
             if (WindowState == WindowState.Maximized)
             {
                 _extendedMargins = new Thickness(0, (borderCaptionThickness.top - borderThickness.top) / RenderScaling, 0, 0);
-                _offScreenMargin = new Thickness(borderThickness.left / PrimaryScreenRenderScaling, borderThickness.top / PrimaryScreenRenderScaling, borderThickness.right / PrimaryScreenRenderScaling, borderThickness.bottom / PrimaryScreenRenderScaling);
+                _offScreenMargin = new Thickness(borderThickness.left / RenderScaling, borderThickness.top / RenderScaling, borderThickness.right / RenderScaling, borderThickness.bottom / RenderScaling);
             }
             else
             {

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1120,8 +1120,8 @@ namespace Avalonia.Win32
             }
             else
             {
-                AdjustWindowRectExForDpi(ref borderCaptionThickness, GetStyle(), false, 0, (uint)(RenderScaling * StandardDpi));
-                AdjustWindowRectExForDpi(ref borderThickness, GetStyle() & ~WindowStyles.WS_CAPTION, false, 0, (uint)(RenderScaling * StandardDpi));
+                AdjustWindowRectExForDpi(ref borderCaptionThickness, GetStyle(), false, 0, scaling);
+                AdjustWindowRectExForDpi(ref borderThickness, GetStyle() & ~WindowStyles.WS_CAPTION, false, 0, scaling);
             }
 
             borderThickness.left *= -1;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR adjusts the border thickness use for title bar visual and nc hit testing when client is extended to decorations, especially when the main display is of a different scaling from other displays on the system.

## What is the current behavior?
Border thickness currently doesn't consider DPI/scaling. This causes all nc hittest to use border thinkness based on the primary display scaling. Any window on other displays that have different scaling will not properly hit test around the edges. This can be easily noticed by moving the mouse pointer along the edge of a maximized window and not activating the Close button when at the edge.


## What is the updated/expected behavior with this PR?

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
`AdjustWindowRectExForDpi` is now used when available. On Windows versions older than 1607, the returned `RECT` is adjusted  with the relative scaling between the main and current display. 


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/19723
