### PR TITLE
Reduce Allocations in Text Rendering

### DIFF
--- a/src/Avalonia.Base/Media/FontFamily.cs
+++ b/src/Avalonia.Base/Media/FontFamily.cs
@@ -131,53 +131,55 @@ namespace Avalonia.Media
         {
             var result = new FrugalStructList<FontSourceIdentifier>(1);
 
-            var segments = name.Split(',');
-
-            for (int i = 0; i < segments.Length; i++)
+            int commaIndex = -1;
+            do
             {
-                var segment = segments[i];
-                var innerSegments = segment.Split('#');
+                // Look for a comma separator to carve out a single segment.
+                int segmentStart = commaIndex + 1;
+                commaIndex = name.IndexOf(',', segmentStart);
+                int segmentEnd = commaIndex == -1
+                    ? name.Length
+                    : commaIndex;
 
-                FontSourceIdentifier identifier = new FontSourceIdentifier(name, null);
+                var segment = name.AsSpan(segmentStart..segmentEnd).Trim();
 
-                switch (innerSegments.Length)
+                FontSourceIdentifier? identifier = null;
+
+                // Check if there is exactly one '#' (i.e., segment is in the format "path#innerName").
+                int separatorIndex = segment.IndexOf('#');
+                if (separatorIndex != -1 && segment[(separatorIndex + 1)..].IndexOf('#') == -1)
                 {
-                    case 1:
+                    var pathSpan = segment[..separatorIndex].Trim();
+                    var innerName = segment[(separatorIndex + 1)..].Trim();
+
+                    if (pathSpan.IsEmpty)
+                    {
+                        identifier = new FontSourceIdentifier(innerName.ToString(), null);
+                    }
+                    else
+                    {
+                        string path = pathSpan.ToString();
+                        if (pathSpan.Contains('/') && Uri.TryCreate(path, UriKind.Relative, out var source))
                         {
-                            identifier = new FontSourceIdentifier(innerSegments[0].Trim(), null);
-                            break;
+                            identifier = new FontSourceIdentifier(innerName.ToString(), source);
                         }
-
-                    case 2:
+                        else
                         {
-                            var path = innerSegments[0].Trim();
-                            var innerName = innerSegments[1].Trim();
-
-                            if (string.IsNullOrEmpty(path))
+                            if (Uri.TryCreate(path, UriKind.Absolute, out source))
                             {
-                                identifier = new FontSourceIdentifier(innerName, null);
+                                identifier = new FontSourceIdentifier(innerName.ToString(), source);
                             }
-                            else
-                            {
-                                if (path.Contains('/') && Uri.TryCreate(path, UriKind.Relative, out var source))
-                                {
-                                    identifier = new FontSourceIdentifier(innerName, source);
-                                }
-                                else
-                                {
-                                    if (Uri.TryCreate(path, UriKind.Absolute, out source))
-                                    {
-                                        identifier = new FontSourceIdentifier(innerName, source);
-                                    }
-                                }
-                            }
-
-                            break;
                         }
+                    }
                 }
 
-                result.Add(identifier);
-            }
+                // If we didn't manage to match it to any known format, treat the entire segment as the font name.
+                identifier ??= new FontSourceIdentifier(
+                    segment.Length == name.Length ? name : segment.ToString(),
+                    null);
+
+                result.Add(identifier.Value);
+            } while (commaIndex != -1);
 
             return result;
         }

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/BiDi.trie.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/BiDi.trie.cs
@@ -16,10 +16,18 @@ internal static class BidiTrie
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => new(Data, 0x00100000, 0x00000000);
-    } 
+    }
     
