### PR TITLE
[WIP] Fix: text input fields on Samsung Android devices should function properly when typing multiple words

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
@@ -126,7 +126,7 @@ namespace Avalonia.Android.Platform.Input
 
             _inputConnection.IsInUpdate = true;
 
-            var selection = Client.ActualSelection;
+            var selection = Client.Selection;
 
             var composition = _inputConnection.EditBuffer.HasComposition ? _inputConnection.EditBuffer.Composition!.Value : new TextSelection(-1,-1);
 

--- a/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
@@ -126,7 +126,7 @@ namespace Avalonia.Android.Platform.Input
 
             _inputConnection.IsInUpdate = true;
 
-            var selection = Client.Selection;
+            var selection = Client.ActualSelection;
 
             var composition = _inputConnection.EditBuffer.HasComposition ? _inputConnection.EditBuffer.Composition!.Value : new TextSelection(-1,-1);
 

--- a/src/Android/Avalonia.Android/Platform/Input/AvaloniaInputConnection.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AvaloniaInputConnection.cs
@@ -279,7 +279,7 @@ namespace Avalonia.Android.Platform.Input
 
         public ICharSequence? GetSelectedTextFormatted([GeneratedEnum] GetTextFlags flags)
         {
-            return new Java.Lang.String(_editBuffer.SelectedText ?? "");
+            return _editBuffer.SelectedText;
         }
 
         public ICharSequence? GetTextAfterCursorFormatted(int n, [GeneratedEnum] GetTextFlags flags)

--- a/src/Android/Avalonia.Android/Platform/Input/AvaloniaInputConnection.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AvaloniaInputConnection.cs
@@ -284,15 +284,12 @@ namespace Avalonia.Android.Platform.Input
 
         public ICharSequence? GetTextAfterCursorFormatted(int n, [GeneratedEnum] GetTextFlags flags)
         {
-            var end = Math.Min(_editBuffer.Selection.End, _editBuffer.Text.Length);
-            return SafeSubstring(_editBuffer.Text, end, Math.Min(n, _editBuffer.Text.Length - end));
+            return _editBuffer.GetTextAfterCursor(n);
         }
 
         public ICharSequence? GetTextBeforeCursorFormatted(int n, [GeneratedEnum] GetTextFlags flags)
         {
-            var start = Math.Max(0, _editBuffer.Selection.Start - n);
-            var length = _editBuffer.Selection.Start - start;
-            return SafeSubstring(_editBuffer.Text, start, length);
+            return _editBuffer.GetTextBeforeCursor(n);
         }
 
         public bool PerformPrivateCommand(string? action, Bundle? data)

--- a/src/Android/Avalonia.Android/Platform/Input/EditCommand.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/EditCommand.cs
@@ -21,9 +21,7 @@ namespace Avalonia.Android.Platform.Input
 
         public override void Apply(TextEditBuffer buffer)
         {
-            var start = Math.Clamp(_start, 0, buffer.Text.Length);
-            var end = Math.Clamp(_end, 0, buffer.Text.Length);
-            buffer.Selection = new TextSelection(start, end);
+            buffer.Selection = new TextSelection(_start, _end);
         }
     }
 
@@ -57,11 +55,13 @@ namespace Avalonia.Android.Platform.Input
 
         public override void Apply(TextEditBuffer buffer)
         {
-            var end = Math.Min(buffer.Text.Length, buffer.Selection.End + _after);
-            var endCount = end - buffer.Selection.End;
-            var start = Math.Max(0, buffer.Selection.Start - _before);
-            buffer.Remove(buffer.Selection.End, endCount);
-            buffer.Remove(start, buffer.Selection.Start - start);
+            var length = buffer.Text.Length;
+            var selection = buffer.Selection;
+            var end = Math.Min(length, selection.End + _after);
+            var endCount = end - selection.End;
+            var start = Math.Max(0, selection.Start - _before);
+            buffer.Remove(selection.End, endCount);
+            buffer.Remove(start, selection.Start - start);
             buffer.Selection = new TextSelection(start, start);
         }
     }
