### PR TITLE
Remove adorner handling hack from the compositor

### DIFF
--- a/samples/ControlCatalog/Pages/AdornerLayerPage.xaml
+++ b/samples/ControlCatalog/Pages/AdornerLayerPage.xaml
@@ -44,21 +44,31 @@
                 VerticalContentAlignment="Center" VerticalAlignment="Stretch" 
                 Width="200" Height="42">
           <AdornerLayer.Adorner>
-            <Canvas x:Name="AdornerCanvas"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    Background="Cyan"
-                    IsHitTestVisible="False"
-                    Opacity="0.3"
-                    IsVisible="True"
-                    AdornerLayer.IsClipEnabled="False">
-              <Line StartPoint="-10000,0" EndPoint="10000,0" Stroke="Cyan" StrokeThickness="1" />
-              <Line StartPoint="-10000,42" EndPoint="10000,42" Stroke="Cyan" StrokeThickness="1" />
-              <Line StartPoint="0,-10000" EndPoint="0,10000" Stroke="Cyan" StrokeThickness="1" />
-              <Line StartPoint="200,-10000" EndPoint="200,10000" Stroke="Cyan" StrokeThickness="1" />
-            </Canvas>
+            <Border AdornerLayer.IsClipEnabled="False" ClipToBounds="False" Background="Red" Opacity="0.3" Margin="-5" Padding="5"
+                    IsHitTestVisible="False">
+              <Canvas
+                x:Name="AdornerCanvas"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                Background="Cyan"
+                IsHitTestVisible="False"
+                IsVisible="True"
+                AdornerLayer.IsClipEnabled="False">
+                <Line StartPoint="-10000,0" EndPoint="10000,0" Stroke="Cyan" StrokeThickness="1" />
+                <Line StartPoint="-10000,42" EndPoint="10000,42" Stroke="Cyan" StrokeThickness="1" />
+                <Line StartPoint="0,-10000" EndPoint="0,10000" Stroke="Cyan" StrokeThickness="1" />
+                <Line StartPoint="200,-10000" EndPoint="200,10000" Stroke="Cyan" StrokeThickness="1" />
+              </Canvas>
+            </Border>
           </AdornerLayer.Adorner>
+          <Button.ContextMenu>
+            <ContextMenu PlacementTarget="{ResolveByName AdornerCanvas}" Placement="TopEdgeAlignedLeft">
+              <MenuItem Header="Menu 1"/>
+              <MenuItem Header="Menu 2"/>
+            </ContextMenu>
+          </Button.ContextMenu>
         </Button>
+        
 
       </LayoutTransformControl>
     </Grid>

--- a/src/Avalonia.Base/Input/TextInput/InputMethodManager.cs
+++ b/src/Avalonia.Base/Input/TextInput/InputMethodManager.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Input.TextInput
         private IInputElement? _focusedElement;
         private Interactive? _visualRoot;
         private TextInputMethodClient? _client;