-    private static readonly uint[] Data = new uint[]
-    {
+    // For Debug builds, we store the data in a separate uint[] field to avoid RuntimeFieldInfoStub allocations.
+    // See also: https://github.com/AvaloniaUI/Avalonia/pull/20175
+
+#if DEBUG
+    public static ReadOnlySpan<uint> Data => s_data;
+    private static uint[] s_data =
+#else
+    public static ReadOnlySpan<uint> Data =>
+#endif
+    [
         0x0000038D, 0x00000395, 0x0000039D, 0x000003A5, 0x000003BD, 0x000003C5, 0x000003CD, 0x000003D5, 0x000003AD, 0x000003B5, 0x000003AD, 0x000003B5, 
         0x000003AD, 0x000003B5, 0x000003AD, 0x000003B5, 0x000003AD, 0x000003B5, 0x000003AD, 0x000003B5, 0x000003DB, 0x000003E3, 0x000003EB, 0x000003F3, 
         0x000003FB, 0x00000403, 0x000003FF, 0x00000407, 0x0000040F, 0x00000417, 0x00000412, 0x0000041A, 0x000003AD, 0x000003B5, 0x000003AD, 0x000003B5, 
@@ -1104,5 +1112,5 @@ internal static class BidiTrie
         0x00000000, 0x00040000, 0x00040000, 0x00040000, 0x00040000, 0x00040000, 0x00000000, 0x00040000, 0x00040000, 0x00040000, 0x00040000, 0x00040000, 
         0x00040000, 0x00040000, 0x00040000, 0x00040000, 0x00040000, 0x00040000, 0x00040000, 0x00040000, 0x00040000, 0x00040000, 0x00040000, 0x00040000, 
         0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000
-    };
+    ];
 }

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/BiDi.trie.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/BiDi.trie.cs
@@ -18,7 +18,7 @@ internal static class BidiTrie
         get => new(Data, 0x00100000, 0x00000000);
     } 
     
-    private static ReadOnlySpan<uint> Data => new uint[]
+    private static readonly uint[] Data = new uint[]
     {
         0x0000038D, 0x00000395, 0x0000039D, 0x000003A5, 0x000003BD, 0x000003C5, 0x000003CD, 0x000003D5, 0x000003AD, 0x000003B5, 0x000003AD, 0x000003B5, 
         0x000003AD, 0x000003B5, 0x000003AD, 0x000003B5, 0x000003AD, 0x000003B5, 0x000003AD, 0x000003B5, 0x000003DB, 0x000003E3, 0x000003EB, 0x000003F3, 

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/EastAsianWidth.trie.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/EastAsianWidth.trie.cs
@@ -18,7 +18,7 @@ internal static class EastAsianWidthTrie
         get => new(Data, 0x00110000, 0x00000000);
     } 
     
-    private static ReadOnlySpan<uint> Data => new uint[]
+    private static readonly uint[] Data = new uint[]
     {
         0x000003E7, 0x000003EF, 0x000003F7, 0x000003FF, 0x0000041F, 0x00000427, 0x0000042F, 0x00000437, 0x0000043F, 0x00000447, 0x0000044F, 0x00000457, 
         0x00000417, 0x0000041F, 0x0000045C, 0x00000464, 0x00000417, 0x0000041F, 0x00000468, 0x00000470, 0x00000417, 0x0000041F, 0x00000477, 0x0000047F, 

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/GraphemeBreak.trie.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/GraphemeBreak.trie.cs
@@ -18,7 +18,7 @@ internal static class GraphemeBreakTrie
         get => new(Data, 0x000E1000, 0x00000000);
     } 
     
-    private static ReadOnlySpan<uint> Data => new uint[]
+    private static readonly uint[] Data = new uint[]
     {
         0x0000035A, 0x00000362, 0x0000036A, 0x00000372, 0x0000038A, 0x00000392, 0x00000362, 0x0000036A, 0x00000362, 0x0000036A, 0x00000362, 0x0000036A, 
         0x00000362, 0x0000036A, 0x00000362, 0x0000036A, 0x00000362, 0x0000036A, 0x00000362, 0x0000036A, 0x00000362, 0x0000036A, 0x00000362, 0x0000036A, 

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/UnicodeData.trie.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/UnicodeData.trie.cs
@@ -16,10 +16,18 @@ internal static class UnicodeDataTrie
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => new(Data, 0x00100000, 0x00000000);
-    } 
-    
-    private static readonly uint[] Data = new uint[]
-    {
+    }
+
+    // For Debug builds, we store the data in a separate uint[] field to avoid RuntimeFieldInfoStub allocations.
+    // See also: https://github.com/AvaloniaUI/Avalonia/pull/20175
+
+#if DEBUG
+    public static ReadOnlySpan<uint> Data => s_data;
+    private static uint[] s_data =
+#else
+    public static ReadOnlySpan<uint> Data =>
+#endif
+    [
         0x00000482, 0x0000048A, 0x00000492, 0x0000049A, 0x000004B2, 0x000004BA, 0x000004C2, 0x000004CA, 0x000004D2, 0x000004DA, 0x000004E0, 0x000004E8, 
         0x000004F0, 0x000004F8, 0x00000500, 0x00000508, 0x0000050E, 0x00000516, 0x0000051E, 0x00000526, 0x00000529, 0x00000531, 0x00000539, 0x00000541, 
         0x00000549, 0x00000551, 0x00000556, 0x0000055E, 0x00000566, 0x0000056E, 0x00000573, 0x0000057B, 0x00000583, 0x0000058B, 0x0000058F, 0x00000597, 
@@ -2351,5 +2359,5 @@ internal static class UnicodeDataTrie
         0x00038061, 0x00038061, 0x00038061, 0x00038061, 0x00038061, 0x00074061, 0x00074061, 0x00074061, 0x00038061, 0x00074061, 0x00074061, 0x00074061, 
         0x00074061, 0x00074061, 0x00074061, 0x00074061, 0x00074061, 0x00074061, 0x00074061, 0x00074061, 0x00074061, 0x00074061, 0x00038061, 0x00038061, 
         0x00000000, 0x00000000, 0x00000000, 0x00000000
-    };
+    ];
 }

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/UnicodeData.trie.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/UnicodeData.trie.cs
@@ -18,7 +18,7 @@ internal static class UnicodeDataTrie
         get => new(Data, 0x00100000, 0x00000000);
     } 
     
