### PR TITLE
XamlX: Embed SourceInfo (file, start line/col) in Debug builds

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -134,6 +134,8 @@
       <AvaloniaXamlIlVerifyIl Condition="'$(AvaloniaXamlIlVerifyIl)' == ''">false</AvaloniaXamlIlVerifyIl>
       <AvaloniaXamlIlDebuggerLaunch Condition="'$(AvaloniaXamlIlDebuggerLaunch)' == ''">false</AvaloniaXamlIlDebuggerLaunch>
       <AvaloniaXamlVerboseExceptions Condition="'$(AvaloniaXamlVerboseExceptions)' == ''">false</AvaloniaXamlVerboseExceptions>
+      <AvaloniaXamlCreateSourceInfo Condition="'$(AvaloniaXamlCreateSourceInfo)' == '' AND '$(Configuration)' == 'Debug'">true</AvaloniaXamlCreateSourceInfo>
+      <AvaloniaXamlCreateSourceInfo Condition="'$(AvaloniaXamlCreateSourceInfo)' == '' AND '$(Configuration)' != 'Debug'">false</AvaloniaXamlCreateSourceInfo>
     </PropertyGroup>
 
     <ItemGroup>
@@ -162,6 +164,7 @@
       DelaySign="$(DelaySign)"
       SkipXamlCompilation="$(_AvaloniaSkipXamlCompilation)"
       DebuggerLaunch="$(AvaloniaXamlIlDebuggerLaunch)"
+      CreateSourceInfo="$(AvaloniaXamlCreateSourceInfo)"
       DefaultCompileBindings="$(AvaloniaUseCompiledBindingsByDefault)"
       VerboseExceptions="$(AvaloniaXamlVerboseExceptions)"
       AnalyzerConfigFiles="@(EditorConfigFiles)"/>

--- a/packages/Avalonia/AvaloniaRules.Project.xml
+++ b/packages/Avalonia/AvaloniaRules.Project.xml
@@ -31,6 +31,11 @@
                 Description="Allow debug XAML compilation"
                 Category="Debug" />
 
+  <BoolProperty Name="AvaloniaXamlCreateSourceInfo"
+                DisplayName="Generate XAML Source Info"
+                Description="When enabled, the XAML compiler embeds SourceInfo metadata (file path, line, and column) into generated code. This allows tools and debuggers to locate the original .axaml source position of a selected element at runtime or in the designer."
+                Category="Debug" />
+
   <BoolProperty Name="AvaloniaXamlVerboseExceptions"
                 DisplayName="Report verbose internal exceptions with stack traces"
                 Description="Also includes inner exceptions"

--- a/src/Avalonia.Build.Tasks/CompileAvaloniaXamlTask.cs
+++ b/src/Avalonia.Build.Tasks/CompileAvaloniaXamlTask.cs
@@ -32,7 +32,7 @@ namespace Avalonia.Build.Tasks
                 ProjectDirectory, VerifyIl, DefaultCompileBindings, outputImportance,
                 new XamlCompilerDiagnosticsFilter(AnalyzerConfigFiles),
                 (SignAssembly && !DelaySign) ? AssemblyOriginatorKeyFile : null,