@@ -81,13 +81,15 @@ namespace Avalonia.Android.Platform.Input
         {
             var beforeLengthInChar = 0;
 
+            var selection = buffer.Selection;
+            var text = buffer.Text;
             for (int i = 0; i < _before; i++)
             {
                 beforeLengthInChar++;
-                if (buffer.Selection.Start > beforeLengthInChar)
+                if (selection.Start > beforeLengthInChar)
                 {
-                    var lead = buffer.Text[buffer.Selection.Start - beforeLengthInChar - 1];
-                    var trail = buffer.Text[buffer.Selection.Start - beforeLengthInChar];
+                    var lead = text[selection.Start - beforeLengthInChar - 1];
+                    var trail = text[selection.Start - beforeLengthInChar];
 
                     if (char.IsSurrogatePair(lead, trail))
                     {
@@ -95,7 +97,7 @@ namespace Avalonia.Android.Platform.Input
                     }
                 }
 
-                if (beforeLengthInChar == buffer.Selection.Start)
+                if (beforeLengthInChar == selection.Start)
                     break;
             }
 
@@ -103,10 +105,10 @@ namespace Avalonia.Android.Platform.Input
             for (int i = 0; i < _after; i++)
             {
                 afterLengthInChar++;
-                if (buffer.Selection.End > afterLengthInChar)
+                if (selection.End > afterLengthInChar)
                 {
-                    var lead = buffer.Text[buffer.Selection.End + afterLengthInChar - 1];
-                    var trail = buffer.Text[buffer.Selection.End + afterLengthInChar];
+                    var lead = text[selection.End + afterLengthInChar - 1];
+                    var trail = text[selection.End + afterLengthInChar];
 
                     if (char.IsSurrogatePair(lead, trail))
                     {
@@ -114,12 +116,12 @@ namespace Avalonia.Android.Platform.Input
                     }
                 }
 
-                if (buffer.Selection.End + afterLengthInChar == buffer.Text.Length)
+                if (selection.End + afterLengthInChar == text.Length)
                     break;
             }
 
-            var start = buffer.Selection.Start - beforeLengthInChar;
-            buffer.Remove(buffer.Selection.End, afterLengthInChar);
+            var start = selection.Start - beforeLengthInChar;
+            buffer.Remove(selection.End, afterLengthInChar);
             buffer.Remove(start, beforeLengthInChar);
             buffer.Selection = new TextSelection(start, start);
         }
@@ -139,7 +141,8 @@ namespace Avalonia.Android.Platform.Input
         public override void Apply(TextEditBuffer buffer)
         {
             buffer.ComposingText = _text;
-            var newCursor = _newCursorPosition > 0 ? buffer.Selection.Start + _newCursorPosition - 1 : buffer.Selection.Start + _newCursorPosition;
+            var selection = buffer.Selection;
+            var newCursor = _newCursorPosition > 0 ? selection.Start + _newCursorPosition - 1 : selection.Start + _newCursorPosition;
             buffer.Selection = new TextSelection(newCursor, newCursor);
         }
     }

--- a/src/Avalonia.Base/Input/TextInput/TextInputMethodClient.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextInputMethodClient.cs
@@ -54,6 +54,8 @@ namespace Avalonia.Input.TextInput
         /// </summary>
         public abstract string SurroundingText { get; }
 
+        internal virtual string Text => SurroundingText;
+
         /// <summary>
         /// Gets the cursor rectangle relative to the TextViewVisual
         /// </summary>
@@ -119,6 +121,11 @@ namespace Avalonia.Input.TextInput
         {
             ResetRequested?.Invoke(this, EventArgs.Empty);
         }
