### PR TITLE
Added support for Classes="{Binding StringValue}"

### DIFF
--- a/src/Avalonia.Base/Controls/Classes.cs
+++ b/src/Avalonia.Base/Controls/Classes.cs
@@ -280,6 +280,26 @@ namespace Avalonia.Controls
             NotifyChanged();
         }
 
+        internal void Replace(IList<string>? toRemove, IList<string> toAdd)
+        {
+            foreach (var name in toAdd)
+            {
+                ThrowIfPseudoclass(name, "added");
+            }
+
+            if (toRemove != null)
+            {
+                foreach (var name in toRemove)
+                {
+                    ThrowIfPseudoclass(name, "removed");
+                }
+                base.RemoveAll(toRemove);
+            }
+
+            base.AddRange(toAdd);
+            NotifyChanged();
+        }
+
         /// <inheritdoc/>
         void IPseudoClasses.Add(string name)
         {

--- a/src/Avalonia.Base/StyledElementExtensions.cs
+++ b/src/Avalonia.Base/StyledElementExtensions.cs
@@ -6,13 +6,13 @@ namespace Avalonia
 {
     public static class StyledElementExtensions
     {
-        public static IDisposable BindClasses(this StyledElement target, BindingBase source, object anchor) =>
+        public static IDisposable BindClasses(this StyledElement target, BindingBase source, object? anchor = null) =>
             ClassBindingManager.BindClasses(target, source, anchor);
 
         public static void SetClasses(this StyledElement target, string classNames) =>
             ClassBindingManager.SetClasses(target, classNames);
 
-        public static IDisposable BindClass(this StyledElement target, string className, BindingBase source, object anchor) =>
+        public static IDisposable BindClass(this StyledElement target, string className, BindingBase source, object? anchor = null) =>
             ClassBindingManager.BindClass(target, className, source, anchor);
 
         public static void SetClass(this StyledElement target, string className, bool value) =>

--- a/src/Avalonia.Base/StyledElementExtensions.cs
+++ b/src/Avalonia.Base/StyledElementExtensions.cs
@@ -15,6 +15,9 @@ namespace Avalonia
         public static IDisposable BindClass(this StyledElement target, string className, BindingBase source, object anchor) =>
             ClassBindingManager.BindClass(target, className, source, anchor);
 
+        public static void SetClass(this StyledElement target, string className, bool value) =>
+            ClassBindingManager.SetClass(target, className, value);
+
         public static AvaloniaProperty GetClassProperty(string className) =>
             ClassBindingManager.GetClassProperty(className);
 

--- a/src/Avalonia.Base/StyledElementExtensions.cs
+++ b/src/Avalonia.Base/StyledElementExtensions.cs
@@ -6,8 +6,14 @@ namespace Avalonia
 {
     public static class StyledElementExtensions
     {
+        public static IDisposable BindClasses(this StyledElement target, BindingBase source, object anchor) =>
+            ClassBindingManager.BindClasses(target, source, anchor);
+
+        public static void SetClasses(this StyledElement target, string classNames) =>
+            ClassBindingManager.SetClasses(target, classNames);
+
         public static IDisposable BindClass(this StyledElement target, string className, BindingBase source, object anchor) =>
-            ClassBindingManager.Bind(target, className, source, anchor);
+            ClassBindingManager.BindClass(target, className, source, anchor);
 
         public static AvaloniaProperty GetClassProperty(string className) =>
             ClassBindingManager.GetClassProperty(className);

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlCompiler.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlCompiler.cs
@@ -45,6 +45,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             // Targeted
             InsertBefore<PropertyReferenceResolver>(
                 new AvaloniaXamlIlResolveClassesPropertiesTransformer(),
+                new AvaloniaXamlIlResolveClassesPropertyTransformer(),
                 new AvaloniaXamlIlTransformInstanceAttachedProperties(),
                 new AvaloniaXamlIlTransformSyntheticCompiledBindingMembers());
             InsertAfter<PropertyReferenceResolver>(

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlClassesPropertyResolver.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlClassesPropertyResolver.cs
@@ -86,7 +86,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                         .Ldloc(bloc.Local)
                         // TODO: provide anchor?
                         .Ldnull();
-                emitter.EmitCall(_types.ClassesBindMethod, true);
+                emitter.EmitCall(_types.BindClassMethod, true);
             }
 
             public IXamlType TargetType => _types.StyledElement;

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlClassesPropertyResolver.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlClassesPropertyResolver.cs
@@ -46,15 +46,11 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             public void Emit(IXamlILEmitter emitter)
             {
                 using (var value = emitter.LocalsPool.GetLocal(_types.XamlIlTypes.Boolean))
-                {
                     emitter
                         .Stloc(value.Local)
-                        .EmitCall(_types.StyledElementClassesProperty.Getter!)
                         .Ldstr(_className)
-                        .Ldloc(value.Local)
-                        .EmitCall(_types.Classes.GetMethod(new FindMethodMethodSignature("Set",
-                        _types.XamlIlTypes.Void, _types.XamlIlTypes.String, _types.XamlIlTypes.Boolean)));
-                }
+                        .Ldloc(value.Local);
+                emitter.EmitCall(_types.SetClassMethod);
             }
 
             public IXamlType TargetType => _types.StyledElement;

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlResolveClassesPropertyTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlResolveClassesPropertyTransformer.cs
@@ -49,12 +49,12 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                     emitter
                         .Stloc(value.Local)
                         .Ldloc(value.Local);
-                emitter.EmitCall(Types.SetClassesMethod, true);
+                emitter.EmitCall(Types.SetClassesMethod);
             }
         }
 
         class ClassesBindingSetter(AvaloniaXamlIlWellKnownTypes types)
-            : ClassesSetter(types, types.IBinding)
+            : ClassesSetter(types, types.BindingBase)
         {
             public override void Emit(IXamlILEmitter emitter)
             {

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlResolveClassesPropertyTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlResolveClassesPropertyTransformer.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using XamlX.Ast;
+using XamlX.Emit;
+using XamlX.IL;
+using XamlX.Transform;
+using XamlX.TypeSystem;
+
+namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
+{
+    class AvaloniaXamlIlResolveClassesPropertyTransformer : IXamlAstTransformer
+    {
+        public IXamlAstNode Transform(AstTransformationContext context, IXamlAstNode node)
+        {
+            var types = context.GetAvaloniaTypes();
+            if (node is XamlAstNamePropertyReference prop &&
+                prop.Name == "Classes" &&
+                prop.TargetType is XamlAstClrTypeReference targetRef &&
+                prop.DeclaringType is XamlAstClrTypeReference declaringRef &&
+                types.StyledElement.IsAssignableFrom(targetRef.Type) &&
+                types.StyledElement.IsAssignableFrom(declaringRef.Type)
+                )
+            {
+                return new XamlAstClrProperty(node, prop.Name, types.StyledElement, types.StyledElementClassesProperty.Getter)
+                {
+                    Setters = { new ClassesStringSetter(types), new ClassesBindingSetter(types) }
+                };
+            }
+            return node;
+        }
+
+        abstract class ClassesSetter(AvaloniaXamlIlWellKnownTypes types, IXamlType parameter)
+            : IXamlEmitablePropertySetter<IXamlILEmitter>
+        {
+            public abstract void Emit(IXamlILEmitter emitter);
+
+            protected AvaloniaXamlIlWellKnownTypes Types { get; } = types;
+            public IXamlType TargetType => Types.StyledElement;
+            public PropertySetterBinderParameters BinderParameters { get; } = new() { AllowXNull = false };
+            public IReadOnlyList<IXamlType> Parameters { get; } = [parameter];
+            public IReadOnlyList<IXamlCustomAttribute> CustomAttributes { get; } = [];
+        }
+
+        class ClassesStringSetter(AvaloniaXamlIlWellKnownTypes types)
+            : ClassesSetter(types, types.XamlIlTypes.String)
+        {
+            public override void Emit(IXamlILEmitter emitter)
+            {
+                using (var value = emitter.LocalsPool.GetLocal(Parameters[0]))
+                    emitter
+                        .Stloc(value.Local)
+                        .Ldloc(value.Local);
+                emitter.EmitCall(Types.SetClassesMethod, true);
+            }
+        }
+
+        class ClassesBindingSetter(AvaloniaXamlIlWellKnownTypes types)
+            : ClassesSetter(types, types.IBinding)
+        {
+            public override void Emit(IXamlILEmitter emitter)
+            {
+                using (var value = emitter.LocalsPool.GetLocal(Parameters[0]))
+                    emitter
+                        .Stloc(value.Local)
+                        .Ldloc(value.Local)
+                        // TODO: provide anchor?
+                        .Ldnull();
+                emitter.EmitCall(Types.BindClassesMethod, true);
+            }
+        }
+    }
+}

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -102,6 +102,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType ColumnDefinitions { get; }
         public IXamlType Classes { get; }
         public IXamlMethod BindClassMethod { get; }
+        public IXamlMethod SetClassMethod { get; }
         public IXamlMethod BindClassesMethod { get; }
         public IXamlMethod SetClassesMethod { get; }
         public IXamlProperty StyledElementClassesProperty { get; }
@@ -302,8 +303,10 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                 StyledElement.Properties.First(x => x.Name == "Classes" && x.PropertyType.Equals(Classes));
             BindClassMethod = cfg.TypeSystem.GetType("Avalonia.StyledElementExtensions")
                 .GetMethod("BindClass", IDisposable, false, StyledElement,
-                cfg.WellKnownTypes.String,
-                BindingBase, cfg.WellKnownTypes.Object);
+                cfg.WellKnownTypes.String, BindingBase, cfg.WellKnownTypes.Object);
+            SetClassMethod = cfg.TypeSystem.GetType("Avalonia.StyledElementExtensions")
+                .GetMethod("SetClass", cfg.WellKnownTypes.Void, false, StyledElement,
+                cfg.WellKnownTypes.String, cfg.WellKnownTypes.Boolean);
             BindClassesMethod = cfg.TypeSystem.GetType("Avalonia.StyledElementExtensions")
                 .GetMethod("BindClasses", IDisposable, false, StyledElement,
                 BindingBase, cfg.WellKnownTypes.Object);

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -101,7 +101,9 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType ColumnDefinition { get; }
         public IXamlType ColumnDefinitions { get; }
         public IXamlType Classes { get; }
-        public IXamlMethod ClassesBindMethod { get; }
+        public IXamlMethod BindClassMethod { get; }
+        public IXamlMethod BindClassesMethod { get; }
+        public IXamlMethod SetClassesMethod { get; }
         public IXamlProperty StyledElementClassesProperty { get; }
         public IXamlType IBrush { get; }
         public IXamlType ImmutableSolidColorBrush { get; }
@@ -298,10 +300,16 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             Classes = cfg.TypeSystem.GetType("Avalonia.Controls.Classes");
             StyledElementClassesProperty =
                 StyledElement.Properties.First(x => x.Name == "Classes" && x.PropertyType.Equals(Classes));
-            ClassesBindMethod = cfg.TypeSystem.GetType("Avalonia.StyledElementExtensions")
+            BindClassMethod = cfg.TypeSystem.GetType("Avalonia.StyledElementExtensions")
                 .GetMethod("BindClass", IDisposable, false, StyledElement,
                 cfg.WellKnownTypes.String,
                 BindingBase, cfg.WellKnownTypes.Object);
+            BindClassesMethod = cfg.TypeSystem.GetType("Avalonia.StyledElementExtensions")
+                .GetMethod("BindClasses", IDisposable, false, StyledElement,
+                BindingBase, cfg.WellKnownTypes.Object);
+            SetClassesMethod = cfg.TypeSystem.GetType("Avalonia.StyledElementExtensions")
+                .GetMethod("SetClasses", cfg.WellKnownTypes.Void, false, StyledElement,
+                cfg.WellKnownTypes.String);
 
             IBrush = cfg.TypeSystem.GetType("Avalonia.Media.IBrush");
             ImmutableSolidColorBrush = cfg.TypeSystem.GetType("Avalonia.Media.Immutable.ImmutableSolidColorBrush");

--- a/tests/Avalonia.Base.UnitTests/ClassBindingManagerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/ClassBindingManagerTests.cs
@@ -1,15 +1,17 @@
-﻿using Xunit;
+﻿using Avalonia.Data;
+using Avalonia.Controls;
+using Xunit;
 
 namespace Avalonia.Base.UnitTests
 {
     public class ClassBindingManagerTests
     {
-
         [Fact]
         public void GetClassProperty_Should_Return_Same_Instance_For_Same_Class()
         {
             var property1 = ClassBindingManager.GetClassProperty("Foo");
             var property2 = ClassBindingManager.GetClassProperty("Foo");
+
             Assert.Same(property1, property2);
         }
 
@@ -18,7 +20,143 @@ namespace Avalonia.Base.UnitTests
         {
             var property1 = ClassBindingManager.GetClassProperty("Foo");
             var property2 = ClassBindingManager.GetClassProperty("Bar");
+
             Assert.NotSame(property1, property2);
+        }
+
+        [Fact]
+        public void SetClass_Should_Add_Class()
+        {
+            var target = new StyledElement();
+
+            ClassBindingManager.SetClass(target, "Foo", true);
+
+            Assert.Contains("Foo", target.Classes);
+        }
+
+        [Fact]
+        public void SetClass_Should_Remove_Added_Class()
+        {
+            var target = new StyledElement();
+
+            ClassBindingManager.SetClass(target, "Foo", true);
+            ClassBindingManager.SetClass(target, "Foo", false);
+
+            Assert.DoesNotContain("Foo", target.Classes);
+        }
+
+        [Fact]
+        public void SetClasses_Should_Add_Classes()
+        {
+            var target = new StyledElement();
+
+            ClassBindingManager.SetClasses(target, "Foo Bar");
+
+            Assert.Contains("Foo", target.Classes);
+            Assert.Contains("Bar", target.Classes);
+        }
+
+        [Fact]
+        public void SetClasses_Should_Remove_Added_Classes()
+        {
+            var target = new StyledElement();
+
+            ClassBindingManager.SetClasses(target, "Foo Bar");
+            ClassBindingManager.SetClasses(target, "");
+
+            Assert.Empty(target.Classes);
+        }
+
+        [Fact]
+        public void SetClasses_Should_Keep_PseudoClasses()
+        {
+            var target = new StyledElement();
+            ((IPseudoClasses)target.Classes).Add(":Baz");
+
+            ClassBindingManager.SetClasses(target, "Foo");
+
+            Assert.Equal(new[] { ":Baz", "Foo" }, target.Classes);
+        }
+
+        [Fact]
+        public void SetClass_Should_Override_SetClasses_Adding()
+        {
+            var target = new StyledElement();
+
+            ClassBindingManager.SetClasses(target, "Foo Bar");
+            ClassBindingManager.SetClass(target, "Foo", false);
+
+            Assert.Contains("Bar", target.Classes);
+            Assert.DoesNotContain("Foo", target.Classes);
+        }
+
+        [Fact]
+        public void SetClass_Should_Override_SetClasses_Adding_When_Set_Before()
+        {
+            var target = new StyledElement();
+
+            ClassBindingManager.SetClass(target, "Foo", false);
+            ClassBindingManager.SetClasses(target, "Foo Bar");
+
+            Assert.Contains("Bar", target.Classes);
+            Assert.DoesNotContain("Foo", target.Classes);
+        }
+
+        [Fact]
+        public void SetClass_Should_Override_SetClasses_Removing()
+        {
+            var target = new StyledElement();
+
+            ClassBindingManager.SetClasses(target, "Bar");
+            ClassBindingManager.SetClass(target, "Foo", true);
+
+            Assert.Contains("Foo", target.Classes);
+            Assert.Contains("Bar", target.Classes);
+        }
+
+        [Fact]
+        public void SetClass_Should_Override_SetClasses_Removing_When_Set_Before()
+        {
+            var target = new StyledElement();
+
+            ClassBindingManager.SetClass(target, "Foo", true);
+            ClassBindingManager.SetClasses(target, "Bar");
+
+            Assert.Contains("Foo", target.Classes);
+            Assert.Contains("Bar", target.Classes);
+        }
+
+        [Fact]
+        public void BindClass_Should_Update_Classes()
+        {
+            var target = new StyledElement();
+
+            using var d = ClassBindingManager.BindClass(target, "Bar", new Binding { Source = true }, null);
+
+            Assert.Contains("Bar", target.Classes);
+        }
+
+        [Fact]
+        public void BindClasses_Should_Update_Classes()
+        {
+            var target = new StyledElement();
+
+            using var d = ClassBindingManager.BindClasses(target, new Binding { Source = "Foo Bar" }, null);
+
+            Assert.Equal("Foo Bar", ClassBindingManager.GetClasses(target));
+            Assert.Contains("Foo", target.Classes);
+            Assert.Contains("Bar", target.Classes);
+        }
+
+        [Fact]
+        public void IsClassesBindingProperty_Should_Detect_Classes_Properties()
+        {
+            var prop = ClassBindingManager.GetClassProperty("Foo");
+
+            var result = ClassBindingManager.IsClassesBindingProperty(prop, out var name);
+
+            Assert.True(result);
+            Assert.Equal("Foo", name);
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Adds support for binding `Classes` property to as string:

```axaml
<Control Classes="{Binding StringValue}" />
```

See feature request:

* #18068

Currently I await API review and suggestions on what to do with `<Control Classes="{Binding #ctl.Classes}">`.

### Public API changes

```diff
  public class StyledElementExtensions
+   public static IDisposable BindClasses(this StyledElement target, IBinding source, object anchor)
+   public static void SetClasses(this StyledElement target, string classNames)
+   public static void SetClass(this StyledElement target, string className, bool value)
```

Why `SetClass` was added: there's a need to differentiate between `Classes` collection modification and `Classes.Foo` setters/bindings in XAML, because the latter need to always overwrite `Classes` setter/binding.

### To do

* [x] Support for `<Control Classes="{Binding StringValue}" Classes.Foo="True">`.

   Specific should override general, like it's happening currently without binding, iiuc.

* [ ] Support for `<Control Classes="{Binding #ctl.Classes}">`.

   Doing `<Control Classes="{Binding #ctl.Classes.ClassesString}">` would be simple, I think, but isn't pretty. However, implicitly appending conversion to string makes behavior of `<Control Classes="{Binding #ctl.Classes, Converter=...}">` unclear, so maybe explicit is better.

## What is the current behavior?

Binding fails with a compilation error due to lack of a setter for `Classes` property.

## What is the updated/expected behavior with this PR?

Now it works, but with limitations. It's currently WIP and I'll continue work if API is approved.

Some things may have broken in the process, like reordering of `Classes` and `Classes.Foo` properties. Haven't tested thoroughly yet.

## How was the solution implemented (if it's not obvious)?

Used implementation of `Classes.Foo="{Binding BoolValue}"` as a base.

Initially I wanted to experiment with binding to events (#3766) but decided to try something simple first.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None planned.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #18068
