### PR TITLE
[Fix] ImmediateRenderer

### DIFF
--- a/src/Avalonia.Base/Media/Imaging/RenderTargetBitmap.cs
+++ b/src/Avalonia.Base/Media/Imaging/RenderTargetBitmap.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Media.Imaging
         public void Render(Visual visual)
         {
             using (var ctx = CreateDrawingContext())
-                ImmediateRenderer.Render(visual, ctx);
+                ImmediateRenderer.Render(ctx, visual);
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Media/VisualBrush.cs
+++ b/src/Avalonia.Base/Media/VisualBrush.cs
@@ -56,7 +56,7 @@ namespace Avalonia.Media
                 initialize.EnsureInitialized();
             
             using var recorder = new RenderDataDrawingContext(null);
-            ImmediateRenderer.Render(Visual, recorder);
+            ImmediateRenderer.Render(recorder, Visual);
             return recorder.GetImmediateSceneBrushContent(this, new(Visual.Bounds.Size), true);
         }
         
@@ -130,7 +130,7 @@ namespace Avalonia.Media
                 initialize.EnsureInitialized();
 
             using var recorder = new RenderDataDrawingContext(c);
-            ImmediateRenderer.Render(Visual, recorder);
+            ImmediateRenderer.Render(recorder, Visual);
             var renderData = recorder.GetRenderResults();
             if (renderData == null)
                 return null;

--- a/src/Avalonia.Base/Media/VisualBrush.cs
+++ b/src/Avalonia.Base/Media/VisualBrush.cs
@@ -56,7 +56,7 @@ namespace Avalonia.Media
                 initialize.EnsureInitialized();
             
             using var recorder = new RenderDataDrawingContext(null);
-            ImmediateRenderer.Render(recorder, Visual, Visual.Bounds);
+            ImmediateRenderer.Render(Visual, recorder);
             return recorder.GetImmediateSceneBrushContent(this, new(Visual.Bounds.Size), true);
         }
         
@@ -130,7 +130,7 @@ namespace Avalonia.Media
                 initialize.EnsureInitialized();
 
             using var recorder = new RenderDataDrawingContext(c);
-            ImmediateRenderer.Render(recorder, Visual, Visual.Bounds);
+            ImmediateRenderer.Render(Visual, recorder);
             var renderData = recorder.GetRenderResults();
             if (renderData == null)
                 return null;

--- a/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
@@ -60,7 +60,7 @@ internal class ImmediateRenderer
             _ => default(DrawingContext.PushedState?)
         })
         using (visual.Clip != null ? context.PushGeometryClip(visual.Clip) : default(DrawingContext.PushedState?))