+
+        internal virtual string GetTextBeforeCaret(int length) => string.Empty;
+        internal virtual string GetTextAfterCaret(int length) => string.Empty;
+
+        internal virtual TextSelection ActualSelection { get => Selection; set => Selection = value; } 
     }
 
     public record struct TextSelection(int Start, int End);

--- a/src/Avalonia.Base/Input/TextInput/TextInputMethodClient.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextInputMethodClient.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia.Media.TextFormatting;
 
 namespace Avalonia.Input.TextInput
 {
@@ -64,7 +65,7 @@ namespace Avalonia.Input.TextInput
         /// <summary>
         /// Gets or sets the curent selection range within current surrounding text.
         /// </summary>
-        public abstract TextSelection Selection { get; set; }
+        public abstract TextSelection SelectionInSurroundingText { get; set; }
 
         /// <summary>
         /// Sets the non-committed input string
@@ -122,10 +123,9 @@ namespace Avalonia.Input.TextInput
             ResetRequested?.Invoke(this, EventArgs.Empty);
         }
 
-        internal virtual string GetTextBeforeCaret(int length) => string.Empty;
-        internal virtual string GetTextAfterCaret(int length) => string.Empty;
+        internal virtual ReadOnlySpan<char> GetTextInRange(int start, int length) => Span<char>.Empty;
 
-        internal virtual TextSelection ActualSelection { get => Selection; set => Selection = value; } 
+        internal virtual TextSelection Selection { get => SelectionInSurroundingText; set => SelectionInSurroundingText = value; } 
     }
 
     public record struct TextSelection(int Start, int End);

--- a/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
+++ b/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
@@ -177,22 +177,30 @@ namespace Avalonia.Controls.Primitives
                 var selectionEnd = _textBox.SelectionEnd;
                 var start = Math.Min(selectionStart, selectionEnd);
                 var length = Math.Max(selectionStart, selectionEnd) - start;
-                var rects = new List<Rect>(_presenter.TextLayout.HitTestTextRange(start, length));
 
-                if (rects.Count > 0)
+                try
                 {
-                    var first = rects[0];
-                    var last = rects[rects.Count -1];
+                    var rects = new List<Rect>(_presenter.TextLayout.HitTestTextRange(start, length));
 
-                    if (handle.SelectionHandleType == SelectionHandleType.Start)
-                        handle?.SetTopLeft(ToLayer(first.BottomLeft));
-                    else
-                        handle?.SetTopLeft(ToLayer(last.BottomRight));
+                    if (rects.Count > 0)
+                    {
+                        var first = rects[0];
+                        var last = rects[rects.Count - 1];
 
-                    if (otherHandle.SelectionHandleType == SelectionHandleType.Start)
-                        otherHandle?.SetTopLeft(ToLayer(first.BottomLeft));
-                    else
-                        otherHandle?.SetTopLeft(ToLayer(last.BottomRight));
+                        if (handle.SelectionHandleType == SelectionHandleType.Start)
+                            handle?.SetTopLeft(ToLayer(first.BottomLeft));
+                        else
+                            handle?.SetTopLeft(ToLayer(last.BottomRight));
+
+                        if (otherHandle.SelectionHandleType == SelectionHandleType.Start)
+                            otherHandle?.SetTopLeft(ToLayer(first.BottomLeft));
+                        else
+                            otherHandle?.SetTopLeft(ToLayer(last.BottomRight));
+                    }
+                }
+                catch(InvalidOperationException)
+                {
+
                 }
 
                 _presenter?.MoveCaretToTextPosition(position);
@@ -241,28 +249,35 @@ namespace Avalonia.Controls.Primitives
                 var start = Math.Min(selectionStart, selectionEnd);
                 var length = Math.Max(selectionStart, selectionEnd) - start;
 
