### PR TITLE
Added an optional "ConvertBack" method to FuncValueConverter

### DIFF
--- a/src/Avalonia.Base/Data/Converters/FuncValueConverter.cs
+++ b/src/Avalonia.Base/Data/Converters/FuncValueConverter.cs
@@ -13,14 +13,26 @@ namespace Avalonia.Data.Converters
     public class FuncValueConverter<TIn, TOut> : IValueConverter
     {
         private readonly Func<TIn?, TOut> _convert;
+        private readonly Func<TOut?, TIn>? _convertBack;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FuncValueConverter{TIn, TOut}"/> class.
         /// </summary>
-        /// <param name="convert">The convert function.</param>
+        /// <param name="convert">The function to convert TIn to TOut.</param>
         public FuncValueConverter(Func<TIn?, TOut> convert)
         {
             _convert = convert;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FuncValueConverter{TIn, TOut}"/> class.
+        /// </summary>
+        /// <param name="convert">The function to convert TIn to TOut.</param>
+        /// <param name="convertBack">The function to convert TOut back to In.</param>
+        public FuncValueConverter(Func<TIn?, TOut> convert, Func<TOut?, TIn>? convertBack)
+        {
+            _convert = convert;
+            _convertBack = convertBack;
         }
 
         /// <inheritdoc/>
@@ -39,7 +51,19 @@ namespace Avalonia.Data.Converters
         /// <inheritdoc/>
         public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            if (_convertBack == null)
+            {
+                throw new NotImplementedException();
+            }
+
+            if (TypeUtilities.CanCast<TOut>(value))
+            {
+                return _convertBack((TOut?)value);
+            }
+            else
+            {
+                return AvaloniaProperty.UnsetValue;
+            }
         }
     }
 
@@ -53,14 +77,26 @@ namespace Avalonia.Data.Converters
     public class FuncValueConverter<TIn, TParam, TOut> : IValueConverter
     {
         private readonly Func<TIn?, TParam?, TOut> _convert;
+        private readonly Func<TOut?, TParam?, TIn>? _convertBack;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FuncValueConverter{TIn, TParam, TOut}"/> class.
         /// </summary>
-        /// <param name="convert">The convert function.</param>
+        /// <param name="convert">The function to convert TIn to TOut.</param>
         public FuncValueConverter(Func<TIn?, TParam?, TOut> convert)
         {
             _convert = convert;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FuncValueConverter{TIn, TParam, TOut}"/> class.
+        /// </summary>
+        /// <param name="convert">The function to convert TIn to TOut.</param>
+        /// <param name="convertBack">The function to convert TOut back to In.</param>
+        public FuncValueConverter(Func<TIn?, TParam?, TOut> convert, Func<TOut?, TParam?, TIn>? convertBack = null)
+        {
+            _convert = convert;
+            _convertBack = convertBack;
         }
 
         /// <inheritdoc/>
@@ -79,7 +115,19 @@ namespace Avalonia.Data.Converters
         /// <inheritdoc/>
         public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            if (_convertBack == null)
+            {
+                throw new NotImplementedException();
+            }
+
+            if (TypeUtilities.CanCast<TOut>(value) && TypeUtilities.CanCast<TParam>(parameter))
+            {
+                return _convertBack((TOut?)value, (TParam?)parameter);
+            }
+            else
+            {
+                return AvaloniaProperty.UnsetValue;
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Allows FuncValueConverter to be used for TwoWay bindings.


## What is the updated/expected behavior with this PR?

You should be able to use FuncValueConverter as a converter in TwoWay bindings.


## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

Related `avalonia-docs` PR: https://github.com/AvaloniaUI/avalonia-docs/pull/746


## Breaking changes

If people are creating `FuncValueConverter`s using reflection or something like that, then this may be a breaking change.


## Fixed issues

None that I could find.
