### PR TITLE
Added LandmarkType to automation properties

### DIFF
--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -133,6 +133,22 @@
     }
 }
 
+- (NSAccessibilitySubrole)accessibilitySubrole
+{
+    auto landmarkType = _peer->GetLandmarkType();
+    switch (landmarkType) {
+        case LandmarkBanner: return @"AXLandmarkBanner";
+        case LandmarkComplementary: return @"AXLandmarkComplementary";
+        case LandmarkContentInfo: return @"AXLandmarkContentInfo";
+        case LandmarkRegion: return @"AXLandmarkRegion";
+        case LandmarkForm: return @"AXLandmarkForm";
+        case LandmarkMain: return @"AXLandmarkMain";
+        case LandmarkNavigation: return @"AXLandmarkNavigation";
+        case LandmarkSearch: return @"AXLandmarkSearch";
+        default: return NSAccessibilityUnknownSubrole;
+    }
+}
+
 - (NSString *)accessibilityIdentifier
 {
     return GetNSStringAndRelease(_peer->GetAutomationId());

--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -149,6 +149,22 @@
     }
 }
 
+- (NSString *)accessibilityRoleDescription
+{
+    auto landmarkType = _peer->GetLandmarkType();
+    switch (landmarkType) {
+        case LandmarkBanner: return @"banner";
+        case LandmarkComplementary: return @"complementary";
+        case LandmarkContentInfo: return @"footer";
+        case LandmarkRegion: return @"region";
+        case LandmarkForm: return @"content";
+        case LandmarkMain: return @"main";
+        case LandmarkNavigation: return @"navigation";
+        case LandmarkSearch: return @"search";
+    }
+    return NSAccessibilityRoleDescription([self accessibilityRole], [self accessibilitySubrole]);
+}
+
 - (NSString *)accessibilityIdentifier
 {
     return GetNSStringAndRelease(_peer->GetAutomationId());

--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -155,9 +155,9 @@
     switch (landmarkType) {
         case LandmarkBanner: return @"banner";
         case LandmarkComplementary: return @"complementary";
-        case LandmarkContentInfo: return @"footer";
+        case LandmarkContentInfo: return @"content";
         case LandmarkRegion: return @"region";
-        case LandmarkForm: return @"content";
+        case LandmarkForm: return @"form";
         case LandmarkMain: return @"main";
         case LandmarkNavigation: return @"navigation";
         case LandmarkSearch: return @"search";

--- a/samples/IntegrationTestApp/MainWindow.axaml
+++ b/samples/IntegrationTestApp/MainWindow.axaml
@@ -46,6 +46,7 @@
         </ListBox.ItemsPanel>
       </ListBox>
       <Decorator Name="PagerContent"
+                 AutomationProperties.AccessibilityView="Control"
                  AutomationProperties.LandmarkType="Main"/>
     </DockPanel>
     

--- a/samples/IntegrationTestApp/MainWindow.axaml
+++ b/samples/IntegrationTestApp/MainWindow.axaml
@@ -37,14 +37,16 @@
                DisplayMemberBinding="{Binding Name}"
                ItemsSource="{Binding Pages}"
                SelectedItem="{Binding SelectedPage}"
-               SelectionChanged="Pager_SelectionChanged">
+               SelectionChanged="Pager_SelectionChanged"
+               AutomationProperties.LandmarkType="Navigation">
         <ListBox.ItemsPanel>
           <ItemsPanelTemplate>
             <StackPanel/>
           </ItemsPanelTemplate>
         </ListBox.ItemsPanel>
       </ListBox>
-      <Decorator Name="PagerContent"/>
+      <Decorator Name="PagerContent"
+                 AutomationProperties.LandmarkType="Main"/>
     </DockPanel>
     
   </DockPanel>

--- a/src/Avalonia.Controls/Automation/AutomationElementIdentifiers.cs
+++ b/src/Avalonia.Controls/Automation/AutomationElementIdentifiers.cs
@@ -32,7 +32,13 @@ namespace Avalonia.Automation
         public static AutomationProperty HelpTextProperty { get; } = new AutomationProperty();
 
         /// <summary>
-        /// Identifiers the heading level automation property. The class name property value is returned
+        /// Identifies the landmark type automation property. The class name property value is returned
+        /// by the <see cref="AutomationPeer.GetLandmarkType"/> method.
+        /// </summary>
+        public static AutomationProperty LandmarkTypeProperty { get; } = new AutomationProperty();
+
+        /// <summary>
+        /// Identifies the heading level automation property. The class name property value is returned
         /// by the <see cref="AutomationPeer.GetHeadingLevel"/> method.
         /// </summary>
         public static AutomationProperty HeadingLevelProperty { get; } = new AutomationProperty();

--- a/src/Avalonia.Controls/Automation/AutomationProperties.cs
+++ b/src/Avalonia.Controls/Automation/AutomationProperties.cs
@@ -105,6 +105,17 @@ namespace Avalonia.Automation
                 typeof(AutomationProperties));
 
         /// <summary>
+        /// Defines the AutomationProperties.LandmarkType attached property.
+        /// </summary>
+        /// <remarks>
+        /// This property affects the default value for <see cref="AutomationPeer.GetLandmarkType"/>
+        /// </remarks>
+        public static readonly AttachedProperty<AutomationLandmarkType?> LandmarkTypeProperty =
+            AvaloniaProperty.RegisterAttached<StyledElement, AutomationLandmarkType?>(
+                "LandmarkType",
+                typeof(AutomationProperties));
+
+        /// <summary>
         /// Defines the AutomationProperties.HeadingLevel attached property.
         /// </summary>
         /// <remarks>
@@ -360,6 +371,24 @@ namespace Avalonia.Automation
         }
 
         /// <summary>