-        private readonly TransformTrackingHelper _transformTracker = new TransformTrackingHelper();
+        private readonly TransformTrackingHelper _transformTracker = new TransformTrackingHelper(true);
 
         public TextInputMethodManager()
         {

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionContainerVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionContainerVisual.cs
@@ -34,15 +34,10 @@ namespace Avalonia.Rendering.Composition.Server
             var (combinedBounds, oldInvalidated, newInvalidated) = base.Update(root, parentCombinedTransform);
             foreach (var child in Children)
             {
-                if (child.AdornedVisual != null)
-                    root.EnqueueAdornerUpdate(child);
-                else
-                {
-                    var res = child.Update(root, GlobalTransformMatrix);
-                    oldInvalidated |= res.InvalidatedOld;
-                    newInvalidated |= res.InvalidatedNew;
-                    combinedBounds = LtrbRect.FullUnion(combinedBounds, res.Bounds);
-                }
+                var res = child.Update(root, GlobalTransformMatrix);
+                oldInvalidated |= res.InvalidatedOld;
+                newInvalidated |= res.InvalidatedNew;
+                combinedBounds = LtrbRect.FullUnion(combinedBounds, res.Bounds);
             }
             
             // If effect is changed, we need to clean both old and new bounds

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -31,7 +31,6 @@ namespace Avalonia.Rendering.Composition.Server
         private bool _fullRedrawRequested;
         private bool _disposed;
         private readonly HashSet<ServerCompositionVisual> _attachedVisuals = new();
-        private readonly Queue<ServerCompositionVisual> _adornerUpdateQueue = new();
 
         public long Id { get; }
         public ulong Revision { get; private set; }
@@ -128,12 +127,6 @@ namespace Avalonia.Rendering.Composition.Server
                 var transform = Matrix.CreateScale(Scaling, Scaling);
                 // Update happens in a separate phase to extend dirty rect if needed
                 Root.Update(this, transform);
-
-                while (_adornerUpdateQueue.Count > 0)
-                {
-                    var adorner = _adornerUpdateQueue.Dequeue();
-                    adorner.Update(this, transform);
-                }
 
                 _updateRequested = false;
                 Readback.CompleteWrite(Revision);
@@ -263,7 +256,5 @@ namespace Avalonia.Rendering.Composition.Server
             if (visual.IsVisibleInFrame)
                 AddDirtyRect(visual.TransformedOwnContentBounds);
         }
-
-        public void EnqueueAdornerUpdate(ServerCompositionVisual visual) => _adornerUpdateQueue.Enqueue(visual);
     }
 }

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.DirtyProperties.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.DirtyProperties.cs
@@ -24,7 +24,6 @@ partial class ServerCompositionVisual
         | CompositionVisualChangedFields.AnchorPointAnimated
         | CompositionVisualChangedFields.CenterPoint
         | CompositionVisualChangedFields.CenterPointAnimated
-        | CompositionVisualChangedFields.AdornedVisual
         | CompositionVisualChangedFields.TransformMatrix
         | CompositionVisualChangedFields.Scale
         | CompositionVisualChangedFields.ScaleAnimated
