### PR TITLE
Properly handle non standard italic/oblique fonts on Windows

### DIFF
--- a/src/Skia/Avalonia.Skia/FontManagerImpl.cs
+++ b/src/Skia/Avalonia.Skia/FontManagerImpl.cs
@@ -50,7 +50,7 @@ namespace Avalonia.Skia
                     skFontStyle = SKFontStyle.BoldItalic;
                     break;
                 default:
-                    skFontStyle = new SKFontStyle((SKFontStyleWeight)fontWeight, (SKFontStyleWidth)fontStretch, (SKFontStyleSlant)fontStyle);
+                    skFontStyle = new SKFontStyle((SKFontStyleWeight)fontWeight, (SKFontStyleWidth)fontStretch, fontStyle.ToSkia());
                     break;
             }
 
@@ -63,7 +63,12 @@ namespace Avalonia.Skia
 
             if (skTypeface != null)
             {
-                fontKey = new Typeface(skTypeface.FamilyName, (FontStyle)skTypeface.FontStyle.Slant, (FontWeight)skTypeface.FontStyle.Weight, (FontStretch)skTypeface.FontStyle.Width);
+                // ToDo: create glyph typeface here to get the correct style/weight/stretch
+                fontKey = new Typeface(
+                    skTypeface.FamilyName,
+                    skTypeface.FontStyle.Slant.ToAvalonia(),
+                    (FontWeight)skTypeface.FontStyle.Weight,
+                    (FontStretch)skTypeface.FontStyle.Width);
 
                 return true;
             }
