### PR TITLE
11.3.x - Android Api 36 fixes

### DIFF
--- a/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
+++ b/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
@@ -285,7 +285,9 @@ namespace Avalonia.Android.Platform
                 if (_isDisplayEdgeToEdgeForced)
                 {
                     // Allow having fully transparent navbars when on api level 35
-                    if (OperatingSystem.IsAndroidVersionAtLeast(35))
+                    if (OperatingSystem.IsAndroidVersionAtLeast(36))
+                        Window.NavigationBarContrastEnforced = false;
+                    else if (OperatingSystem.IsAndroidVersionAtLeast(35))
                         Window.NavigationBarContrastEnforced = _systemBarColor != Colors.Transparent;
                     return;
                 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes issues with apps targeting API 36, either through specifying the sdk version in manifest or building with net 10 on 11.3.x.
The following issues are fixed;
1. OnBackPressed is no longer supported on android 16. This PR switches to `OnBackInvokedDispatcher`.
2. Force fully transparent nav bar on Android 16. Current behavior has the contrast enabled, which defaults to a white color on some devices. This creates a weird white nav bar. Issue doesn't occur on android 15 .


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
