### PR TITLE
Android - Directly use the surface window handle cached in InvalidationAwareSurfaceView instead of requesting new handles

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/AndroidFramebuffer.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/AndroidFramebuffer.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using Android.Runtime;
-using Android.Views;
 using Avalonia.Platform;
 
 namespace Avalonia.Android.Platform.SkiaPlatform
@@ -11,11 +9,11 @@ namespace Avalonia.Android.Platform.SkiaPlatform
     {
         private IntPtr _window;
 
-        public AndroidFramebuffer(Surface surface, double scaling)
+        public AndroidFramebuffer(InvalidationAwareSurfaceView surface, double scaling)
         {
             if(surface == null)
                 throw new ArgumentNullException(nameof(surface));
-            _window = ANativeWindow_fromSurface(JNIEnv.Handle, surface.Handle);
+            _window = (surface as IPlatformHandle).Handle;
             if (_window == IntPtr.Zero)
                 throw new Exception("Unable to obtain ANativeWindow");
             ANativeWindow_Buffer buffer;
@@ -39,7 +37,6 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         public void Dispose()
         {
             ANativeWindow_unlockAndPost(_window);
-            ANativeWindow_release(_window);
             _window = IntPtr.Zero;
             Address = IntPtr.Zero;
         }

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/FramebufferManager.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/FramebufferManager.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         }
 
         public ILockedFramebuffer Lock() => new AndroidFramebuffer(
-            _topLevel.InternalView.Holder?.Surface ?? throw new InvalidOperationException("TopLevel.InternalView.Holder.Surface was not expected to be null."),
+            _topLevel.InternalView ?? throw new InvalidOperationException("TopLevel.InternalView was not expected to be null."),
             _topLevel.RenderScaling);
 
         public IFramebufferRenderTarget CreateFramebufferRenderTarget() => new FuncFramebufferRenderTarget(Lock);

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
@@ -42,26 +42,26 @@ namespace Avalonia.Android
 
         public virtual void SurfaceChanged(ISurfaceHolder holder, Format format, int width, int height)
         {
-            CacheSurfaceProperties(holder);
             Logger.TryGet(LogEventLevel.Verbose, LogArea.AndroidPlatform)?
-                .Log(this, "InvalidationAwareSurfaceView Changed");
+                .Log(this, $"InvalidationAwareSurfaceView Changed. Format:{format} Size:{width} x {height}");
+            CacheSurfaceProperties(holder);
         }
 
         public void SurfaceCreated(ISurfaceHolder holder)
         {
-            CacheSurfaceProperties(holder);
             Logger.TryGet(LogEventLevel.Verbose, LogArea.AndroidPlatform)?
                 .Log(this, "InvalidationAwareSurfaceView Created");
+            CacheSurfaceProperties(holder);
             SurfaceWindowCreated?.Invoke(this, EventArgs.Empty);
         }
 
         public void SurfaceDestroyed(ISurfaceHolder holder)
         {
+            Logger.TryGet(LogEventLevel.Verbose, LogArea.AndroidPlatform)?
+                .Log(this, "InvalidationAwareSurfaceView Destroyed");
             ReleaseNativeWindowHandle();
             _size = new PixelSize(1, 1);
             _scaling = 1;
-            Logger.TryGet(LogEventLevel.Verbose, LogArea.AndroidPlatform)?
-                .Log(this, "InvalidationAwareSurfaceView Destroyed");
         }
 
         public virtual void SurfaceRedrawNeeded(ISurfaceHolder holder)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Use the cached surface handle in `InvalidationAwareSurfaceView` for `AndroidFramebuffer` instead of requesting new native window handles for the same surface.


## What is the current behavior?
When using software rendering, any update to the native surface will request new native window references to the same surface. After multiple surface updates, the OS runs out of strong references to the same surface and crashes the app with the follow error, `Abort message: 'decStrong() called on 0xb400007ac3b6df40 too many times'`.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Should fully fix https://github.com/AvaloniaUI/Avalonia/issues/18995
