### PR TITLE
[macOS]  Correct key mapping for scan code 0x18

### DIFF
--- a/native/Avalonia.Native/src/OSX/KeyTransform.mm
+++ b/native/Avalonia.Native/src/OSX/KeyTransform.mm
@@ -33,7 +33,7 @@ const KeyInfo keyInfos[] =
     { 0x1A, AvnPhysicalKeyDigit7, AvnKeyD7, '7' },
     { 0x1C, AvnPhysicalKeyDigit8, AvnKeyD8, '8' },
     { 0x19, AvnPhysicalKeyDigit9, AvnKeyD9, '9' },
-    { 0x18, AvnPhysicalKeyEqual, AvnKeyOemMinus, '-' },
+    { 0x18, AvnPhysicalKeyEqual, AvnKeyOemPlus, '=' },
     { 0x0A, AvnPhysicalKeyIntlBackslash, AvnKeyOem102, 0 },
     { 0x5E, AvnPhysicalKeyIntlRo, AvnKeyOem102, 0 },
     { 0x5D, AvnPhysicalKeyIntlYen, AvnKeyOem5, 0 },


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes an incorrect key mapping on macOS. Scan code` 0x18` (physical key for `=` on mac keyboards) was previously mapped to `AvnKeyOemMinus`.This PR corrects it to `AvnKeyOemPlus`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When using certain input methods (e.g.,`Pinyin – Simplified`), pressing `⌘++` is misinterpreted as `⌘+-`. This happens because the equals key (`=`) is incorrectly mapped to `AvnKeyOemMinus`. 
Under the `ABC Keyboard` input method, the issue does not occur.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #20003 
