### PR TITLE
Partially fixes #11665, virtual keyboard or Browser mobile android fix

### DIFF
--- a/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
+++ b/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices.JavaScript;
 using Avalonia.Browser.Interop;
 using Avalonia.Collections.Pooled;
+using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
 
@@ -40,7 +41,7 @@ internal class BrowserInputHandler
         TextInputMethod = new BrowserTextInputMethod(this, container, inputElement);
         InputPane = new BrowserInputPane();
 
-        InputHelper.SubscribeInputEvents(container, topLevelId);
+        InputHelper.SubscribeInputEvents(container, inputElement, topLevelId);
     }
 
     public BrowserTextInputMethod TextInputMethod { get; }
@@ -229,6 +230,14 @@ internal class BrowserInputHandler
 
     public bool OnKeyDown(string code, string key, int modifier)
     {
+        //If we are processing beforeInput we must not process Backspace
+        //but onBeforeInput itself calls OnKeyBackspace, so filtering must be done at the same level.
+        //onBeforeInput will call RawKeyboardEvent.
+        if (key == "Backspace")
+        {
+            //return true;  //why?
+        }
+
         var handled = RawKeyboardEvent(RawKeyEventType.KeyDown, code, key, (RawInputModifiers)modifier);
 
         if (!handled && key.Length == 1)
@@ -303,7 +312,7 @@ internal class BrowserInputHandler
         return false;
     }
 
-    private bool RawKeyboardEvent(RawKeyEventType type, string domCode, string domKey, RawInputModifiers modifiers)
+    internal bool RawKeyboardEvent(RawKeyEventType type, string domCode, string domKey, RawInputModifiers modifiers)
     {
         if (_inputRoot is null)
             return false;

--- a/src/Browser/Avalonia.Browser/Interop/InputHelper.cs
+++ b/src/Browser/Avalonia.Browser/Interop/InputHelper.cs
@@ -12,7 +12,7 @@ internal static partial class InputHelper
         return Task.CompletedTask;
     }
 
-    public static Task<T> RedirectInputRetunAsync<T>(int topLevelId, Func<BrowserTopLevelImpl,T> handler, T @default)
+    public static Task<T> RedirectInputReturnAsync<T>(int topLevelId, Func<BrowserTopLevelImpl,T> handler, T @default)
     {
         if (BrowserTopLevelImpl.TryGetTopLevel(topLevelId) is { } topLevelImpl)
             return Task.FromResult(handler(topLevelImpl));
@@ -20,19 +20,19 @@ internal static partial class InputHelper
     }
 
     [JSImport("InputHelper.subscribeInputEvents", AvaloniaModule.MainModuleName)]
-    public static partial void SubscribeInputEvents(JSObject htmlElement, int topLevelId);
+    public static partial void SubscribeInputEvents(JSObject htmlElement, JSObject inputElement, int topLevelId);
 
     [JSExport]
     public static Task<bool> OnKeyDown(int topLevelId, string code, string key, int modifier) =>
-        RedirectInputRetunAsync(topLevelId, t => t.InputHandler.OnKeyDown(code, key, modifier), false);
+        RedirectInputReturnAsync(topLevelId, t => t.InputHandler.OnKeyDown(code, key, modifier), false);
 
     [JSExport]
     public static Task<bool> OnKeyUp(int topLevelId, string code, string key, int modifier) =>
-        RedirectInputRetunAsync(topLevelId, t => t.InputHandler.OnKeyUp(code, key, modifier), false);
+        RedirectInputReturnAsync(topLevelId, t => t.InputHandler.OnKeyUp(code, key, modifier), false);
 
     [JSExport]
-    public static Task OnBeforeInput(int topLevelId, string inputType, int start, int end) =>
-        RedirectInputAsync(topLevelId, t => t.InputHandler.TextInputMethod.OnBeforeInput(inputType, start, end));
+    public static Task OnBeforeInput(int topLevelId, string inputType, int start, int end, string data) =>
+        RedirectInputAsync(topLevelId, t => t.InputHandler.TextInputMethod.OnBeforeInput(inputType, start, end, data));
 
     [JSExport]
     public static Task OnCompositionStart(int topLevelId) =>

--- a/src/Browser/Avalonia.Browser/webapp/modules/avalonia/dom.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/avalonia/dom.ts
@@ -72,6 +72,7 @@ export class AvaloniaDOM {
 
         // IME
         const inputElement = document.createElement("input");
+        inputElement.contentEditable = "true";
         inputElement.id = `inputElement${containerId}`;
         inputElement.classList.add("avalonia-input-element");
         inputElement.autocapitalize = "none";


### PR DESCRIPTION

This partially fixes issue #11665, where no keypresses are recorded on android virtual keyboards.  The sequence of events differ like this:

Key sequences, desktop Chrome
Key "a" pressed [event: keydown]
Key "a" about to be input [event: beforeinput]
Key "a" input [event: input]
Key "a" released [event: keyup]

android browser chrome virtual keyboard
Key "Unidentified" pressed [event: keydown]
Key "a" about to be input [event: beforeinput]
Key "a" input [event: input]
Key "Unidentified" released [event: keyup]

The event is documented here: https://developer.mozilla.org/en-US/docs/Web/API/Element/beforeinput_event

Since Avalonia is marking the keyDown event as handled (preventDefault or javascript side) the beforeinput does not fire on desktop browser.

So, typing work the same as before on desktop browser. 

The official documentation says the mobile events from IME keyboards should be handled with input, beforeinput, and composing events. InputEvent interface has about 50 possible values for the inputType (https://w3c.github.io/input-events/#interface-InputEvent-Attributes), and here we are ignoring 48 of them.

## How was the solution implemented (if it's not obvious)?
Debugging by instrumenting code and logging over HTTP.
## Checklist
No tests.
## Breaking changes
Possible.  

