### PR TITLE
[OBSOLETE] Fix ComVariant native size (add extended field and asserts)

### DIFF
--- a/src/Windows/Avalonia.Win32.Automation/Marshalling/ComVariant.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Marshalling/ComVariant.cs
@@ -18,6 +18,25 @@ internal struct ComVariant : IDisposable
     internal const short VARIANT_TRUE = -1;
     internal const short VARIANT_FALSE = 0;
 
+#if DEBUG
+    static unsafe ComVariant()
+    {
+        // Variant size is the size of 4 pointers (16 bytes) on a 32-bit processor,
+        // and 3 pointers (24 bytes) on a 64-bit processor.
+        // See definition in oaidl.h in the Windows SDK.
+        int variantSize = sizeof(ComVariant);
+        if (IntPtr.Size == 4)
+        {
+            Debug.Assert(variantSize == (4 * IntPtr.Size));
+        }
+        else
+        {
+            Debug.Assert(IntPtr.Size == 8);
+            Debug.Assert(variantSize == (3 * IntPtr.Size));
+        }
+    }
+#endif
+
     // Most of the data types in the Variant are carried in _typeUnion
     [FieldOffset(0)] private TypeUnion _typeUnion;
 
@@ -30,6 +49,13 @@ internal struct ComVariant : IDisposable
         public ushort _wReserved3;
 
         public UnionTypes _unionTypes;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Record
+    {
+        public IntPtr _record;
+        public IntPtr _recordInfo;
     }
 
     [StructLayout(LayoutKind.Explicit)]
@@ -56,6 +82,7 @@ internal struct ComVariant : IDisposable
         [FieldOffset(0)] public IntPtr _dispatch;
         [FieldOffset(0)] public IntPtr _pvarVal;
         [FieldOffset(0)] public IntPtr _byref;
+        [FieldOffset(0)] public Record _record;
         [FieldOffset(0)] public SafeArrayRef parray;
         [FieldOffset(0)] public SafeArrayRef*pparray;
     }


### PR DESCRIPTION

Based on dotnet/runtime implementation https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This fixes an issue #17827 with Avalonia-based applications crashes if any accessibility tool like On-Screen Keyboard or Narrator is enabled on ARM64-based systems.

## What is the current behavior?
Application crashes with AccessViolationException on ARM64 if any accessibility tool enabled.

## What is the updated/expected behavior with this PR?
No random crashes anymore.

## How was the solution implemented (if it's not obvious)?
Root cause was introduced here https://github.com/AvaloniaUI/Avalonia/pull/16543 with introduction of ComGenerated interop apis. As it stated in the comment `Avalonia.Win32.Automation.Marshalling.ComVariant` was based on https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs. 
But there are probably incomplete migration or the same issue was fixed there as well. Currently there are Debug.Asserts on ComVariant native size and more fields than in Avalonia implementation.
Fix added the same debug asserts and Record field that fixes the size of ComVariant.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #17827