-                var rects = new List<Rect>(_presenter.TextLayout.HitTestTextRange(start, length));
-
-                if (rects.Count > 0)
+                try
                 {
-                    var first = rects[0];
-                    var last = rects[rects.Count - 1];
+                    var rects = new List<Rect>(_presenter.TextLayout.HitTestTextRange(start, length));
 
-                    if (!_startHandle.IsDragging)
+                    if (rects.Count > 0)
                     {
-                        _startHandle.SetTopLeft(ToLayer(first.BottomLeft));
-                        _startHandle.SelectionHandleType = selectionStart < selectionEnd ?
-                            SelectionHandleType.Start :
-                            SelectionHandleType.End;
-                    }
+                        var first = rects[0];
+                        var last = rects[rects.Count - 1];
 
-                    if (!_endHandle.IsDragging)
-                    {
-                        _endHandle.SetTopLeft(ToLayer(last.BottomRight));
-                        _endHandle.SelectionHandleType = selectionStart > selectionEnd ?
-                            SelectionHandleType.Start :
-                            SelectionHandleType.End;
+                        if (!_startHandle.IsDragging)
+                        {
+                            _startHandle.SetTopLeft(ToLayer(first.BottomLeft));
+                            _startHandle.SelectionHandleType = selectionStart < selectionEnd ?
+                                SelectionHandleType.Start :
+                                SelectionHandleType.End;
+                        }
+
+                        if (!_endHandle.IsDragging)
+                        {
+                            _endHandle.SetTopLeft(ToLayer(last.BottomRight));
+                            _endHandle.SelectionHandleType = selectionStart > selectionEnd ?
+                                SelectionHandleType.Start :
+                                SelectionHandleType.End;
+                        }
                     }
+                }
+                catch (InvalidOperationException)
+                {
+
                 }
             }
         }

--- a/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
+++ b/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
@@ -55,7 +55,7 @@ namespace Avalonia.Controls
                 return base.GetTextInRange(start, length);
             }
             var end = Math.Max(0 ,Math.Min(start + length, Text.Length - 1));
-            start = Math.Max(start, 0);
+            start = Math.Min(Math.Max(start, 0), end);
             return Text.AsSpan().Slice(start, end - start);
         }
 

--- a/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
+++ b/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
@@ -48,97 +48,15 @@ namespace Avalonia.Controls
 
         internal override string Text => _presenter?.Text ?? string.Empty;
 
-        internal override string GetTextBeforeCaret(int length)
+        internal override ReadOnlySpan<char> GetTextInRange(int start, int length)
         {
             if (_presenter is null || _parent is null)
             {
-                return "";
+                return base.GetTextInRange(start, length);
             }
-            var selectionStart = _presenter.SelectionStart;
-
-            var lineIndex = _presenter.TextLayout.GetLineIndexFromCharacterIndex(selectionStart, false);
-
-            var textLine = _presenter.TextLayout.TextLines[lineIndex];
-
-            var offset = selectionStart - textLine.FirstTextSourceIndex;
-
-            var currentLineLength = Math.Min(offset, length);
-            var start = Math.Max(offset - currentLineLength, 0);
-
-            var lineText = GetTextLineText(textLine);
-            var text = lineText.Substring(start, currentLineLength);
-
-            var newText = text;
-
-            length -= currentLineLength;
-
-            while (length > 0)
-            {
-                lineIndex--;
-                if (lineIndex >= 0)
-                {
-                    textLine = _presenter.TextLayout.TextLines[lineIndex];
-                    currentLineLength = Math.Min(textLine.Length, length);
-
-                    lineText = GetTextLineText(textLine);
-                    text = lineText.Substring(textLine.Length - currentLineLength, currentLineLength);
-
-                    newText = text + newText;
-
-                    length -= currentLineLength;
-                }
-                else
-                    break;
-            }
-
-            return newText;
-        }
-
-        internal override string GetTextAfterCaret(int length)
-        {
-            if (_presenter is null || _parent is null)
-            {
-                return "";
-            }
-
-            var selectionEnd = _presenter.SelectionStart;
-
-            var lineIndex = _presenter.TextLayout.GetLineIndexFromCharacterIndex(selectionEnd, false);
-
-            var textLine = _presenter.TextLayout.TextLines[lineIndex];
-            var lastIndex = textLine.FirstTextSourceIndex + textLine.Length;
-
-            var currentLineLength = Math.Min(lastIndex - selectionEnd, length);
-            var start = Math.Max(selectionEnd - textLine.FirstTextSourceIndex, 0);
-
-            var builder = new StringBuilder();
-
-            var lineText = GetTextLineText(textLine);
-
-            builder.Append(lineText.Substring(start, currentLineLength));
-
-            length -= currentLineLength;
-
-            while (length > 0)
-            {
-                lineIndex++;
-                if (lineIndex < _presenter.TextLayout.TextLines.Count)
-                {
-                    textLine = _presenter.TextLayout.TextLines[lineIndex];
-                    currentLineLength = Math.Min(textLine.Length, length);
-
-                    lineText = GetTextLineText(textLine);
-                    var text = lineText.Substring(0, currentLineLength);
-
-                    builder.Append(text);
-
-                    length -= currentLineLength;
-                }
-                else
-                    break;
-            }
-
-            return builder.ToString();
+            var end = Math.Max(0 ,Math.Min(start + length, Text.Length - 1));
+            start = Math.Max(start, 0);
+            return Text.AsSpan().Slice(start, end - start);
         }
 
         public override Rect CursorRectangle