-                SkipXamlCompilation, DebuggerLaunch, VerboseExceptions);
+                SkipXamlCompilation, DebuggerLaunch, VerboseExceptions, CreateSourceInfo);
 
             if (res.Success && !res.WrittenFile)
             {
@@ -98,6 +98,8 @@ namespace Avalonia.Build.Tasks
         public ITaskHost HostObject { get; set; }
 
         public bool DebuggerLaunch { get; set; }
+
+        public bool CreateSourceInfo { get; set; }
 
         public bool VerboseExceptions { get; set; }
 

--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
@@ -52,7 +52,7 @@ namespace Avalonia.Build.Tasks
             string[] references, string projectDirectory,
             bool verifyIl, bool defaultCompileBindings, MessageImportance logImportance,
             XamlCompilerDiagnosticsFilter diagnosticsFilter, string strongNameKey,
-            bool skipXamlCompilation, bool debuggerLaunch, bool verboseExceptions)
+            bool skipXamlCompilation, bool debuggerLaunch, bool verboseExceptions, bool createSourceInfo)
         {
             try
             {
@@ -67,7 +67,7 @@ namespace Avalonia.Build.Tasks
 	                var compileRes = CompileCore(
                         engine, typeSystem, projectDirectory, verifyIl,
                         defaultCompileBindings, logImportance, diagnosticsFilter,
-                        debuggerLaunch, verboseExceptions);
+                        debuggerLaunch, verboseExceptions, createSourceInfo);
 	                if (compileRes == null)
 	                    return new CompileResult(true);
 	                if (compileRes == false)
@@ -107,7 +107,8 @@ namespace Avalonia.Build.Tasks
             MessageImportance logImportance,
             XamlCompilerDiagnosticsFilter diagnosticsFilter,
             bool debuggerLaunch,
-            bool verboseExceptions)
+            bool verboseExceptions,
+            bool createSourceInfo)
         {
             if (debuggerLaunch)
             {
@@ -210,6 +211,7 @@ namespace Avalonia.Build.Tasks
             {
                 EnableIlVerification = verifyIl,
                 DefaultCompileBindings = defaultCompileBindings,
+                CreateSourceInfo = createSourceInfo,
                 DynamicSetterContainerProvider = new DefaultXamlDynamicSetterContainerProvider(dynamicSettersBuilder)
             };
 
@@ -476,6 +478,30 @@ namespace Avalonia.Build.Tasks
                                 FieldAttributes.Static | FieldAttributes.Private, designLoaderFieldTypeReference);
                             classTypeDefinition.Fields.Add(designLoaderField);
                             typeSystem.AddCompilerGeneratedAttribute(designLoaderField);
+
+                            // Add [XamlSourceInfoAttribute] to the generated class.
+                            // Used at design time to locate the original .axaml file,
+                            // since the runtime loader substitutes a fake file name.
+                            if (createSourceInfo && document.FileSource.FilePath is { } filePath) 
+                            {
+                                var attrType = typeSystem.FindType("Avalonia.Markup.Xaml.Diagnostics.XamlSourceInfoAttribute");
+                                var attrTypeRef = asm.MainModule.ImportReference(typeSystem.GetTypeReference(attrType));
+
+                                var attrCtorDef = attrTypeRef.Resolve()
+                                    .Methods.First(m => m.IsConstructor
+                                                     && m.Parameters.Count == 1
+                                                     && m.Parameters[0].ParameterType.FullName == "System.String");
+
+                                var attrCtorRef = asm.MainModule.ImportReference(attrCtorDef);
+                                var designFilenameAttribute = new CustomAttribute(attrCtorRef);
+                                designFilenameAttribute.ConstructorArguments.Add(
+                                    new CustomAttributeArgument(
+                                        asm.MainModule.TypeSystem.String,
+                                        filePath
+                                    )
+                                );
+                                classTypeDefinition.CustomAttributes.Add(designFilenameAttribute);
+                            }
 
                             const string TrampolineName = "!XamlIlPopulateTrampoline";
                             var trampolineMethodWithoutSP = new Lazy<MethodDefinition>(() => CreateTrampolineMethod(false));

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/AvaloniaXamlIlRuntimeCompiler.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/AvaloniaXamlIlRuntimeCompiler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -344,7 +344,8 @@ namespace Avalonia.Markup.Xaml.XamlIl
             {
                 EnableIlVerification = true,
                 DefaultCompileBindings = configuration.UseCompiledBindingsByDefault,
-                IsDesignMode = configuration.DesignMode
+                IsDesignMode = configuration.DesignMode,
+                CreateSourceInfo = configuration.DesignMode,
             };
 
             var parsedDocuments = new List<XamlDocumentResource>();

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlCompiler.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlCompiler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Avalonia.Markup.Xaml.Loader.CompilerExtensions.Transformers;
 using Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.GroupTransformers;
 using Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers;
 using XamlX;
@@ -20,6 +21,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
         private readonly IXamlType _contextType = null!;
         private readonly AvaloniaXamlIlDesignPropertiesTransformer _designTransformer;
         private readonly AvaloniaBindingExtensionTransformer _bindingTransformer;
+        private readonly AvaloniaXamlIlAddSourceInfoTransformer _addSourceInfoTransformer;
 
         private AvaloniaXamlIlCompiler(TransformerConfiguration configuration, XamlLanguageEmitMappings<IXamlILEmitter, XamlILNodeEmitResult> emitMappings)
             : base(configuration, emitMappings, true)
@@ -46,7 +48,11 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             InsertBefore<PropertyReferenceResolver>(
                 new AvaloniaXamlIlResolveClassesPropertiesTransformer(),
                 new AvaloniaXamlIlTransformInstanceAttachedProperties(),
-                new AvaloniaXamlIlTransformSyntheticCompiledBindingMembers());
+                new AvaloniaXamlIlTransformSyntheticCompiledBindingMembers(),
+                _addSourceInfoTransformer = new AvaloniaXamlIlAddSourceInfoTransformer()
+                );
+
+
             InsertAfter<PropertyReferenceResolver>(
                 new AvaloniaXamlIlAvaloniaPropertyResolver(),
                 new AvaloniaXamlIlReorderClassesPropertiesTransformer(),
@@ -121,6 +127,12 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
 
         public const string PopulateName = "__AvaloniaXamlIlPopulate";
         public const string BuildName = "__AvaloniaXamlIlBuild";
+
+        public bool CreateSourceInfo 
+        { 
+            get => _addSourceInfoTransformer.CreateSourceInfo; 
+            set => _addSourceInfoTransformer.CreateSourceInfo = value; 
+        }
 
         public bool IsDesignMode
         {

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlAddSourceInfoTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlAddSourceInfoTransformer.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers;
+using XamlX.Ast;
+using XamlX.Transform;
+
+namespace Avalonia.Markup.Xaml.Loader.CompilerExtensions.Transformers
+{
+    /// <summary>
+    /// An XAMLIL AST transformer that injects <see cref="Avalonia.Markup.Xaml.Diagnostics.XamlSourceInfo"/> metadata into the generated XAML code.
+    /// </summary>
+    /// <remarks>
+    /// This transformer runs during XAML compilation and attaches <see cref="Avalonia.Markup.Xaml.Diagnostics.XamlSourceInfo"/> 
+    /// values to each created control node, allowing runtime and design-time tools to map visual elements 
+    /// back to their original XAML source locations.
+    /// <para/>
+    /// The transformation is only applied when <see cref="CreateSourceInfo"/> is set to <c>true</c>, which 
+    /// typically occurs when the MSBuild property <c>AvaloniaXamlCreateSourceInfo</c> is enabled 
+    /// (for example, in Debug or design-time builds).
+    /// <para/>
+    /// Adding <see cref="Avalonia.Markup.Xaml.Diagnostics.XamlSourceInfo"/> helps tooling like the Avalonia designer or visual inspectors 
+    /// jump directly to the defining <c>.axaml</c> file and line number of a selected element.
+    /// </remarks>
+    internal class AvaloniaXamlIlAddSourceInfoTransformer : IXamlAstTransformer
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether source information should be generated
+        /// and injected into the compiled XAML output.
+        /// </summary>
+        /// <remarks>
+        /// This is usually enabled automatically by the build system when 
+        /// <c>AvaloniaXamlCreateSourceInfo</c> is set.
+        /// </remarks>
+        public bool CreateSourceInfo { get; set; }
+
+        public IXamlAstNode Transform(AstTransformationContext context, IXamlAstNode node)
+        {
+            if (CreateSourceInfo && node is XamlAstObjectNode objNode)
+            {
+                var avaloniaTypes = context.GetAvaloniaTypes();
+
+                var clrType = objNode.Type.GetClrType();
+                if (avaloniaTypes.Control.IsAssignableFrom(clrType))
+                {
+                    var line = node.Line;
+                    var col = node.Position;
+
+                    // Create a CLR property representation for the attached SourceInfo property.
+                    var sourceProperty = new XamlAstClrProperty(node,
+                        "SourceInfo",
+                        avaloniaTypes.VisualDiagnosticsType,
+                        null,
+                        [avaloniaTypes.SourceInfoPropertySetter], null);
+
+                    var sourceInfoTypeRef = new XamlAstClrTypeReference(node, avaloniaTypes.SourceInfoType, false);
+                    XamlAstNewClrObjectNode valueNode;
+
+                    if(context.Document != null)
+                    {
+                        valueNode = new XamlAstNewClrObjectNode(node, sourceInfoTypeRef, avaloniaTypes.SourceInfoConstructorFull,
+                        [
+                            new XamlConstantNode(node, avaloniaTypes.XamlIlTypes.Int32, line),
+                            new XamlConstantNode(node, avaloniaTypes.XamlIlTypes.Int32, col),
+                            new XamlConstantNode(node, avaloniaTypes.XamlIlTypes.String, context.Document)
+                        ]);
+                    }
+                    else
+                    {
+                        valueNode = new XamlAstNewClrObjectNode(node, sourceInfoTypeRef, avaloniaTypes.SourceInfoConstructor,
+                        [
+                            new XamlConstantNode(node, avaloniaTypes.XamlIlTypes.Int32, line),
+                            new XamlConstantNode(node, avaloniaTypes.XamlIlTypes.Int32, col)
+                        ]);
+                    }
+
+                    var propNode = new XamlAstXamlPropertyValueNode(
+                        node,
+                        sourceProperty,
+                        valueNode,
+                        isAttributeSyntax: true);
+
+                    objNode.Children.Add(propNode);
+                }
+            }
+
+            return node;
+        }
+    }
+}

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -134,6 +134,13 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType EventHandlerT {  get; }
         public IXamlMethod GetClassProperty { get; }
 
+        public IXamlType SourceInfoType { get; }
+        
+        public IXamlConstructor SourceInfoConstructor { get; }
+        public IXamlConstructor SourceInfoConstructorFull { get; }
+        public IXamlType VisualDiagnosticsType { get; }
+        public IXamlMethod SourceInfoPropertySetter { get; }
+
         sealed internal class InteractivityWellKnownTypes
         {
             public IXamlType Interactive { get; }
@@ -341,6 +348,16 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                 allowDowncast:false,
                 cfg.WellKnownTypes.String
                 );
+
+            VisualDiagnosticsType = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.Diagnostics.VisualDiagnostics");
+            SourceInfoType = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.Diagnostics.XamlSourceInfo");
+            SourceInfoConstructor = SourceInfoType.GetConstructor([XamlIlTypes.Int32, XamlIlTypes.Int32]);
+            SourceInfoConstructorFull = SourceInfoType.GetConstructor([
+                XamlIlTypes.Int32, XamlIlTypes.Int32, XamlIlTypes.String
+            ]);
+
+            SourceInfoPropertySetter =
+               VisualDiagnosticsType.GetMethod("SetSourceInfo", XamlIlTypes.Void, false, AvaloniaObject, SourceInfoType);
         }
     }
 

