### PR TITLE
Improve NuGet.Config by clearing all package source options to make it independent of global NuGet.Config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,5 +4,18 @@
   <packageSources>
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="azure-dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <clear />
+  </packageSourceMapping>
+  <auditSources>
+    <clear />
+  </auditSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+  <fallbackPackageFolders>
+    <clear />
+  </fallbackPackageFolders>
 </configuration>

--- a/nukebuild/_build.csproj
+++ b/nukebuild/_build.csproj
@@ -9,8 +9,6 @@
     <TargetFramework>$(AvsCurrentTargetFramework)</TargetFramework>
     <!-- See https://github.com/nuke-build/nuke/issues/818 -->
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
-    <!-- Necessary for Microsoft.DotNet.ApiDiff.Tool -->
-    <RestoreAdditionalProjectSources>https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json</RestoreAdditionalProjectSources>
   </PropertyGroup>
 
   <Import Project="..\build\JetBrains.dotMemoryUnit.props" />


### PR DESCRIPTION
## What does the pull request do?

Fixes:

* #20168

Updated `NuGet.Config` to clear all elements related to package sources (`packageSourceMapping`, `auditSources`, `disabledPackageSources`, `fallbackPackageFolders`), which makes it independent of global `NuGet.Config`.

## What is the current behavior?

Building `Avalonia.Desktop.slnf` from source causes numerous NuGet restore errors if global `NuGet.Config` (`%APPDATA%\NuGet\NuGet.Config` in Windows) contains `<packageSourceMapping>` configuration which is incompatible with Avalonia's added `api.nuget.org` element.

See more details in the linked issue.

## What is the updated/expected behavior with this PR?

Build (`dotnet build Avalonia.Desktop.slnf`) succeeds, no matter how global `NuGet.Config` is configured.

Note: currently there's another issue of `Avalonia.Desktop.slnf` including renamed `Controls.Catalog.NetCore` project and removed `*.Direct2D1.*` projects. I can include the fix to the solution filter file too, if needed. I was just concerned the PR won't be focused on the NuGet problem exclusively.

## How was the solution implemented (if it's not obvious)?

`NuGet.Config` from NuGet's own sources is used as a reference:

https://github.com/NuGet/NuGet.Client/blob/dev/NuGet.Config

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

Development-related changes, so unit tests and everything else is impossible.

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #20168