@@ -78,8 +83,7 @@ namespace Avalonia.Skia
         {
             glyphTypeface = null;
 
-            var fontStyle = new SKFontStyle((SKFontStyleWeight)weight, (SKFontStyleWidth)stretch,
-                (SKFontStyleSlant)style);
+            var fontStyle = new SKFontStyle((SKFontStyleWeight)weight, (SKFontStyleWidth)stretch, style.ToSkia());
 
             var skTypeface = _skFontManager.MatchFamily(familyName, fontStyle);
 
@@ -127,7 +131,7 @@ namespace Avalonia.Skia
 
             var set = _skFontManager.GetFontStyles(familyName);
 
-            if(set.Count == 0)
+            if (set.Count == 0)
             {
                 return false;
             }

--- a/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
+++ b/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
@@ -16,7 +16,6 @@ namespace Avalonia.Skia
     internal class GlyphTypefaceImpl : IGlyphTypeface2
     {
         private bool _isDisposed;
-        private readonly SKTypeface _typeface;
         private readonly NameTable? _nameTable;
         private readonly OS2Table? _os2Table;
         private readonly HorizontalHeadTable? _hhTable;
@@ -24,7 +23,7 @@ namespace Avalonia.Skia
 
         public GlyphTypefaceImpl(SKTypeface typeface, FontSimulations fontSimulations)
         {
-            _typeface = typeface ?? throw new ArgumentNullException(nameof(typeface));
+            SKTypeface = typeface ?? throw new ArgumentNullException(nameof(typeface));
 
             Face = new Face(GetTable) { UnitsPerEm = typeface.UnitsPerEm };
 
@@ -95,6 +94,11 @@ namespace Avalonia.Skia
             Weight = (fontSimulations & FontSimulations.Bold) != 0 ? FontWeight.Bold : fontWeight;
 
             var style = _os2Table != null ? GetFontStyle(_os2Table.FontStyle) : FontStyle.Normal;
+
+            if (typeface.FontStyle.Slant == SKFontStyleSlant.Oblique)
+            {
+                style = FontStyle.Oblique;
+            }
 
             Style = (fontSimulations & FontSimulations.Oblique) != 0 ? FontStyle.Italic : style;
 
@@ -205,6 +209,8 @@ namespace Avalonia.Skia
             }
         }
 
+        public SKTypeface SKTypeface { get; }
+
         public Face Face { get; }
 
         public Font Font { get; }
@@ -300,12 +306,12 @@ namespace Avalonia.Skia
 
         private static FontStyle GetFontStyle(OS2Table.FontStyleSelection styleSelection)
         {
-            if((styleSelection & OS2Table.FontStyleSelection.ITALIC) != 0)
+            if ((styleSelection & OS2Table.FontStyleSelection.ITALIC) != 0)
             {
                 return FontStyle.Italic;
             }
 
-            if((styleSelection & OS2Table.FontStyleSelection.OBLIQUE) != 0)
+            if ((styleSelection & OS2Table.FontStyleSelection.OBLIQUE) != 0)
             {
                 return FontStyle.Oblique;
             }
@@ -315,18 +321,18 @@ namespace Avalonia.Skia
 
         private Blob? GetTable(Face face, Tag tag)
         {
-            var size = _typeface.GetTableSize(tag);
+            var size = SKTypeface.GetTableSize(tag);
 
             var data = Marshal.AllocCoTaskMem(size);
 
             var releaseDelegate = new ReleaseDelegate(() => Marshal.FreeCoTaskMem(data));
 
-            return _typeface.TryGetTableData(tag, 0, size, data) ?
+            return SKTypeface.TryGetTableData(tag, 0, size, data) ?
                 new Blob(data, size, MemoryMode.ReadOnly, releaseDelegate) : null;
         }
 
         public SKFont CreateSKFont(float size)
-            => new(_typeface, size, skewX: (FontSimulations & FontSimulations.Oblique) != 0 ? -0.3f : 0.0f)
+            => new(SKTypeface, size, skewX: (FontSimulations & FontSimulations.Oblique) != 0 ? -0.3f : 0.0f)
             {
                 LinearMetrics = true,
                 Embolden = (FontSimulations & FontSimulations.Bold) != 0
@@ -348,7 +354,7 @@ namespace Avalonia.Skia
 
             Font.Dispose();
             Face.Dispose();
-            _typeface.Dispose();
+            SKTypeface.Dispose();
         }
 
         public void Dispose()
@@ -359,14 +365,14 @@ namespace Avalonia.Skia
 
         public bool TryGetTable(uint tag, out byte[] table)
         {
-            return _typeface.TryGetTableData(tag, out table);
+            return SKTypeface.TryGetTableData(tag, out table);
         }
 
         public bool TryGetStream([NotNullWhen(true)] out Stream? stream)
         {
             try
             {
-                var asset = _typeface.OpenStream();
+                var asset = SKTypeface.OpenStream();
                 var size = asset.Length;
                 var buffer = new byte[size];
 

--- a/src/Skia/Avalonia.Skia/SkiaSharpExtensions.cs
+++ b/src/Skia/Avalonia.Skia/SkiaSharpExtensions.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Avalonia.Media;
-using Avalonia.Platform;
 using Avalonia.Media.Imaging;
+using Avalonia.Platform;
 using SkiaSharp;
 
 namespace Avalonia.Skia
@@ -70,7 +70,7 @@ namespace Avalonia.Skia
         {
             return new SKPoint((float)p.X, (float)p.Y);
         }
-        
+
         public static SKPoint ToSKPoint(this Vector p)
         {
             return new SKPoint((float)p.X, (float)p.Y);
@@ -80,17 +80,17 @@ namespace Avalonia.Skia
         {
             return new SKRect((float)r.X, (float)r.Y, (float)r.Right, (float)r.Bottom);
         }
-        
+
         internal static SKRect ToSKRect(this LtrbRect r)
         {
             return new SKRect((float)r.Left, (float)r.Right, (float)r.Right, (float)r.Bottom);
         }
-        
+
         public static SKRectI ToSKRectI(this PixelRect r)
         {
             return new SKRectI(r.X, r.Y, r.Right, r.Bottom);
         }
-        
+
         internal static SKRectI ToSKRectI(this LtrbPixelRect r)
         {
             return new SKRectI(r.Left, r.Top, r.Right, r.Bottom);
@@ -106,7 +106,7 @@ namespace Avalonia.Skia
                    {
                         r.RadiiTopLeft.ToSKPoint(), r.RadiiTopRight.ToSKPoint(),
                         r.RadiiBottomRight.ToSKPoint(), r.RadiiBottomLeft.ToSKPoint(),
-                   });            
+                   });
 
             return result;
         }
@@ -115,17 +115,17 @@ namespace Avalonia.Skia
         {
             return new Rect(r.Left, r.Top, r.Right - r.Left, r.Bottom - r.Top);
         }
-        
+
         internal static LtrbRect ToAvaloniaLtrbRect(this SKRect r)
         {
             return new LtrbRect(r.Left, r.Top, r.Right, r.Bottom);
         }
-        
+
         public static PixelRect ToAvaloniaPixelRect(this SKRectI r)
         {
             return new PixelRect(r.Left, r.Top, r.Right - r.Left, r.Bottom - r.Top);
         }
-        
+
         internal static LtrbPixelRect ToAvaloniaLtrbPixelRect(this SKRectI r)
         {
             return new LtrbPixelRect(r.Left, r.Top, r.Right, r.Bottom);
@@ -173,7 +173,7 @@ namespace Avalonia.Skia
 
             return sm;
         }
-        
+
         internal static Matrix ToAvaloniaMatrix(this SKMatrix m) => new(
             m.ScaleX, m.SkewY, m.Persp0,
             m.SkewX, m.ScaleY, m.Persp1,
@@ -253,9 +253,12 @@ namespace Avalonia.Skia
             switch (m)
             {
                 default:
-                case GradientSpreadMethod.Pad: return SKShaderTileMode.Clamp;
-                case GradientSpreadMethod.Reflect: return SKShaderTileMode.Mirror;
-                case GradientSpreadMethod.Repeat: return SKShaderTileMode.Repeat;
+                case GradientSpreadMethod.Pad:
+                    return SKShaderTileMode.Clamp;
+                case GradientSpreadMethod.Reflect:
+                    return SKShaderTileMode.Mirror;
+                case GradientSpreadMethod.Repeat:
+                    return SKShaderTileMode.Repeat;
             }
         }
 
@@ -264,9 +267,12 @@ namespace Avalonia.Skia
             switch (a)
             {
                 default:
-                case TextAlignment.Left: return SKTextAlign.Left;
-                case TextAlignment.Center: return SKTextAlign.Center;
-                case TextAlignment.Right: return SKTextAlign.Right;
+                case TextAlignment.Left:
+                    return SKTextAlign.Left;
+                case TextAlignment.Center:
+                    return SKTextAlign.Center;
+                case TextAlignment.Right:
+                    return SKTextAlign.Right;
             }
         }
 
@@ -295,9 +301,12 @@ namespace Avalonia.Skia
             switch (a)
             {
                 default:
-                case SKTextAlign.Left: return TextAlignment.Left;
-                case SKTextAlign.Center: return TextAlignment.Center;
-                case SKTextAlign.Right: return TextAlignment.Right;
+                case SKTextAlign.Left:
+                    return TextAlignment.Left;
+                case SKTextAlign.Center:
+                    return TextAlignment.Center;
+                case SKTextAlign.Right:
+                    return TextAlignment.Right;
             }
         }
 