@@ -63,7 +62,6 @@ partial class ServerCompositionVisual
         if (offset == s_IdOfSizeProperty
             || offset == s_IdOfAnchorPointProperty
             || offset == s_IdOfCenterPointProperty
-            || offset == s_IdOfAdornedVisualProperty
             || offset == s_IdOfTransformMatrixProperty
             || offset == s_IdOfScaleProperty
             || offset == s_IdOfRotationAngleProperty

--- a/src/Avalonia.Base/composition-schema.xml
+++ b/src/Avalonia.Base/composition-schema.xml
@@ -29,8 +29,6 @@
         <Property Name="Orientation" Type="Quaternion" DefaultValue="Quaternion.Identity" Animated="true"/>
         <Property Name="Scale" Type="Vector3D" DefaultValue="new Avalonia.Vector3D(1, 1, 1)" Animated="true"/>
         <Property Name="TransformMatrix" Type="Avalonia.Matrix" DefaultValue="Avalonia.Matrix.Identity" Animated="true" Internal="true"/>
-        <Property Name="AdornedVisual" Type="CompositionVisual?" Internal="true" />
-        <Property Name="AdornerIsClipped" Type="bool" Internal="true" />
         <Property Name="OpacityMaskBrush" ClientName="OpacityMaskBrushTransportField" Type="Avalonia.Media.IBrush?" Private="true"  />
         <Property Name="Effect" Type="Avalonia.Media.IImmutableEffect?" Internal="true" />
         <Property Name="RenderOptions" Type="Avalonia.Media.RenderOptions" />

--- a/src/Avalonia.Controls/Primitives/AdornerHelper.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerHelper.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+
+namespace Avalonia.Controls.Primitives;
+
+class AdornerHelper
+{
+
+    public static IDisposable SubscribeToAncestorPropertyChanges(Visual visual, 
+        bool includeClip, Action changed)
+    {
+        return new AncestorPropertyChangesSubscription(visual, includeClip, changed);
+    }
+
+    private class AncestorPropertyChangesSubscription : IDisposable
+    {
+        private readonly Visual _visual;
+        private readonly bool _includeClip;
+        private readonly Action _changed;
+        private readonly EventHandler<AvaloniaPropertyChangedEventArgs> _propertyChangedHandler;
+        private readonly List<Visual> _subscriptions = new List<Visual>();
+        private bool _isDisposed;
+
+        public AncestorPropertyChangesSubscription(Visual visual, bool includeClip, Action changed)
+        {
+            _visual = visual;
+            _includeClip = includeClip;
+            _changed = changed;
+            _propertyChangedHandler = OnPropertyChanged;
+
+            _visual.AttachedToVisualTree += OnAttachedToVisualTree;
+            _visual.DetachedFromVisualTree += OnDetachedFromVisualTree;
+
+            if (_visual.IsAttachedToVisualTree)
+            {
+                SubscribeToAncestors();
+            }
+        }
+
+        private void SubscribeToAncestors()
+        {
+            UnsubscribeFromAncestors();
+
+            // Subscribe to the visual's own Bounds property
+            _visual.PropertyChanged += _propertyChangedHandler;
+            _subscriptions.Add(_visual);
+
+            // Walk up the ancestor chain
+            var ancestor = _visual.VisualParent;
+            while (ancestor != null)
+            {
+                if (ancestor is Visual visualAncestor)
+                {
+                    visualAncestor.PropertyChanged += _propertyChangedHandler;
+                    _subscriptions.Add(visualAncestor);
+                }
+                ancestor = ancestor.VisualParent;
+            }
+        }
+
+        private void UnsubscribeFromAncestors()
+        {
+            foreach (var subscription in _subscriptions)
+            {
+                subscription.PropertyChanged -= _propertyChangedHandler;
+            }
+            _subscriptions.Clear();
+        }
+
+        private void OnPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (!e.IsEffectiveValueChange)
+                return;
+
+            bool shouldNotify = false;
+
+            if (e.Property == Visual.RenderTransformProperty || e.Property == Visual.BoundsProperty)
+            {
+                shouldNotify = true;
+            }
+            else if (_includeClip)
+            {
+                if (e.Property == Visual.ClipToBoundsProperty ||
+                    e.Property == Visual.ClipProperty) shouldNotify = true;
+            }
+            
+            if (shouldNotify)
+            {
+                _changed();
+            }
+        }
+
+        private void OnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+        {
+            SubscribeToAncestors();
+            _changed();
+        }
+
+        private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+        {
+            UnsubscribeFromAncestors();
+            _changed();
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+                return;
+
+            _isDisposed = true;
+            UnsubscribeFromAncestors();
+            _visual.AttachedToVisualTree -= OnAttachedToVisualTree;
+            _visual.DetachedFromVisualTree -= OnDetachedFromVisualTree;
+        }
+    }
+
+    public static Geometry? CalculateAdornerClip(Visual adornedElement)
+    {
+        // Walk ancestor stack and calculate clip geometry relative to the current visual.
+        // If ClipToBounds = true, add extra RectangleGeometry for Bounds.Size
+        
+        Geometry? result = null;
+        var ancestor = adornedElement.VisualParent;
+
+        while (ancestor != null)
+        {
+            if (ancestor is Visual visualAncestor)
+            {
+                Geometry? ancestorClip = null;
+
+                // Check if ancestor has ClipToBounds enabled
+                if (visualAncestor.ClipToBounds)
+                {
+                    ancestorClip = new RectangleGeometry(new Rect(visualAncestor.Bounds.Size));
+                }
+
+                // Check if ancestor has explicit Clip geometry
+                if (visualAncestor.Clip != null)
+                {
+                    if (ancestorClip != null)
+                    {
+                        ancestorClip = new CombinedGeometry(GeometryCombineMode.Intersect, ancestorClip, visualAncestor.Clip);
+                    }
+                    else
+                    {
+                        ancestorClip = visualAncestor.Clip;
+                    }
+                }
+
+                // Transform the clip geometry to adorned element's coordinate space
+                if (ancestorClip != null)
+                {
+                    var transform = visualAncestor.TransformToVisual(adornedElement);
+                    if (transform.HasValue && !transform.Value.IsIdentity)
+                    {
+                        ancestorClip = ancestorClip.Clone();
+                        ancestorClip.Transform = new MatrixTransform(transform.Value);
+                    }
+
+                    // Combine with existing result
+                    if (result != null)
+                    {
+                        result = new CombinedGeometry(GeometryCombineMode.Intersect, result, ancestorClip);
+                    }
+                    else
+                    {
+                        result = ancestorClip;
+                    }
+                }
+            }
+
+            ancestor = ancestor.VisualParent;
+        }
+
+        return result;
+    }
+    
+}