+        /// Helper for setting the value of the <see cref="LandmarkTypeProperty"/> on a StyledElement.
+        /// </summary>
+        public static void SetLandmarkType(StyledElement element, AutomationLandmarkType? value)
+        {
+            _ = element ?? throw new ArgumentNullException(nameof(element));
+            element.SetValue(LandmarkTypeProperty, value);
+        }
+
+        /// <summary>
+        /// Helper for reading the value of the <see cref="LandmarkTypeProperty"/> on a StyledElement.
+        /// </summary>
+        public static AutomationLandmarkType? GetLandmarkType(StyledElement element)
+        {
+            _ = element ?? throw new ArgumentNullException(nameof(element));
+            return element.GetValue(LandmarkTypeProperty);
+        }
+
+        /// <summary>
         /// Helper for setting the value of the <see cref="HeadingLevelProperty"/> on a StyledElement.
         /// </summary>
         public static void SetHeadingLevel(StyledElement element, int value)
@@ -371,7 +400,6 @@ namespace Avalonia.Automation
         /// <summary>
         /// Helper for reading the value of the <see cref="HeadingLevelProperty"/> on a StyledElement.
         /// </summary>
-        /// <returns></returns>
         public static int GetHeadingLevel(StyledElement element)
         {
             _ = element ?? throw new ArgumentNullException(nameof(element));

--- a/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
@@ -49,6 +49,18 @@ namespace Avalonia.Automation.Peers
         Separator,
     }
 
+    public enum AutomationLandmarkType
+    {
+        Banner,
+        Complementary,
+        ContentInfo,
+        Region,
+        Form,
+        Main,
+        Navigation,
+        Search,
+    }
+
     /// <summary>
     /// Provides a base class that exposes an element to UI Automation.
     /// </summary>
@@ -269,6 +281,25 @@ namespace Avalonia.Automation.Peers
         /// </list>
         /// </remarks>
         public string GetHelpText() => GetHelpTextCore() ?? string.Empty;
+
+        /// <summary>
+        /// Gets the control type for the element that is associated with the UI Automation peer.
+        /// </summary>
+        /// <remarks>
+        /// Gets the type of the element.
+        /// 
+        /// <list type="table">
+        ///   <item>
+        ///     <term>Windows</term>
+        ///     <description><c>UIA_LandmarkTypePropertyId</c>, <c>UIA_LocalizedLandmarkTypePropertyId</c></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>macOS</term>
+        ///     <description><c>NSAccessibilityProtocol.accessibilityRole</c>, <c>NSAccessibilityProtocol.accessibilitySubrole</c></description>
+        ///   </item>
+        /// </list>
+        /// </remarks>
+        public AutomationLandmarkType? GetLandmarkType() => GetLandmarkTypeCore();
 
         /// <summary>
         /// Gets the heading level that is associated with this automation peer.