@@ -308,7 +317,18 @@ namespace Avalonia.Skia
                 SKFontStyleSlant.Upright => FontStyle.Normal,
                 SKFontStyleSlant.Italic => FontStyle.Italic,
                 SKFontStyleSlant.Oblique => FontStyle.Oblique,
-                _ => throw new ArgumentOutOfRangeException(nameof (slant), slant, null)
+                _ => throw new ArgumentOutOfRangeException(nameof(slant), slant, null)
+            };
+        }
+
+        public static SKFontStyleSlant ToSkia(this FontStyle style)
+        {
+            return style switch
+            {
+                FontStyle.Normal => SKFontStyleSlant.Upright,
+                FontStyle.Italic => SKFontStyleSlant.Italic,
+                FontStyle.Oblique => SKFontStyleSlant.Oblique,
+                _ => throw new ArgumentOutOfRangeException(nameof(style), style, null)
             };
         }
 

--- a/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
 using Avalonia.Fonts.Inter;
 using Avalonia.Headless;
 using Avalonia.Media;
@@ -103,7 +101,7 @@ namespace Avalonia.Skia.UnitTests.Media
             {
                 Assert.True(FontManager.Current.TryGetGlyphTypeface(Typeface.Default, out _));
 
-                for (int i = 0;i < 10; i++)
+                for (int i = 0; i < 10; i++)
                 {
                     FontManager.Current.TryGetGlyphTypeface(new Typeface("Unknown"), out _);
                 }
@@ -313,7 +311,7 @@ namespace Avalonia.Skia.UnitTests.Media
                 {
                     Assert.True(FontManager.Current.TryGetGlyphTypeface(new Typeface("微軟正黑體"), out var glyphTypeface));
 
-                    Assert.Equal("Microsoft JhengHei",glyphTypeface.FamilyName);
+                    Assert.Equal("Microsoft JhengHei", glyphTypeface.FamilyName);
                 }
             }
         }
