### PR TITLE
Android - fix external app not reading text in clipboard

### DIFF
--- a/src/Android/Avalonia.Android/Platform/ClipboardImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/ClipboardImpl.cs
@@ -85,7 +85,7 @@ namespace Avalonia.Android.Platform
                 if (DataFormat.Text.Equals(dataFormat))
                 {
                     var text = await item.TryGetValueAsync(DataFormat.Text);
-                    return new ClipData.Item(text, string.Empty);
+                    return new ClipData.Item(text);
                 }
 
                 if (DataFormat.File.Equals(dataFormat))


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR uses the text only constructor for `ClipData.Item` when saving text to clipboard. Currently, we use the constructor that also has html text parameter, even though we set it as empty. This creates issues in text apps that don't use the `CoerseToText` method when reading text from clipboard, as the empty html text is what they get.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/19949