@@ -505,6 +536,7 @@ namespace Avalonia.Automation.Peers
                 AutomationControlType.SplitButton => "split button",
                 AutomationControlType.HeaderItem => "header item",
                 AutomationControlType.TitleBar => "title bar",
+                AutomationControlType.None => (GetLandmarkType()?.ToString() ?? controlType.ToString()).ToLowerInvariant(),
                 _ => controlType.ToString().ToLowerInvariant(),
             };
         }
@@ -520,6 +552,7 @@ namespace Avalonia.Automation.Peers
         protected abstract AutomationPeer? GetLabeledByCore();
         protected abstract string? GetNameCore();
         protected virtual string? GetHelpTextCore() => null;
+        protected virtual AutomationLandmarkType? GetLandmarkTypeCore() => null;
         protected virtual int GetHeadingLevelCore() => 0;
         protected abstract AutomationPeer? GetParentCore();
         protected abstract bool HasKeyboardFocusCore();

--- a/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
@@ -134,6 +134,7 @@ namespace Avalonia.Automation.Peers
 
             return result;
         }
+        protected override AutomationLandmarkType? GetLandmarkTypeCore() => AutomationProperties.GetLandmarkType(Owner);
         protected override int GetHeadingLevelCore() => AutomationProperties.GetHeadingLevel(Owner);
         protected override AutomationPeer? GetParentCore()
         {

--- a/src/Avalonia.Native/AvnAutomationPeer.cs
+++ b/src/Avalonia.Native/AvnAutomationPeer.cs
@@ -40,6 +40,7 @@ namespace Avalonia.Native
         public IAvnAutomationPeer? LabeledBy => Wrap(_inner.GetLabeledBy());
         public IAvnString Name => _inner.GetName().ToAvnString();
         public IAvnString HelpText => _inner.GetHelpText().ToAvnString();
+        public AvnLandmarkType LandmarkType => (AvnLandmarkType?)_inner.GetLandmarkType() ?? AvnLandmarkType.LandmarkNone;
         public int HeadingLevel => _inner.GetHeadingLevel();
         public IAvnAutomationPeer? Parent => Wrap(_inner.GetParent());
         public IAvnAutomationPeer? VisualRoot => Wrap(_inner.GetVisualRoot());

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -654,6 +654,19 @@ enum AvnAutomationControlType
     AutomationSeparator,
 }
 
+enum AvnLandmarkType
+{
+    LandmarkNone = -1,
+    LandmarkBanner,
+    LandmarkComplementary,
+    LandmarkContentInfo,
+    LandmarkRegion,
+    LandmarkForm,
+    LandmarkMain,
+    LandmarkNavigation,
+    LandmarkSearch,
+}
+
 enum AvnWindowTransparencyMode
 {
     Opaque,
@@ -1307,6 +1320,8 @@ interface IAvnAutomationPeer : IUnknown
      void ValueProvider_SetValue(char* value);
 
      IAvnString* GetHelpText();
+
+     AvnLandmarkType GetLandmarkType();
      int GetHeadingLevel();
 }
 

--- a/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
+++ b/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
@@ -37,6 +37,7 @@ namespace Avalonia.Win32.Automation
             { AutomationElementIdentifiers.ClassNameProperty, UiaPropertyId.ClassName },
             { AutomationElementIdentifiers.NameProperty, UiaPropertyId.Name },
             { AutomationElementIdentifiers.HelpTextProperty, UiaPropertyId.HelpText },
+            { AutomationElementIdentifiers.LandmarkTypeProperty, UiaPropertyId.LandmarkType },
             { AutomationElementIdentifiers.HeadingLevelProperty, UiaPropertyId.HeadingLevel },
             { ExpandCollapsePatternIdentifiers.ExpandCollapseStateProperty, UiaPropertyId.ExpandCollapseExpandCollapseState },
             { RangeValuePatternIdentifiers.IsReadOnlyProperty, UiaPropertyId.RangeValueIsReadOnly},