--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -233,11 +233,18 @@ namespace Avalonia.Controls.Primitives
                     
                     if (adorned != null)
                     {
+                        child.Arrange(new(adorned.Bounds.Size));
                         var transform = adorned.TransformToVisual(this);
+                        // If somebody decides that having Margin on an adorner is a good idea,
+                        // we need to compensate for element being positioned at non-(0,0) coords.
+                        if (transform != null && child.Bounds.Position != default)
+                        {
+                            transform = Matrix.CreateTranslation(child.Bounds.Position) * transform.Value *
+                                        Matrix.CreateTranslation(-child.Bounds.Position);
+                        }
                         child.RenderTransform = new MatrixTransform(transform ?? default);
                         child.RenderTransformOrigin = new RelativePoint(new Point(0, 0), RelativeUnit.Absolute);
                         UpdateClip(child, adorned, isClipEnabled);
-                        child.Arrange(new(adorned.Bounds.Size));
                     }
                     else
                     {

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -470,7 +470,7 @@ namespace Avalonia.Controls.Primitives
 
             if (InheritsTransform)
             {
-                TransformTrackingHelper.Track(placementTarget, PlacementTargetTransformChanged)
+                TransformTrackingHelper.Track(placementTarget, true, PlacementTargetTransformChanged)
                     .DisposeWith(handlerCleanup);
             }
             else

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
@@ -571,16 +571,8 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             var target = positionRequest.Target;
             if (target == null)
                 throw new InvalidOperationException("Placement mode is not Pointer and PlacementTarget is null");
-            Matrix? matrix;
-            if (TryGetAdorner(target, out var adorned, out var adornerLayer))
-            {
-                matrix = adorned!.TransformToVisual(topLevel) * target.TransformToVisual(adornerLayer!);
-            }
-            else
-            {
-                matrix = target.TransformToVisual(topLevel);
-            }
-
+            Matrix? matrix = target.TransformToVisual(topLevel);
+            
             if (matrix == null)
             {
                 if (target.GetVisualRoot() == null)
@@ -591,25 +583,6 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             var bounds = new Rect(default, target.Bounds.Size);
             var anchorRect = positionRequest.AnchorRect ?? bounds;
             return anchorRect.Intersect(bounds).TransformToAABB(matrix.Value);
-        }
-
-        private static bool TryGetAdorner(Visual target, out Visual? adorned, out Visual? adornerLayer)
-        {
-            var element = target;
-            while (element != null)
-            {
-                if (AdornerLayer.GetAdornedElement(element) is { } adornedElement)
-                {
-                    adorned = adornedElement;
-                    adornerLayer = AdornerLayer.GetAdornerLayer(adorned);
-                    return true;
-                }
-                element = element.VisualParent;
-            }
-
-            adorned = null;
-            adornerLayer = null;
-            return false;
         }
     }
 


### PR DESCRIPTION
During migration from DeferredRenderer to the current composition engine, we've also fixed a bug with adorners being out of sync with adorned elements (off by one frame). 

The fix was implemented by hardcoding adorners into the compositor and having a separate pass for them which made them sort of guaranteed to be in sync. However it is still a hack.

The original issue was caused by our layout pass not supporting changes being made during the same pass. Now that we've implemented MediaContext infra from WPF this is no longer a problem.

This PR moves adorner handling back to the UI thread.