### PR TITLE
feat: Handle Datavalidations on base class "Control"

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
@@ -653,24 +653,6 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Called to update the validation state for properties for which data validation is
-        /// enabled.
-        /// </summary>
-        /// <param name="property">The property.</param>
-        /// <param name="state">The current data binding state.</param>
-        /// <param name="error">The current data binding error, if any.</param>
-        protected override void UpdateDataValidation(
-            AvaloniaProperty property,
-            BindingValueType state,
-            Exception? error)
-        {
-            if (property == TextProperty || property == SelectedItemProperty)
-            {
-                DataValidationErrors.SetError(this, error);
-            }
-        }
-
-        /// <summary>
         /// Provides handling for the
         /// <see cref="E:Avalonia.InputElement.KeyDown" /> event.
         /// </summary>

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Windows.Input;
 using Avalonia.Automation.Peers;
@@ -552,6 +553,26 @@ namespace Avalonia.Controls
 
         protected override AutomationPeer OnCreateAutomationPeer() => new ButtonAutomationPeer(this);
 
+        /// <inheritdoc/>
+        protected override void UpdateDataValidation(
+            AvaloniaProperty property,
+            BindingValueType state,
+            Exception? error)
+        {
+            base.UpdateDataValidation(property, state, error);
+            if (property == CommandProperty)
+            {
+                if (state == BindingValueType.BindingError)
+                {
+                    if (_commandCanExecute)
+                    {
+                        _commandCanExecute = false;
+                        UpdateIsEffectivelyEnabled();
+                    }
+                }
+            }
+        }
+        
         internal void PerformClick() => OnClick();
 
         private static void OnAccessKeyPressed(Button sender, AccessKeyPressedEventArgs e)

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -552,26 +552,6 @@ namespace Avalonia.Controls
 
         protected override AutomationPeer OnCreateAutomationPeer() => new ButtonAutomationPeer(this);
 
-        /// <inheritdoc/>
-        protected override void UpdateDataValidation(
-            AvaloniaProperty property,
-            BindingValueType state,
-            Exception? error)
-        {
-            base.UpdateDataValidation(property, state, error);
-            if (property == CommandProperty)
-            {
-                if (state == BindingValueType.BindingError)
-                {
-                    if (_commandCanExecute)
-                    {
-                        _commandCanExecute = false;
-                        UpdateIsEffectivelyEnabled();
-                    }
-                }
-            }
-        }
-
         internal void PerformClick() => OnClick();
 
         private static void OnAccessKeyPressed(Button sender, AccessKeyPressedEventArgs e)

--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -326,17 +326,6 @@ namespace Avalonia.Controls
         }
 
         /// <inheritdoc/>
-        protected override void UpdateDataValidation(AvaloniaProperty property, BindingValueType state, Exception? error)
-        {
-            if (property == SelectedDateProperty)
-            {
-                DataValidationErrors.SetError(this, error);
-            }
-
-            base.UpdateDataValidation(property, state, error);
-        }
-
-        /// <inheritdoc/>
         protected override void OnPointerPressed(PointerPressedEventArgs e)
         {
             base.OnPointerPressed(e);

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
+using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
@@ -562,6 +563,13 @@ namespace Avalonia.Controls
                     OnSizeChanged(sizeChangedEventArgs);
                 }
             }
+        }
+        
+        /// <inheritdoc />
+        protected override void UpdateDataValidation(AvaloniaProperty property, BindingValueType state, Exception? error)
+        {
+            DataValidationErrors.SetError(this, error);
+            base.UpdateDataValidation(property, state, error);
         }
 
         // Since we are resetting the dispatcher instance, the callback might never arrive

--- a/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
@@ -426,13 +426,5 @@ namespace Avalonia.Controls
         {
             SetCurrentValue(SelectedDateProperty, null);
         }
-
-        protected override void UpdateDataValidation(AvaloniaProperty property, BindingValueType state, Exception? error)
-        {
-            base.UpdateDataValidation(property, state, error);
-
-            if (property == SelectedDateProperty)
-                DataValidationErrors.SetError(this, error);
-        }
     }
 }

--- a/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
@@ -407,13 +407,5 @@ namespace Avalonia.Controls
         {
             SetCurrentValue(SelectedTimeProperty, null);
         }