@@ -139,6 +140,8 @@ namespace Avalonia.Win32.Automation
                 UiaPropertyId.LocalizedControlType => InvokeSync(() => Peer.GetLocalizedControlType()),
                 UiaPropertyId.Name => InvokeSync(() => Peer.GetName()),
                 UiaPropertyId.HelpText => InvokeSync(() => Peer.GetHelpText()),
+                UiaPropertyId.LandmarkType => InvokeSync(() => ToUiaLandmarkType(Peer.GetLandmarkType())),
+                UiaPropertyId.LocalizedLandmarkType => InvokeSync(() => ToUiaLocalizedLandmarkType(Peer.GetLandmarkType())),
                 UiaPropertyId.HeadingLevel => InvokeSync(() => ToUiaHeadingLevel(Peer.GetHeadingLevel())),
                 UiaPropertyId.ProcessId => s_pid,
                 UiaPropertyId.RuntimeId => _runtimeId,
@@ -357,6 +360,34 @@ namespace Avalonia.Win32.Automation
                 AutomationControlType.TitleBar => UiaControlTypeId.TitleBar,
                 AutomationControlType.Separator => UiaControlTypeId.Separator,
                 _ => UiaControlTypeId.Custom,
+            };
+        }
+
+        private static UiaLandmarkType? ToUiaLandmarkType(AutomationLandmarkType? landmarkType)
+        {
+            return landmarkType switch
+            {
+                AutomationLandmarkType.Banner or
+                AutomationLandmarkType.Complementary or
+                AutomationLandmarkType.ContentInfo or
+                AutomationLandmarkType.Region => UiaLandmarkType.Custom,
+                AutomationLandmarkType.Form => UiaLandmarkType.Form,
+                AutomationLandmarkType.Main => UiaLandmarkType.Main,
+                AutomationLandmarkType.Navigation => UiaLandmarkType.Navigation,
+                AutomationLandmarkType.Search => UiaLandmarkType.Search,
+                _ => null,
+            };
+        }
+
+        private static string? ToUiaLocalizedLandmarkType(AutomationLandmarkType? landmarkType)
+        {
+            return landmarkType switch
+            {
+                AutomationLandmarkType.Banner => "banner",
+                AutomationLandmarkType.Complementary => "complementary",
+                AutomationLandmarkType.ContentInfo => "content information",
+                AutomationLandmarkType.Region => "region",
+                _ => null,
             };
         }
 

--- a/src/Windows/Avalonia.Win32.Automation/Interop/IRawElementProviderSimple.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Interop/IRawElementProviderSimple.cs
@@ -277,6 +277,15 @@ internal enum UiaControlTypeId
     AppBar
 };
 
+internal enum UiaLandmarkType
+{
+    Custom = 80000,
+    Form,
+    Main,
+    Navigation,
+    Search,
+};
+
 internal enum UiaHeadingLevel
 {
     None = 80050,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This implements `LandmarkType` in `AutomationProperties`, and can be used to indicate big "landmark" points within the app that the user can navigate between quickly.

## What is the updated/expected behavior with this PR?
Add `AutomationProperty.LandmarkType="Main"` to some main content. This element will now get the `Main` landmark type on Windows UIA and Mac AX.

Something that I haven't quite figured out yet is how Mac VoiceOver *finds* landmarks. It's not able to navigate between or find the landmarks (despite having the properties set correctly). I'll investigate a bit more, but this PR should at least be a good first step.

## How was the solution implemented (if it's not obvious)?
I implemented this as an enum, because implementation is not straight forward between Windows and Mac. To be precise:

UIA `LandmarkType` | Mac `AXSubrole` | Mac `AXRoleDescription` | Avalonia
--------|--------|--------|--------
Custom: "banner" | AXLandmarkBanner | banner | Banner
Custom: "complementary" | AXLandmarkComplementary | complementary | Complementary
Custom: "content information" | AXLandmarkContentInfo | content | ContentInfo
Custom: "region" | AXLandmarkRegion | region | Region
Form | AXLandmarkForm | form | Form
Main | AXLandmarkMain | main | Main
Navigation | AXLandmarkNavigation | navigation | Navigation
Search | AXLandmarkSearch | search | Search

This follows [the mapping role table from w3c](https://www.w3.org/TR/core-aam-1.2/#mapping_role_table).

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
