### PR TITLE
Preserve run formatting when applying SelectionForegroundBrush in SelectableTextBlock

### DIFF
--- a/src/Avalonia.Controls/SelectableTextBlock.cs
+++ b/src/Avalonia.Controls/SelectableTextBlock.cs
@@ -197,20 +197,48 @@ namespace Avalonia.Controls
                 LineSpacing = LineSpacing
             };
 
-            IReadOnlyList<ValueSpan<TextRunProperties>>? textStyleOverrides = null;
+            List<ValueSpan<TextRunProperties>>? textStyleOverrides = null;
             var selectionStart = SelectionStart;
             var selectionEnd = SelectionEnd;
             var start = Math.Min(selectionStart, selectionEnd);
             var length = Math.Max(selectionStart, selectionEnd) - start;
 
-            if (length > 0 && SelectionForegroundBrush != null)
+            if (length > 0 && SelectionForegroundBrush != null && _textRuns != null)
             {
-                textStyleOverrides = new[]
+                // Apply selection foreground color without changing the original text formatting.
+                // The built-in SelectableTextBlock selection logic recreates TextRunProperties,
+                // which overwrites run-specific Typeface/FontFeatures/FontSize and breaks bold/italic.
+                // Here we reuse each run's existing properties and only override the foreground brush.
+
+                var accumulatedLength = 0;
+                foreach (var textRun in _textRuns)
                 {
-                        new ValueSpan<TextRunProperties>(start, length,
-                        new GenericTextRunProperties(typeface, FontFeatures, FontSize,
-                            foregroundBrush: SelectionForegroundBrush))
-                    };
+                    var runLength = textRun.Text.Length;
+                    if (accumulatedLength + runLength <= start ||
+                        accumulatedLength >= start + length)
+                    {
+                        accumulatedLength += runLength;
+                        continue;
+                    }
+
+                    var overlapStart = Math.Max(start, accumulatedLength);
+                    var overlapEnd = Math.Min(start + length, accumulatedLength + runLength);
+                    var overlapLength = overlapEnd - overlapStart;
+
+                    textStyleOverrides ??= [];
+
+                    textStyleOverrides.Add(
+                        new ValueSpan<TextRunProperties>(
+                            overlapStart,
+                            overlapLength,
+                            new GenericTextRunProperties(
+                                textRun.Properties?.Typeface ?? typeface,
+                                textRun.Properties?.FontFeatures ?? FontFeatures,
+                                FontSize,
+                                foregroundBrush: SelectionForegroundBrush)));
+
+                    accumulatedLength += runLength;
+                }
             }
 
             ITextSource textSource;

--- a/tests/Avalonia.Controls.UnitTests/SelectableTextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SelectableTextBlockTests.cs
@@ -1,0 +1,59 @@
+﻿using System.Linq;
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests
+{
+    public class SelectableTextBlockTests : ScopedTestBase
+    {
+        [Fact]
+        public void SelectionForeground_Should_Not_Reset_Run_Typeface_And_Style()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var target = new SelectableTextBlock
+                {
+                    SelectionForegroundBrush = Brushes.Red
+                };
+
+                var run = new Run("Hello")
+                {
+                    FontWeight = FontWeight.Bold,
+                    FontStyle = FontStyle.Italic,
+                    FontSize = 20
+                };
+
+                target.Inlines.Add(run);
+
+                target.Measure(Size.Infinity);
+
+                target.SelectionStart = 0;
+                target.SelectionEnd = run.Text.Length;
+
+                target.Measure(Size.Infinity);
+
+                var textLayout = target.TextLayout;
+                Assert.NotNull(textLayout);
+
+                var textRuns = textLayout.TextLines
+                    .SelectMany(l => l.TextRuns)
+                    .OfType<ShapedTextRun>()
+                    .ToList();
+
+                Assert.NotEmpty(textRuns);
+
+                var selectedRun = textRuns[0];
+                var props = selectedRun.Properties;
+
+                Assert.Equal(FontWeight.Bold, props.Typeface.Weight);
+                Assert.Equal(FontStyle.Italic, props.Typeface.Style);
+
+                Assert.Same(target.SelectionForegroundBrush, props.ForegroundBrush);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a rendering bug in `SelectableTextBlock` where applying `SelectionForegroundBrush` would reset the formatting of the selected text (e.g. bold/italic) and adds a regression test to ensure the original text formatting is preserved while selected.

## What is the current behavior?
When `SelectionForegroundBrush` is set, selecting text in `SelectableTextBlock` causes the selected text to lose its run-specific formatting:
- `FontWeight` (e.g. bold) is lost.
- `FontStyle` (e.g. italic) is lost.
- Run-specific `Typeface` / `FontFeatures` can be overridden.

## What is the updated/expected behavior with this PR?
With this PR, the original per-run formatting is preserved during selection:
- `FontWeight` (e.g. bold) is kept.
- `FontStyle` (e.g. italic) is kept.
- Run-specific `Typeface` and `FontFeatures` are preserved.

A unit test is added to verify that:
- The selection foreground is applied, and
- Bold/italic are not reset when the text is selected.

## How was the solution implemented (if it's not obvious)?
- Iterate over the existing `_textRuns`.
- Compute the overlapping range between each run and the selection (start, length).
- For each overlapping span, create a `ValueSpan<TextRunProperties>` where:
  - `Typeface` is taken from `textRun.Properties?.Typeface` (fallback to the control’s `typeface`).
  - `FontFeatures` is taken from `textRun.Properties?.FontFeatures` (fallback to `FontFeatures`).
  - Only `foregroundBrush` is overridden with `SelectionForegroundBrush`.

This way, we reuse the original per-run text properties and only change the foreground brush for the selected span.

*Special Thanks: @DearVa*

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #20109
