### PR TITLE
Fix exception when deleting a non-empty directory

### DIFF
--- a/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageItem.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageItem.cs
@@ -58,7 +58,17 @@ internal abstract class BclStorageItem(FileSystemInfo fileSystemInfo) : IStorage
         _ => null
     };
 
-    internal static void DeleteCore(FileSystemInfo fileSystemInfo) => fileSystemInfo.Delete();
+    internal static void DeleteCore(FileSystemInfo fileSystemInfo)
+    {
+        if (fileSystemInfo is DirectoryInfo directoryInfo)
+        {
+            directoryInfo.Delete(true);
+        }
+        else
+        {
+            fileSystemInfo.Delete();
+        }
+    }
 
     internal static Uri GetPathCore(FileSystemInfo fileSystemInfo)
     {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR fixes a crash occurring when deleting a folder that is not empty.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Added a call to the `DirectoryInfo`-specific `Delete` method with recursion enabled.
