### PR TITLE
Fix TryCreateGlyphTypeface return on macOS with SkiaSharp 2.88

### DIFF
--- a/src/Skia/Avalonia.Skia/FontManagerImpl.cs
+++ b/src/Skia/Avalonia.Skia/FontManagerImpl.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
+using Avalonia.Compatibility;
 using Avalonia.Media;
 using Avalonia.Platform;
 using SkiaSharp;
@@ -123,6 +124,17 @@ namespace Avalonia.Skia
             var fontStyle = new SKFontStyle((SKFontStyleWeight)weight, (SKFontStyleWidth)stretch, style.ToSkia());
 
             var skTypeface = _skFontManager.MatchFamily(familyName, fontStyle);
+
+            // SkiaSharp 2.88 can return the default family name (Helvetica) on macOS here.
+            // On Windows and Linux, this returns null instead. Adjust the behavior on macOS to return null instead.
+            // (With SkiaSharp 3.119, all platforms return null).
+            if (OperatingSystemEx.IsMacOS()
+                && skTypeface is not null
+                && skTypeface.FamilyName != familyName
+                && skTypeface.FamilyName == GetDefaultFontFamilyName())
+            {
+                return false;
+            }
 
             if (skTypeface is null)
             {


### PR DESCRIPTION
## What does the pull request do?
The test `FontManagerTests.Should_Match_Chararcter_Width_Embedded_Fallbacks` is [failing on macOS](https://dev.azure.com/AvaloniaUI/AvaloniaUI/_build/results?buildId=60098&view=ms.vss-test-web.build-test-results-tab) on the `release/11.3` branch, blocking the release of Avalonia 11.3.9.

PR #19987 is causing the failure. After some head scratching (and banging), thinking it was some bad merge (the related PRs merged cleanly) or some missing change since the test passes on master, it turns out that it's an old Skia bug.

After debugging, the added [TryGetGlyphTypeface](https://github.com/Gillibald/Avalonia/blob/892b88396ac0535e9dd614b4beec5fa24f4da214/src/Avalonia.Base/Media/FontManager.cs#L291) call returns... _Helvetica_ for the _NotFound_ font?! And that comes directly from the `SKFontManager.MatchFamily` call. It's different in latest Skia versions. SkiaSharp 3.119 that we use on master doesn't exhibit the problem (it returns `null` on all platforms), but SkiaSharp 2.88 on 11.3 does.

Note that the documentation for `MatchFamily` says:
> Will never return null, as it will return the default font if no matching font is found.

This is absolutely false on Windows and Linux where it **does** return null.

Considering that:
 - It's fixed in SkiaSharp 3.119
 - @Gillibald is reworking the font loading stuff in #19852

I'm instead adding a workaround for macOS + SkiaSharp 2.88 in Avalonia 11.3 by returning null in `FontManagerImpl.TryCreateGlyphTypeFace` if the returned family is the default and doesn't match the requested name.

The master branch (Avalonia v12) stays unchanged.
