### PR TITLE
Fix - Ignore PointerOver change when pointer event is CancelCapture

### DIFF
--- a/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
+++ b/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
@@ -77,7 +77,7 @@ namespace Avalonia.Input
                         args.InputModifiers.ToKeyModifiers());
                 }
                 else if (pointerDevice.TryGetPointer(args) is { } pointer &&
-                    pointer.Type != PointerType.Touch)
+                    pointer.Type != PointerType.Touch && args.Type != RawPointerEventType.CancelCapture)
                 {
                     var element = GetEffectivePointerOverElement(
                         args.InputHitTestResult.firstEnabledAncestor,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes a regression from https://github.com/AvaloniaUI/Avalonia/pull/19685 . `CancelCapture` no longer  updates pointer over state.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/19798
