### PR TITLE
Added try-catch to synchronization context

### DIFF
--- a/src/Avalonia.Base/Threading/AvaloniaSynchronizationContext.cs
+++ b/src/Avalonia.Base/Threading/AvaloniaSynchronizationContext.cs
@@ -61,17 +61,35 @@ namespace Avalonia.Threading
         /// <inheritdoc/>
         public override void Post(SendOrPostCallback d, object? state)
         {
-            _dispatcher.Post(d, state, Priority);
+            try
+            {
+                _dispatcher.Post(d, state, Priority);
+            }
+            catch (Exception e)
+            {
+                // Swallow exceptions that happen because the dispatcher is shutting down.
+                if (!_dispatcher.HasShutdownStarted)
+                    throw;
+            }
         }
 
         /// <inheritdoc/>
         public override void Send(SendOrPostCallback d, object? state)
         {
-            if (_dispatcher.CheckAccess())
-                // Same-thread, use send priority to avoid any reentrancy.
-                _dispatcher.Send(d, state, DispatcherPriority.Send);
-            else
-                _dispatcher.Send(d, state, Priority);
+            try
+            {
+                if (_dispatcher.CheckAccess())
+                    // Same-thread, use send priority to avoid any reentrancy.
+                    _dispatcher.Send(d, state, DispatcherPriority.Send);
+                else
+                    _dispatcher.Send(d, state, Priority);
+            }
+            catch (Exception e)
+            {
+                // Swallow exceptions that happen because the dispatcher is shutting down.
+                if (!_dispatcher.HasShutdownStarted)
+                    throw;
+            }
         }
 
 #if !NET6_0_OR_GREATER


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Added try-catch to suppress exceptions on shutdown inside dispatcher

## What is the current behavior?

Right now any exception thrown by dispatcher crashes the app.  A great example is in this issue https://github.com/AvaloniaUI/Avalonia/issues/19523

It's impossible to catch or suppress the exception from application side. UnhandledException in AppDomain does fire, but at this point application is in termination state.

## What is the updated/expected behavior with this PR?

Try catch in synchronization context dispatcher suppresses exceptions thrown on shutdown. It's not a proper fix, but dispatcher exceptions on shutdown can usually be safely ignored. 


## How was the solution implemented (if it's not obvious)?


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
"Fixes" https://github.com/AvaloniaUI/Avalonia/issues/19523
