### PR TITLE
[X11] Clean up IME inconsistencies

### DIFF
--- a/src/Avalonia.FreeDesktop/DBusIme/X11DBusImeHelper.cs
+++ b/src/Avalonia.FreeDesktop/DBusIme/X11DBusImeHelper.cs
@@ -31,6 +31,18 @@ namespace Avalonia.FreeDesktop.DBusIme
                     return factory;
             }
 
+            var modifiers = Environment.GetEnvironmentVariable("XMODIFIERS");
+            if (modifiers is not null && modifiers.Contains("@im="))
+            {
+                foreach (var pair in KnownMethods)
+                {
+                    if (modifiers.Contains($"@im={pair.Key}"))
+                    {
+                        return pair.Value;
+                    }
+                }
+            }
+
             return null;
         }
 

--- a/src/Avalonia.FreeDesktop/DBusIme/X11DBusImeHelper.cs
+++ b/src/Avalonia.FreeDesktop/DBusIme/X11DBusImeHelper.cs
@@ -34,13 +34,12 @@ namespace Avalonia.FreeDesktop.DBusIme
             var modifiers = Environment.GetEnvironmentVariable("XMODIFIERS");
             if (modifiers is not null && modifiers.Contains("@im="))
             {
-                foreach (var pair in KnownMethods)
-                {
-                    if (modifiers.Contains($"@im={pair.Key}"))
-                    {
-                        return pair.Value;
-                    }
-                }
+                int imNameStart = modifiers.IndexOf("@im=") + "@im=".Length;
+                int imNameEnd = modifiers.IndexOf("@", imNameStart);
+                string imName = imNameEnd == -1 ? modifiers.Substring(imNameStart) : modifiers.Substring(imNameStart, imNameEnd - imNameStart);
+
+                if (KnownMethods.TryGetValue(imName, out var factory))
+                    return factory;
             }
 
             return null;

--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -166,27 +166,26 @@ namespace Avalonia.X11
 
         private static bool ShouldUseXim()
         {
+            // Priority: AVALONIA_IM_MODULE > GTK_IM_MODULE >= QT_IM_MODULE
+            string? imeOverride = Environment.GetEnvironmentVariable("AVALONIA_IM_MODULE");
+            if (string.IsNullOrEmpty(imeOverride))
+                imeOverride = Environment.GetEnvironmentVariable("GTK_IM_MODULE");
+            if (string.IsNullOrEmpty(imeOverride))
+                imeOverride = Environment.GetEnvironmentVariable("QT_IM_MODULE");
+
             // Check if we are forbidden from using IME
-            if (Environment.GetEnvironmentVariable("AVALONIA_IM_MODULE") == "none"
-                || Environment.GetEnvironmentVariable("GTK_IM_MODULE") == "none"
-                || Environment.GetEnvironmentVariable("QT_IM_MODULE") == "none")
-                return true;
-            
+            if (imeOverride == "none")
+                return false;
+
             // Check if XIM is configured
             var modifiers = Environment.GetEnvironmentVariable("XMODIFIERS");
-            if (modifiers == null)
-                return false;
-            if (modifiers.Contains("@im=none") || modifiers.Contains("@im=null"))
-                return false;
-            if (!modifiers.Contains("@im="))
-                return false;
-            
-            // Check if we are configured to use it
-            if (Environment.GetEnvironmentVariable("GTK_IM_MODULE") == "xim"
-                || Environment.GetEnvironmentVariable("QT_IM_MODULE") == "xim"
-                || Environment.GetEnvironmentVariable("AVALONIA_IM_MODULE") == "xim")
-                return true;
-            
+            if (modifiers is not null && modifiers.Contains("@im="))
+            {
+                // If XIM is explicitly requested, or no IME override is configured
+                if (imeOverride == "xim" || string.IsNullOrEmpty(imeOverride))
+                    return true;
+            }
+
             return false;
         }
         


### PR DESCRIPTION
This fixes #19963 

* For XWayland apps setting `XMODIFIERS=@im=fcitx` alone should make IME work. `*_IM_MODULE` should not be required.
* Fix where combinations like `GTK_IM_MODULE=none XMODIFIERS=@im=fcitx` can actually enable IME instead of forbid it - this is consistent with `AvaloniaX11Platform.EnableIme()`
* XIM should always be used if none of `IM_MODULE` is set (instead of only when they are explicitly set to `xim`)