### PR TITLE
Fix on screen keyboard is missing decimal separator on iOS

### DIFF
--- a/src/iOS/Avalonia.iOS/TextInputResponder.Properties.cs
+++ b/src/iOS/Avalonia.iOS/TextInputResponder.Properties.cs
@@ -24,8 +24,9 @@ partial class AvaloniaView
                 _view._options.ContentType switch
                 {
                     TextInputContentType.Alpha => UIKeyboardType.AsciiCapable,
-                    TextInputContentType.Digits or TextInputContentType.Number => UIKeyboardType.NumberPad,
+                    TextInputContentType.Digits => UIKeyboardType.PhonePad,
                     TextInputContentType.Pin => UIKeyboardType.NumberPad,
+                    TextInputContentType.Number => UIKeyboardType.DecimalPad,
                     TextInputContentType.Email => UIKeyboardType.EmailAddress,
                     TextInputContentType.Url => UIKeyboardType.Url,
                     TextInputContentType.Name => UIKeyboardType.NamePhonePad,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Aims to solve #20275

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When a TextBox control with its ContentType is set to Number gains focus, it opens an on screen keyboard. But that keyboard lacks a decimal separator button, unlike the behavior described at the [document](https://api-docs.avaloniaui.net/docs/T_Avalonia_Input_TextInput_TextInputContentType).

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The on screen keyboard has the decimal separator, as stated at the document, enabling user to input decimal numbers.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
TextInputContentType.Number currently maps to UIKeyboardType.NumberPad, which does not have a decimal separator. This PR maps TextInputContentType.Number to UIKeyboardType.DecimalPad instead, which has a decimal separator. And for the sake of completeness, maps TextInputContentType.Digits to UIKeyboardType.PhonePad.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
None.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
None.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #20275
