### PR TITLE
Fixed XButtons event handler for MacOs

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -456,13 +456,12 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
     switch(event.buttonNumber)
     {
         case 2:
-        case 3:
             [self mouseEvent:event withType:MiddleButtonDown];
             break;
-        case 4:
+        case 3:
             [self mouseEvent:event withType:XButton1Down];
             break;
-        case 5:
+        case 4:
             [self mouseEvent:event withType:XButton2Down];
             break;
 
@@ -487,13 +486,12 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
     switch(event.buttonNumber)
     {
         case 2:
-        case 3:
             [self mouseEvent:event withType:MiddleButtonUp];
             break;
-        case 4:
+        case 3:
             [self mouseEvent:event withType:XButton1Up];
             break;
-        case 5:
+        case 4:
             [self mouseEvent:event withType:XButton2Up];
             break;
 


### PR DESCRIPTION
## What does the pull request do?
Currently XButton1 is mapped to the MiddleMouseButton and XButton2 is mapped to the XButton1 on MacOS. This PR fixes that.
