### PR TITLE
Hotfix for 11.3.x - Add parent/automationPeer null guards 

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -943,7 +943,7 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
     auto window = (AvnWindow*)[self window];
     auto peer = [window automationPeer];
 
-    if (!peer->IsRootProvider())
+    if (peer == nullptr || !peer->IsRootProvider())
         return nil;
 
     auto clientPoint = [window convertPointFromScreen:point];
@@ -980,6 +980,10 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
     // of the AvnView.
     auto window = (AvnWindow*)[self window];
     auto peer = [window automationPeer];
+    if (peer == nullptr)
+    {
+        return;
+    }
     auto childPeers = peer->GetChildren();
     auto childCount = childPeers != nullptr ? childPeers->GetCount() : 0;
 


### PR DESCRIPTION
Hotfix for adding null guards for 11.3.x release.