@@ -325,7 +323,7 @@ namespace Avalonia.Skia.UnitTests.Media
             {
                 using (AvaloniaLocator.EnterScope())
                 {
-                     FontManager.Current.AddFontCollection(new InterFontCollection());
+                    FontManager.Current.AddFontCollection(new InterFontCollection());
 
                     Assert.True(FontManager.Current.TryGetGlyphTypeface(new Typeface("fonts:Inter#Inter"),
                         out var glyphTypeface));
@@ -346,12 +344,12 @@ namespace Avalonia.Skia.UnitTests.Media
             {
                 using (AvaloniaLocator.EnterScope())
                 {
-                    AvaloniaLocator.CurrentMutable.BindToSelf(new FontManagerOptions 
-                    { 
-                        DefaultFamilyName = s_fontUri, 
-                        FontFamilyMappings = new Dictionary<string, FontFamily> 
-                        { 
-                            { "Segoe UI", new FontFamily("fonts:Inter#Inter") } 
+                    AvaloniaLocator.CurrentMutable.BindToSelf(new FontManagerOptions
+                    {
+                        DefaultFamilyName = s_fontUri,
+                        FontFamilyMappings = new Dictionary<string, FontFamily>
+                        {
+                            { "Segoe UI", new FontFamily("fonts:Inter#Inter") }
                         }
                     });
 
@@ -424,6 +422,33 @@ namespace Avalonia.Skia.UnitTests.Media
                     var glyphTypeface = new Typeface(fontFamily).GlyphTypeface;
 
                     Assert.Equal("Arial", glyphTypeface.FamilyName);
+                }
+            }
+        }
+
+
+        [Win32Fact("Windows specific font")]
+        public void Should_Get_Regular_Font_After_Matching_Italic_Font()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl())))
+            {
+                using (AvaloniaLocator.EnterScope())
+                {
+                    Assert.True(FontManager.Current.TryMatchCharacter('こ', FontStyle.Italic, FontWeight.Normal, FontStretch.Normal, null, null, out var italicTypeface));
+
+                    Assert.Equal(FontSimulations.None, italicTypeface.GlyphTypeface.FontSimulations);
+
+                    Assert.Equal("Yu Gothic UI", italicTypeface.GlyphTypeface.FamilyName);
+
+                    Assert.NotEqual(FontStyle.Normal, italicTypeface.Style);
+
+                    Assert.True(FontManager.Current.TryMatchCharacter('こ', FontStyle.Normal, FontWeight.Normal, FontStretch.Normal, null, null, out var regularTypeface));
+
+                    Assert.Equal("Yu Gothic UI", regularTypeface.GlyphTypeface.FamilyName);
+
+                    Assert.Equal(FontStyle.Normal, regularTypeface.Style);
+
+                    Assert.NotEqual(((GlyphTypefaceImpl)italicTypeface.GlyphTypeface).SKTypeface, ((GlyphTypefaceImpl)regularTypeface.GlyphTypeface).SKTypeface);
                 }
             }
         }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR changes the Skia IGlyphTypeface implementation so it reports oblique SKTypefaces as they are properly authored as oblique when they are not.

On Windows, some CJK fonts do not properly report that they are italic or oblique, but DWrite still treats them as such.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes: #19847