### PR TITLE
Don't let the PreviewerWindow be any size

### DIFF
--- a/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
+++ b/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
@@ -64,6 +64,12 @@ namespace Avalonia.DesignerSupport.Remote
         
         public void Resize(Size clientSize, WindowResizeReason reason)
         {
+            // Don't let it clientSize be unconstrained or risk running Out Of Memory 
+            clientSize = new Size(
+                Math.Min(clientSize.Width, MaxAutoSizeHint.Width),
+                Math.Min(clientSize.Height, MaxAutoSizeHint.Height)
+            );
+
             _transport.Send(new RequestViewportResizeMessage
             {
                 Width = Math.Ceiling(clientSize.Width * RenderScaling),


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Stops the Visual Studio extension from crashing when the previewer tries to create an image for a very large window (or control).

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

If the `d:DesignHeight` or `d:DesignWidth` of a window are set too large (accidentally or deliberately) it can cause Visual Studio to freeze and then crash.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

This PR stops the image created for the preview from being so large that it causes an exception that crashes Visual Studio.

The size limit used (4096 DIP) is a common limit for UI dimensions and is large enough to avoid risking any issues with actual design sizes while still avoiding memory constraint issues on all but very low-powered machines.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

This is crude fix to clamp the specified size to the hardcoded maximum.
The fix is comparable to other `IWindowImpl` implementations that limit potential max sizes as appropriate for each platform. The previewer implementation previously had no consideration for this.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes: https://github.com/AvaloniaUI/AvaloniaVS/issues/505
