### PR TITLE
Update CalendarClosed event and internal state handling in CalendarDa…

### DIFF
--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -55,7 +55,7 @@ namespace Avalonia.Controls
         /// Occurs when the drop-down
         /// <see cref="T:Avalonia.Controls.Calendar" /> is closed.
         /// </summary>
-        public event EventHandler? CalendarClosed;
+        public event EventHandler? ;
 
         /// <summary>
         /// Occurs when the drop-down
@@ -231,7 +231,7 @@ namespace Avalonia.Controls
                             _isPressed = false;
 
                             UpdatePseudoClasses();
-                            OnCalendarClosed(new RoutedEventArgs());
+                            On(new RoutedEventArgs());
                         }
                     }
                 }
@@ -521,6 +521,24 @@ namespace Avalonia.Controls
         private void OnCalendarClosed(EventArgs e)
         {
             CalendarClosed?.Invoke(this, e);
+
+            //there is a problem with the calendar, after you first select an element and the popup closes
+            //, the internal field _isMouseLeftButtonDown from inside CalendarItem remains trul
+            //and because of this the folowing time we open the popup it will trigger selection just by hovering over items
+            //to sove this I wrote the following code here
+            if(_calendar != null)
+            {
+                var calendarItem = _calendar?.GetType().GetProperty("MonthControl", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                    .GetValue(calendar) as CalendarItem;
+                if (calendarItem != null)
+                {
+                    var isMouseLeftButtonDownProperty = calendarItem.GetType().GetField("_isMouseLeftButtonDown", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    if (isMouseLeftButtonDownProperty != null)
+                    {
+                        isMouseLeftButtonDownProperty.SetValue(calendarItem, false);
+                    }
+                }
+            }
         }
 
         private void OnCalendarOpened(EventArgs e)


### PR DESCRIPTION
…tePicker

There is a problem with the calendar, after you first select an element and the popup closes , the internal field _isMouseLeftButtonDown from inside CalendarItem remains true and because of this the following time we open the popup it will trigger selection just by hovering over items, I worked around this issue through reflection

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
