### PR TITLE
Fixed ReversibleStackPanel not invalidating arrange on ReverseOrder change

### DIFF
--- a/src/Avalonia.Controls/Notifications/ReversibleStackPanel.cs
+++ b/src/Avalonia.Controls/Notifications/ReversibleStackPanel.cs
@@ -24,6 +24,11 @@ namespace Avalonia.Controls
             set => SetValue(ReverseOrderProperty, value);
         }
 
+        static ReversibleStackPanel()
+        {
+            AffectsArrange<ReversibleStackPanel>(ReverseOrderProperty);
+        }
+
         /// <inheritdoc/>
         protected override Size ArrangeOverride(Size finalSize)
         {

--- a/tests/Avalonia.Controls.UnitTests/ReversibleStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ReversibleStackPanelTests.cs
@@ -1,0 +1,48 @@
+﻿using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests
+{
+    public class ReversibleStackPanelTests : ScopedTestBase
+    {
+        [Fact]
+        public void Arranges_In_Reverse_Order()
+        {
+            var target = new ReversibleStackPanel
+            {
+                ReverseOrder = true,
+                Children =
+                {
+                    new Border { Height = 30, Width = 10 },
+                    new Border { Height = 50 },
+                }
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+
+            Assert.Equal(new Rect(0, 50, 10, 30), target.Children[0].Bounds);
+            Assert.Equal(new Rect(0, 0, 10, 50), target.Children[1].Bounds);
+        }
+
+        [Fact]
+        public void Invalidates_Arrange_On_Reverse_Order_Change()
+        {
+            var target = new ReversibleStackPanel
+            {
+                Children =
+                {
+                    new Border(),
+                    new Border(),
+                }
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+            target.ReverseOrder = true;
+
+            Assert.True(target.IsMeasureValid);
+            Assert.False(target.IsArrangeValid);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Fixes:

* #20171

## What is the current behavior?

When `ReverseOrder` property of `ReversibleStackPanel` is switched between `true` and `false`, it doesn't invalidate arrange and the controls stay in the same place.

## What is the updated/expected behavior with this PR?

Controls are rearranged when `ReverseOrder` is changed.

## How was the solution implemented (if it's not obvious)?

Added call to `AffectsArrange`.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #20171