### PR TITLE
Don't clear X11 clipboard if we still have the ownership

### DIFF
--- a/src/Avalonia.X11/Clipboard/X11Clipboard.cs
+++ b/src/Avalonia.X11/Clipboard/X11Clipboard.cs
@@ -50,7 +50,10 @@ namespace Avalonia.X11.Clipboard
         {
             if (ev.type == XEventName.SelectionClear)
             {
-                _storedDataTransfer = null;
+                // We night have already regained the clipboard ownership by the time a SelectionClear message arrives.
+                if (GetOwner() != _handle)
+                    _storedDataTransfer = null;
+
                 _storeAtomTcs?.TrySetResult(true);
                 return;
             }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the X11 clipboard inadvertently clearing if `SetDataAsync` is called right after `ClearDataAsync` and the application is owning the clipboard.

## How was the solution implemented (if it's not obvious)?
Currently, when `ClearDataAsync` is called, we're setting the clipboard selection owner to zero. If the application is currently the owner, a `SelectionClear` event will be received. However, by the time we receive it, we may already be the owner again (if `SetDataAsync` was called). Ignore it in this case.

## Fixed issues
 - Fixes #20130