### PR TITLE
Fix Checkbox and RadioButton height in compact density of Fluent theme.

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/CheckBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CheckBox.xaml
@@ -13,6 +13,7 @@
   </Design.PreviewWith>
 
   <StreamGeometry x:Key="CheckMarkPathData">M5.5 10.586 1.707 6.793A1 1 0 0 0 .293 8.207l4.5 4.5a1 1 0 0 0 1.414 0l11-11A1 1 0 0 0 15.793.293L5.5 10.586Z</StreamGeometry>
+  <x:Double x:Key="CheckBoxMinHeight">32</x:Double> 
   
   <ControlTheme x:Key="{x:Type CheckBox}" TargetType="CheckBox">
     <Setter Property="Padding" Value="8,0,0,0" />
@@ -21,7 +22,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-    <Setter Property="MinHeight" Value="32" />
+    <Setter Property="MinHeight" Value="{DynamicResource CheckBoxMinHeight}" />
     <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUnchecked}" />
     <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUnchecked}" />
     <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUnchecked}" />
@@ -35,7 +36,7 @@
                   BorderThickness="{TemplateBinding BorderThickness}"
                   CornerRadius="{TemplateBinding CornerRadius}" />
 
-          <Grid VerticalAlignment="Top" Height="32">
+          <Grid VerticalAlignment="Top" Height="{DynamicResource CheckBoxMinHeight}">
             <Border x:Name="NormalRectangle"
                     BorderBrush="{DynamicResource CheckBoxCheckBackgroundStrokeUnchecked}"
                     Background="{DynamicResource CheckBoxCheckBackgroundFillUnchecked}"

--- a/src/Avalonia.Themes.Fluent/Controls/RadioButton.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/RadioButton.xaml
@@ -11,6 +11,8 @@
     </Border>
   </Design.PreviewWith>
   
+  <x:Double x:Key="RadioButtonMinHeight">32</x:Double>
+  
   <ControlTheme x:Key="{x:Type RadioButton}" TargetType="RadioButton">
     <Setter Property="Background" Value="{DynamicResource RadioButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource RadioButtonForeground}" />
@@ -30,7 +32,7 @@
             BorderThickness="{TemplateBinding BorderThickness}"
             CornerRadius="{TemplateBinding CornerRadius}">
           <Grid ColumnDefinitions="20,*">
-            <Grid Height="32" VerticalAlignment="Top">
+            <Grid Height="{DynamicResource RadioButtonMinHeight}" VerticalAlignment="Top">
 
               <Ellipse
                   Name="OuterEllipse"

--- a/src/Avalonia.Themes.Fluent/DensityStyles/Compact.xaml
+++ b/src/Avalonia.Themes.Fluent/DensityStyles/Compact.xaml
@@ -21,4 +21,6 @@
   <x:Double x:Key="TabItemMinHeight">28</x:Double>
   <Thickness x:Key="TabItemHeaderMargin">6, 0</Thickness>
   <Thickness x:Key="ButtonPadding">6,4</Thickness>
+  <x:Double x:Key="CheckBoxMinHeight">24</x:Double>
+  <x:Double x:Key="RadioButtonMinHeight">24</x:Double>
 </ResourceDictionary>


### PR DESCRIPTION
## What does the pull request do?
This PR is trying to fix the look of Checkbox and RadioButton in the Compact density of Fluent theme.

## What is the current behavior?
Currently the height of the checkbox bounding box is higher than of text elements, so having the checkbox on the same line as e.g. TextBox leads to necessity to have higher line and possible stretching of TextBox height if the vertical alignment is not altered. (e.g. textbox and checkbox within the same horizontally oriented stackpanel).

<img width="639" height="106" alt="Current" src="https://github.com/user-attachments/assets/a74e5305-d9ef-4e45-ac59-c6bc384def21" />

## What is the updated/expected behavior with this PR?
When using compact theme the height of the Checkbox and RadioButton should match the height of the TextBox.

<img width="600" alt="expected" src="https://github.com/user-attachments/assets/e07ca1a1-40fb-4cff-b14d-7bdc97e30206" />


## How was the solution implemented (if it's not obvious)?
Added two resources CheckBoxMinHeight and RadioButtonMinHeight and used them within the source, so that Compact.xaml can modify them.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
Possibly none (unless someone rely on default behaviour)

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
No

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
