### PR TITLE
Fix ServerCompositionSimplePen memory leak

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Drawing/ServerCompositionSimplePen.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/ServerCompositionSimplePen.cs
@@ -1,12 +1,18 @@
-using System;
 using Avalonia.Media;
-using Avalonia.Media.Immutable;
-using Avalonia.Rendering.Composition.Server;
-using Avalonia.Rendering.Composition.Transport;
 
 namespace Avalonia.Rendering.Composition.Server;
 
 internal partial class ServerCompositionSimplePen : IPen
 {
     IDashStyle? IPen.DashStyle => DashStyle;
+
+    /// <inheritdoc/>
+    public override void Dispose()
+    {
+        // Dispose of the brush resource, this will remove the pen from the brush observers.
+        // This was causing the pen to be retained in memory by long lived brush resources (e.g. those defined in
+        // the theme or app resources), hence was causing memory leaks; see Issue #16451
+        SetValue(ref _brush, null!);
+        base.Dispose();
+    }
 }

--- a/src/Avalonia.Base/Rendering/Composition/Drawing/ServerCompositionSimplePen.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/ServerCompositionSimplePen.cs
@@ -9,10 +9,11 @@ internal partial class ServerCompositionSimplePen : IPen
     /// <inheritdoc/>
     public override void Dispose()
     {
-        // Dispose of the brush resource, this will remove the pen from the brush observers.
-        // This was causing the pen to be retained in memory by long lived brush resources (e.g. those defined in
+        // Remove the pen from the brush observers.
+        // Without this, the pen was being retained in memory by long lived brush resources (e.g. those defined in
         // the theme or app resources), hence was causing memory leaks; see Issue #16451
-        SetValue(ref _brush, null!);
+        RemoveObserversFromProperty(ref _brush);
+        _brush = null;
         base.Dispose();
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Bug fix for the ```ServerCompositionSimplePen``` memory leak


## What is the current behavior?
```ServerCompositionSimplePen``` objects are leaking as when the compositor creates ```ServerCompositionSimplePen``` resources that use shared brushes defined in the Theme or Window resources.


## What is the updated/expected behavior with this PR?
Fixes the memory leak.


## How was the solution implemented (if it's not obvious)?
The ```ServerCompositionSimplePen``` is being held in memory because it it is added to the ```ServerCompositionSimpleBrush``` list of observers but is never removed when the pen is disposed.
If the associated brush is long lived; i.e. a static or dynamic resource created in the theme or main window, the number of ```ServerCompositionSimplePen``` in it's list of observers increases every time a pen is created for that brush.
Added a Dispose override to remove the pen from the brush observers.

## Checklist
Not sure how to add a unit test for this as it doesn't appear to be possible to get a count of live objects of a class from GC.

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #16451