### PR TITLE
Android - Fix scaling of inset when app is launched

### DIFF
--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -777,6 +777,8 @@ namespace Avalonia.Controls
             _scaling = ValidateScaling(scaling);
             LayoutHelper.InvalidateSelfAndChildrenMeasure(this);
             Dispatcher.UIThread.Send(_ => ScalingChanged?.Invoke(this, EventArgs.Empty));
+
+            InvalidateChildInsetsPadding();
         }
 
         private void HandleTransparencyLevelChanged(WindowTransparencyLevel transparencyLevel)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This pr forces insets to be invalidated when scaling changes on android.


## What is the current behavior?
On launch on .net 9+, due to display end to end being enforced by the OS, apps must always apply inset padding, or safe area padding. On launch, the top level only initializes safe area padding once, but that before the OS configuration is read and the actual display scaling is retrieved. This causes safe area padding to be too large due to using a scaling of 1.
![Screenshot_2025-10-09-11-26-20-328_com avalonia safeareademo](https://github.com/user-attachments/assets/0968a2eb-0421-490e-9ab8-88a8f0bca3ee)


## What is the updated/expected behavior with this PR?
Anytime scaling changes, including the first time it's retrieved, safe area padding is invalidated, thus setting to to the correctly scaled values.
![Screenshot_2025-10-09-11-24-38-650_com avalonia safeareademo](https://github.com/user-attachments/assets/af7b7aae-6ab7-45d3-9210-2abf529558e8)


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
