### PR TITLE
Fix PlatformDataTransferItem.TryGetRaw for unknown formats

### DIFF
--- a/src/Avalonia.Base/Input/IAsyncDataTransferItem.cs
+++ b/src/Avalonia.Base/Input/IAsyncDataTransferItem.cs
@@ -26,7 +26,7 @@ public interface IAsyncDataTransferItem
     /// of the generic argument of the underlying <see cref="DataFormat{T}"/>.
     /// </para>
     /// <para>
-    /// To retrieve a typed value, use <see cref="DataTransferItemExtensions.TryGetValue"/>.
+    /// To retrieve a typed value, use <see cref="AsyncDataTransferItemExtensions.TryGetValueAsync"/>.
     /// </para>
     /// </remarks>
     /// <seealso cref="AsyncDataTransferItemExtensions.TryGetValueAsync"/>

--- a/src/Avalonia.Base/Input/Platform/PlatformDataTransferItem.cs
+++ b/src/Avalonia.Base/Input/Platform/PlatformDataTransferItem.cs
@@ -27,7 +27,7 @@ internal abstract class PlatformDataTransferItem : IDataTransferItem, IAsyncData
         => Array.IndexOf(Formats, format) >= 0;
 
     public object? TryGetRaw(DataFormat format)
-        => Contains(format) ? TryGetRawCore(format) : Task.FromResult<object?>(null);
+        => Contains(format) ? TryGetRawCore(format) : null;
 
     public Task<object?> TryGetRawAsync(DataFormat format)
     {

--- a/tests/Avalonia.Base.UnitTests/Input/PlatformDataTransferItemTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/PlatformDataTransferItemTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Threading.Tasks;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Input;
+
+public sealed class PlatformDataTransferItemTests
+{
+    [Fact]
+    public void TryGetRaw_Should_Return_Null_When_Format_Is_Unknown()
+    {
+        var format = DataFormat.CreateBytesApplicationFormat("test-format");
+        var item = new TestPlatformDataTransferItem([]);
+
+        var value = item.TryGetRaw(format);
+
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryGetRaw_Should_Return_Expected_Value_When_Format_Is_Known()
+    {
+        var format = DataFormat.CreateBytesApplicationFormat("test-format");
+        var item = new TestPlatformDataTransferItem([format]);
+
+        var value = item.TryGetRaw(format);
+
+        Assert.Same(format, value);
+    }
+
+    [Fact]
+    public async Task TryGetRawAsync_Should_Return_Null_When_Format_Is_Unknown()
+    {
+        var format = DataFormat.CreateBytesApplicationFormat("test-format");
+        var item = new TestPlatformDataTransferItem([]);
+
+        var value = await item.TryGetRawAsync(format);
+
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public async Task TryGetRawAsync_Should_Return_Expected_Value_When_Format_Is_Known()
+    {
+        var format = DataFormat.CreateBytesApplicationFormat("test-format");
+        var item = new TestPlatformDataTransferItem([format]);
+
+        var value = await item.TryGetRawAsync(format);
+
+        Assert.Same(format, value);
+    }
+
+    private sealed class TestPlatformDataTransferItem(DataFormat[] dataFormats) : PlatformDataTransferItem
+    {
+        protected override DataFormat[] ProvideFormats()
+            => dataFormats;
+
+        protected override object TryGetRawCore(DataFormat format)
+            => format;
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
This PR fixes `PlatformDataTransferItem.TryGetRaw()` not returning `null` for unknown formats.
Unit tests have been added.

## What is the current behavior?
`TryGetRaw()` incorrectly returns a `Task`.

## What is the updated/expected behavior with this PR?
`TryGetRaw()` returns null.

## Fixed issues
- Fixes #19790