--- a/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
@@ -39,6 +39,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RuntimeXamlLoaderConfiguration.cs" />
     <Compile Include="RuntimeXamlLoaderDocument.cs" />
+    <Compile Include="Diagnostics\XamlSourceInfo.cs" />
     <Compile Include="Styling\MergeResourceInclude.cs" />
     <Compile Include="Styling\ResourceInclude.cs" />
     <Compile Include="Styling\StyleInclude.cs" />

--- a/src/Markup/Avalonia.Markup.Xaml/Diagnostics/XamlSourceInfo.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Diagnostics/XamlSourceInfo.cs
@@ -1,0 +1,218 @@
+﻿using System;
+using Avalonia.Controls;
+
+namespace Avalonia.Markup.Xaml.Diagnostics
+{
+    /// <summary>
+    /// Represents source location information for an element within a XAML or code file.
+    /// </summary>
+    // ReSharper disable once ClassNeverInstantiated.Global //This class is instantiated through the XAML compiler.
+    public sealed class XamlSourceInfo : IEquatable<XamlSourceInfo>
+    {
+        /// <summary>
+        /// Gets the full path of the source file containing the element, or <c>null</c> if unavailable.
+        /// </summary>
+        public string? FilePath { get; }
+        
+        /// <summary>
+        /// Gets the 1-based line number in the source file where the element is defined.
+        /// </summary>
+        public int Line { get; }
+
+        /// <summary>
+        /// Gets the 1-based column number in the source file where the element is defined.
+        /// </summary>
+        public int Column { get; }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XamlSourceInfo"/> class
+        /// with a specified line, column, and file path.
+        /// </summary>
+        /// <param name="line">The line number of the source element.</param>
+        /// <param name="column">The column number of the source element.</param>
+        /// <param name="filePath">The full path of the source file.</param>
+        public XamlSourceInfo(int line, int column, string? filePath)
+        {
+            Line = line;
+            Column = column;
+            FilePath = filePath;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XamlSourceInfo"/> class
+        /// with a specified line and column.
+        /// </summary>
+        /// <param name="line">The line number of the source element.</param>
+        /// <param name="column">The column number of the source element.</param>
+        public XamlSourceInfo(int line, int column)
+        {
+            Line = line;
+            Column = column;
+        }
+        
+        /// <summary>
+        /// Returns a string that represents the current <see cref="XamlSourceInfo"/>.
+        /// </summary>
+        /// <returns>
+        /// A formatted string in the form <c>"FilePath:Line,Column"</c>,
+        /// or <c>"(unknown):Line,Column"</c> if the file path is not set.
+        /// </returns>
+        public override string ToString()
+        {
+            var file = string.IsNullOrEmpty(FilePath) ? "(unknown)" : System.IO.Path.GetFileName(FilePath);
+            return $"{file}:{Line},{Column}";
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current <see cref="XamlSourceInfo"/>.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current instance.</param>
+        /// <returns>
+        /// <c>true</c> if <paramref name="obj"/> is a <see cref="XamlSourceInfo"/> with the same
+        /// <see cref="Line"/>, <see cref="Column"/>, and <see cref="FilePath"/> values; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object? obj)
+        {
+            return obj is XamlSourceInfo info &&
+                   Line == info.Line &&
+                   Column == info.Column &&
+                   FilePath == info.FilePath;
+        }
+
+        /// <summary>
+        /// Returns a hash code for this <see cref="XamlSourceInfo"/>.
+        /// </summary>
+        /// <returns>An integer hash code computed from <see cref="Line"/>, <see cref="Column"/>, and <see cref="FilePath"/>.</returns>
+        public override int GetHashCode()
+        {
+            int hash = 17;
+            hash = hash * 31 + (Line.GetHashCode());
+            hash = hash * 31 + (Column.GetHashCode());
+            hash = hash * 31 + (FilePath?.GetHashCode() ?? 0);
+            return hash;
+        }
+
+        /// <summary>
+        /// Determines whether two <see cref="XamlSourceInfo"/> instances are equal.
+        /// </summary>
+        /// <param name="left">Left-hand operand.</param>
+        /// <param name="right">Right-hand operand.</param>
+        /// <returns><c>true</c> when both operands represent the same source location; otherwise <c>false</c>.</returns>
+        public static bool operator ==(XamlSourceInfo? left, XamlSourceInfo? right)
+        {
+            if (ReferenceEquals(left, right))
+                return true;
+            if (left is null || right is null)
+                return false;
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Determines whether two <see cref="XamlSourceInfo"/> instances are not equal.
+        /// </summary>
+        /// <param name="left">Left-hand operand.</param>
+        /// <param name="right">Right-hand operand.</param>
+        /// <returns><c>true</c> when operands do not represent the same source location; otherwise <c>false</c>.</returns>
+        public static bool operator !=(XamlSourceInfo? left, XamlSourceInfo? right)
+        {
+            return !(left == right);
+        }
+
+        /// <summary>
+        /// Indicates whether the current instance is equal to another <see cref="XamlSourceInfo"/>.
+        /// </summary>
+        /// <param name="other">The other <see cref="XamlSourceInfo"/> to compare with.</param>
+        /// <returns><c>true</c> when both instances represent the same source location; otherwise <c>false</c>.</returns>
+        public bool Equals(XamlSourceInfo? other)
+        {
+            if (other is null)
+                return false;
+            
+            return Line == other.Line && Column == other.Column && FilePath == other.FilePath;
+        }
+    }
+
+
+    /// <summary>
+    /// Provides an attached property for storing <see cref="XamlSourceInfo"/> metadata on Avalonia controls.
+    /// </summary>
+    /// <remarks>
+    /// This class is primarily used by the XAML compiler or runtime tooling to associate 
+    /// source location information (file path, line, and column) with UI elements.
+    /// <para/>
+    /// The <see cref="XamlSourceInfo"/> property is typically populated automatically by the Avalonia XAML compiler:
+    /// <list type="number">
+    /// <item>
+    /// When running in <b>design mode</b> — to enable designer tools to map rendered elements back to source XAML.
+    /// </item>
+    /// <item>
+    /// When running in a <b>debug configuration</b> — allowing runtime inspection or navigation
+    /// back to the originating XAML source (this can be overridden by setting the 
+    /// <c>AvaloniaXamlCreateSourceInfo</c> build property).
+    /// </item>
+    /// </list>
+    /// </remarks>
+    public static class VisualDiagnostics
+    {
+        /// <summary>
+        /// Defines the attached <see cref="XamlSourceInfo"/> property that stores the source location
+        /// information for a control.
+        /// </summary>
+        public static readonly AttachedProperty<XamlSourceInfo> SourceInfoProperty =
+            AvaloniaProperty.RegisterAttached<AvaloniaObject, XamlSourceInfo>(
+                "SourceInfo",
+                typeof(VisualDiagnostics));
+
+        /// <summary>
+        /// Gets the <see cref="XamlSourceInfo"/> value associated with the specified visual.
+        /// </summary>
+        /// <param name="v">The control from which to retrieve the source information.</param>
+        /// <returns>
+        /// The <see cref="XamlSourceInfo"/> that describes where the control was defined in XAML.
+        /// If no value is set, the default (empty) <see cref="XamlSourceInfo"/> is returned.
+        /// </returns>
+        public static XamlSourceInfo? GetSourceInfo(AvaloniaObject v)
+        {
+            return v.GetValue(SourceInfoProperty);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="XamlSourceInfo"/> value for the specified control.
+        /// </summary>
+        /// <param name="v">The control to associate with the source information.</param>
+        /// <param name="value">The <see cref="XamlSourceInfo"/> describing the control’s origin in XAML.</param>
+        /// <remarks>
+        /// Normally this method is invoked automatically by the XAML compiler or design-time tools.
+        /// You generally do not need to set this property manually unless you are generating controls dynamically.
+        /// </remarks>
+        public static void SetSourceInfo(AvaloniaObject v, XamlSourceInfo value)
+        {
+            v.SetValue(SourceInfoProperty, value);
+        }
+    }
+
+    /// <summary>
+    /// Attribute applied to types generated from XAML to record the original source file name.
+    /// </summary>
+    /// <remarks>
+    /// The XAML compiler may add this attribute to generated classes so design-time tooling
+    /// can map a runtime type back to its originating XAML file.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public sealed class XamlSourceInfoAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the source file name that produced the type.
+        /// </summary>
+        public string SourceFileName { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XamlSourceInfoAttribute"/> class.
+        /// </summary>
+        /// <param name="sourceFileName">The source file name associated with the generated type.</param>
+        public XamlSourceInfoAttribute(string sourceFileName)
+        {
+            SourceFileName = sourceFileName;
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Adds SourceInfo emission to the XamlX compiler for **Debug** builds. The compiler will embed the source file path plus the **starting** line and column for XAML nodes. This enables design-time and runtime tooling to jump from an element to its source (e.g., open the `.axaml` at the correct location).

This PR is a simplified, compiler-only subset of #20082 and fixes #19962.

## Current behavior

Runtime code can locate a XAML node’s source information by searching the runtime stack trace for frames that reference `.xaml`/`.axaml` files and extracting file/line information from those frames. This approach is more of a hack and cannot be used in design-time scenarios (the designer).

## New behavior / how to test

* Debug builds include SourceInfo (file, start line, start column) on compiled XAML nodes.
* Tooling that reads SourceInfo can perform jump-to-source in designer or DevTools.

## Implementation notes

* Implemented in the XamlX pipeline; emits source file and starting line/column for nodes in Debug builds.
* A reverse mapping (SourceInfo → AvaloniaObject) could be added later (for example via a store reacting to a `SourceInfoProperty` change) without changing public APIs.

## Fixed issues

Fixes #19962
Related: #20082