-
-        protected override void UpdateDataValidation(AvaloniaProperty property, BindingValueType state, Exception? error)
-        {
-            base.UpdateDataValidation(property, state, error);
-
-            if (property == SelectedTimeProperty)
-                DataValidationErrors.SetError(this, error);
-        }
     }
 }

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -554,6 +554,7 @@ namespace Avalonia.Controls
             return new MenuItemAutomationPeer(this);
         }
 
+        // TODO: This is confusing for some ppl. Need to think about alternatives here. 
         protected override void UpdateDataValidation(
             AvaloniaProperty property,
             BindingValueType state,

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -442,24 +442,6 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Called to update the validation state for properties for which data validation is
-        /// enabled.
-        /// </summary>
-        /// <param name="property">The property.</param>
-        /// <param name="state">The current data binding state.</param>
-        /// <param name="error">The current data binding error, if any.</param>
-        protected override void UpdateDataValidation(
-            AvaloniaProperty property,
-            BindingValueType state,
-            Exception? error)
-        {
-            if (property == TextProperty || property == ValueProperty)
-            {
-                DataValidationErrors.SetError(this, error);
-            }
-        }
-
-        /// <summary>
         /// Called when the <see cref="NumberFormat"/> property value changed.
         /// </summary>
         /// <param name="oldValue">The old value.</param>

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -569,24 +569,6 @@ namespace Avalonia.Controls.Primitives
             EndUpdating();
         }
 
-        /// <summary>
-        /// Called to update the validation state for properties for which data validation is
-        /// enabled.
-        /// </summary>
-        /// <param name="property">The property.</param>
-        /// <param name="state">The current data binding state.</param>
-        /// <param name="error">The current data binding error, if any.</param>
-        protected override void UpdateDataValidation(
-            AvaloniaProperty property,
-            BindingValueType state,
-            Exception? error)
-        {
-            if (property == SelectedItemProperty)
-            {
-                DataValidationErrors.SetError(this, error);
-            }
-        }
-
         /// <inheritdoc />
         protected override void OnInitialized()
         {

--- a/src/Avalonia.Controls/Slider.cs
+++ b/src/Avalonia.Controls/Slider.cs
@@ -393,18 +393,6 @@ namespace Avalonia.Controls
             SetCurrentValue(ValueProperty, IsSnapToTickEnabled ? SnapToTick(finalValue) : finalValue);
         }
 
-        /// <inheritdoc />
-        protected override void UpdateDataValidation(
-            AvaloniaProperty property,
-            BindingValueType state,
-            Exception? error)
-        {
-            if (property == ValueProperty)
-            {
-                DataValidationErrors.SetError(this, error);
-            }
-        }
-
         protected override AutomationPeer OnCreateAutomationPeer()
         {
             return new SliderAutomationPeer(this);

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1884,17 +1884,6 @@ namespace Avalonia.Controls
             return new TextBoxAutomationPeer(this);
         }
 
-        protected override void UpdateDataValidation(
-            AvaloniaProperty property,
-            BindingValueType state,
-            Exception? error)
-        {
-            if (property == TextProperty)
-            {
-                DataValidationErrors.SetError(this, error);
-            }
-        }
-
         internal static int CoerceCaretIndex(AvaloniaObject sender, int value)
         {
             var text = sender.GetValue(TextProperty); // method also used by TextPresenter and SelectableTextBlock


### PR DESCRIPTION
## What does the pull request do?
Simplify how DataValidations are handled.

## What is the current behavior?
Every control developer need to override `UpdateDataValidation` method if they want to enable this feature on thier side. 

## What is the updated/expected behavior with this PR?
`UpdateDataValidation` is handled by default, thus implementation is easier and existing controls can be extended to support DataValidation. This idea was taken from this discussion: https://github.com/AvaloniaUI/Avalonia/discussions/20020#discussioncomment-14934364 . The discribed solution should now work. 

> [!WARNING]
> this may be a breaking change in behavior, so I think it should not be backported. 

> [!NOTE]
> There is one **TODO** comment I left for MenuItem. Currently, a missing command will disable the control. But probably it would be better to either print a warning to the logs or throw an exception. It may be confusing for newbies otherwise. Let me know your thoughts. 

## Fixed issues
- [x] I need to scan open issues if any will be fixed by this PR
- Fixes https://github.com/AvaloniaUI/Avalonia/issues/19681
- Fixes https://github.com/AvaloniaUI/Avalonia/issues/16937