@@ -161,7 +79,7 @@ namespace Avalonia.Controls
             }
         }
 
-        public override TextSelection Selection
+        public override TextSelection SelectionInSurroundingText
         {
             get
             {
@@ -205,7 +123,7 @@ namespace Avalonia.Controls
             }
         }
 
-        internal override TextSelection ActualSelection
+        internal override TextSelection Selection
         {
             get
             {

--- a/src/Avalonia.Native/AvaloniaNativeTextInputMethod.cs
+++ b/src/Avalonia.Native/AvaloniaNativeTextInputMethod.cs
@@ -97,7 +97,7 @@ namespace Avalonia.Native
             }
             
             var surroundingText = _client.SurroundingText;
-            var selection = _client.Selection;
+            var selection = _client.SelectionInSurroundingText;
 
             _inputMethod.SetSurroundingText(
                 surroundingText ?? "",
@@ -137,7 +137,7 @@ namespace Avalonia.Native
             {
                 if (_client.SupportsSurroundingText)
                 {
-                    _client.Selection = new TextSelection(start, end);
+                    _client.SelectionInSurroundingText = new TextSelection(start, end);
                 }
             }
         }

--- a/src/Browser/Avalonia.Browser/BrowserTextInputMethod.cs
+++ b/src/Browser/Avalonia.Browser/BrowserTextInputMethod.cs
@@ -47,7 +47,7 @@ internal class BrowserTextInputMethod(
             ShowIme();
 
             var surroundingText = _client.SurroundingText ?? "";
-            var selection = _client.Selection;
+            var selection = _client.SelectionInSurroundingText;
 
             InputHelper.SetSurroundingText(_inputElement, surroundingText, selection.Start, selection.End);
         }
@@ -76,7 +76,7 @@ internal class BrowserTextInputMethod(
         if (_client != null)
         {
             var surroundingText = _client.SurroundingText ?? "";
-            var selection = _client.Selection;
+            var selection = _client.SelectionInSurroundingText;
 
             InputHelper.SetSurroundingText(_inputElement, surroundingText, selection.Start, selection.End);
         }
@@ -86,7 +86,7 @@ internal class BrowserTextInputMethod(
     {
         InputHelper.FocusElement(_inputElement);
         InputHelper.SetBounds(_inputElement, (int)rect.X, (int)rect.Y, (int)rect.Width, (int)rect.Height,
-            _client?.Selection.End ?? 0);
+            _client?.SelectionInSurroundingText.End ?? 0);
         InputHelper.FocusElement(_inputElement);
     }
 
@@ -118,7 +118,7 @@ internal class BrowserTextInputMethod(
 
         if (start != -1 && end != -1 && _client != null)
         {
-            _client.Selection = new TextSelection(start, end);
+            _client.SelectionInSurroundingText = new TextSelection(start, end);
         }
     }
 

--- a/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
+++ b/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
@@ -298,7 +298,7 @@ namespace Avalonia.Win32.Input
             {
                 Client.SetPreeditText(null);
 
-                if (Client.SupportsSurroundingText && Client.Selection.Start != Client.Selection.End)
+                if (Client.SupportsSurroundingText && Client.SelectionInSurroundingText.Start != Client.SelectionInSurroundingText.End)
                 {
                     KeyPress(Key.Delete, PhysicalKey.Delete);
                 }

--- a/src/iOS/Avalonia.iOS/TextInputResponder.cs
+++ b/src/iOS/Avalonia.iOS/TextInputResponder.cs
@@ -231,7 +231,7 @@ partial class AvaloniaView
             }
             else
             {
-                var currentSelection = _client.Selection;
+                var currentSelection = _client.SelectionInSurroundingText;
                 var span = new CombinedSpan3<char>(surroundingText.AsSpan(0, currentSelection.Start),
                     _markedText,
                     surroundingText.AsSpan(currentSelection.Start, currentSelection.End - currentSelection.Start));
@@ -249,7 +249,7 @@ partial class AvaloniaView
             var r = (AvaloniaTextRange)range;
             Logger.TryGet(LogEventLevel.Debug, ImeLog)?
                 .Log(null, "IUIKeyInput.ReplaceText {start} {end} {text}", r.StartIndex, r.EndIndex, text);
-            _client.Selection = new TextSelection(r.StartIndex, r.EndIndex);
+            _client.SelectionInSurroundingText = new TextSelection(r.StartIndex, r.EndIndex);
             TextInput(text);
         }
 
@@ -470,19 +470,19 @@ partial class AvaloniaView
         {
             get
             {
-                return new AvaloniaTextRange(_client.Selection.Start, _client.Selection.End);
+                return new AvaloniaTextRange(_client.SelectionInSurroundingText.Start, _client.SelectionInSurroundingText.End);
             }
             set
             {
                 if (_inSurroundingTextUpdateEvent > 0)
                     return;
                 if (value == null)
-                    _client.Selection = default;
+                    _client.SelectionInSurroundingText = default;
                 else
                 {
                     var r = (AvaloniaTextRange)value;
 
-                    _client.Selection = new TextSelection(r.StartIndex, r.EndIndex);
+                    _client.SelectionInSurroundingText = new TextSelection(r.StartIndex, r.EndIndex);
                 }
             }
         }
@@ -504,7 +504,7 @@ partial class AvaloniaView
             {
                 if (string.IsNullOrWhiteSpace(_markedText))
                     return null!;
-                return new AvaloniaTextRange(_client.Selection.Start, _client.Selection.Start + _markedText.Length);
+                return new AvaloniaTextRange(_client.SelectionInSurroundingText.Start, _client.SelectionInSurroundingText.Start + _markedText.Length);
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This pull request is a draft for fixes related to proprietary, non-standard keyboard behavior on Samsung Android systems. See #19770 for more information and a video demonstration.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Currently, there is strange behavior with how the Samsung virtual keyboard handles space characters, either when typing them, or when backspacing them. On some devices, the cursor will be moved back by a single character when a space is typed. On others, there is weirdness when backspacing multiple words. 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
This PR is a heavy work-in-progress and aims to fix the behaviors outlined above to mirror functionality on non-Samsung devices. 

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
WIP

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Fixes #19770 