-    private static ReadOnlySpan<uint> Data => new uint[]
+    private static readonly uint[] Data = new uint[]
     {
         0x00000482, 0x0000048A, 0x00000492, 0x0000049A, 0x000004B2, 0x000004BA, 0x000004C2, 0x000004CA, 0x000004D2, 0x000004DA, 0x000004E0, 0x000004E8, 
         0x000004F0, 0x000004F8, 0x00000500, 0x00000508, 0x0000050E, 0x00000516, 0x0000051E, 0x00000526, 0x00000529, 0x00000531, 0x00000539, 0x00000541, 

--- a/src/Skia/Avalonia.Skia/TextShaperImpl.cs
+++ b/src/Skia/Avalonia.Skia/TextShaperImpl.cs
@@ -43,7 +43,10 @@ namespace Avalonia.Skia
 
             var usedCulture = culture ?? CultureInfo.CurrentCulture;
 
-            buffer.Language = s_cachedLanguage.GetOrAdd(usedCulture.LCID, _ => new Language(usedCulture));
+            buffer.Language = s_cachedLanguage.GetOrAdd(
+                usedCulture.LCID,
+                static (_, culture) => new Language(culture),
+                usedCulture);
 
             var font = ((GlyphTypefaceImpl)typeface).Font;
 

--- a/tests/Avalonia.Base.UnitTests/Media/TextFormatting/UnicodeDataGenerator.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/TextFormatting/UnicodeDataGenerator.cs
@@ -92,7 +92,7 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
                           get => new(Data, 0x{{trie.HighStart:X8}}, 0x{{trie.ErrorValue:X8}});
                       } 
                       
-                      private static ReadOnlySpan<uint> Data => new uint[]
+                      private static readonly uint[] Data = new uint[]
                       {
                   """);
 

--- a/tests/Avalonia.Base.UnitTests/Media/TextFormatting/UnicodeDataGenerator.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/TextFormatting/UnicodeDataGenerator.cs
@@ -67,7 +67,7 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
 
         public static void GenerateTrieClass(string name, UnicodeTrie trie)
         {
-            using var fileStream = File.Create($"Generated\\{name}.trie.cs");
+            using var fileStream = File.Create(Path.Combine("Generated", $"{name}.trie.cs"));
             using var writer = new StreamWriter(fileStream);
 
             writer.Write(
@@ -90,10 +90,18 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
                       {
                           [MethodImpl(MethodImplOptions.AggressiveInlining)]
                           get => new(Data, 0x{{trie.HighStart:X8}}, 0x{{trie.ErrorValue:X8}});
-                      } 
-                      
-                      private static readonly uint[] Data = new uint[]
-                      {
+                      }
+
+                      // For Debug builds, we store the data in a separate uint[] field to avoid RuntimeFieldInfoStub allocations.
+                      // See also: https://github.com/AvaloniaUI/Avalonia/pull/20175
+
+                  #if DEBUG
+                      public static ReadOnlySpan<uint> Data => s_data;
+                      private static uint[] s_data =
+                  #else
+                      public static ReadOnlySpan<uint> Data =>
+                  #endif
+                      [
                   """);
 
             for (int i = 0; i < trie.Data.Length; ++i)
