### PR TITLE
Fix: Enable network location browsing in GTK file chooser dialogs

### DIFF
--- a/src/Avalonia.X11/NativeDialogs/Gtk.cs
+++ b/src/Avalonia.X11/NativeDialogs/Gtk.cs
@@ -61,7 +61,10 @@ namespace Avalonia.X11.NativeDialogs
 
         [DllImport(GtkName)]
         public static extern void gtk_file_chooser_set_select_multiple(IntPtr chooser, bool allow);
-        
+
+        [DllImport(GtkName)]
+        public static extern void gtk_file_chooser_set_local_only(IntPtr chooser, bool local_only);
+
         [DllImport(GtkName)]
         public static extern void gtk_file_chooser_set_do_overwrite_confirmation(IntPtr chooser, bool do_overwrite_confirmation);
 

--- a/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
+++ b/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
@@ -87,6 +87,7 @@ namespace Avalonia.X11.NativeDialogs
             }
 
             gtk_window_set_modal(dlg, true);
+            gtk_file_chooser_set_local_only(dlg, false);
             var tcs = new TaskCompletionSource<string[]?>();
             List<IDisposable>? disposables = null;
 


### PR DESCRIPTION
## Description
Fixes GTK file chooser dialogs to show network locations (SMB, SFTP, NFS) on Linux.

## Problem
GTK file choosers in Avalonia currently hide network locations because they inherit GTK's default `local_only=TRUE` behavior. This prevents users from browsing to GVFS-mounted network shares.

## Solution
- Added `gtk_file_chooser_set_local_only()` P/Invoke declaration to `Gtk.cs`
- Call `gtk_file_chooser_set_local_only(dlg, false)` after dialog creation in `GtkNativeFileDialogs.cs`

## Changes
- `src/Avalonia.X11/NativeDialogs/Gtk.cs`: Added P/Invoke declaration
- `src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs`: Added call to enable network locations

## Testing
Tested on Ubuntu 24.04 with:
- SMB/CIFS shares mounted via GVFS ✅
- SFTP mounts ✅
- Local file browsing (regression test) ✅

## References
- GTK Documentation: https://docs.gtk.org/gtk3/method.FileChooser.set_local_only.html
- Similar fix in PyQt5: https://stackoverflow.com/questions/42997657/pyqt5-filedialog-show-network-folders

## Impact
- Improves usability for Linux users with network shares
- No breaking changes to existing functionality
- Non-controversial bug fix