### PR TITLE
Use androidx lib for backpressed callback

### DIFF
--- a/api/Avalonia.Android.nupkg.xml
+++ b/api/Avalonia.Android.nupkg.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Android.AvaloniaActivity</Target>
+    <Left>baseline/Avalonia.Android/lib/net10.0-android36.0/Avalonia.Android.dll</Left>
+    <Right>current/Avalonia.Android/lib/net10.0-android36.0/Avalonia.Android.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Android.AvaloniaMainActivity</Target>
+    <Left>baseline/Avalonia.Android/lib/net10.0-android36.0/Avalonia.Android.dll</Left>
+    <Right>current/Avalonia.Android/lib/net10.0-android36.0/Avalonia.Android.dll</Right>
+  </Suppression>
+</Suppressions>

--- a/src/Android/Avalonia.Android/AvaloniaActivity.cs
+++ b/src/Android/Avalonia.Android/AvaloniaActivity.cs
@@ -20,13 +20,14 @@ namespace Avalonia.Android;
 /// Common implementation of android activity that is integrated with Avalonia views.
 /// If you need a base class for main activity of Avalonia app, see <see cref="AvaloniaMainActivity"/>.  
 /// </summary>
-public class AvaloniaActivity : AppCompatActivity, IAvaloniaActivity, IOnBackInvokedCallback
+public class AvaloniaActivity : AppCompatActivity, IAvaloniaActivity
 {
     private EventHandler<ActivatedEventArgs>? _onActivated, _onDeactivated;
     private GlobalLayoutListener? _listener;
     private object? _content;
     private bool _contentViewSet;
     internal AvaloniaView? _view;
+    private BackPressedCallback? _currentBackPressedCallback;
 
     public Action<int, Result, Intent?>? ActivityResult { get; set; }
     public Action<int, string[], Permission[]>? RequestPermissionsResult { get; set; }
@@ -127,7 +128,8 @@ public class AvaloniaActivity : AppCompatActivity, IAvaloniaActivity, IOnBackInv
 
         if (OperatingSystem.IsAndroidVersionAtLeast(33))
         {
-            OnBackInvokedDispatcher.UnregisterOnBackInvokedCallback(this);
+            _currentBackPressedCallback?.Remove();
+            _currentBackPressedCallback = null;
         }
         base.OnStop();
     }
@@ -138,7 +140,8 @@ public class AvaloniaActivity : AppCompatActivity, IAvaloniaActivity, IOnBackInv
 
         if (OperatingSystem.IsAndroidVersionAtLeast(33))
         {
-            OnBackInvokedDispatcher.RegisterOnBackInvokedCallback(IOnBackInvokedDispatcher.PriorityDefault, this);
+            _currentBackPressedCallback = new BackPressedCallback(this);
+            OnBackPressedDispatcher.AddCallback(this, _currentBackPressedCallback);
         }
         base.OnStart();
     }

--- a/src/Android/Avalonia.Android/BackPressedCallback.cs
+++ b/src/Android/Avalonia.Android/BackPressedCallback.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using AndroidX.Activity;
+
+namespace Avalonia.Android
+{
+    internal class BackPressedCallback(AvaloniaActivity activity) : OnBackPressedCallback(true)
+    {
+        public override void HandleOnBackPressed()
+        {
+            activity.OnBackInvoked();
+        }
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Switches to using AndroidX's OnBackPressedCallback, thus allowing apps to run on API33 and lower.


## What is the current behavior?
Previously, on the update to Net 10, we used the android sdk's api for BackPressed callback. The issue with that is it's not backwards compatible with API 33 and lower, thus causing a crash as an API 34 only launcher activity is being run on Android 13 and older devices.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/20278
