### PR TITLE
Primary mouse device

### DIFF
--- a/src/Avalonia.Base/Input/MouseDevice.cs
+++ b/src/Avalonia.Base/Input/MouseDevice.cs
@@ -18,6 +18,9 @@ namespace Avalonia.Input
     [PrivateApi]
     public class MouseDevice : IMouseDevice, IDisposable
     {
+        private static MouseDevice? _primary;
+        internal static MouseDevice Primary => _primary ?? new MouseDevice();
+
         private int _clickCount;
         private Rect _lastClickRect;
         private ulong _lastClickTime;
@@ -29,6 +32,16 @@ namespace Avalonia.Input
         public MouseDevice(Pointer? pointer = null)
         {
             _pointer = pointer ?? new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, true);
+        }
+
+        internal static TMouseDevice GetOrCreatePrimary<TMouseDevice>() where TMouseDevice : MouseDevice, new()
+        {
+            if (_primary is TMouseDevice device)
+                return device;
+
+            device = new TMouseDevice();
+            _primary = device;
+            return device;
         }
 
         public void ProcessRawEvent(RawInputEventArgs e)
@@ -300,6 +313,8 @@ namespace Avalonia.Input
 
         public void Dispose()
         {
+            System.Diagnostics.Debug.Assert(this != _primary, "Disposing primary mouse device.");
+
             _disposed = true;
             _pointer?.Dispose();
         }

--- a/src/Avalonia.Base/Input/MouseDevice.cs
+++ b/src/Avalonia.Base/Input/MouseDevice.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Input
     public class MouseDevice : IMouseDevice, IDisposable
     {
         private static MouseDevice? _primary;
-        internal static MouseDevice Primary => _primary ?? new MouseDevice();
+        internal static MouseDevice Primary => _primary ??= new MouseDevice();
 
         private int _clickCount;
         private Rect _lastClickRect;

--- a/src/Avalonia.Native/TopLevelImpl.cs
+++ b/src/Avalonia.Native/TopLevelImpl.cs
@@ -89,7 +89,7 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
         Factory = factory;
 
         _keyboard = AvaloniaLocator.Current.GetService<IKeyboardDevice>();
-        _mouse = new MouseDevice();
+        _mouse = Avalonia.Input.MouseDevice.Primary;
         _pen = new PenDevice();
         _cursorFactory = AvaloniaLocator.Current.GetService<ICursorFactory>();
     }
@@ -387,8 +387,6 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
 
         _nativeControlHost?.Dispose();
         _nativeControlHost = null;
-
-        _mouse?.Dispose();
     }
 
     protected virtual bool ChromeHitTest(RawPointerEventArgs e)

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -96,7 +96,7 @@ namespace Avalonia.X11
             _popup = popupParent != null;
             _overrideRedirect = _popup || overrideRedirect;
             _x11 = platform.Info;
-            _mouse = new MouseDevice();
+            _mouse = Avalonia.Input.MouseDevice.Primary;
             _touch = new TouchDevice();
             _keyboard = platform.KeyboardDevice;
 
@@ -1072,7 +1072,6 @@ namespace Avalonia.X11
                 _platform.XI2?.OnWindowDestroyed(_handle);
                 var handle = _handle;
                 _handle = IntPtr.Zero;
-                _mouse.Dispose();
                 _touch.Dispose();
                 if (!fromDestroyNotification) 
                     XDestroyWindow(_x11.Display, handle);

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -119,7 +119,7 @@ namespace Avalonia.Win32
         public WindowImpl()
         {
             _touchDevice = new TouchDevice();
-            _mouseDevice = new WindowsMouseDevice();
+            _mouseDevice = Avalonia.Input.MouseDevice.GetOrCreatePrimary<WindowsMouseDevice>();
             _penDevice = new PenDevice();
 
 #if USE_MANAGED_DRAG
@@ -177,7 +177,9 @@ namespace Avalonia.Win32
             _nativeControlHost = new Win32NativeControlHost(this, !UseRedirectionBitmap);
             _defaultTransparencyLevel = UseRedirectionBitmap ? WindowTransparencyLevel.None : WindowTransparencyLevel.Transparent;
             _transparencyLevel = _defaultTransparencyLevel;
-            s_instances.Add(this);
+
+            lock (s_instances)
+                s_instances.Add(this);
         }
 
         internal IInputRoot Owner


### PR DESCRIPTION
## What does the pull request do?

Ensures only single mouse-captured element across the application.

As a critical consequence, capture will not be cancelled if a different window of the same application (like a popup) takes it.

## What is the current behavior?

Currently each window has its own mouse device, with it a pointer device and with it its own captured element. No OS supports this model. A single physical device can only have one captured element.

## What is the updated/expected behavior with this PR?

All windows/top levels will share a single mouse device. Notably the behavior does not affect mice or pointers themselves. (In multi touch scenario, different fingers should be able to capture different elements. In the future, we can see if there should be a primary pointer.)

## How was the solution implemented (if it's not obvious)?

Introduced internal static `MouseDevice.Primary` that is used in windows/top levels constructors. It should never be disposed.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

These changes were only minimally tested to ensure specific capture issues are fixed. This change has a potential for unexpected issues to appear and more testing should be done before merging.

