### PR TITLE
Fixed Selector.ValidateNestingSelector not calling overrides when iterating up through parent selectors

### DIFF
--- a/src/Avalonia.Base/Styling/ChildSelector.cs
+++ b/src/Avalonia.Base/Styling/ChildSelector.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Styling
         {
             if (_selectorString == null)
             {
-                _selectorString = _parent.ToString(owner) + " > ";
+                _selectorString = _parent.ToString(owner, true) + " > ";
             }
 
             return _selectorString;

--- a/src/Avalonia.Base/Styling/DescendentSelector.cs
+++ b/src/Avalonia.Base/Styling/DescendentSelector.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Styling
         {
             if (_selectorString == null)
             {
-                _selectorString = _parent.ToString(owner) + ' ';
+                _selectorString = _parent.ToString(owner, true) + ' ';
             }
 
             return _selectorString;

--- a/src/Avalonia.Base/Styling/NotSelector.cs
+++ b/src/Avalonia.Base/Styling/NotSelector.cs
@@ -39,7 +39,7 @@ namespace Avalonia.Styling
         {
             if (_selectorString == null)
             {
-                _selectorString = $"{_previous?.ToString(owner)}:not({_argument})";
+                _selectorString = $"{_previous?.ToString(owner, true)}:not({_argument})";
             }
 
             return _selectorString;

--- a/src/Avalonia.Base/Styling/NthChildSelector.cs
+++ b/src/Avalonia.Base/Styling/NthChildSelector.cs
@@ -109,9 +109,9 @@ namespace Avalonia.Styling
         public override string ToString(Style? owner)
         {
             var expectedCapacity = NthLastChildSelectorName.Length + 8;
-            var stringBuilder =  StringBuilderCache.Acquire(expectedCapacity);
-            stringBuilder.Append(_previous?.ToString(owner));
-            
+            var stringBuilder = StringBuilderCache.Acquire(expectedCapacity);
+            stringBuilder.Append(_previous?.ToString(owner, true));
+
             stringBuilder.Append(':');
             stringBuilder.Append(_reversed ? NthLastChildSelectorName : NthChildSelectorName);
             stringBuilder.Append('(');

--- a/src/Avalonia.Base/Styling/OrSelector.cs
+++ b/src/Avalonia.Base/Styling/OrSelector.cs
@@ -45,11 +45,19 @@ namespace Avalonia.Styling
         internal override Type? TargetType => _targetType ??= EvaluateTargetType();
 
         /// <inheritdoc/>
-        public override string ToString(Style? owner)
+        public override string ToString(Style? owner) => ToString(owner, false);
+
+        /// <inheritdoc/>
+        internal override string ToString(Style? owner, bool hasNext)
         {
             if (_selectorString == null)
             {
-                _selectorString = string.Join(", ", _selectors.Select(x => x.ToString(owner)));
+                _selectorString = string.Join(", ", _selectors.Select(x => x.ToString(owner, true)));
+
+                if (hasNext)
+                {
+                    _selectorString = $"({_selectorString})";
+                }
             }
 
             return _selectorString;

--- a/src/Avalonia.Base/Styling/OrSelector.cs
+++ b/src/Avalonia.Base/Styling/OrSelector.cs
@@ -97,13 +97,13 @@ namespace Avalonia.Styling
         private protected override Selector? MovePrevious() => null;
         private protected override Selector? MovePreviousOrParent() => null;
 
-        internal override void ValidateNestingSelector(bool inControlTheme)
+        internal override void ValidateNestingSelector(bool inControlTheme, int templateCount = 0)
         {
             var count = _selectors.Count;
 
             for (var i = 0; i < count; i++)
             {
-                _selectors[i].ValidateNestingSelector(inControlTheme);
+                _selectors[i].ValidateNestingSelector(inControlTheme, templateCount);
             }
         }
 

--- a/src/Avalonia.Base/Styling/PropertyEqualsSelector.cs
+++ b/src/Avalonia.Base/Styling/PropertyEqualsSelector.cs
@@ -45,7 +45,7 @@ namespace Avalonia.Styling
 
                 if (_previous != null)
                 {
-                    builder.Append(_previous.ToString(owner));
+                    builder.Append(_previous.ToString(owner, true));
                 }
 
                 builder.Append('[');
@@ -85,7 +85,6 @@ namespace Avalonia.Styling
                     ? SelectorMatch.AlwaysThisInstance
                     : SelectorMatch.NeverThisInstance;
             }
-            
         }
 
         private protected override Selector? MovePrevious() => _previous;

--- a/src/Avalonia.Base/Styling/Selector.cs
+++ b/src/Avalonia.Base/Styling/Selector.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Styling
             // right-to-left, so MatchUntilCombinator reverses this order because the type selector
             // will be on the left.
             var match = MatchUntilCombinator(control, this, parent, subscribe, out var combinator);
-            
+
             // If the pre-combinator selector matches, we can now match the combinator, if any.
             if (match.IsMatch && combinator is object)
             {
@@ -75,6 +75,10 @@ namespace Avalonia.Styling
         /// </summary>
         /// <param name="owner">The owner style.</param>
         public abstract string ToString(Style? owner);
+
+        /// <inheritdoc cref="ToString(Style?)"/>
+        /// <param name="hasNext">Whether there is a selector that comes after this one.</param>
+        internal virtual string ToString(Style? owner, bool hasNext) => ToString(owner);
 
         /// <summary>
         /// Evaluates the selector for a match.
@@ -113,7 +117,7 @@ namespace Avalonia.Styling
                     throw new InvalidOperationException(
                         "ControlTemplate styles cannot contain multiple template selectors.");
             }
-            
+
             var previous = s.MovePreviousOrParent();
 
             if (previous is null)

--- a/src/Avalonia.Base/Styling/Selectors.cs
+++ b/src/Avalonia.Base/Styling/Selectors.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Avalonia.Styling
 {
@@ -124,7 +123,7 @@ namespace Avalonia.Styling
         {
             return new NotSelector(previous, argument(null));
         }
-        
+
         /// <summary>
         /// Returns a selector which inverts the results of selector argument.
         /// </summary>

--- a/src/Avalonia.Base/Styling/TemplateSelector.cs
+++ b/src/Avalonia.Base/Styling/TemplateSelector.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Styling
         {
             if (_selectorString == null)
             {
-                _selectorString = _parent.ToString(owner) + " /template/ ";
+                _selectorString = _parent.ToString(owner, true) + " /template/ ";
             }
 
             return _selectorString;

--- a/src/Avalonia.Base/Styling/TypeNameAndClassSelector.cs
+++ b/src/Avalonia.Base/Styling/TypeNameAndClassSelector.cs
@@ -143,7 +143,7 @@ namespace Avalonia.Styling
 
             if (_previous != null)
             {
-                builder.Append(_previous.ToString(owner));
+                builder.Append(_previous.ToString(owner, true));
             }
 
             if (TargetType != null)

--- a/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Or.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Or.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Controls;
 using Avalonia.Styling;
 using Xunit;
@@ -88,6 +89,24 @@ namespace Avalonia.Base.UnitTests.Styling
                 default(Selector).Class("bar"));
 
             Assert.Equal(null, target.TargetType);
+        }
+        
+        [Fact]
+        public void ValidateNestingSelector_Checks_Children_When_Parent_Is_An_OrSelector()
+        {
+            var target = Selectors.Or(
+                default(Selector).Class("foo"),
+                default(Selector).Class("bar")
+            ).Name("baz");
+
+            Assert.Throws<InvalidOperationException>(() => target.ValidateNestingSelector(false));
+            
+            target = Selectors.Or(
+                default(Selector).Nesting().Class("foo"),
+                default(Selector).Nesting().Class("bar")
+            ).Name("baz");
+            
+            target.ValidateNestingSelector(false);
         }
 
         public class Control1 : Control


### PR DESCRIPTION
## What does the pull request do?

Suggested fix for #19943


## What is the current behavior?

Explained in #19943


## What is the updated/expected behavior with this PR?

Explained in #19943


## How was the solution implemented (if it's not obvious)?

Changed ValidateNestingSelector to call recursively, walking up the hierarchy of parent selectors. This means function overrides are taken into account when walking up the tree. Now if a leaf selector has an OrSelector as its parent, it doesn't throw an exception.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation


## Breaking changes

Should not break anything.


## Fixed issues

Fixes #19943