### PR TITLE
[WIP] Expose platform FontFamilyMappings

### DIFF
--- a/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
@@ -43,12 +43,6 @@ namespace Avalonia.Media.Fonts
 
             var key = new FontCollectionKey(style, weight, stretch);
 
-            //Check cache first to avoid unnecessary calls to the font manager
-            if (_glyphTypefaceCache.TryGetValue(familyName, out var glyphTypefaces) && glyphTypefaces.TryGetValue(key, out glyphTypeface))
-            {
-                return glyphTypeface != null;
-            }
-
             //Try to create the glyph typeface via system font manager
             if (!_platformImpl.TryCreateGlyphTypeface(familyName, style, weight, stretch, out glyphTypeface))
             {
@@ -62,6 +56,15 @@ namespace Avalonia.Media.Fonts
             if (!TryAddGlyphTypeface(glyphTypeface))
             {
                 return false;
+            }
+
+            if (_platformImpl is IFontManagerImpl2 fontManagerImpl2 && fontManagerImpl2.FontFamilyMappings.TryGetValue(familyName, out var mappedFontFamily))
+            {
+                if(base.TryGetGlyphTypeface(mappedFontFamily.Name, style, weight, stretch, out glyphTypeface))
+                {
+                    //Add to cache with mapped family name
+                    TryAddGlyphTypeface(familyName, key, glyphTypeface);
+                }
             }
 
             //Requested glyph typeface should be in cache now

--- a/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
@@ -64,10 +64,11 @@ namespace Avalonia.Media.Fonts
                 {
                     //Add to cache with mapped family name
                     TryAddGlyphTypeface(familyName, key, glyphTypeface);
+
                     return true;
                 }
-                // If mapping lookup fails, fall through and return true for the created glyphTypeface
-                return true;
+
+                return false;
             }
 
             // Successfully created and cached glyphTypeface, return true

--- a/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
@@ -43,6 +43,12 @@ namespace Avalonia.Media.Fonts
 
             var key = new FontCollectionKey(style, weight, stretch);
 
+            // We need to check our cache first to be able to avoid multiple calls to platform font manager when a null value was cached before.
+            if (_glyphTypefaceCache.TryGetValue(familyName, out var glyphTypefaces) && glyphTypefaces.TryGetValue(key, out glyphTypeface))
+            {
+                return glyphTypeface != null;
+            }
+
             //Try to create the glyph typeface via system font manager
             if (!_platformImpl.TryCreateGlyphTypeface(familyName, style, weight, stretch, out glyphTypeface))
             {

--- a/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
@@ -60,15 +60,18 @@ namespace Avalonia.Media.Fonts
 
             if (_platformImpl is IFontManagerImpl2 fontManagerImpl2 && fontManagerImpl2.FontFamilyMappings.TryGetValue(familyName, out var mappedFontFamily))
             {
-                if(base.TryGetGlyphTypeface(mappedFontFamily.Name, style, weight, stretch, out glyphTypeface))
+                if (base.TryGetGlyphTypeface(mappedFontFamily.Name, style, weight, stretch, out glyphTypeface))
                 {
                     //Add to cache with mapped family name
                     TryAddGlyphTypeface(familyName, key, glyphTypeface);
+                    return true;
                 }
+                // If mapping lookup fails, fall through and return true for the created glyphTypeface
+                return true;
             }
 
-            //Requested glyph typeface should be in cache now
-            return base.TryGetGlyphTypeface(familyName, style, weight, stretch, out glyphTypeface);
+            // Successfully created and cached glyphTypeface, return true
+            return true;
         }
 
         public override bool TryGetFamilyTypefaces(string familyName, [NotNullWhen(true)] out IReadOnlyList<Typeface>? familyTypefaces)

--- a/src/Avalonia.Base/Platform/IFontManagerImpl.cs
+++ b/src/Avalonia.Base/Platform/IFontManagerImpl.cs
@@ -65,6 +65,10 @@ namespace Avalonia.Platform
 
     internal interface IFontManagerImpl2 : IFontManagerImpl
     {
+        /// <summary>
+        /// Gets a read-only dictionary that maps requested font family names to actual font family names.
+        /// This is typically populated when the platform resolves font aliases or provides different font families than requested.
+        /// </summary>
         IReadOnlyDictionary<string, FontFamily> FontFamilyMappings { get; }
 
         /// <summary>

--- a/src/Avalonia.Base/Platform/IFontManagerImpl.cs
+++ b/src/Avalonia.Base/Platform/IFontManagerImpl.cs
@@ -65,6 +65,8 @@ namespace Avalonia.Platform
 
     internal interface IFontManagerImpl2 : IFontManagerImpl
     {
+        IReadOnlyDictionary<string, FontFamily> FontFamilyMappings { get; }
+
         /// <summary>
         ///     Tries to match a specified character to a typeface that supports specified font properties.
         /// </summary>

--- a/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
@@ -106,7 +106,7 @@ namespace Avalonia.Skia.UnitTests.Media
                     FontManager.Current.TryGetGlyphTypeface(new Typeface("Unknown"), out _);
                 }
 
-                Assert.Equal(fontManagerImpl.TryCreateGlyphTypefaceCount, 2);
+                Assert.Equal(2, fontManagerImpl.TryCreateGlyphTypefaceCount);
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

This PR introduces a mechanism to track and expose font family name mappings when the platform font manager returns a different font family than the one requested. This handles cases where font names are aliases or when the system provides alternative fonts.

**Key changes:**
- Adds a `FontFamilyMappings` property to `IFontManagerImpl2` that exposes a read-only dictionary of requested font names to actual resolved font names
- Implements automatic detection and caching of font aliases when the platform returns a different font family than requested
- Modifies `SystemFontCollection.TryGetGlyphTypeface` to use these mappings to cache typefaces under both the requested and actual family names

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
