### PR TITLE
make selection model properly handle incc move events without droppin…

### DIFF
--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -757,7 +757,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
-        public void Moving_Selected_Item_Should_Clear_Selection()
+        public void Moving_Selected_Item_Should_Not_Clear_Selection()
         {
             using var app = Start();
             var items = new ObservableCollection<string> { "foo", "bar" };
@@ -777,18 +777,15 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
             target.SelectionChanged += (_, args) => receivedArgs = args;
 
-            var removed = items[1];
             items.Move(1, 0);
 
-            Assert.Null(target.SelectedItem);
-            Assert.Equal(-1, target.SelectedIndex);
-            Assert.NotNull(receivedArgs);
-            Assert.Empty(receivedArgs.AddedItems);
-            Assert.Equal(new[] { removed }, receivedArgs.RemovedItems);
+            Assert.Equal(items[0], target.SelectedItem);
+            Assert.Equal(0, target.SelectedIndex);
+            Assert.Null(receivedArgs);
         }
 
         [Fact]
-        public void Moving_Selected_Container_Should_Not_Clear_Selection()
+        public void Moving_Selected_Container_Should_Clear_Selection()
         {
             var items = new AvaloniaList<Item>
             {
@@ -815,16 +812,12 @@ namespace Avalonia.Controls.UnitTests.Primitives
             var moved = items[1];
             items.Move(1, 0);
 
-            // Because the moved container is still marked as selected on the insert part of the
-            // move, it will remain selected.
-            Assert.Same(moved, target.SelectedItem);
-            Assert.Equal(0, target.SelectedIndex);
+            Assert.Null(target.SelectedItem);
+            Assert.Equal(-1, target.SelectedIndex);
             Assert.NotNull(receivedArgs);
-            Assert.Equal(2, receivedArgs.Count);
+            Assert.Single(receivedArgs);
             Assert.Equal(new[] { moved }, receivedArgs[0].RemovedItems);
-            Assert.Equal(new[] { moved }, receivedArgs[1].AddedItems);
-            Assert.True(items[0].IsSelected);
-            Assert.False(items[1].IsSelected);
+            Assert.True(items.All(x => !x.IsSelected));
         }
 
         [Fact]

--- a/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Multiple.cs
@@ -1290,24 +1290,50 @@ namespace Avalonia.Controls.UnitTests.Selection
 
                 target.SelectionChanged += (s, e) =>
                 {
-                    Assert.Empty(e.DeselectedIndexes);
-                    Assert.Equal(new[] { "bar" }, e.DeselectedItems);
-                    Assert.Empty(e.SelectedIndexes);
-                    Assert.Empty(e.SelectedItems);
                     ++selectionChangedRaised;
                 };
 
                 data.Move(1, 0);
 
-                Assert.Equal(2, target.SelectedIndex);
-                Assert.Equal(new[] { 2, 3, 4 }, target.SelectedIndexes);
-                Assert.Equal("baz", target.SelectedItem);
-                Assert.Equal(new[] { "baz", "qux", "quux" }, target.SelectedItems);
-                Assert.Equal(2, target.AnchorIndex);
-                Assert.Equal(1, selectionChangedRaised);
+                Assert.Equal(0, target.SelectedIndex);
+                Assert.Equal(new[] { 0, 2, 3, 4 }, target.SelectedIndexes);
+                Assert.Equal("bar", target.SelectedItem);
+                Assert.Equal(new[] { "bar", "baz", "qux", "quux" }, target.SelectedItems);
+                Assert.Equal(0, target.AnchorIndex);
+                Assert.Equal(0, selectionChangedRaised);
                 Assert.Equal(1, selectedIndexRaised);
                 Assert.Equal(1, selectedItemRaised);
                 Assert.Equal(0, indexesChangedRaised);
+            }
+
+            [Fact]
+            public void Moving_Selected_Item_Does_Not_Deselect_Items()
+            {
+                var target = CreateTarget();
+                var data = (AvaloniaList<string>)target.Source!;
+                var selectionChangedRaised = false;
+                IReadOnlyList<int>? deselectedIndexes = null;
+                IReadOnlyList<string?>? deselectedItems = null;
+
+                target.Source = data;
+                target.SelectRange(1, 4);
+
+                target.SelectionChanged += (s, e) =>
+                {
+                    selectionChangedRaised = true;
+                    deselectedIndexes = e.DeselectedIndexes;
+                    deselectedItems = e.DeselectedItems;
+                };
+
+                data.Move(1, 0);
+
+                Assert.False(selectionChangedRaised);
+                Assert.Null(deselectedIndexes);
+                Assert.Null(deselectedItems);
+                Assert.Equal(0, target.SelectedIndex);
+                Assert.Equal(new[] { 0, 2, 3, 4 }, target.SelectedIndexes);
+                Assert.Equal("bar", target.SelectedItem);
+                Assert.Equal(new[] { "bar", "baz", "qux", "quux" }, target.SelectedItems);
             }
 
             [Fact]

