### PR TITLE
Improve `AvaloniaNameIncrementalGenerator` error handling

### DIFF
--- a/src/tools/Avalonia.Generators/Common/EquatableList.cs
+++ b/src/tools/Avalonia.Generators/Common/EquatableList.cs
@@ -9,6 +9,8 @@ namespace Avalonia.Generators.Common;
 internal class EquatableList<T>(IList<T> collection)
     : ReadOnlyCollection<T>(collection), IEquatable<EquatableList<T>>
 {
+    public static readonly EquatableList<T> Empty = new([]);
+
     public bool Equals(EquatableList<T>? other)
     {
         // If the other list is null or a different size, they're not equal

--- a/src/tools/Avalonia.Generators/GeneratorExtensions.cs
+++ b/src/tools/Avalonia.Generators/GeneratorExtensions.cs
@@ -1,14 +1,9 @@
-using System;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Avalonia.Generators;
 
 internal static class GeneratorExtensions
 {
-    private const string UnhandledErrorDescriptorId = "AXN0002";
-    private const string InvalidTypeDescriptorId = "AXN0001";
-
     public static string GetMsBuildProperty(
         this AnalyzerConfigOptions options,
         string name,
@@ -17,27 +12,4 @@ internal static class GeneratorExtensions
         options.TryGetValue($"build_property.{name}", out var value);
         return value ?? defaultValue;
     }
-
-    public static DiagnosticDescriptor NameGeneratorUnhandledError(Exception error) => new(
-        UnhandledErrorDescriptorId,
-        title: "Unhandled exception occurred while generating typed Name references. " +
-               "Please file an issue: https://github.com/avaloniaui/Avalonia",
-        messageFormat: error.Message,
-        description: error.ToString(),
-        category: "Usage",
-        defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
-
-    public static DiagnosticDescriptor NameGeneratorInvalidType(string typeName) => new(
-        InvalidTypeDescriptorId,
-        title: $"Avalonia x:Name generator was unable to generate names for type '{typeName}'. " +
-               $"The type '{typeName}' does not exist in the assembly.",
-        messageFormat: $"Avalonia x:Name generator was unable to generate names for type '{typeName}'. " +
-                       $"The type '{typeName}' does not exist in the assembly.",
-        category: "Usage",
-        defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
-
-    public static void Report(this SourceProductionContext context, DiagnosticDescriptor diagnostics) =>
-        context.ReportDiagnostic(Diagnostic.Create(diagnostics, Location.None));
 }

--- a/src/tools/Avalonia.Generators/NameGenerator/NameGeneratorDiagnostics.cs
+++ b/src/tools/Avalonia.Generators/NameGenerator/NameGeneratorDiagnostics.cs
@@ -1,0 +1,39 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+
+namespace Avalonia.Generators.NameGenerator;
+
+internal static class NameGeneratorDiagnostics
+{
+    private const string Category = "Avalonia.NameGenerator";
+    private const string BugReportLink = "https://github.com/AvaloniaUI/Avalonia/issues/new/choose";
+
+    // Name generation errors should typicially be warnings, because that allows the compile to proceed and
+    // reach the point at which code errors are reported. These can give the user actionable information
+    // about what they need to fix, which the name generator doesn't have.
+
+    public static readonly DiagnosticDescriptor InvalidType = new(
+        "AXN0001", $"Invalid type",
+        "Avalonia could not generate code-behind properties or the InitializeContext method because the x:Class type '{0}' was not found in the project",
+        Category,
+        defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    [SuppressMessage("MicrosoftCodeAnalysisDesign", "RS1032:Define diagnostic message correctly", Justification = "Printing internal exception")]
+    public static readonly DiagnosticDescriptor InternalError = new(
+        "AXN0002", "Internal error",
+        messageFormat: $"Avalonia encountered an internal error while generating code-behind properties and/or the InitializeContext method. " +
+                       $"Please file a bug report at {BugReportLink}. The exception is {{0}}",
+        Category,
+        DiagnosticSeverity.Error, true,
+        helpLinkUri: BugReportLink);
+
+    public static readonly DiagnosticDescriptor ParseFailed = new(
+        "AXN0003", $"XAML error",
+        "Avalonia could not generate code-behind properties for named elements due to a XAML error: {0}",
+        Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor NamedElementFailed = new(
+        "AXN0004", $"XAML error",
+        "Avalonia could not generate code-behind property for '{0}' due to a XAML error: {1}",
+        Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+}


### PR DESCRIPTION
Some three years ago, #8411 reported that certain error messages don't include file information. It turns out that this is because they are being emitted by `AvaloniaNameIncrementalGenerator`, and not the actual XAML compile task as you would expect.

If you are using Avalonia's new Visual Studio extension then you do actually get a good error message from Intellisense. This won't help command line builds though. So this PR:

- Adds file and if possible line information to diagnostics emitted from the name generator
- Make XML/XAML parsing failures warnings, so that the compile can continue and fail "properly" later
- Rewrites the text of the diagnostics for clarity
- Adds a pure XML parsing fallback which allows `InitializeContext` to be generated even if XAML parsing failed

## What is the current behavior?

For a project containing this invalid XAML:
```xaml
<TextBlock Name="MyNamedElement" Text="{Binding "/>
```

We get this build output:
```
CSC : error AXN0002: Unexpected token None Line 4, position 36.
Avalonia\samples\Sandbox\MainWindow.axaml.cs(14,13,14,32): error CS0103: The name 'InitializeComponent' does not exist in the current context
```

Note that even though the first error includes a line and position, this is just some random text in the error message and isn't recognised by any tooling. There isn't a filename anyway.

The second error is a C# error which occurs because `InitializeComponent` wasn't generated due to the XAML parsing error. Because C# is compiled before XAML, the XAML compiler never executes and this is all we get.

## What is the updated/expected behavior with this PR?
If no names are referenced:
```
Avalonia\samples\Sandbox\MainWindow.axaml(4,36,4,36): warning AXN0003: Avalonia could not generate code-behind properties for named elements due to a XAML error: Unexpected token None Line 4, position 36.
Avalonia\samples\Sandbox\MainWindow.axaml(4,36,4,36): Avalonia error AVLN2000: XamlX.XamlParseException: Unexpected token None Line 4, position 36.
```

If names are referenced:
```
Avalonia\samples\Sandbox\MainWindow.axaml(4,36,4,36): warning AXN0003: Avalonia could not generate code-behind properties for named elements due to a XAML error: Unexpected token None Line 4, position 36.
Avalonia\samples\Sandbox\MainWindow.axaml.cs(15,17,15,31): error CS0103: The name 'MyNamedElement' does not exist in the current context
```

Note how in this second case the C# error again blocks the XAML compiler from executing. This is why the name generator must emit the error message itself, even though it might be reported again later.

In either case, we no longer get the unhelpful `'InitializeComponent' does not exist` message. This will now only happen if raw XML parsing fails, and the name generator reports an informative diagnostic about it.

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #8411