-        using (visual.OpacityMask != null ? context.PushOpacityMask(visual.OpacityMask, bounds) : default(DrawingContext.PushedState?))
+        using (visual.OpacityMask != null ? context.PushOpacityMask(visual.OpacityMask, clipBounds) : default(DrawingContext.PushedState?))
         {
             visual.Render(context);
 

--- a/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
@@ -1,124 +1,67 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using Avalonia.Logging;
 using Avalonia.Media;
-using Avalonia.Platform;
 using Avalonia.VisualTree;
 
-namespace Avalonia.Rendering
+namespace Avalonia.Rendering;
+
+/// <summary>
+/// This class is used to render the visual tree into a DrawingContext by doing
+/// a simple tree traversal.
+/// It's currently used mostly for RenderTargetBitmap.Render and VisualBrush
+/// </summary>
+internal class ImmediateRenderer
 {
     /// <summary>
-    /// This class is used to render the visual tree into a DrawingContext by doing
-    /// a simple tree traversal.
-    /// It's currently used mostly for RenderTargetBitmap.Render and VisualBrush
+    /// Renders a visual to a drawing context.
     /// </summary>
-    internal class ImmediateRenderer
+    /// <param name="visual">The visual.</param>
+    /// <param name="context">The drawing context.</param>
+    public static void Render(Visual visual, DrawingContext context)
     {
-        /// <summary>
-        /// Renders a visual to a drawing context.
-        /// </summary>
-        /// <param name="visual">The visual.</param>
-        /// <param name="context">The drawing context.</param>
-        public static void Render(Visual visual, DrawingContext context)
+        Render(context, visual, new Rect(visual.Bounds.Size));
+    }
+
+    public static void Render(DrawingContext context, Visual visual, Rect bounds)
+    {
+        if (!visual.IsVisible || visual.Opacity is not ({ } opacity and > 0))
         {
-            Render(context, visual, visual.Bounds);
+            return;
         }
 
-        private static Rect GetTransformedBounds(Visual visual)
+        var renderTransform = default(Matrix?);
+        if (visual.RenderTransform != null)
         {
-            if (visual.RenderTransform == null)
-            {
-                return visual.Bounds;
-            }
-            else
-            {
-                var origin = visual.RenderTransformOrigin.ToPixels(new Size(visual.Bounds.Width, visual.Bounds.Height));
-                var offset = Matrix.CreateTranslation(visual.Bounds.Position + origin);
-                var m = (-offset) * visual.RenderTransform.Value * (offset);
-                return visual.Bounds.TransformToAABB(m);
-            }
+            var origin = visual.RenderTransformOrigin.ToPixels(new Size(visual.Bounds.Width, visual.Bounds.Height));
+            var offset = Matrix.CreateTranslation(origin);
+            renderTransform = (-offset) * visual.RenderTransform.Value * (offset);
         }
 
+        var clipBounds = new Rect(bounds.Size);
 
-        public static void Render(DrawingContext context, Visual visual, Rect clipRect)
+        using (visual.RenderOptions != default ? context.PushRenderOptions(visual.RenderOptions) : default(DrawingContext.PushedState?))
+        using (context.PushTransform(new TranslateTransform(bounds.Position.X, bounds.Position.Y).Value))
+        using (renderTransform is { } matrix ? context.PushTransform(matrix) : default(DrawingContext.PushedState?))
+        using (visual.HasMirrorTransform ? context.PushTransform(new Matrix(-1.0, 0.0, 0.0, 1.0, visual.Bounds.Width, 0)) : default(DrawingContext.PushedState?))
+        using (context.PushOpacity(opacity))
+        using (visual switch
         {
-            using(visual.RenderOptions != default ? context.PushRenderOptions(visual.RenderOptions) : (DrawingContext.PushedState?)null)
+            { ClipToBounds: true } and IVisualWithRoundRectClip roundClipVisual => context.PushClip(new RoundedRect(clipBounds, roundClipVisual.ClipToBoundsRadius)),
+            { ClipToBounds: true } => context.PushClip(clipBounds),
+            _ => default(DrawingContext.PushedState?)
+        })
+        using (visual.Clip != null ? context.PushGeometryClip(visual.Clip) : default(DrawingContext.PushedState?))
+        using (visual.OpacityMask != null ? context.PushOpacityMask(visual.OpacityMask, bounds) : default(DrawingContext.PushedState?))
+        {
+            visual.Render(context);
+
+            IEnumerable<Visual> childrenEnumerable = visual.HasNonUniformZIndexChildren
+                ? visual.VisualChildren.OrderBy(x => x, ZIndexComparer.Instance)
+                : visual.VisualChildren;
+
+            foreach (var child in childrenEnumerable)
             {
-                var opacity = visual.Opacity;
-                var clipToBounds = visual.ClipToBounds;
-                var bounds = new Rect(visual.Bounds.Size);
-
-                if (visual.IsVisible && opacity > 0)
-                {
-                    var m = Matrix.CreateTranslation(visual.Bounds.Position);
-
-                    var renderTransform = Matrix.Identity;
-
-                    // this should be calculated BEFORE renderTransform
-                    if (visual.HasMirrorTransform)
-                    {
-                        var mirrorMatrix = new Matrix(-1.0, 0.0, 0.0, 1.0, visual.Bounds.Width, 0);
-                        renderTransform *= mirrorMatrix;
-                    }
-
-                    if (visual.RenderTransform != null)
-                    {
-                        var origin = visual.RenderTransformOrigin.ToPixels(new Size(visual.Bounds.Width, visual.Bounds.Height));
-                        var offset = Matrix.CreateTranslation(origin);
-                        var finalTransform = (-offset) * visual.RenderTransform.Value * (offset);
-                        renderTransform *= finalTransform;
-                    }
-
-                    m = renderTransform * m;
-
-                    if (clipToBounds)
-                    {
-                        if (visual.RenderTransform != null)
-                        {
-                            clipRect = new Rect(visual.Bounds.Size);
-                        }
-                        else
-                        {
-                            clipRect = clipRect.Intersect(new Rect(visual.Bounds.Size));
-                        }
-                    }
-
-                    using (context.PushTransform(m))
-                    using (context.PushOpacity(opacity))
-                    using (clipToBounds
-#pragma warning disable CS0618 // Type or member is obsolete
-                        ? visual is IVisualWithRoundRectClip roundClipVisual
-                            ? context.PushClip(new RoundedRect(bounds, roundClipVisual.ClipToBoundsRadius))
-                            : context.PushClip(bounds)
-                        : default)
-#pragma warning restore CS0618 // Type or member is obsolete
-
-                    using (visual.Clip != null ? context.PushGeometryClip(visual.Clip) : default)
-                    using (visual.OpacityMask != null ? context.PushOpacityMask(visual.OpacityMask, bounds) : default)
-                    using (context.PushTransform(Matrix.Identity))
-                    {
-                        visual.Render(context);
-
-                        var childrenEnumerable = visual.HasNonUniformZIndexChildren
-                            ? visual.VisualChildren.OrderBy(x => x, ZIndexComparer.Instance)
-                            : (IEnumerable<Visual>)visual.VisualChildren;
-
-                        foreach (var child in childrenEnumerable)
-                        {
-                            var childBounds = GetTransformedBounds(child);
-
-                            if (!child.ClipToBounds || clipRect.Intersects(childBounds))
-                            {
-                                var childClipRect = child.RenderTransform == null
-                                    ? clipRect.Translate(-childBounds.Position)
-                                    : clipRect;
-                                Render(context, child, childClipRect);
-                            }
-                        }                      
-                    }
-                }
+                Render(context, child, child.Bounds);
             }
         }
     }

--- a/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
@@ -19,12 +19,21 @@ internal class ImmediateRenderer
     /// <param name="context">The drawing context.</param>
     public static void Render(Visual visual, DrawingContext context)
     {
-        Render(context, visual, new Rect(visual.Bounds.Size));
+        RenderInternal(context, visual, new Rect(visual.Bounds.Size));
     }
 
-    public static void Render(DrawingContext context, Visual visual, Rect bounds)
+    public static void Render(DrawingContext context, Visual visual, Rect clipRect)
     {
-        if (!visual.IsVisible || visual.Opacity is not ({ } opacity and > 0))
+        using (context.PushTransform(new TranslateTransform(-clipRect.Position.X, -clipRect.Position.Y).Value))
+        using (context.PushClip(clipRect))
+        {
+            Render(visual, context);
+        }
+    }
+
+    private static void RenderInternal(DrawingContext context, Visual visual, Rect bounds)
+    {
+        if (!visual.IsVisible || visual.Opacity is not (var opacity and > 0))
         {
             return;
         }
@@ -61,7 +70,7 @@ internal class ImmediateRenderer
 
             foreach (var child in childrenEnumerable)
             {
-                Render(context, child, child.Bounds);
+                RenderInternal(context, child, child.Bounds);
             }
         }
     }

--- a/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
@@ -17,7 +17,7 @@ internal class ImmediateRenderer
     /// </summary>
     /// <param name="visual">The visual.</param>
     /// <param name="context">The drawing context.</param>
-    public static void Render(Visual visual, DrawingContext context)
+    public static void Render(DrawingContext context, Visual visual)
         => Render(context, visual, new Rect(visual.Bounds.Size));
 
     public static void Render(DrawingContext context, Visual visual, Rect clipRect)

--- a/tests/Avalonia.Base.UnitTests/RenderTests_Culling.cs
+++ b/tests/Avalonia.Base.UnitTests/RenderTests_Culling.cs
@@ -215,7 +215,7 @@ namespace Avalonia.Base.UnitTests
             var ctx = CreateDrawingContext();
             control.Measure(Size.Infinity);
             control.Arrange(new Rect(control.DesiredSize));
-            ImmediateRenderer.Render(control, ctx);
+            ImmediateRenderer.Render(ctx, control);
         }
 
         private DrawingContext CreateDrawingContext()