@@ -114,7 +122,7 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
             writer.Write(
                 """
                 
-                    };
+                    ];
                 }
                 
                 """);


### PR DESCRIPTION
## What does the pull request do?
This PR addresses some performance regressions and reduces overall allocations when rendering a lot of (complex) text runs.


## What is the current behavior?
When I upgraded to the latest version of Avalonia and .NET 10 in [AvaloniaHex](https://github.com/Washi1337/AvaloniaHex), I noticed a pretty significant bump in memory allocations and performance degradation in rendering of many (complex) text runs. Upon profiling, I found a couple of related hotspots:

1. In `Avalonia.Media.TextFormatting` there are various precompiled tries stored as raw data. This data is recreated on every access of the trie. E.g., here is `UnicodeData.trie`:
 
   https://github.com/AvaloniaUI/Avalonia/blob/0b5a82884e2cfa24499f5f05fc84e0dd52c734dd/src/Avalonia.Base/Media/TextFormatting/Unicode/UnicodeData.trie.cs#L15-L22

   These computed tries are used quite extensively throughout the library. This results in a significant number of unnecessary allocations of very large data blobs (literally millions of instances), significantly slowing down controls that do a lot of (complex) text rendering. Below, an example of how AvaloniaHex is affected when scrolling once down and up in the example project:
   <img width="1068" height="204" alt="image" src="https://github.com/user-attachments/assets/91fe9c8c-650e-4b09-bbde-6120f83ea79e" />

2. `FontFamily.Parse` eventually calls `FontFamily.GetFontSourceIdentifier`, which always allocates extra `string` and `string[]` instances when parsing a font by name, even if the font name is a simple font without any fallback fonts:

    <img width="1068" height="204" alt="image" src="https://github.com/user-attachments/assets/68569bf1-575a-4140-8aa9-46b0bc133116" />

3. `FontShaperImpl.ShapeText` in `Avalonia.Skia` uses a language cache with a `GetOrAdd` construction that uses a non-static / closure capturing lambda for its factory.
 
    https://github.com/AvaloniaUI/Avalonia/blob/0b5a82884e2cfa24499f5f05fc84e0dd52c734dd/src/Skia/Avalonia.Skia/TextShaperImpl.cs#L45-L47

    This results in a closure being created for every text run that isn't used most of the time because the used culture doesn't change in most cases:

    <img width="1068" height="204" alt="image" src="https://github.com/user-attachments/assets/bbd51754-8372-4e68-9ec2-20e3ee0960a1" />

4.  `LineBreakEnumerator` always creates a `LineBreakState` heap allocation (even if a text run does not contain line breaks). This is wasteful, especially considering `LineBreakEnumerator` is already a `ref struct` and will never appear on the heap:

     <img width="1068" height="264" alt="image" src="https://github.com/user-attachments/assets/47a1c66c-bb2f-48ec-bd25-4cfb0d1efdbc" />


## What is the updated/expected behavior with this PR?

This PR removes the vast majority of these allocations. Running the example project of [AvaloniaHex](https://github.com/Washi1337/AvaloniaHex) with these changes applied to Avalonia makes scrolling much smoother.


## How was the solution implemented (if it's not obvious)?
In chronological order of the issues described above:

1. `UnicodeDataGenerator` was updated to generate code with a readonly `Data` field as opposed to a computed property. This removes all `RuntimeFieldInfoStub` allocations.
2. `FontFamily.GetFontSourceIdentifier` was rewritten to avoid any array allocations and most string reallocations using `ReadOnlySpan<char>`s and slicing.
3. `FontShaperImpl.ShapeText` now uses the overload of `GetOrAdd` that passes an argument to the factory lambda.
4. `LineBreakEnumerator+LineBreakState` was turned into a `ref struct` and is now passed along as a `ref` parameter to all unicode rule methods.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None. All changes are made on internal or private APIs.

## Obsoletions / Deprecations

None

## Fixed issues

Related to #16390


## Additional Questions

Maybe out of this scope for this PR, but I am still seeing a lot of instances of `SKFont` (scaling linearly with the number of text runs I create) in AvaloniaHex, even though I reuse the same `Typeface` instances as much as possible. Is there any possibility/talks on caching `SKFont` instances?