### PR TITLE
Fixed thread-race condition in Dispatcher on shutdown

### DIFF
--- a/src/Avalonia.Base/Threading/Dispatcher.MainLoop.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.MainLoop.cs
@@ -141,6 +141,8 @@ public partial class Dispatcher
                 else
                 {
                     operation = null;
+                    _impl.UpdateTimer(null);
+                    _hasShutdownFinished = true;
                 }
             }
 
@@ -150,8 +152,6 @@ public partial class Dispatcher
             }
         } while (operation != null);
 
-        _impl.UpdateTimer(null);
-        _hasShutdownFinished = true;
         ShutdownFinished?.Invoke(this, EventArgs.Empty);
     }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR fixes thread-race condition in Dispatcher which may lead to operation added to execution queue after it is emptied on shutdown


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The `InvokeAsyncImpl` protected by lock block may be called after the `ShutdownImpl` aborts all operations but before the _hasShutdownFinished is set to true. This leads to abandoned operations in the queue which will never be executed. The awaiting of execution completion for such operations is never completed. 


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The operation addition is impossible after the shutdown

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
The modification of `_hasShutdownFinished` is performed inside the lock statement

## Checklist

- [ -] Added unit tests (if possible)?
- [ -] Added XML documentation to any related classes?
- [ -] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
No breaking changes