--- a/tests/Avalonia.Base.UnitTests/RenderTests_Culling.cs
+++ b/tests/Avalonia.Base.UnitTests/RenderTests_Culling.cs
@@ -110,6 +110,45 @@ namespace Avalonia.Base.UnitTests
         }
 
         [Fact]
+        public void Transformed_Child_Control_With_ClipToBounds_True_Should_Be_Rendered()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                TestControl target;
+
+                var container = new Panel
+                {
+                    Width = 100,
+                    Height = 20,
+                    ClipToBounds = true,
+                    Children =
+                    {
+                        new Panel
+                        {
+                            Width = 100,
+                            Height = 20,
+                            RenderTransform = new TranslateTransform(0, 30),
+                            Children =
+                            {
+                                (target = new TestControl
+                                {
+                                    Width = 100,
+                                    Height = 20,
+                                    ClipToBounds = true,
+                                    RenderTransform = new TranslateTransform(0, -30),
+                                })
+                            }
+                        }
+                    }
+                };
+
+                Render(container);
+
+                Assert.True(target.Rendered);
+            }
+        }
+
+        [Fact]
         public void RenderTransform_Should_Be_Respected()
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))


### PR DESCRIPTION
## What does the pull request do?
Fixed invalid rendering of `Visual` with `VisualBrush` and `RenderTargetBitmap` when `Bounds.Position` is not zero.
Fixed disappearing text of `TextBlock` when places inside `LayoutTransformControl` with scaling.

## What is the current behavior?
`ImmediateRenderer` doesn't render controls in some usecases. Affects `VisualBrush` and `RenderTargetBitmap`.

## What is the updated/expected behavior with this PR?
Now `ImmediateRenderer` renders controls correctly.

## Fixed issues
Fixes #20152