--- a/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Single.cs
+++ b/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Single.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using Avalonia.Collections;
@@ -1170,23 +1171,49 @@ namespace Avalonia.Controls.UnitTests.Selection
 
                 target.SelectionChanged += (s, e) =>
                 {
-                    Assert.Empty(e.DeselectedIndexes);
-                    Assert.Equal(new[] { "bar" }, e.DeselectedItems);
-                    Assert.Empty(e.SelectedIndexes);
-                    Assert.Empty(e.SelectedItems);
                     ++selectionChangedRaised;
                 };
 
                 data.Move(1, 0);
 
-                Assert.Equal(-1, target.SelectedIndex);
-                Assert.Empty(target.SelectedIndexes);
-                Assert.Null(target.SelectedItem);
-                Assert.Empty(target.SelectedItems);
-                Assert.Equal(-1, target.AnchorIndex);
-                Assert.Equal(1, selectionChangedRaised);
+                Assert.Equal(0, target.SelectedIndex);
+                Assert.Equal(new[] { 0 }, target.SelectedIndexes);
+                Assert.Equal("bar", target.SelectedItem);
+                Assert.Equal(new[] { "bar" }, target.SelectedItems);
+                Assert.Equal(0, target.AnchorIndex);
+                Assert.Equal(0, selectionChangedRaised);
                 Assert.Equal(1, selectedIndexRaised);
                 Assert.Equal(1, selectedItemRaised);
+            }
+
+            [Fact]
+            public void Moving_Selected_Item_Does_Not_Deselect_Item()
+            {
+                var target = CreateTarget();
+                var data = (AvaloniaList<string>)target.Source!;
+                var selectionChangedRaised = false;
+                IReadOnlyList<int>? deselectedIndexes = null;
+                IReadOnlyList<string?>? deselectedItems = null;
+
+                target.Source = data;
+                target.Select(1);
+
+                target.SelectionChanged += (s, e) =>
+                {
+                    selectionChangedRaised = true;
+                    deselectedIndexes = e.DeselectedIndexes;
+                    deselectedItems = e.DeselectedItems;
+                };
+
+                data.Move(1, 0);
+
+                Assert.False(selectionChangedRaised);
+                Assert.Null(deselectedIndexes);
+                Assert.Null(deselectedItems);
+                Assert.Equal(0, target.SelectedIndex);
+                Assert.Equal(new[] { 0 }, target.SelectedIndexes);
+                Assert.Equal("bar", target.SelectedItem);
+                Assert.Equal(new[] { "bar" }, target.SelectedItems);
             }
 
             [Fact]

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingCarouselPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingCarouselPanelTests.cs
@@ -110,7 +110,7 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.Single(target.Children);
             Assert.Same(container, target.Children[0]);
-            Assert.Equal("bar", container.Content);
+            Assert.Equal("foo", container.Content);
         }
 
         [Fact]


### PR DESCRIPTION
Currently if your underlying INCC collection emits move events for the selected item, the selection model will clear the selection. Because it turns the move into a Remove and Add.

This PR properly handles the move events, so a move operation occurs on the selection model too.

The selection is now maintained.

before:
https://github.com/user-attachments/assets/b8f8cb64-510d-4ecc-8ab5-c555d72b5cc2

after:
https://github.com/user-attachments/assets/ebde2759-3e82-4882-be64-f904b2911558

