### PR TITLE
Enable nullability in Base/Markup/Markup.Xaml unit tests

### DIFF
--- a/src/Avalonia.Base/Media/IGlyphTypeface.cs
+++ b/src/Avalonia.Base/Media/IGlyphTypeface.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Avalonia.Metadata;
 
 namespace Avalonia.Media
@@ -109,6 +110,6 @@ namespace Avalonia.Media
         /// <param name="tag">The table tag to get the data for.</param>
         /// <param name="table">The contents of the table data for the specified tag.</param>
         /// <returns>Returns <c>true</c> if the content exists, otherwise <c>false</c>.</returns>
-        bool TryGetTable(uint tag, out byte[] table);
+        bool TryGetTable(uint tag, [NotNullWhen(true)] out byte[]? table);
     }
 }

--- a/src/Avalonia.Base/Utilities/StringSplitter.cs
+++ b/src/Avalonia.Base/Utilities/StringSplitter.cs
@@ -21,7 +21,7 @@ internal static class StringSplitter
     /// <param name="closingBracket">The character that closes a bracketed section. <c>)</c> by default.</param>
     /// <param name="options">Options for trimming entries and removing empty entries.</param>
     /// <returns>An array of split segments. Returns an empty array if the input is null or only whitespace.</returns>
-    public static string[] SplitRespectingBrackets(string s, char separator,
+    public static string[] SplitRespectingBrackets(string? s, char separator,
         char openingBracket = DefaultOpeningParenthesis, char closingBracket = DefaultClosingParenthesis,
         StringSplitOptions options = StringSplitOptions.None) =>
         SplitRespectingBrackets(s, [separator], openingBracket, closingBracket, options);
@@ -36,7 +36,7 @@ internal static class StringSplitter
     /// <param name="closingBracket">The character that closes a bracketed section. <c>)</c> by default.</param>
     /// <param name="options">Options for trimming entries and removing empty entries.</param>
     /// <returns>An array of split segments. Returns an empty array if the input is null or only whitespace.</returns>
-    public static string[] SplitRespectingBrackets(string s, ReadOnlySpan<char> separators,
+    public static string[] SplitRespectingBrackets(string? s, ReadOnlySpan<char> separators,
         char openingBracket = DefaultOpeningParenthesis, char closingBracket = DefaultClosingParenthesis,
         StringSplitOptions options = StringSplitOptions.None)
     {

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/ExpressionNodeFactory.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/ExpressionNodeFactory.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Markup.Parsers
 #endif
         public static List<ExpressionNode>? CreateFromAst(
             List<BindingExpressionGrammar.INode> astNodes,
-            Func<string?, string, Type>? typeResolver,
+            Func<string?, string, Type?>? typeResolver,
             INameScope? nameScope,
             out bool isRooted)
         {
@@ -111,7 +111,7 @@ namespace Avalonia.Markup.Parsers
         }
 
         private static AvaloniaPropertyAccessorNode AttachedPropertyNode(
-            Func<string?, string, Type>? typeResolver,
+            Func<string?, string, Type?>? typeResolver,
             BindingExpressionGrammar.AttachedPropertyNameNode attached)
         {
             var type = LookupType(typeResolver, attached.Namespace, attached.TypeName);
@@ -121,7 +121,7 @@ namespace Avalonia.Markup.Parsers
         }
 
         private static LogicalAncestorElementNode LogicalAncestorNode(
-            Func<string?, string, Type>? typeResolver,
+            Func<string?, string, Type?>? typeResolver,
             BindingExpressionGrammar.AncestorNode ancestor)
         {
             Type? type = null;
@@ -135,7 +135,7 @@ namespace Avalonia.Markup.Parsers
         }
 
         private static Type LookupType(
-            Func<string?, string, Type>? typeResolver,
+            Func<string?, string, Type?>? typeResolver,
             string? @namespace,
             string? name)
         {

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorParser.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorParser.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Markup.Parsers
     /// </summary>
     internal class SelectorParser
     {
-        private readonly Func<string, string, Type> _typeResolver;
+        private readonly Func<string, string, Type?> _typeResolver;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SelectorParser"/> class.
@@ -23,7 +23,7 @@ namespace Avalonia.Markup.Parsers
         /// a type name and a XML namespace prefix and a type name, and should return the resolved
         /// type or throw an exception.
         /// </param>
-        public SelectorParser(Func<string, string, Type> typeResolver)
+        public SelectorParser(Func<string, string, Type?> typeResolver)
         {
             _typeResolver = typeResolver;
         }

--- a/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
+++ b/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
@@ -355,7 +355,7 @@ namespace Avalonia.Skia
             GC.SuppressFinalize(this);
         }
 
-        public bool TryGetTable(uint tag, out byte[] table)
+        public bool TryGetTable(uint tag, [NotNullWhen(true)] out byte[]? table)
         {
             return SKTypeface.TryGetTableData(tag, out table);
         }

--- a/tests/Avalonia.Base.UnitTests/Animation/AnimatableTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Animation/AnimatableTests.cs
@@ -98,7 +98,7 @@ namespace Avalonia.Base.UnitTests.Animation
         [Theory]
         [InlineData(null)] //null value
         [InlineData("stringValue")] //string value
-        public void Invalid_Values_In_Animation_Should_Not_Crash_Animations(object invalidValue)
+        public void Invalid_Values_In_Animation_Should_Not_Crash_Animations(object? invalidValue)
         {
             var keyframe1 = new KeyFrame()
             {
@@ -226,7 +226,7 @@ namespace Avalonia.Base.UnitTests.Animation
                 0.5));
             target.Invocations.Clear();
 
-            var root = (TestRoot)control.Parent;
+            var root = (TestRoot?)control.Parent;
             Assert.NotNull(root);
             root.Child = null;
             control.Opacity = 0.8;
@@ -675,8 +675,8 @@ namespace Avalonia.Base.UnitTests.Animation
         }
 
         private static Control CreateStyledControl(
-            ITransition transition1 = null,
-            ITransition transition2 = null)
+            ITransition? transition1 = null,
+            ITransition? transition2 = null)
         {
             transition1 = transition1 ?? CreateTarget().Object;
             transition2 = transition2 ?? CreateTransition(Layoutable.WidthProperty).Object;

--- a/tests/Avalonia.Base.UnitTests/Animation/KeySplineTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Animation/KeySplineTests.cs
@@ -19,9 +19,7 @@ namespace Avalonia.Base.UnitTests.Animation
         {
             var conv = new KeySplineTypeConverter();
 
-            var keySpline = (KeySpline)conv.ConvertFrom(input);
-
-            Assert.NotNull(keySpline);
+            var keySpline = Assert.IsAssignableFrom<KeySpline>(conv.ConvertFrom(input));
 
             Assert.Equal(1, keySpline.ControlPointX1);
             Assert.Equal(2, keySpline.ControlPointY1);
@@ -36,7 +34,7 @@ namespace Avalonia.Base.UnitTests.Animation
         {
             var conv = new KeySplineTypeConverter();
 
-            Assert.ThrowsAny<Exception>(() => (KeySpline)conv.ConvertFrom(input));
+            Assert.ThrowsAny<Exception>(() => (KeySpline?)conv.ConvertFrom(input));
         }
 
         [Theory]

--- a/tests/Avalonia.Base.UnitTests/Animation/SpringTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Animation/SpringTests.cs
@@ -16,7 +16,7 @@ public class SpringTests
     {
         var conv = new SpringTypeConverter();
 
-        var spring = (Spring)conv.ConvertFrom(input);
+        var spring = Assert.IsAssignableFrom<Spring>(conv.ConvertFrom(input));
 
         Assert.NotNull(spring);
         Assert.Equal(1, spring.Mass);
@@ -32,7 +32,7 @@ public class SpringTests
     {
         var conv = new SpringTypeConverter();
 
-        Assert.ThrowsAny<Exception>(() => (Spring)conv.ConvertFrom(input));
+        Assert.ThrowsAny<Exception>(() => (Spring?)conv.ConvertFrom(input));
     }
 
     [Fact]

--- a/tests/Avalonia.Base.UnitTests/Animation/TestClock.cs
+++ b/tests/Avalonia.Base.UnitTests/Animation/TestClock.cs
@@ -7,7 +7,7 @@ namespace Avalonia.Base.UnitTests.Animation
     {
         private TimeSpan _curTime;
 
-        private IObserver<TimeSpan> _observer;
+        private IObserver<TimeSpan>? _observer;
 
         public PlayState PlayState { get; set; } = PlayState.Run;
 

--- a/tests/Avalonia.Base.UnitTests/Avalonia.Base.UnitTests.csproj
+++ b/tests/Avalonia.Base.UnitTests/Avalonia.Base.UnitTests.csproj
@@ -12,6 +12,7 @@
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\Microsoft.Reactive.Testing.props" />
   <Import Project="..\..\build\SharedVersion.props" />
+  <Import Project="..\..\build\NullableEnable.props" />
   <ItemGroup>
     <EmbeddedResource Include="..\Avalonia.RenderTests\**\*.ttf" />
     <EmbeddedResource Remove="..\Avalonia.RenderTests\Assets\NotoColorEmoji.ttf" />

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Direct.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Direct.cs
@@ -79,8 +79,8 @@ namespace Avalonia.Base.UnitTests
 
             target.PropertyChanged += (s, e) =>
                 raised = e.Property == Class1.FooProperty &&
-                         (string)e.OldValue == "initial" &&
-                         (string)e.NewValue == "newvalue" &&
+                         (string?)e.OldValue == "initial" &&
+                         (string?)e.NewValue == "newvalue" &&
                          e.Priority == BindingPriority.LocalValue;
 
             target.SetValue(Class1.FooProperty, "newvalue");
@@ -131,13 +131,13 @@ namespace Avalonia.Base.UnitTests
         public void Bind_Raises_PropertyChanged()
         {
             var target = new Class1();
-            var source = new Subject<BindingValue<string>>();
+            var source = new Subject<BindingValue<string?>>();
             bool raised = false;
 
             target.PropertyChanged += (s, e) =>
                 raised = e.Property == Class1.FooProperty &&
-                         (string)e.OldValue == "initial" &&
-                         (string)e.NewValue == "newvalue" &&
+                         (string?)e.OldValue == "initial" &&
+                         (string?)e.NewValue == "newvalue" &&
                          e.Priority == BindingPriority.LocalValue;
 
             target.Bind(Class1.FooProperty, source);
@@ -150,7 +150,7 @@ namespace Avalonia.Base.UnitTests
         public void PropertyChanged_Not_Raised_When_Value_Unchanged()
         {
             var target = new Class1();
-            var source = new Subject<BindingValue<string>>();
+            var source = new Subject<BindingValue<string?>>();
             var raised = 0;
 
             target.PropertyChanged += (s, e) => ++raised;
@@ -189,8 +189,8 @@ namespace Avalonia.Base.UnitTests
                 Assert.Same(target, s);
                 Assert.Equal(BindingPriority.LocalValue, e.Priority);
                 Assert.Equal(Class1.FooProperty, e.Property);
-                Assert.Equal("newvalue", (string)e.OldValue);
-                Assert.Equal("unset", (string)e.NewValue);
+                Assert.Equal("newvalue", (string?)e.OldValue);
+                Assert.Equal("unset", (string?)e.NewValue);
                 ++raised;
             };
 
@@ -203,7 +203,7 @@ namespace Avalonia.Base.UnitTests
         public void GetObservable_Returns_Values()
         {
             var target = new Class1();
-            List<string> values = new List<string>();
+            var values = new List<string?>();
 
             target.GetObservable(Class1.FooProperty).Subscribe(x => values.Add(x));
             target.Foo = "newvalue";
@@ -428,11 +428,11 @@ namespace Avalonia.Base.UnitTests
         public void Binding_Error_Reverts_To_Default_Value()
         {
             var target = new Class1();
-            var source = new Subject<BindingValue<string>>();
+            var source = new Subject<BindingValue<string?>>();
 
             target.Bind(Class1.FooProperty, source);
             source.OnNext("initial");
-            source.OnNext(BindingValue<string>.BindingError(new InvalidOperationException("Foo")));
+            source.OnNext(BindingValue<string?>.BindingError(new InvalidOperationException("Foo")));
 
             Assert.Equal("unset", target.GetValue(Class1.FooProperty));
         }
@@ -441,11 +441,11 @@ namespace Avalonia.Base.UnitTests
         public void Binding_Error_With_FallbackValue_Causes_Target_Update()
         {
             var target = new Class1();
-            var source = new Subject<BindingValue<string>>();
+            var source = new Subject<BindingValue<string?>>();
 
             target.Bind(Class1.FooProperty, source);
             source.OnNext("initial");
-            source.OnNext(BindingValue<string>.BindingError(new InvalidOperationException("Foo"), "bar"));
+            source.OnNext(BindingValue<string?>.BindingError(new InvalidOperationException("Foo"), "bar"));
 
             Assert.Equal("bar", target.GetValue(Class1.FooProperty));
         }
@@ -454,11 +454,11 @@ namespace Avalonia.Base.UnitTests
         public void DataValidationError_Does_Not_Cause_Target_Update()
         {
             var target = new Class1();
-            var source = new Subject<BindingValue<string>>();
+            var source = new Subject<BindingValue<string?>>();
 
             target.Bind(Class1.FooProperty, source);
             source.OnNext("initial");
-            source.OnNext(BindingValue<string>.DataValidationError(new InvalidOperationException("Foo")));
+            source.OnNext(BindingValue<string?>.DataValidationError(new InvalidOperationException("Foo")));
 
             Assert.Equal("initial", target.GetValue(Class1.FooProperty));
         }
@@ -467,11 +467,11 @@ namespace Avalonia.Base.UnitTests
         public void DataValidationError_With_FallbackValue_Causes_Target_Update()
         {
             var target = new Class1();
-            var source = new Subject<BindingValue<string>>();
+            var source = new Subject<BindingValue<string?>>();
 
             target.Bind(Class1.FooProperty, source);
             source.OnNext("initial");
-            source.OnNext(BindingValue<string>.DataValidationError(new InvalidOperationException("Foo"), "bar"));
+            source.OnNext(BindingValue<string?>.DataValidationError(new InvalidOperationException("Foo"), "bar"));
 
             Assert.Equal("bar", target.GetValue(Class1.FooProperty));
         }
@@ -480,11 +480,11 @@ namespace Avalonia.Base.UnitTests
         public void BindingError_With_FallbackValue_Causes_Target_Update()
         {
             var target = new Class1();
-            var source = new Subject<BindingValue<string>>();
+            var source = new Subject<BindingValue<string?>>();
 
             target.Bind(Class1.FooProperty, source);
             source.OnNext("initial");
-            source.OnNext(BindingValue<string>.BindingError(new InvalidOperationException("Foo"), "fallback"));
+            source.OnNext(BindingValue<string?>.BindingError(new InvalidOperationException("Foo"), "fallback"));
 
             Assert.Equal("fallback", target.GetValue(Class1.FooProperty));
         }
@@ -589,15 +589,15 @@ namespace Avalonia.Base.UnitTests
 
         private class Class1 : AvaloniaObject
         {
-            public static readonly DirectProperty<Class1, string> FooProperty =
-                AvaloniaProperty.RegisterDirect<Class1, string>(
+            public static readonly DirectProperty<Class1, string?> FooProperty =
+                AvaloniaProperty.RegisterDirect<Class1, string?>(
                     nameof(Foo),
                     o => o.Foo,
                     (o, v) => o.Foo = v,
                     unsetValue: "unset");
 
-            public static readonly DirectProperty<Class1, string> BarProperty =
-                AvaloniaProperty.RegisterDirect<Class1, string>(nameof(Bar), o => o.Bar);
+            public static readonly DirectProperty<Class1, string?> BarProperty =
+                AvaloniaProperty.RegisterDirect<Class1, string?>(nameof(Bar), o => o.Bar);
 
             public static readonly DirectProperty<Class1, int> BazProperty =
                 AvaloniaProperty.RegisterDirect<Class1, int>(
@@ -612,26 +612,26 @@ namespace Avalonia.Base.UnitTests
                     o => o.DoubleValue,
                     (o, v) => o.DoubleValue = v);
 
-            public static readonly DirectProperty<Class1, object> FrankProperty =
-                AvaloniaProperty.RegisterDirect<Class1, object>(
+            public static readonly DirectProperty<Class1, object?> FrankProperty =
+                AvaloniaProperty.RegisterDirect<Class1, object?>(
                     nameof(Frank),
                     o => o.Frank,
                     (o, v) => o.Frank = v,
                     unsetValue: "Kups");
 
-            private string _foo = "initial";
-            private readonly string _bar = "bar";
+            private string? _foo = "initial";
+            private readonly string? _bar = "bar";
             private int _baz = 5;
             private double _doubleValue;
-            private object _frank;
+            private object? _frank;
 
-            public string Foo
+            public string? Foo
             {
                 get { return _foo; }
                 set { SetAndRaise(FooProperty, ref _foo, value); }
             }
 
-            public string Bar
+            public string? Bar
             {
                 get { return _bar; }
             }
@@ -648,7 +648,7 @@ namespace Avalonia.Base.UnitTests
                 set { SetAndRaise(DoubleValueProperty, ref _doubleValue, value); }
             }
 
-            public object Frank
+            public object? Frank
             {
                 get { return _frank; }
                 set { SetAndRaise(FrankProperty, ref _frank, value); }
@@ -657,16 +657,16 @@ namespace Avalonia.Base.UnitTests
 
         private class Class2 : AvaloniaObject
         {
-            public static readonly DirectProperty<Class2, string> FooProperty =
+            public static readonly DirectProperty<Class2, string?> FooProperty =
                 Class1.FooProperty.AddOwner<Class2>(o => o.Foo, (o, v) => o.Foo = v);
 
-            private string _foo = "initial2";
+            private string? _foo = "initial2";
 
             static Class2()
             {
             }
 
-            public string Foo
+            public string? Foo
             {
                 get { return _foo; }
                 set { SetAndRaise(FooProperty, ref _foo, value); }
@@ -681,7 +681,7 @@ namespace Avalonia.Base.UnitTests
 
             private double _value;
 
-            public event PropertyChangedEventHandler PropertyChanged;
+            public event PropertyChangedEventHandler? PropertyChanged;
 
             public double Value
             {

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_GetValue.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_GetValue.cs
@@ -119,9 +119,9 @@ namespace Avalonia.Base.UnitTests
                 FooProperty.OverrideDefaultValue(typeof(Class2), "foooverride");
             }
 
-            public Class1 Parent
+            public Class1? Parent
             {
-                get { return (Class1)InheritanceParent; }
+                get { return (Class1?)InheritanceParent; }
                 set { InheritanceParent = value; }
             }
         }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Inheritance.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Inheritance.cs
@@ -132,8 +132,8 @@ namespace Avalonia.Base.UnitTests
             child.PropertyChanged += (s, e) =>
                 raised = s == child &&
                          e.Property == Class1.BazProperty &&
-                         (string)e.OldValue == "bazdefault" &&
-                         (string)e.NewValue == "changed" &&
+                         (string?)e.OldValue == "bazdefault" &&
+                         (string?)e.NewValue == "changed" &&
                          e.Priority == BindingPriority.Inherited;
 
             child.Parent = parent;
@@ -156,8 +156,8 @@ namespace Avalonia.Base.UnitTests
             child.PropertyChanged += (s, e) =>
                 raised = s == child &&
                          e.Property == Class1.BazProperty &&
-                         (string)e.OldValue == "bazdefault" &&
-                         (string)e.NewValue == "changed2" &&
+                         (string?)e.OldValue == "bazdefault" &&
+                         (string?)e.NewValue == "changed2" &&
                          e.Priority == BindingPriority.Inherited;
 
             child.Parent = parent;
@@ -178,8 +178,8 @@ namespace Avalonia.Base.UnitTests
             child.PropertyChanged += (s, e) =>
                 raised = s == child &&
                          e.Property == AttachedOwner.AttachedProperty &&
-                         (string)e.OldValue == null &&
-                         (string)e.NewValue == "changed";
+                         (string?)e.OldValue == null &&
+                         (string?)e.NewValue == "changed";
 
             child.Parent = parent;
 
@@ -216,8 +216,8 @@ namespace Avalonia.Base.UnitTests
             child.PropertyChanged += (s, e) =>
                 raised = s == child &&
                          e.Property == Class1.BazProperty &&
-                         (string)e.OldValue == "bazdefault" &&
-                         (string)e.NewValue == "changed";
+                         (string?)e.OldValue == "bazdefault" &&
+                         (string?)e.NewValue == "changed";
             child.Parent = parent;
 
             parent.SetValue(Class1.BazProperty, "changed");
@@ -237,8 +237,8 @@ namespace Avalonia.Base.UnitTests
             child.PropertyChanged += (s, e) =>
                 raised = s == child &&
                          e.Property == AttachedOwner.AttachedProperty &&
-                         (string)e.OldValue == null &&
-                         (string)e.NewValue == "changed";
+                         (string?)e.OldValue == null &&
+                         (string?)e.NewValue == "changed";
             child.Parent = parent;
 
             parent.SetValue(AttachedOwner.AttachedProperty, "changed");
@@ -260,8 +260,8 @@ namespace Avalonia.Base.UnitTests
             child.PropertyChanged += (s, e) =>
                 raised = s == child &&
                          e.Property == Class1.BazProperty &&
-                         (string)e.OldValue == "changed" &&
-                         (string)e.NewValue == "bazdefault";
+                         (string?)e.OldValue == "changed" &&
+                         (string?)e.NewValue == "bazdefault";
 
             parent.ClearValue(Class1.BazProperty);
 
@@ -379,9 +379,9 @@ namespace Avalonia.Base.UnitTests
                 FooProperty.OverrideDefaultValue(typeof(Class2), "foooverride");
             }
 
-            public Class1 Parent
+            public Class1? Parent
             {
-                get { return (Class1)InheritanceParent; }
+                get { return (Class1?)InheritanceParent; }
                 set { InheritanceParent = value; }
             }
         }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Metadata.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Metadata.cs
@@ -61,15 +61,15 @@ namespace Avalonia.Base.UnitTests
 
         private class Class1 : AvaloniaObject
         {
-            public static readonly StyledProperty<string> StyledProperty =
-                AvaloniaProperty.Register<Class1, string>("Styled", "foo");
+            public static readonly StyledProperty<string?> StyledProperty =
+                AvaloniaProperty.Register<Class1, string?>("Styled", "foo");
 
-            public static readonly DirectProperty<Class1, string> DirectProperty =
-                AvaloniaProperty.RegisterDirect<Class1, string>("Styled", o => o.Direct, unsetValue: "foo");
+            public static readonly DirectProperty<Class1, string?> DirectProperty =
+                AvaloniaProperty.RegisterDirect<Class1, string?>("Styled", o => o.Direct, unsetValue: "foo");
 
-            private string _direct = default;
+            private string? _direct = null;
 
-            public string Direct
+            public string? Direct
             {
                 get => _direct;
             }
@@ -80,26 +80,26 @@ namespace Avalonia.Base.UnitTests
             static Class2()
             {
                 StyledProperty.OverrideDefaultValue<Class2>("bar");
-                DirectProperty.OverrideMetadata<Class2>(new DirectPropertyMetadata<string>("bar"));
+                DirectProperty.OverrideMetadata<Class2>(new DirectPropertyMetadata<string?>("bar"));
             }
         }
 
         private class Class3 : AvaloniaObject
         {
-            public static readonly StyledProperty<string> StyledProperty =
+            public static readonly StyledProperty<string?> StyledProperty =
                 Class1.StyledProperty.AddOwner<Class3>();
 
-            public static readonly DirectProperty<Class3, string> DirectProperty =
+            public static readonly DirectProperty<Class3, string?> DirectProperty =
                 Class1.DirectProperty.AddOwner<Class3>(o => o.Direct, unsetValue: "baz");
 
-            private string _direct = default;
+            private string? _direct = null;
 
             static Class3()
             {
                 StyledProperty.OverrideDefaultValue<Class3>("baz");
             }
 
-            public string Direct
+            public string? Direct
             {
                 get => _direct;
             }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_MultiBinding.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_MultiBinding.cs
@@ -76,7 +76,7 @@ namespace Avalonia.Base.UnitTests
         {
             var target = new Class1();
 
-            var b = new Subject<object>();
+            var b = new Subject<object?>();
 
             var mb = new MultiBinding()
             {
@@ -104,7 +104,7 @@ namespace Avalonia.Base.UnitTests
         {
             var target = new Class1();
 
-            var b = new Subject<object>();
+            var b = new Subject<object?>();
 
             var mb = new MultiBinding()
             {
@@ -128,7 +128,7 @@ namespace Avalonia.Base.UnitTests
         {
             var target = new FuncMultiValueConverter<string, string>(v => string.Join(",", v.ToArray()));
 
-            object value = target.Convert(new[] { "Foo", "Bar", "Baz" }, typeof(string), null, CultureInfo.InvariantCulture);
+            object? value = target.Convert(new[] { "Foo", "Bar", "Baz" }, typeof(string), null, CultureInfo.InvariantCulture);
 
             Assert.Equal("Foo,Bar,Baz", value);
 
@@ -142,14 +142,14 @@ namespace Avalonia.Base.UnitTests
         {
             var target = new FuncMultiValueConverter<StringValueTypeWrapper, string>(v => string.Join(",", v.ToArray()));
 
-            IList<object> create(string[] values) =>
-                values.Select(v => (object)(v != null ? new StringValueTypeWrapper() { Value = v } : default)).ToList();
+            IList<object?> Create(string?[] values) =>
+                values.Select(v => (object?)(v != null ? new StringValueTypeWrapper() { Value = v } : default)).ToList();
 
-            object value = target.Convert(create(new[] { "Foo", "Bar", "Baz" }), typeof(string), null, CultureInfo.InvariantCulture);
+            var value = target.Convert(Create(new[] { "Foo", "Bar", "Baz" }), typeof(string), null, CultureInfo.InvariantCulture);
 
             Assert.Equal("Foo,Bar,Baz", value);
 
-            value = target.Convert(create(new[] { null, "Bar", "Baz" }), typeof(string), null, CultureInfo.InvariantCulture);
+            value = target.Convert(Create(new[] { null, "Bar", "Baz" }), typeof(string), null, CultureInfo.InvariantCulture);
 
             Assert.Equal(",Bar,Baz", value);
         }
@@ -157,9 +157,9 @@ namespace Avalonia.Base.UnitTests
         [Fact]
         public void MultiValueConverter_Supports_Indexing_The_Parameters()
         {
-            var target = new FuncMultiValueConverter<string, string>(v => v[0]);
+            var target = new FuncMultiValueConverter<string, string?>(v => v[0]);
 
-            object value = target.Convert(new[] { "Foo", "Bar", "Baz" }, typeof(string), null, CultureInfo.InvariantCulture);
+            var value = target.Convert(new[] { "Foo", "Bar", "Baz" }, typeof(string), null, CultureInfo.InvariantCulture);
 
             Assert.Equal("Foo", value);
 

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetCurrentValue.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetCurrentValue.cs
@@ -516,9 +516,9 @@ namespace Avalonia.Base.UnitTests
 
         private class ViewModel : NotifyingBase
         {
-            private string _value;
+            private string? _value;
 
-            public string Value
+            public string? Value
             {
                 get => _value;
                 set

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetValue.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetValue.cs
@@ -44,8 +44,8 @@ namespace Avalonia.Base.UnitTests
                 Assert.Same(target, s);
                 Assert.Equal(BindingPriority.Unset, e.Priority);
                 Assert.Equal(Class1.FooProperty, e.Property);
-                Assert.Equal("newvalue", (string)e.OldValue);
-                Assert.Equal("foodefault", (string)e.NewValue);
+                Assert.Equal("newvalue", (string?)e.OldValue);
+                Assert.Equal("foodefault", (string?)e.NewValue);
                 ++raised;
             };
 
@@ -113,8 +113,8 @@ namespace Avalonia.Base.UnitTests
             {
                 raised = s == target &&
                          e.Property == Class1.FooProperty &&
-                         (string)e.OldValue == "foodefault" &&
-                         (string)e.NewValue == "newvalue";
+                         (string?)e.OldValue == "foodefault" &&
+                         (string?)e.NewValue == "newvalue";
             };
 
             target.SetValue(Class1.FooProperty, "newvalue");
@@ -132,8 +132,8 @@ namespace Avalonia.Base.UnitTests
             {
                 raised = s == target &&
                          e.Property == Class1.FooProperty &&
-                         (string)e.OldValue == "foodefault" &&
-                         (string)e.NewValue == "newvalue";
+                         (string?)e.OldValue == "foodefault" &&
+                         (string?)e.NewValue == "newvalue";
             };
 
             target.SetValue(Class1.FooProperty, "newvalue", BindingPriority.Style);
@@ -331,6 +331,7 @@ namespace Avalonia.Base.UnitTests
             Class1 target = new Class1();
 
             var d = target.SetValue(Class1.FooProperty, "foo", BindingPriority.Style);
+            Assert.NotNull(d);
             d.Dispose();
 
             Assert.Equal("foodefault", target.GetValue(Class1.FooProperty));
@@ -343,6 +344,7 @@ namespace Avalonia.Base.UnitTests
 
             target.SetValue(Class1.FooProperty, "foo", BindingPriority.Style);
             var d = target.SetValue(Class1.FooProperty, "bar", BindingPriority.Style);
+            Assert.NotNull(d);
             d.Dispose();
 
             Assert.Equal("foo", target.GetValue(Class1.FooProperty));
@@ -355,6 +357,7 @@ namespace Avalonia.Base.UnitTests
 
             target.SetValue(Class1.FooProperty, "foo", BindingPriority.LocalValue);
             var d = target.SetValue(Class1.FooProperty, "bar", BindingPriority.Animation);
+            Assert.NotNull(d);
             d.Dispose();
 
             Assert.Equal("foo", target.GetValue(Class1.FooProperty));
@@ -380,9 +383,9 @@ namespace Avalonia.Base.UnitTests
             public static readonly StyledProperty<double?> FredProperty =
                 AvaloniaProperty.Register<Class2, double?>("Fred");
 
-            public Class1 Parent
+            public Class1? Parent
             {
-                get { return (Class1)InheritanceParent; }
+                get { return (Class1?)InheritanceParent; }
                 set { InheritanceParent = value; }
             }
         }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Threading.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Threading.cs
@@ -143,8 +143,8 @@ namespace Avalonia.Base.UnitTests
             public static readonly StyledProperty<string> StyledProperty =
                 AvaloniaProperty.Register<Class1, string>("Foo", "foodefault");
 
-            public static readonly DirectProperty<Class1, string> DirectProperty =
-                AvaloniaProperty.RegisterDirect<Class1, string>("Qux", _ => null, (o, v) => { });
+            public static readonly DirectProperty<Class1, string?> DirectProperty =
+                AvaloniaProperty.RegisterDirect<Class1, string?>("Qux", _ => null, (o, v) => { });
         }
 
         private class TestDipatcherImpl : IDispatcherImpl
@@ -157,16 +157,14 @@ namespace Avalonia.Base.UnitTests
 
             public bool CurrentThreadIsLoopThread { get; set; }
 
-#pragma warning disable 67
-            public event Action Signaled;
-            public event Action Timer;
+            public event Action? Signaled { add { } remove { } }
+            public event Action? Timer { add { } remove { } }
             public long Now => 0;
             public void UpdateTimer(long? dueTimeInMs)
             {
                 throw new NotImplementedException();
             }
             public void Signal() => throw new NotImplementedException();
-#pragma warning restore 67
 
             
         }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaPropertyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaPropertyTests.cs
@@ -72,7 +72,6 @@ namespace Avalonia.Base.UnitTests
         public void OverrideMetadata_Should_Merge_Values()
         {
             var metadata = new TestMetadata(BindingMode.TwoWay);
-            var notify = (Action<AvaloniaObject, bool>)((a, b) => { });
             var overridden = new TestMetadata();
             var target = new TestProperty<string>("test", typeof(Class1), metadata);
 
@@ -107,7 +106,7 @@ namespace Avalonia.Base.UnitTests
         public void Changed_Observable_Fired()
         {
             var target = new Class1();
-            string value = null;
+            string? value = null;
 
             Class1.FooProperty.Changed.Subscribe(x => value = x.NewValue.GetValueOrDefault());
             target.SetValue(Class1.FooProperty, "newvalue");
@@ -119,7 +118,7 @@ namespace Avalonia.Base.UnitTests
         public void Changed_Observable_Fired_Only_On_Effective_Value_Change()
         {
             var target = new Class1();
-            var result = new List<string>();
+            var result = new List<string?>();
 
             Class1.FooProperty.Changed.Subscribe(x => result.Add(x.NewValue.GetValueOrDefault()));
             target.SetValue(Class1.FooProperty, "animated", BindingPriority.Animation);
@@ -149,7 +148,7 @@ namespace Avalonia.Base.UnitTests
             Assert.False(p1 == null);
             Assert.False(null == p1);
             Assert.False(p1.Equals(null));
-            Assert.True((AvaloniaProperty)null == (AvaloniaProperty)null);
+            Assert.True((AvaloniaProperty?)null == (AvaloniaProperty?)null);
         }
 
         [Fact]
@@ -162,11 +161,11 @@ namespace Avalonia.Base.UnitTests
 
         private class TestMetadata : AvaloniaPropertyMetadata
         {
-            public Action<AvaloniaObject> OwnerSpecificAction { get; }
+            public Action<AvaloniaObject>? OwnerSpecificAction { get; }
 
             public TestMetadata(BindingMode defaultBindingMode = BindingMode.Default, 
                 bool? enableDataValidation = null,
-                Action<AvaloniaObject> ownerSpecificAction = null) 
+                Action<AvaloniaObject>? ownerSpecificAction = null)
                 : base(defaultBindingMode, enableDataValidation)
             {
                 OwnerSpecificAction = ownerSpecificAction;
@@ -178,7 +177,7 @@ namespace Avalonia.Base.UnitTests
 
         private class TestProperty<TValue> : AvaloniaProperty<TValue>
         {
-            public TestProperty(string name, Type ownerType, TestMetadata metadata = null)
+            public TestProperty(string name, Type ownerType, TestMetadata? metadata = null)
                 : base(name, ownerType, ownerType, metadata ?? new TestMetadata())
             {
             }
@@ -190,7 +189,7 @@ namespace Avalonia.Base.UnitTests
 
             internal override IDisposable RouteBind(
                 AvaloniaObject o,
-                IObservable<object> source,
+                IObservable<object?> source,
                 BindingPriority priority)
             {
                 throw new NotImplementedException();
@@ -218,13 +217,13 @@ namespace Avalonia.Base.UnitTests
 
             internal override IDisposable RouteSetValue(
                 AvaloniaObject o,
-                object value,
+                object? value,
                 BindingPriority priority)
             {
                 throw new NotImplementedException();
             }
 
-            internal override void RouteSetCurrentValue(AvaloniaObject o, object value)
+            internal override void RouteSetCurrentValue(AvaloniaObject o, object? value)
             {
                 throw new NotImplementedException();
             }

--- a/tests/Avalonia.Base.UnitTests/Collections/AvaloniaDictionaryTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Collections/AvaloniaDictionaryTests.cs
@@ -22,6 +22,7 @@ namespace Avalonia.Base.UnitTests.Collections
             Assert.NotNull(tracker.Args);
             Assert.Equal(NotifyCollectionChangedAction.Add, tracker.Args.Action);
             Assert.Equal(-1, tracker.Args.NewStartingIndex);
+            Assert.NotNull(tracker.Args.NewItems);
             Assert.Equal(1, tracker.Args.NewItems.Count);
             Assert.Equal(new KeyValuePair<string, string>("foo", "bar"), tracker.Args.NewItems[0]);
         }
@@ -48,6 +49,7 @@ namespace Avalonia.Base.UnitTests.Collections
             Assert.NotNull(tracker.Args);
             Assert.Equal(NotifyCollectionChangedAction.Add, tracker.Args.Action);
             Assert.Equal(-1, tracker.Args.NewStartingIndex);
+            Assert.NotNull(tracker.Args.NewItems);
             Assert.Equal(1, tracker.Args.NewItems.Count);
             Assert.Equal(new KeyValuePair<string, string>("foo", "bar"), tracker.Args.NewItems[0]);
         }
@@ -64,6 +66,7 @@ namespace Avalonia.Base.UnitTests.Collections
             Assert.NotNull(tracker.Args);
             Assert.Equal(NotifyCollectionChangedAction.Replace, tracker.Args.Action);
             Assert.Equal(-1, tracker.Args.NewStartingIndex);
+            Assert.NotNull(tracker.Args.NewItems);
             Assert.Equal(1, tracker.Args.NewItems.Count);
             Assert.Equal(new KeyValuePair<string, string>("foo", "bar"), tracker.Args.NewItems[0]);
         }
@@ -103,6 +106,7 @@ namespace Avalonia.Base.UnitTests.Collections
             Assert.NotNull(tracker.Args);
             Assert.Equal(NotifyCollectionChangedAction.Remove, tracker.Args.Action);
             Assert.Equal(-1, tracker.Args.OldStartingIndex);
+            Assert.NotNull(tracker.Args.OldItems);
             Assert.Equal(1, tracker.Args.OldItems.Count);
             Assert.Equal(new KeyValuePair<string, string>("foo", "bar"), tracker.Args.OldItems[0]);
         }
@@ -142,6 +146,7 @@ namespace Avalonia.Base.UnitTests.Collections
             Assert.NotNull(tracker.Args);
             Assert.Equal(NotifyCollectionChangedAction.Remove, tracker.Args.Action);
             Assert.Equal(-1, tracker.Args.OldStartingIndex);
+            Assert.NotNull(tracker.Args.OldItems);
             Assert.Equal(2, tracker.Args.OldItems.Count);
             Assert.Equal(new KeyValuePair<string, string>("foo", "bar"), tracker.Args.OldItems[0]);
         }
@@ -164,7 +169,7 @@ namespace Avalonia.Base.UnitTests.Collections
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                var target = new AvaloniaDictionary<string, string>(null, null);
+                var target = new AvaloniaDictionary<string, string>(null!, null);
             });
         }
 

--- a/tests/Avalonia.Base.UnitTests/Collections/AvaloniaListTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Collections/AvaloniaListTests.cs
@@ -25,7 +25,7 @@ namespace Avalonia.Base.UnitTests.Collections
         {
             var target = new AvaloniaList<int>();
 
-            Assert.Throws<ArgumentNullException>(() => target.AddRange(null));
+            Assert.Throws<ArgumentNullException>(() => target.AddRange(null!));
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace Avalonia.Base.UnitTests.Collections
         {
             var target = new AvaloniaList<int>();
 
-            Assert.Throws<ArgumentNullException>(() => target.RemoveAll(null));
+            Assert.Throws<ArgumentNullException>(() => target.RemoveAll(null!));
         }
 
         [Fact]
@@ -41,7 +41,7 @@ namespace Avalonia.Base.UnitTests.Collections
         {
             var target = new AvaloniaList<int>();
 
-            Assert.Throws<ArgumentNullException>(() => target.InsertRange(1, null));
+            Assert.Throws<ArgumentNullException>(() => target.InsertRange(1, null!));
         }
 
         [Fact]
@@ -140,6 +140,7 @@ namespace Avalonia.Base.UnitTests.Collections
             {
                 Assert.Equal(target, s);
                 Assert.Equal(NotifyCollectionChangedAction.Add, e.Action);
+                Assert.NotNull(e.NewItems);
                 Assert.Equal(new[] { 3 }, e.NewItems.Cast<int>());
                 Assert.Equal(2, e.NewStartingIndex);
 
@@ -161,6 +162,7 @@ namespace Avalonia.Base.UnitTests.Collections
             {
                 Assert.Equal(target, s);
                 Assert.Equal(NotifyCollectionChangedAction.Add, e.Action);
+                Assert.NotNull(e.NewItems);
                 Assert.Equal(new[] { 3, 4 }, e.NewItems.Cast<int>());
                 Assert.Equal(2, e.NewStartingIndex);
 
@@ -198,6 +200,7 @@ namespace Avalonia.Base.UnitTests.Collections
 
             target.CollectionChanged += (sender, args) =>
             {
+                Assert.NotNull(args.NewItems);
                 eventItems.AddRange(args.NewItems.Cast<object>());
             };
             
@@ -216,7 +219,9 @@ namespace Avalonia.Base.UnitTests.Collections
             {
                 Assert.Equal(target, s);
                 Assert.Equal(NotifyCollectionChangedAction.Replace, e.Action);
+                Assert.NotNull(e.OldItems);
                 Assert.Equal(new[] { 2 }, e.OldItems.Cast<int>());
+                Assert.NotNull(e.NewItems);
                 Assert.Equal(new[] { 3 }, e.NewItems.Cast<int>());
                 Assert.Equal(1, e.OldStartingIndex);
                 Assert.Equal(1, e.NewStartingIndex);
@@ -239,6 +244,7 @@ namespace Avalonia.Base.UnitTests.Collections
             {
                 Assert.Equal(target, s);
                 Assert.Equal(NotifyCollectionChangedAction.Add, e.Action);
+                Assert.NotNull(e.NewItems);
                 Assert.Equal(new[] { 3 }, e.NewItems.Cast<int>());
                 Assert.Equal(1, e.NewStartingIndex);
 
@@ -260,6 +266,7 @@ namespace Avalonia.Base.UnitTests.Collections
             {
                 Assert.Equal(target, s);
                 Assert.Equal(NotifyCollectionChangedAction.Add, e.Action);
+                Assert.NotNull(e.NewItems);
                 Assert.Equal(new[] { 3, 4 }, e.NewItems.Cast<int>());
                 Assert.Equal(1, e.NewStartingIndex);
 
@@ -281,6 +288,7 @@ namespace Avalonia.Base.UnitTests.Collections
             {
                 Assert.Equal(target, s);
                 Assert.Equal(NotifyCollectionChangedAction.Remove, e.Action);
+                Assert.NotNull(e.OldItems);
                 Assert.Equal(new[] { 3 }, e.OldItems.Cast<int>());
                 Assert.Equal(2, e.OldStartingIndex);
 
@@ -302,7 +310,9 @@ namespace Avalonia.Base.UnitTests.Collections
             {
                 Assert.Equal(target, s);
                 Assert.Equal(NotifyCollectionChangedAction.Move, e.Action);
+                Assert.NotNull(e.OldItems);
                 Assert.Equal(new[] { 3 }, e.OldItems.Cast<int>());
+                Assert.NotNull(e.NewItems);
                 Assert.Equal(new[] { 3 }, e.NewItems.Cast<int>());
                 Assert.Equal(2, e.OldStartingIndex);
                 Assert.Equal(0, e.NewStartingIndex);
@@ -325,7 +335,9 @@ namespace Avalonia.Base.UnitTests.Collections
             {
                 Assert.Equal(target, s);
                 Assert.Equal(NotifyCollectionChangedAction.Move, e.Action);
+                Assert.NotNull(e.OldItems);
                 Assert.Equal(new[] { 2, 3 }, e.OldItems.Cast<int>());
+                Assert.NotNull(e.NewItems);
                 Assert.Equal(new[] { 2, 3 }, e.NewItems.Cast<int>());
                 Assert.Equal(1, e.OldStartingIndex);
                 Assert.Equal(0, e.NewStartingIndex);
@@ -368,6 +380,7 @@ namespace Avalonia.Base.UnitTests.Collections
             {
                 Assert.Equal(target, s);
                 Assert.Equal(NotifyCollectionChangedAction.Remove, e.Action);
+                Assert.NotNull(e.OldItems);
                 Assert.Equal(new[] { 1, 2, 3 }, e.OldItems.Cast<int>());
                 Assert.Equal(0, e.OldStartingIndex);
 
@@ -580,7 +593,7 @@ namespace Avalonia.Base.UnitTests.Collections
 
             return;
 
-            void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs actualEvent)
+            void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs actualEvent)
             {
                 Assert.Multiple(() =>
                 {

--- a/tests/Avalonia.Base.UnitTests/Collections/CollectionChangedTracker.cs
+++ b/tests/Avalonia.Base.UnitTests/Collections/CollectionChangedTracker.cs
@@ -10,14 +10,14 @@ namespace Avalonia.Base.UnitTests.Collections
             collection.CollectionChanged += CollectionChanged;
         }
 
-        public NotifyCollectionChangedEventArgs Args { get; private set; }
+        public NotifyCollectionChangedEventArgs? Args { get; private set; }
 
         public void Reset()
         {
             Args = null;
         }
 
-        private void CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (Args != null)
             {

--- a/tests/Avalonia.Base.UnitTests/Collections/PropertyChangedTracker.cs
+++ b/tests/Avalonia.Base.UnitTests/Collections/PropertyChangedTracker.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -8,18 +7,18 @@ namespace Avalonia.Base.UnitTests.Collections
     {
         public PropertyChangedTracker(INotifyPropertyChanged obj)
         {
-            Names = new List<string>();
+            Names = [];
             obj.PropertyChanged += PropertyChanged;
         }
 
-        public List<string> Names { get; }
+        public List<string?> Names { get; }
 
         public void Reset()
         {
             Names.Clear();
         }
 
-        private void PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             Names.Add(e.PropertyName);
         }

--- a/tests/Avalonia.Base.UnitTests/Composition/BatchStreamTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Composition/BatchStreamTests.cs
@@ -13,7 +13,7 @@ public class BatchStreamTests
     {
         var data = new BatchStreamData();
         var memPool = new BatchStreamMemoryPool(false, 100, _ => { });
-        var objPool = new BatchStreamObjectPool<object>(false, 10, _ => { });
+        var objPool = new BatchStreamObjectPool<object?>(false, 10, _ => { });
 
         var guids = new List<Guid>();
         var objects = new List<object>();

--- a/tests/Avalonia.Base.UnitTests/Composition/CompositionAnimationTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Composition/CompositionAnimationTests.cs
@@ -82,7 +82,7 @@ public class CompositionAnimationTests : ScopedTestBase
         var compositor =
             new Compositor(new RenderLoop(new CompositorTestServices.ManualRenderTimer()), null);
         var target = compositor.CreateSolidColorVisual();
-        var ani = new ScalarKeyFrameAnimation(null);
+        var ani = new ScalarKeyFrameAnimation(compositor);
         foreach (var frame in data.Frames)
             ani.InsertKeyFrame(frame.key, frame.value, new LinearEasing());
         ani.Duration = TimeSpan.FromSeconds(1);

--- a/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.DataValidation.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.DataValidation.cs
@@ -6,8 +6,6 @@ using Avalonia.Data;
 using Avalonia.UnitTests;
 using Xunit;
 
-#nullable enable
-
 namespace Avalonia.Base.UnitTests.Data.Core;
 
 public partial class BindingExpressionTests
@@ -373,11 +371,12 @@ public partial class BindingExpressionTests
 
         public override bool HasErrors => _mustBePositive >= 0;
 
-        public override IEnumerable? GetErrors(string propertyName)
+        public override IEnumerable GetErrors(string? propertyName)
         {
-            IList<string>? result;
-            _errors.TryGetValue(propertyName, out result);
-            return result;
+            if (propertyName is not null && _errors.TryGetValue(propertyName, out var result))
+                return result;
+
+            return Array.Empty<string>();
         }
     }
 
@@ -392,7 +391,7 @@ public partial class BindingExpressionTests
         }
 
         public override bool HasErrors => false;
-        public override IEnumerable? GetErrors(string propertyName) => null;
+        public override IEnumerable GetErrors(string? propertyName) => Array.Empty<string>();
     }
 
     private class DataAnnotationsViewModel : NotifyingBase
@@ -420,14 +419,14 @@ public partial class BindingExpressionTests
 
         public override bool HasErrors => RequiredString is null;
         
-        public override IEnumerable? GetErrors(string propertyName)
+        public override IEnumerable GetErrors(string? propertyName)
         {
             if (propertyName == nameof(RequiredString) && RequiredString is null)
             {
                 return new[] { "String is required!" };
             }
 
-            return null;
+            return Array.Empty<string>();
         }
     }   
 

--- a/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.Observable.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.Observable.cs
@@ -43,7 +43,7 @@ public partial class BindingExpressionTests
         using var sync = UnitTestSynchronizationContext.Begin();
         var source = new BehaviorSubject<ViewModel>(new() { StringValue = "foo" });
         var data = new ViewModel { NextObservable = source };
-        var target = CreateTargetWithSource(data, o => o.NextObservable.StreamBinding().StringValue);
+        var target = CreateTargetWithSource(data, o => o.NextObservable!.StreamBinding().StringValue);
 
         Assert.Equal("foo", target.String);
 

--- a/tests/Avalonia.Base.UnitTests/Data/Core/IndeiBase.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/IndeiBase.cs
@@ -8,18 +8,18 @@ namespace Avalonia.Base.UnitTests.Data.Core
 {
     internal abstract class IndeiBase : NotifyingBase, INotifyDataErrorInfo
     {
-        private EventHandler<DataErrorsChangedEventArgs> _errorsChanged;
+        private EventHandler<DataErrorsChangedEventArgs>? _errorsChanged;
 
         public abstract bool HasErrors { get; }
         public int ErrorsChangedSubscriptionCount { get; private set; }
 
-        public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged
+        public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged
         {
             add { _errorsChanged += value; ++ErrorsChangedSubscriptionCount; }
             remove { _errorsChanged -= value; --ErrorsChangedSubscriptionCount; }
         }
 
-        public abstract IEnumerable GetErrors(string propertyName);
+        public abstract IEnumerable GetErrors(string? propertyName);
 
         protected void RaiseErrorsChanged([CallerMemberName] string propertyName = "")
         {

--- a/tests/Avalonia.Base.UnitTests/Data/Core/Plugins/DataAnnotationsValidationPluginTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/Plugins/DataAnnotationsValidationPluginTests.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Base.UnitTests.Data.Core.Plugins
             var target = new DataAnnotationsValidationPlugin();
             var data = new Data();
 
-            Assert.True(target.Match(new WeakReference<object>(data), nameof(Data.Between5And10)));
+            Assert.True(target.Match(new WeakReference<object?>(data), nameof(Data.Between5And10)));
         }
 
         [Fact]
@@ -27,7 +27,7 @@ namespace Avalonia.Base.UnitTests.Data.Core.Plugins
             var target = new DataAnnotationsValidationPlugin();
             var data = new Data();
 
-            Assert.True(target.Match(new WeakReference<object>(data), nameof(Data.PhoneNumber)));
+            Assert.True(target.Match(new WeakReference<object?>(data), nameof(Data.PhoneNumber)));
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace Avalonia.Base.UnitTests.Data.Core.Plugins
             var target = new DataAnnotationsValidationPlugin();
             var data = new Data();
 
-            Assert.False(target.Match(new WeakReference<object>(data), nameof(Data.Unvalidated)));
+            Assert.False(target.Match(new WeakReference<object?>(data), nameof(Data.Unvalidated)));
         }
 
         [Fact]
@@ -45,9 +45,10 @@ namespace Avalonia.Base.UnitTests.Data.Core.Plugins
             var inpcAccessorPlugin = new InpcPropertyAccessorPlugin();
             var validatorPlugin = new DataAnnotationsValidationPlugin();
             var data = new Data();
-            var accessor = inpcAccessorPlugin.Start(new WeakReference<object>(data), nameof(data.Between5And10));
-            var validator = validatorPlugin.Start(new WeakReference<object>(data), nameof(data.Between5And10), accessor);
-            var result = new List<object>();
+            var accessor = inpcAccessorPlugin.Start(new WeakReference<object?>(data), nameof(data.Between5And10));
+            Assert.NotNull(accessor);
+            var validator = validatorPlugin.Start(new WeakReference<object?>(data), nameof(data.Between5And10), accessor);
+            var result = new List<object?>();
             
             var errmsg = new RangeAttribute(5, 10).FormatErrorMessage(nameof(Data.Between5And10));
 
@@ -77,9 +78,10 @@ namespace Avalonia.Base.UnitTests.Data.Core.Plugins
             var inpcAccessorPlugin = new InpcPropertyAccessorPlugin();
             var validatorPlugin = new DataAnnotationsValidationPlugin();
             var data = new Data();
-            var accessor = inpcAccessorPlugin.Start(new WeakReference<object>(data), nameof(data.PhoneNumber));
-            var validator = validatorPlugin.Start(new WeakReference<object>(data), nameof(data.PhoneNumber), accessor);
-            var result = new List<object>();
+            var accessor = inpcAccessorPlugin.Start(new WeakReference<object?>(data), nameof(data.PhoneNumber));
+            Assert.NotNull(accessor);
+            var validator = validatorPlugin.Start(new WeakReference<object?>(data), nameof(data.PhoneNumber), accessor);
+            var result = new List<object?>();
 
             validator.Subscribe(x => result.Add(x));
             validator.SetValue("123456", BindingPriority.LocalValue);
@@ -88,10 +90,10 @@ namespace Avalonia.Base.UnitTests.Data.Core.Plugins
             Assert.Equal(3, result.Count);
             Assert.Equal(new BindingNotification(null), result[0]);
             Assert.Equal(new BindingNotification("123456"), result[1]);
-            var errorResult = (BindingNotification)result[2];
+            var errorResult = Assert.IsAssignableFrom<BindingNotification>(result[2]);
             Assert.Equal(BindingErrorType.DataValidationError, errorResult.ErrorType);
             Assert.Equal("abcdefghijklm", errorResult.Value);
-            var exceptions = ((AggregateException)(errorResult.Error)).InnerExceptions;
+            var exceptions = Assert.IsAssignableFrom<AggregateException>(errorResult.Error).InnerExceptions;
             Assert.True(exceptions.Any(ex =>
                 ex.Message.Contains("The PhoneNumber field is not a valid phone number.")));
             Assert.True(exceptions.Any(ex =>
@@ -108,7 +110,7 @@ namespace Avalonia.Base.UnitTests.Data.Core.Plugins
 
             [Phone]
             [MaxLength(10)]
-            public string PhoneNumber { get; set; }
+            public string? PhoneNumber { get; set; }
         }
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Data/Core/Plugins/ExceptionValidationPluginTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/Plugins/ExceptionValidationPluginTests.cs
@@ -15,9 +15,10 @@ namespace Avalonia.Base.UnitTests.Data.Core.Plugins
             var inpcAccessorPlugin = new InpcPropertyAccessorPlugin();
             var validatorPlugin = new ExceptionValidationPlugin();
             var data = new Data();
-            var accessor = inpcAccessorPlugin.Start(new WeakReference<object>(data), nameof(data.MustBePositive));
-            var validator = validatorPlugin.Start(new WeakReference<object>(data), nameof(data.MustBePositive), accessor);
-            var result = new List<object>();
+            var accessor = inpcAccessorPlugin.Start(new WeakReference<object?>(data), nameof(data.MustBePositive));
+            Assert.NotNull(accessor);
+            var validator = validatorPlugin.Start(new WeakReference<object?>(data), nameof(data.MustBePositive), accessor);
+            var result = new List<object?>();
 
             validator.Subscribe(x => result.Add(x));
             validator.SetValue(5, BindingPriority.LocalValue);

--- a/tests/Avalonia.Base.UnitTests/Data/Core/Plugins/IndeiValidationPluginTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/Plugins/IndeiValidationPluginTests.cs
@@ -16,9 +16,10 @@ namespace Avalonia.Base.UnitTests.Data.Core.Plugins
             var inpcAccessorPlugin = new InpcPropertyAccessorPlugin();
             var validatorPlugin = new IndeiValidationPlugin();
             var data = new Data { Maximum = 5 };
-            var accessor = inpcAccessorPlugin.Start(new WeakReference<object>(data), nameof(data.Value));
-            var validator = validatorPlugin.Start(new WeakReference<object>(data), nameof(data.Value), accessor);
-            var result = new List<object>();
+            var accessor = inpcAccessorPlugin.Start(new WeakReference<object?>(data), nameof(data.Value));
+            Assert.NotNull(accessor);
+            var validator = validatorPlugin.Start(new WeakReference<object?>(data), nameof(data.Value), accessor);
+            var result = new List<object?>();
 
             validator.Subscribe(x => result.Add(x));
             validator.SetValue(5, BindingPriority.LocalValue);
@@ -51,8 +52,9 @@ namespace Avalonia.Base.UnitTests.Data.Core.Plugins
             var inpcAccessorPlugin = new InpcPropertyAccessorPlugin();
             var validatorPlugin = new IndeiValidationPlugin();
             var data = new Data { Maximum = 5 };
-            var accessor = inpcAccessorPlugin.Start(new WeakReference<object>(data), nameof(data.Value));
-            var validator = validatorPlugin.Start(new WeakReference<object>(data), nameof(data.Value), accessor);
+            var accessor = inpcAccessorPlugin.Start(new WeakReference<object?>(data), nameof(data.Value));
+            Assert.NotNull(accessor);
+            var validator = validatorPlugin.Start(new WeakReference<object?>(data), nameof(data.Value), accessor);
 
             Assert.Equal(0, data.ErrorsChangedSubscriptionCount);
             validator.Subscribe(_ => { });
@@ -67,7 +69,7 @@ namespace Avalonia.Base.UnitTests.Data.Core.Plugins
         {
             private int _value;
             private int _maximum;
-            private string _error;
+            private string? _error;
 
             public override bool HasErrors => _error != null;
 
@@ -92,14 +94,14 @@ namespace Avalonia.Base.UnitTests.Data.Core.Plugins
                 }
             }
 
-            public override IEnumerable GetErrors(string propertyName)
+            public override IEnumerable GetErrors(string? propertyName)
             {
                 if (propertyName == nameof(Value) && _error != null)
                 {
                     return new[] { _error };
                 }
 
-                return null;
+                return Array.Empty<string?>();
             }
 
             private void UpdateError()

--- a/tests/Avalonia.Base.UnitTests/Data/DefaultValueConverterTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/DefaultValueConverterTests.cs
@@ -190,9 +190,9 @@ namespace Avalonia.Base.UnitTests.Data
                 null,
                 CultureInfo.InvariantCulture);
 
-            Assert.IsAssignableFrom<ICommand>(result);
+            var command = Assert.IsAssignableFrom<ICommand>(result);
 
-            (result as ICommand).Execute(5);
+            command.Execute(5);
 
             Assert.Equal(5, commandResult);
         }
@@ -208,9 +208,9 @@ namespace Avalonia.Base.UnitTests.Data
                 null,
                 CultureInfo.InvariantCulture);
 
-            Assert.IsAssignableFrom<ICommand>(result);
+            var command = Assert.IsAssignableFrom<ICommand>(result);
 
-            (result as ICommand).Execute(null);
+            command.Execute(null);
 
             Assert.Equal(1, commandResult);
         }
@@ -246,7 +246,7 @@ namespace Avalonia.Base.UnitTests.Data
                 Value = value;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return obj is CustomType other && this.Value == other.Value;
             }
@@ -259,22 +259,22 @@ namespace Avalonia.Base.UnitTests.Data
 
         private class CustomTypeConverter : TypeConverter
         {
-            public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+            public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
             {
                 return destinationType == typeof(int);
             }
 
-            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
             {
                 return sourceType == typeof(int);
             }
 
-            public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+            public override object ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
             {
-                return ((CustomType)value).Value;
+                return ((CustomType)value!).Value;
             }
 
-            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            public override object ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
             {
                 return new CustomType((int)value);
             }

--- a/tests/Avalonia.Base.UnitTests/Data/ReflectionClrPropertyInfoTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/ReflectionClrPropertyInfoTests.cs
@@ -7,7 +7,7 @@ public class ReflectionClrPropertyInfoTests
 {
     public class TestClass
     {
-        public string Test { get; set; }
+        public string? Test { get; set; }
     }
 
     [Fact]
@@ -19,6 +19,6 @@ public class ReflectionClrPropertyInfoTests
         const string result = "qwerty";
         propertyInfo.Set(target, result);
         Assert.Equal(result, target.Test);
-        Assert.Equal(result, (string)propertyInfo.Get(target));
+        Assert.Equal(result, (string?)propertyInfo.Get(target));
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Data/StringConvertersTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/StringConvertersTests.cs
@@ -10,7 +10,7 @@ public class StringConvertersTests
     [InlineData("hello", false)]
     [InlineData("", true)]
     [InlineData(null, true)]
-    public void StringConverters_IsNullOrEmpty_Works(string input, bool expected)
+    public void StringConverters_IsNullOrEmpty_Works(string? input, bool expected)
     {
         var converter = StringConverters.IsNullOrEmpty;
         var result = converter.Convert(input, typeof(bool), null, CultureInfo.CurrentCulture);
@@ -21,7 +21,7 @@ public class StringConvertersTests
     [InlineData("hello", true)]
     [InlineData("", false)]
     [InlineData(null, false)]
-    public void StringConverters_IsNotNullOrEmpty_Works(string input, bool expected)
+    public void StringConverters_IsNotNullOrEmpty_Works(string? input, bool expected)
     {
         var converter = StringConverters.IsNotNullOrEmpty;
         var result = converter.Convert(input, typeof(bool), null, CultureInfo.CurrentCulture);

--- a/tests/Avalonia.Base.UnitTests/DirectPropertyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/DirectPropertyTests.cs
@@ -8,11 +8,11 @@ namespace Avalonia.Base.UnitTests
         [Fact]
         public void IsDirect_Property_Returns_True()
         {
-            var target = new DirectProperty<Class1, string>(
+            var target = new DirectProperty<Class1, string?>(
                 "test", 
                 o => null, 
                 null,
-                new DirectPropertyMetadata<string>());
+                new DirectPropertyMetadata<string?>());
 
             Assert.True(target.IsDirect);
         }
@@ -68,12 +68,12 @@ namespace Avalonia.Base.UnitTests
 
         private class Class1 : AvaloniaObject
         {
-            public static readonly DirectProperty<Class1, string> FooProperty =
-                AvaloniaProperty.RegisterDirect<Class1, string>(nameof(Foo), o => o.Foo, (o, v) => o.Foo = v);
+            public static readonly DirectProperty<Class1, string?> FooProperty =
+                AvaloniaProperty.RegisterDirect<Class1, string?>(nameof(Foo), o => o.Foo, (o, v) => o.Foo = v);
 
-            private string _foo = "foo";
+            private string? _foo = "foo";
 
-            public string Foo
+            public string? Foo
             {
                 get { return _foo; }
                 set { SetAndRaise(FooProperty, ref _foo, value); }

--- a/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
+++ b/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
@@ -25,8 +25,8 @@ public partial class DispatcherTests
                 AskedForSignal = true;
         }
 
-        public event Action Signaled;
-        public event Action Timer;
+        public event Action? Signaled;
+        public event Action? Timer;
         public long? NextTimer { get; private set; }
         public bool AskedForSignal { get; private set; }
 
@@ -64,7 +64,7 @@ public partial class DispatcherTests
     class SimpleDispatcherWithBackgroundProcessingImpl : SimpleDispatcherImpl, IDispatcherImplWithExplicitBackgroundProcessing
     {
         public bool AskedForBackgroundProcessing { get; private set; }
-        public event Action ReadyForBackgroundProcessing;
+        public event Action? ReadyForBackgroundProcessing;
         public void RequestBackgroundProcessing()
         {
             if (!CurrentThreadIsLoopThread)
@@ -607,7 +607,6 @@ public partial class DispatcherTests
         Dispatcher.UIThread.MainLoop(tokenSource.Token);
     }
 
-#nullable enable
     private class AsyncLocalTestClass
     {
         public AsyncLocal<string?> AsyncLocalField { get; set; } = new AsyncLocal<string?>();
@@ -776,6 +775,5 @@ public partial class DispatcherTests
             Assert.NotEqual("sux-Shaw-UM", oldCulture.Name);
         }
     }
-#nullable restore
 
 }

--- a/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
@@ -485,11 +485,12 @@ namespace Avalonia.Base.UnitTests.Input
                 Assert.True(root.Classes.Contains(":focus-within"));
                 Assert.True(root.IsKeyboardFocusWithin);
 
-                Assert.Equal(KeyboardDevice.Instance.FocusedElement, target1);
+                var keyboardDevice = KeyboardDevice.Instance!;
+                Assert.Equal(keyboardDevice.FocusedElement, target1);
                 
                 root.Child = null;
                 
-                Assert.Null(KeyboardDevice.Instance.FocusedElement);
+                Assert.Null(keyboardDevice.FocusedElement);
                 
                 Assert.False(target1.IsFocused);
                 Assert.False(target1.Classes.Contains(":focus-within"));
@@ -541,7 +542,7 @@ namespace Avalonia.Base.UnitTests.Input
                 Assert.True(root1.Classes.Contains(":focus-within"));
                 Assert.True(root1.IsKeyboardFocusWithin);
 
-                Assert.Equal(KeyboardDevice.Instance.FocusedElement, target1);
+                Assert.Equal(KeyboardDevice.Instance!.FocusedElement, target1);
                 
                 target2.Focus();
                 
@@ -622,7 +623,7 @@ namespace Avalonia.Base.UnitTests.Input
             innerButton.Focus();
 
             // Remove the focused control from the tree.
-            ((Panel)innerButton.Parent).Children.Remove(innerButton);
+            ((Panel)innerButton.Parent!).Children.Remove(innerButton);
 
             var focusManager = Assert.IsType<FocusManager>(root.FocusManager);
             Assert.Same(outerButton, focusManager.GetFocusedElement());
@@ -658,7 +659,7 @@ namespace Avalonia.Base.UnitTests.Input
             innerButton.Focus();
 
             // Remove the inner focus scope.
-            ((Panel)innerScope.Parent).Children.Remove(innerScope);
+            ((Panel)innerScope.Parent!).Children.Remove(innerScope);
 
             var focusManager = Assert.IsType<FocusManager>(root.FocusManager);
             Assert.Same(outerButton, focusManager.GetFocusedElement());
@@ -795,6 +796,7 @@ namespace Avalonia.Base.UnitTests.Input
                 };
 
                 var focusManager = FocusManager.GetFocusManager(container);
+                Assert.NotNull(focusManager);
                 target1.Focus();
 
                 var next = focusManager.FindNextElement(NavigationDirection.Next);
@@ -841,6 +843,7 @@ namespace Avalonia.Base.UnitTests.Input
                 root.ExecuteInitialLayoutPass();
 
                 var focusManager = FocusManager.GetFocusManager(container);
+                Assert.NotNull(focusManager);
                 target1.Focus();
 
                 var options = new FindNextElementOptions()
@@ -892,6 +895,7 @@ namespace Avalonia.Base.UnitTests.Input
                 };
 
                 var focusManager = FocusManager.GetFocusManager(container);
+                Assert.NotNull(focusManager);
 
                 var hasMoved = focusManager.TryMoveFocus(NavigationDirection.Next);
 
@@ -939,6 +943,7 @@ namespace Avalonia.Base.UnitTests.Input
                 };
 
                 var focusManager = FocusManager.GetFocusManager(container);
+                Assert.NotNull(focusManager);
 
                 center.Focus();
 

--- a/tests/Avalonia.Base.UnitTests/Input/KeyboardNavigationTests_Custom.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/KeyboardNavigationTests_Custom.cs
@@ -203,9 +203,9 @@ namespace Avalonia.Base.UnitTests.Input
         private class CustomNavigatingStackPanel : StackPanel, ICustomKeyboardNavigation
         {
             public bool CustomNavigates { get; set; } = true;
-            public IInputElement NextControl { get; set; }
+            public IInputElement? NextControl { get; set; }
 
-            public (bool handled, IInputElement next) GetNext(IInputElement element, NavigationDirection direction)
+            public (bool handled, IInputElement? next) GetNext(IInputElement element, NavigationDirection direction)
             {
                 return (CustomNavigates, NextControl);
             }

--- a/tests/Avalonia.Base.UnitTests/Input/KeyboardNavigationTests_Tab.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/KeyboardNavigationTests_Tab.cs
@@ -1169,7 +1169,7 @@ namespace Avalonia.Base.UnitTests.Input
                 }
             };
 
-            var result = new List<string>();
+            var result = new List<string?>();
             var current = (IInputElement)start;
 
             do
@@ -1215,14 +1215,14 @@ namespace Avalonia.Base.UnitTests.Input
                 }
             };
 
-            var result = new List<string>();
+            var result = new List<string?>();
             var current = (IInputElement)start;
 
             do
             {
                 result.Add(((Control)current).Name);
                 current = KeyboardNavigationHandler.GetNext(current, NavigationDirection.Previous);
-            } while (current is object && current != start);
+            } while (current is not null && current != start);
 
             Assert.Equal(new[]
             {

--- a/tests/Avalonia.Base.UnitTests/Input/MouseDeviceTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/MouseDeviceTests.cs
@@ -80,7 +80,7 @@ namespace Avalonia.Base.UnitTests.Input
             }, renderer.Object);
 
             // Synthesize event to receive a pointer.
-            IPointer result = null;
+            IPointer? result = null;
             root.PointerMoved += (_, a) =>
             {
                 result = a.Pointer;

--- a/tests/Avalonia.Base.UnitTests/Input/PointerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/PointerTests.cs
@@ -22,7 +22,7 @@ namespace Avalonia.Base.UnitTests.Input
                     (newParent = new Border { Child = newCapture = new Border() })
                 }
             };
-            var receivers = new List<object>();
+            var receivers = new List<object?>();
             var root = new TestRoot(el);
             foreach (InputElement d in root.GetSelfAndVisualDescendants())
                 d.PointerCaptureLost += (s, e) => receivers.Add(s);

--- a/tests/Avalonia.Base.UnitTests/Input/TouchDeviceTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/TouchDeviceTests.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Input.UnitTests
                 isTapped = true;
                 executedTimes++;
             };
-            TapOnce(InputManager.Instance, touchDevice, root);
+            TapOnce(InputManager.Instance!, touchDevice, root);
             Assert.True(isTapped);
             Assert.Equal(1, executedTimes);
 
@@ -49,8 +49,9 @@ namespace Avalonia.Input.UnitTests
             {
                 tappedExecutedTimes++;
             };
-            TapOnce(InputManager.Instance, touchDevice, root);
-            TapOnce(InputManager.Instance, touchDevice, root, touchPointId: 1);
+            var inputManager = InputManager.Instance!;
+            TapOnce(inputManager, touchDevice, root);
+            TapOnce(inputManager, touchDevice, root, touchPointId: 1);
             Assert.Equal(1, tappedExecutedTimes);
             Assert.True(isDoubleTapped);
             Assert.Equal(1, doubleTappedExecutedTimes);
@@ -75,9 +76,10 @@ namespace Avalonia.Input.UnitTests
                 pointerPressedClicks = e.ClickCount;
                 pointerPressedExecutedTimes++;
             };
+            var inputManager = InputManager.Instance!;
             for (int i = 0; i < clickCount; i++)
             {
-                TapOnce(InputManager.Instance, touchDevice, root, touchPointId: i);
+                TapOnce(inputManager, touchDevice, root, touchPointId: i);
             }
 
             Assert.Equal(clickCount, pointerPressedExecutedTimes);
@@ -103,8 +105,9 @@ namespace Avalonia.Input.UnitTests
             {
                 tappedExecutedTimes++;
             };
-            TapOnce(InputManager.Instance, touchDevice, root);
-            TapOnce(InputManager.Instance, touchDevice, root, 21, 1);
+            var inputManager = InputManager.Instance!;
+            TapOnce(inputManager, touchDevice, root);
+            TapOnce(inputManager, touchDevice, root, 21, 1);
             Assert.Equal(2, tappedExecutedTimes);
             Assert.False(isDoubleTapped);
             Assert.Equal(0, doubleTappedExecutedTimes);
@@ -130,8 +133,9 @@ namespace Avalonia.Input.UnitTests
             {
                 tappedExecutedTimes++;
             };
-            SendXTouchContactsWithIds(InputManager.Instance, touchDevice, root, RawPointerEventType.TouchBegin, 0, 1);
-            SendXTouchContactsWithIds(InputManager.Instance, touchDevice, root, RawPointerEventType.TouchEnd, 0, 1);
+            var inputManager = InputManager.Instance!;
+            SendXTouchContactsWithIds(inputManager, touchDevice, root, RawPointerEventType.TouchBegin, 0, 1);
+            SendXTouchContactsWithIds(inputManager, touchDevice, root, RawPointerEventType.TouchEnd, 0, 1);
             Assert.Equal(2, tappedExecutedTimes);
             Assert.False(isDoubleTapped);
             Assert.Equal(0, doubleTappedExecutedTimes);
@@ -191,14 +195,15 @@ namespace Avalonia.Input.UnitTests
             {
                 tappedExecutedTimes++;
             };
-            SendXTouchContactsWithIds(InputManager.Instance, touchDevice, root, RawPointerEventType.TouchBegin, 0, 1);
-            SendXTouchContactsWithIds(InputManager.Instance, touchDevice, root, RawPointerEventType.TouchEnd, 0, 1);
-            TapOnce(InputManager.Instance, touchDevice, root, touchPointId: 2);
-            TapOnce(InputManager.Instance, touchDevice, root, touchPointId: 3);
-            TapOnce(InputManager.Instance, touchDevice, root, touchPointId: 4);
-            SendXTouchContactsWithIds(InputManager.Instance, touchDevice, root, RawPointerEventType.TouchBegin, 5, 6, 7);
-            SendXTouchContactsWithIds(InputManager.Instance, touchDevice, root, RawPointerEventType.TouchEnd, 5, 6, 7);
-            TapOnce(InputManager.Instance, touchDevice, root, touchPointId: 8);
+            var inputManager = InputManager.Instance!;
+            SendXTouchContactsWithIds(inputManager, touchDevice, root, RawPointerEventType.TouchBegin, 0, 1);
+            SendXTouchContactsWithIds(inputManager, touchDevice, root, RawPointerEventType.TouchEnd, 0, 1);
+            TapOnce(inputManager, touchDevice, root, touchPointId: 2);
+            TapOnce(inputManager, touchDevice, root, touchPointId: 3);
+            TapOnce(inputManager, touchDevice, root, touchPointId: 4);
+            SendXTouchContactsWithIds(inputManager, touchDevice, root, RawPointerEventType.TouchBegin, 5, 6, 7);
+            SendXTouchContactsWithIds(inputManager, touchDevice, root, RawPointerEventType.TouchEnd, 5, 6, 7);
+            TapOnce(inputManager, touchDevice, root, touchPointId: 8);
             Assert.Equal(6, tappedExecutedTimes);
             Assert.Equal(9, pointerPressedExecutedTimes);
             Assert.True(isDoubleTapped);

--- a/tests/Avalonia.Base.UnitTests/Interactivity/InteractiveTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Interactivity/InteractiveTests.cs
@@ -13,8 +13,8 @@ namespace Avalonia.Base.UnitTests.Interactivity
         public void Direct_Event_Should_Go_Straight_To_Source()
         {
             var ev = new RoutedEvent("test", RoutingStrategies.Direct, typeof(RoutedEventArgs), typeof(TestInteractive));
-            var invoked = new List<string>();
-            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s).Name);
+            var invoked = new List<string?>();
+            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s!).Name);
             var target = CreateTree(ev, handler, RoutingStrategies.Direct);
 
             var args = new RoutedEventArgs(ev, target);
@@ -47,8 +47,8 @@ namespace Avalonia.Base.UnitTests.Interactivity
         public void Bubbling_Event_Should_Bubble_Up()
         {
             var ev = new RoutedEvent("test", RoutingStrategies.Bubble, typeof(RoutedEventArgs), typeof(TestInteractive));
-            var invoked = new List<string>();
-            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s).Name);
+            var invoked = new List<string?>();
+            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s!).Name);
             var target = CreateTree(ev, handler, RoutingStrategies.Bubble | RoutingStrategies.Tunnel);
 
             var args = new RoutedEventArgs(ev, target);
@@ -61,8 +61,8 @@ namespace Avalonia.Base.UnitTests.Interactivity
         public void Tunneling_Event_Should_Tunnel()
         {
             var ev = new RoutedEvent("test", RoutingStrategies.Tunnel, typeof(RoutedEventArgs), typeof(TestInteractive));
-            var invoked = new List<string>();
-            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s).Name);
+            var invoked = new List<string?>();
+            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s!).Name);
             var target = CreateTree(ev, handler, RoutingStrategies.Bubble | RoutingStrategies.Tunnel);
 
             var args = new RoutedEventArgs(ev, target);
@@ -79,8 +79,8 @@ namespace Avalonia.Base.UnitTests.Interactivity
                 RoutingStrategies.Bubble | RoutingStrategies.Tunnel,
                 typeof(RoutedEventArgs),
                 typeof(TestInteractive));
-            var invoked = new List<string>();
-            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s).Name);
+            var invoked = new List<string?>();
+            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s!).Name);
             var target = CreateTree(ev, handler, RoutingStrategies.Bubble | RoutingStrategies.Tunnel);
 
             var args = new RoutedEventArgs(ev, target);
@@ -118,11 +118,11 @@ namespace Avalonia.Base.UnitTests.Interactivity
         public void Handled_Bubbled_Event_Should_Not_Propogate_Further()
         {
             var ev = new RoutedEvent("test", RoutingStrategies.Bubble, typeof(RoutedEventArgs), typeof(TestInteractive));
-            var invoked = new List<string>();
+            var invoked = new List<string?>();
 
             EventHandler<RoutedEventArgs> handler = (s, e) =>
             {
-                var t = (TestInteractive)s;
+                var t = (TestInteractive)s!;
                 invoked.Add(t.Name);
                 e.Handled = t.Name == "2b";
             };
@@ -143,11 +143,11 @@ namespace Avalonia.Base.UnitTests.Interactivity
                 RoutingStrategies.Bubble | RoutingStrategies.Tunnel, 
                 typeof(RoutedEventArgs), 
                 typeof(TestInteractive));
-            var invoked = new List<string>();
+            var invoked = new List<string?>();
 
             EventHandler<RoutedEventArgs> handler = (s, e) =>
             {
-                var t = (TestInteractive)s;
+                var t = (TestInteractive)s!;
                 invoked.Add(t.Name);
                 e.Handled = t.Name == "2b";
             };
@@ -239,11 +239,11 @@ namespace Avalonia.Base.UnitTests.Interactivity
                 RoutingStrategies.Bubble | RoutingStrategies.Tunnel,
                 typeof(RoutedEventArgs),
                 typeof(TestInteractive));
-            var invoked = new List<string>();
+            var invoked = new List<string?>();
 
             EventHandler<RoutedEventArgs> handler = (s, e) =>
             {
-                invoked.Add(((TestInteractive)s).Name);
+                invoked.Add(((TestInteractive)s!).Name);
                 e.Handled = true;
             };
 
@@ -263,8 +263,8 @@ namespace Avalonia.Base.UnitTests.Interactivity
                 RoutingStrategies.Direct,
                 typeof(RoutedEventArgs),
                 typeof(TestInteractive));
-            var invoked = new List<string>();
-            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s).Name);
+            var invoked = new List<string?>();
+            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s!).Name);
 
             var target = CreateTree(ev, null, 0);
 
@@ -284,8 +284,8 @@ namespace Avalonia.Base.UnitTests.Interactivity
                 RoutingStrategies.Bubble | RoutingStrategies.Tunnel,
                 typeof(RoutedEventArgs),
                 typeof(TestInteractive));
-            var invoked = new List<string>();
-            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s).Name);
+            var invoked = new List<string?>();
+            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s!).Name);
 
             var target = CreateTree(ev, null, 0);
 
@@ -305,8 +305,8 @@ namespace Avalonia.Base.UnitTests.Interactivity
                 RoutingStrategies.Bubble | RoutingStrategies.Tunnel,
                 typeof(RoutedEventArgs),
                 typeof(TestInteractive));
-            var invoked = new List<string>();
-            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s).Name);
+            var invoked = new List<string?>();
+            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s!).Name);
 
             var target = CreateTree(ev, null, 0);
 
@@ -334,7 +334,9 @@ namespace Avalonia.Base.UnitTests.Interactivity
             target.RaiseEvent(args);
 
             Assert.True(target.ClassHandlerInvoked);
-            Assert.True(target.GetVisualParent<TestInteractive>().ClassHandlerInvoked);
+            var interactive = target.GetVisualParent<TestInteractive>();
+            Assert.NotNull(interactive);
+            Assert.True(interactive.ClassHandlerInvoked);
         }
 
         [Fact]
@@ -355,7 +357,9 @@ namespace Avalonia.Base.UnitTests.Interactivity
 
             Assert.True(args.Handled);
             Assert.True(target.ClassHandlerInvoked);
-            Assert.True(target.GetVisualParent<TestInteractive>().ClassHandlerInvoked);
+            var interactive = target.GetVisualParent<TestInteractive>();
+            Assert.NotNull(interactive);
+            Assert.True(interactive.ClassHandlerInvoked);
         }
 
         [Fact]
@@ -381,8 +385,8 @@ namespace Avalonia.Base.UnitTests.Interactivity
         {
             // Issue #3176
             var ev = new RoutedEvent("test", RoutingStrategies.Bubble, typeof(RoutedEventArgs), typeof(TestInteractive));
-            var invoked = new List<string>();
-            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s).Name);
+            var invoked = new List<string?>();
+            EventHandler<RoutedEventArgs> handler = (s, e) => invoked.Add(((TestInteractive)s!).Name);
             var parent = CreateTree(ev, handler, RoutingStrategies.Bubble | RoutingStrategies.Tunnel);
             var target = (Interactive)parent.GetVisualChildren().Single();
 
@@ -401,7 +405,7 @@ namespace Avalonia.Base.UnitTests.Interactivity
 
         private static TestInteractive CreateTree(
             RoutedEvent ev,
-            EventHandler<RoutedEventArgs> handler,
+            EventHandler<RoutedEventArgs>? handler,
             RoutingStrategies handlerRoutes,
             bool handledEventsToo = false)
         {
@@ -444,19 +448,19 @@ namespace Avalonia.Base.UnitTests.Interactivity
         private class TestInteractive : Interactive
         {
             public bool ClassHandlerInvoked { get; private set; }
-            public new string Name { get; set; }
+            public new string? Name { get; set; }
 
             public IEnumerable<Visual> Children
             {
                 get
                 {
-                    return ((Visual)this).VisualChildren.AsEnumerable();
+                    return VisualChildren.AsEnumerable();
                 }
 
                 set
                 {
                     VisualChildren.Clear();
-                    VisualChildren.AddRange(value.Cast<Visual>());
+                    VisualChildren.AddRange(value);
                 }
             }
 

--- a/tests/Avalonia.Base.UnitTests/Layout/LayoutTestControl.cs
+++ b/tests/Avalonia.Base.UnitTests/Layout/LayoutTestControl.cs
@@ -8,8 +8,8 @@ namespace Avalonia.Base.UnitTests.Layout
     {
         public bool Measured { get; set; }
         public bool Arranged { get; set; }
-        public Func<Layoutable, Size, Size> DoMeasureOverride { get; set; }
-        public Func<Layoutable, Size, Size> DoArrangeOverride { get; set; }
+        public Func<Layoutable, Size, Size>? DoMeasureOverride { get; set; }
+        public Func<Layoutable, Size, Size>? DoArrangeOverride { get; set; }
         public bool CallBaseMeasure { get; set; }
         public bool CallBaseArrange { get; set; }
 

--- a/tests/Avalonia.Base.UnitTests/Layout/LayoutTestRoot.cs
+++ b/tests/Avalonia.Base.UnitTests/Layout/LayoutTestRoot.cs
@@ -8,8 +8,8 @@ namespace Avalonia.Base.UnitTests.Layout
     {
         public bool Measured { get; set; }
         public bool Arranged { get; set; }
-        public Func<Layoutable, Size, Size> DoMeasureOverride { get; set; }
-        public Func<Layoutable, Size, Size> DoArrangeOverride { get; set; }
+        public Func<Layoutable, Size, Size>? DoMeasureOverride { get; set; }
+        public Func<Layoutable, Size, Size>? DoArrangeOverride { get; set; }
 
         protected override Size MeasureOverride(Size availableSize)
         {

--- a/tests/Avalonia.Base.UnitTests/Layout/LayoutableTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Layout/LayoutableTests.cs
@@ -188,7 +188,7 @@ namespace Avalonia.Base.UnitTests.Layout
             };
             var raised = 0;
 
-            void ValidateBounds(object sender, EventArgs e)
+            void ValidateBounds(object? sender, EventArgs e)
             {
                 Assert.Equal(new Rect(0, 0, 100, 100), border1.Bounds);
                 Assert.Equal(new Rect(0, 0, 100, 100), border2.Bounds);
@@ -225,7 +225,7 @@ namespace Avalonia.Base.UnitTests.Layout
                 LayoutManager = layoutManager.Object,
             };
 
-            void Handler(object sender, EventArgs e) {}
+            void Handler(object? sender, EventArgs e) {}
 
             layoutManager.Invocations.Clear();
             target.LayoutUpdated += Handler;

--- a/tests/Avalonia.Base.UnitTests/Layout/LayoutableTests_EffectiveViewportChanged.cs
+++ b/tests/Avalonia.Base.UnitTests/Layout/LayoutableTests_EffectiveViewportChanged.cs
@@ -401,7 +401,7 @@ namespace Avalonia.Base.UnitTests.Layout
                 var target = new Canvas();
                 var raised = 0;
 
-                void OnTargetOnEffectiveViewportChanged(object s, EffectiveViewportChangedEventArgs e)
+                void OnTargetOnEffectiveViewportChanged(object? s, EffectiveViewportChangedEventArgs e)
                 {
                     target.EffectiveViewportChanged -= OnTargetOnEffectiveViewportChanged;
                     ++raised;
@@ -460,9 +460,9 @@ namespace Avalonia.Base.UnitTests.Layout
             TestRoot root,
             ScrollViewer scroller,
             Control target,
-            Action<object, EffectiveViewportChangedEventArgs> handler)
+            Action<object?, EffectiveViewportChangedEventArgs> handler)
         {
-            void ViewportChanged(object sender, EffectiveViewportChangedEventArgs e)
+            void ViewportChanged(object? sender, EffectiveViewportChangedEventArgs e)
             {
                 handler(sender, e);
             }

--- a/tests/Avalonia.Base.UnitTests/Logging/LoggingTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Logging/LoggingTests.cs
@@ -31,10 +31,10 @@ namespace Avalonia.Base.UnitTests.Logging
                         calledTimes++;
                     }
                 });
-                var panel = window.FindControl<Panel>("panel");
-                var rect = window.FindControl<Rectangle>("rect");
+                var panel = window.GetControl<Panel>("panel");
+                var rect = window.GetControl<Rectangle>("rect");
                 window.ApplyTemplate();
-                ((Control)window.Presenter).ApplyTemplate();
+                window.Presenter!.ApplyTemplate();
                 panel.Children.Remove(rect);
                 Assert.Equal(0, calledTimes);
             }
@@ -63,7 +63,7 @@ namespace Avalonia.Base.UnitTests.Logging
                 });
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
                 window.ApplyTemplate();
-                ((Control)window.Presenter).ApplyTemplate();
+                window.Presenter!.ApplyTemplate();
                 Assert.Equal(1, calledTimes);
             }
         }

--- a/tests/Avalonia.Base.UnitTests/Media/ColorTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/ColorTests.cs
@@ -183,7 +183,7 @@ namespace Avalonia.Base.UnitTests.Media
         [Fact]
         public void Parse_Throws_ArgumentNullException_For_Null_Input()
         {
-            Assert.Throws<ArgumentNullException>(() => Color.Parse((string)null));
+            Assert.Throws<ArgumentNullException>(() => Color.Parse(null!));
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace Avalonia.Base.UnitTests.Media
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void TryParse_Returns_False_For_Invalid_Input(string input)
+        public void TryParse_Returns_False_For_Invalid_Input(string? input)
         {
             Assert.False(Color.TryParse(input, out _));
         }

--- a/tests/Avalonia.Base.UnitTests/Media/FontFamilyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/FontFamilyTests.cs
@@ -130,7 +130,7 @@ namespace Avalonia.Base.UnitTests.Media
         [InlineData(null, "resm:Avalonia.Visuals.UnitTests.Assets.Fonts#MyFont")]
         [InlineData("avares://Avalonia.Visuals.UnitTests/Assets/Fonts", "/#MyFont")]
         [InlineData("avares://Avalonia.Visuals.UnitTests", "/Assets/Fonts#MyFont")]
-        public void Should_Create_FontFamily_From_Uri_With_Base_Uri(string @base, string name)
+        public void Should_Create_FontFamily_From_Uri_With_Base_Uri(string? @base, string name)
         {
             var baseUri = @base != null ? new Uri(@base) : null;
 
@@ -147,7 +147,7 @@ namespace Avalonia.Base.UnitTests.Media
         [InlineData("avares://Avalonia.Fonts.Inter", "/Assets#Inter", "Inter", "avares://Avalonia.Fonts.Inter/Assets")]
         [InlineData("avares://ControlCatalog/MainWindow.xaml", "avares://Avalonia.Fonts.Inter/Assets#Inter", "Inter", "avares://Avalonia.Fonts.Inter/Assets")]
         [Theory]
-        public void Should_Parse_FontFamily_With_BaseUri(string baseUri, string s, string expectedName, string expectedUri)
+        public void Should_Parse_FontFamily_With_BaseUri(string? baseUri, string s, string expectedName, string? expectedUri)
         {
             var b = baseUri is not null ? new Uri(baseUri) : null;
 
@@ -184,10 +184,12 @@ namespace Avalonia.Base.UnitTests.Media
                     }
                     else
                     {
+                        Assert.NotNull(fontUri);
                         fontUri = new Uri(fontUri, sourceUri);
                     }
                 }
 
+                Assert.NotNull(fontUri);
                 Assert.Equal(expectedUri, fontUri.AbsoluteUri);
             }
         }

--- a/tests/Avalonia.Base.UnitTests/Media/FontManagerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/FontManagerTests.cs
@@ -30,8 +30,8 @@ namespace Avalonia.Base.UnitTests.Media
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface
                .With(fontManagerImpl: new HeadlessFontManagerWithMultipleSystemFontsStub(
-                   installedFontFamilyNames: new string[] { },
-                   defaultFamilyName: null))))
+                   installedFontFamilyNames: [],
+                   defaultFamilyName: null!))))
             {
                 Assert.Throws<InvalidOperationException>(() => FontManager.Current);
             }
@@ -82,8 +82,8 @@ namespace Avalonia.Base.UnitTests.Media
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface
                 .With(fontManagerImpl: new HeadlessFontManagerWithMultipleSystemFontsStub(
-                    installedFontFamilyNames: new[] { "DejaVu", "Verdana" },
-                    defaultFamilyName: null))))
+                    installedFontFamilyNames: ["DejaVu", "Verdana"],
+                    defaultFamilyName: null!))))
             {
                 Assert.Equal("DejaVu", FontManager.Current.DefaultFontFamily.Name);
             }

--- a/tests/Avalonia.Base.UnitTests/Media/Fonts/FamilyNameCollectionTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/Fonts/FamilyNameCollectionTests.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Base.UnitTests.Media.Fonts
         [Fact]
         public void Exception_Should_Be_Thrown_If_Names_Is_Null()
         {
-            Assert.Throws<ArgumentNullException>(() => new FamilyNameCollection(null));
+            Assert.Throws<ArgumentNullException>(() => new FamilyNameCollection(null!));
         }
 
         [Fact]

--- a/tests/Avalonia.Base.UnitTests/Media/Fonts/FontFamilyKeyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/Fonts/FontFamilyKeyTests.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Base.UnitTests.Media.Fonts
         [Fact]
         public void Exception_Should_Be_Thrown_If_Source_Is_Null()
         {
-            Assert.Throws<ArgumentNullException>(() => new FontFamilyKey(null));
+            Assert.Throws<ArgumentNullException>(() => new FontFamilyKey(null!));
         }
 
         [Fact]

--- a/tests/Avalonia.Base.UnitTests/Media/PathMarkupParserTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/PathMarkupParserTests.cs
@@ -19,6 +19,7 @@ namespace Avalonia.Base.UnitTests.Media
             {
                 parser.Parse("M10 10");
 
+                Assert.NotNull(pathGeometry.Figures);
                 var figure = pathGeometry.Figures[0];
 
                 Assert.Equal(new Point(10, 10), figure.StartPoint);
@@ -34,8 +35,10 @@ namespace Avalonia.Base.UnitTests.Media
             {
                 parser.Parse("M0 0L10 10");
 
+                Assert.NotNull(pathGeometry.Figures);
                 var figure = pathGeometry.Figures[0];
 
+                Assert.NotNull(figure.Segments);
                 var segment = figure.Segments[0];
 
                 Assert.IsType<LineSegment>(segment);
@@ -55,6 +58,7 @@ namespace Avalonia.Base.UnitTests.Media
             {
                 parser.Parse("M0 0L10 10z");
 
+                Assert.NotNull(pathGeometry.Figures);
                 var figure = pathGeometry.Figures[0];
 
                 Assert.True(figure.IsClosed);
@@ -86,8 +90,10 @@ namespace Avalonia.Base.UnitTests.Media
             {
                 parser.Parse(pathData);
 
+                Assert.NotNull(pathGeometry.Figures);
                 var figure = pathGeometry.Figures[0];
 
+                Assert.NotNull(figure.Segments);
                 var segment = figure.Segments[0];
 
                 Assert.IsType<LineSegment>(segment);
@@ -118,8 +124,10 @@ namespace Avalonia.Base.UnitTests.Media
             {
                 parser.Parse(pathData);
 
+                Assert.NotNull(pathGeometry.Figures);
                 var figure = pathGeometry.Figures[0];
 
+                Assert.NotNull(figure.Segments);
                 var segment = figure.Segments[0];
 
                 Assert.IsType<LineSegment>(segment);
@@ -147,6 +155,7 @@ namespace Avalonia.Base.UnitTests.Media
             {
                 parser.Parse("M -1.01725E-005 -1.01725e-005");
 
+                Assert.NotNull(pathGeometry.Figures);
                 var figure = pathGeometry.Figures[0];
 
                 Assert.Equal(
@@ -281,6 +290,7 @@ namespace Avalonia.Base.UnitTests.Media
             {
                 parser.Parse("M10,10L100,100Z m10,10");
 
+                Assert.NotNull(pathGeometry.Figures);
                 Assert.Equal(2, pathGeometry.Figures.Count);
 
                 var figure = pathGeometry.Figures[0];
@@ -289,6 +299,7 @@ namespace Avalonia.Base.UnitTests.Media
 
                 Assert.Equal(true, figure.IsClosed);
 
+                Assert.NotNull(figure.Segments);
                 Assert.Equal(new Point(100, 100), ((LineSegment)figure.Segments[0]).Point);
 
                 figure = pathGeometry.Figures[1];
@@ -306,6 +317,7 @@ namespace Avalonia.Base.UnitTests.Media
             {
                 parser.Parse("a.898.898 0 01.27.188");
 
+                Assert.NotNull(pathGeometry.Figures);
                 var figure = pathGeometry.Figures[0];
 
                 var segments = figure.Segments;
@@ -328,6 +340,7 @@ namespace Avalonia.Base.UnitTests.Media
             using var parser = new PathMarkupParser(context);
             parser.Parse("M50,50z l -5,-5");
 
+            Assert.NotNull(pathGeometry.Figures);
             Assert.Equal(2, pathGeometry.Figures.Count);
 
             var firstFigure = pathGeometry.Figures[0];

--- a/tests/Avalonia.Base.UnitTests/Media/TextFormatting/BiDiTestDataGenerator.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/TextFormatting/BiDiTestDataGenerator.cs
@@ -42,7 +42,7 @@ namespace Avalonia.Visuals.UnitTests.Media.TextFormatting
                         var lineNumber = 0;
 
                         // Process each line
-                        int[] levels = null;
+                        int[]? levels = null;
 
                         while (!reader.EndOfStream)
                         {
@@ -121,7 +121,7 @@ namespace Avalonia.Visuals.UnitTests.Media.TextFormatting
                                     lineNumber,
                                     directions,
                                     paragraphEmbeddingLevel,
-                                    levels
+                                    levels!
                                 ]);
 
                                 break;

--- a/tests/Avalonia.Base.UnitTests/Media/TextFormatting/FormattedTextSourceTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/TextFormatting/FormattedTextSourceTests.cs
@@ -22,9 +22,10 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
                 new ValueSpan<TextRunProperties>(13, 2, new GenericTextRunProperties(typeface, backgroundBrush: Brushes.Aqua)),
             };
 
-            FormattedTextSource textSource = new FormattedTextSource(text, defaultTextRunProperties, textStyleOverrides);
-            TextRun textRun = textSource.GetTextRun(0);
+            var textSource = new FormattedTextSource(text, defaultTextRunProperties, textStyleOverrides);
+            var textRun = textSource.GetTextRun(0);
 
+            Assert.NotNull(textRun);
             Assert.Equal(2, textRun.Length);
             Assert.Equal("He", textRun.Text.ToString());
         }

--- a/tests/Avalonia.Base.UnitTests/Media/TextFormatting/UnicodeDataGenerator.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/TextFormatting/UnicodeDataGenerator.cs
@@ -468,15 +468,15 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
     
     internal class UnicodeDataEntries
     {
-        public IReadOnlyList<DataEntry> Scripts { get; set; }
-        public IReadOnlyList<DataEntry> GeneralCategories{ get; set; }
-        public IReadOnlyList<DataEntry> LineBreakClasses{ get; set; }
+        public IReadOnlyList<DataEntry> Scripts { get; set; } = [];
+        public IReadOnlyList<DataEntry> GeneralCategories { get; set; } = [];
+        public IReadOnlyList<DataEntry> LineBreakClasses { get; set; } = [];
     }
     
     internal class BiDiDataEntries
     {
-        public IReadOnlyList<DataEntry> PairedBracketTypes { get; set; }
-        public IReadOnlyList<DataEntry> BiDiClasses{ get; set; }
+        public IReadOnlyList<DataEntry> PairedBracketTypes { get; set; } = [];
+        public IReadOnlyList<DataEntry> BiDiClasses { get; set; } = [];
     }
 
     internal readonly struct CodepointRange

--- a/tests/Avalonia.Base.UnitTests/Media/TextFormatting/UnicodeEnumsGenerator.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/TextFormatting/UnicodeEnumsGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using Xunit;
 
 namespace Avalonia.Base.UnitTests.Media.TextFormatting
 {
@@ -129,12 +130,13 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
 
             using (var stream =
                 typeof(UnicodeEnumsGenerator).Assembly.GetManifestResourceStream(
-                    "Avalonia.Base.UnitTests.Media.TextFormatting.BreakPairTable.txt"))
+                    "Avalonia.Base.UnitTests.Media.TextFormatting.BreakPairTable.txt")!)
             using (var reader = new StreamReader(stream))
             {
                 while (!reader.EndOfStream)
                 {
                     var line = reader.ReadLine();
+                    Assert.NotNull(line);
 
                     var columns = line.Split('\t');
 

--- a/tests/Avalonia.Base.UnitTests/Media/UnicodeRangeTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/UnicodeRangeTests.cs
@@ -11,6 +11,7 @@ namespace Avalonia.Visuals.UnitTests.Media
         {
             var range = UnicodeRange.Parse("U+0, U+1, U+2, U+3");
 
+            Assert.NotNull(range.Segments);
             Assert.Equal(new[] { 0, 1, 2, 3 }, range.Segments.Select(x => x.Start));
         }
     }

--- a/tests/Avalonia.Base.UnitTests/PixelSizeTests.cs
+++ b/tests/Avalonia.Base.UnitTests/PixelSizeTests.cs
@@ -8,9 +8,9 @@ public class PixelSizeTests
 {
     [Theory]
     [MemberData(nameof(ParseArguments))]
-    public void Parse(string source, PixelSize expected, Exception exception)
+    public void Parse(string source, PixelSize expected, Exception? exception)
     {
-        Exception error = null;
+        Exception? error = null;
         PixelSize result = default;
         try
         {
@@ -26,9 +26,9 @@ public class PixelSizeTests
 
     [Theory]
     [MemberData(nameof(TryParseArguments))]
-    public void TryParse(string source, PixelSize? expected, Exception exception)
+    public void TryParse(string source, PixelSize? expected, Exception? exception)
     {
-        Exception error = null;
+        Exception? error = null;
         PixelSize result = PixelSize.Empty;
         try
         {
@@ -43,35 +43,35 @@ public class PixelSizeTests
         Assert.Equal(expected, result);
     }
 
-    public static IEnumerable<object[]> ParseArguments()
+    public static IEnumerable<object?[]> ParseArguments()
     {
-        yield return new object[]
-        {
+        yield return
+        [
             "1024,768",
             new PixelSize(1024, 768),
-            null,
-        };
-        yield return new object[]
-        {
+            null
+        ];
+        yield return
+        [
             "1024x768",
             default(PixelSize),
-            new FormatException("Invalid PixelSize."),
-        };
+            new FormatException("Invalid PixelSize.")
+        ];
     }
 
-    public static IEnumerable<object[]> TryParseArguments()
+    public static IEnumerable<object?[]> TryParseArguments()
     {
-        yield return new object[]
-        {
+        yield return
+        [
             "1024,768",
             new PixelSize(1024, 768),
-            null,
-        };
-        yield return new object[]
-        {
+            null
+        ];
+        yield return
+        [
             "1024x768",
             PixelSize.Empty,
-            null,
-        };
+            null
+        ];
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Rendering/SceneGraph/DrawOperationTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/SceneGraph/DrawOperationTests.cs
@@ -81,7 +81,8 @@ namespace Avalonia.Base.UnitTests.Rendering.SceneGraph
             using (ctx.Context.PushTransform(Matrix.CreateScale(scaleX, scaleY)))
                 ctx.Context.DrawRectangle(null, new ImmutablePen(Brushes.Black, penThickness), new Rect(x, y, width, height));
 
-            Assert.Equal(new Rect(expectedX, expectedY, expectedWidth, expectedHeight), ctx.GetBounds().Value);
+            var bounds = Assert.NotNull(ctx.GetBounds());
+            Assert.Equal(new Rect(expectedX, expectedY, expectedWidth, expectedHeight), bounds);
         }
 
         [Theory, InlineData(false), InlineData(true)]

--- a/tests/Avalonia.Base.UnitTests/Styling/ResourceDictionaryTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/ResourceDictionaryTests.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Base.UnitTests.Styling
         public void Cannot_Add_Null_Key()
         {
             var target = new ResourceDictionary();
-            Assert.Throws<ArgumentNullException>(() => target.Add(null, "null"));
+            Assert.Throws<ArgumentNullException>(() => target.Add(null!, "null"));
         }
 
         [Fact]

--- a/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Child.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Child.cs
@@ -47,8 +47,8 @@ namespace Avalonia.Base.UnitTests.Styling
 
             var selector = default(Selector).OfType<TestLogical1>().Class("foo").Child().OfType<TestLogical2>();
             var activator = selector.Match(child).Activator;
-            var result = new List<bool>();
 
+            Assert.NotNull(activator);
             Assert.False(await activator.Take(1));
             parent.Classes.Add("foo");
             Assert.True(await activator.Take(1));
@@ -75,7 +75,7 @@ namespace Avalonia.Base.UnitTests.Styling
 
         public abstract class TestLogical : Control
         {
-            public ILogical LogicalParent
+            public ILogical? LogicalParent
             {
                 get => Parent;
                 set => ((ISetLogicalParent)this).SetParent(value);

--- a/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Class.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Class.cs
@@ -38,6 +38,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var match = target.Match(control);
 
             Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.NotNull(match.Activator);
             Assert.True(await match.Activator.Take(1));
         }
 
@@ -53,6 +54,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var match = target.Match(control);
 
             Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.NotNull(match.Activator);
             Assert.False(await match.Activator.Take(1));
         }
 
@@ -69,6 +71,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var match = target.Match(control);
 
             Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.NotNull(match.Activator);
             Assert.True(await match.Activator.Take(1));
         }
 
@@ -78,11 +81,13 @@ namespace Avalonia.Base.UnitTests.Styling
             var control = new Control1();
 
             var target = default(Selector).Class("foo");
-            var activator = target.Match(control).Activator.ToObservable();
+            var activator = target.Match(control).Activator;
+            Assert.NotNull(activator);
+            var observable = activator.ToObservable();
 
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
             control.Classes.Add("foo");
-            Assert.True(await activator.Take(1));
+            Assert.True(await observable.Take(1));
         }
 
         [Fact]
@@ -94,11 +99,13 @@ namespace Avalonia.Base.UnitTests.Styling
             };
 
             var target = default(Selector).Class("foo");
-            var activator = target.Match(control).Activator.ToObservable();
+            var activator = target.Match(control).Activator;
+            Assert.NotNull(activator);
+            var observable = activator.ToObservable();
 
-            Assert.True(await activator.Take(1));
+            Assert.True(await observable.Take(1));
             control.Classes.Remove("foo");
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
         }
 
         [Fact]
@@ -106,15 +113,17 @@ namespace Avalonia.Base.UnitTests.Styling
         {
             var control = new Control1();
             var target = default(Selector).Class("foo").Class("bar");
-            var activator = target.Match(control).Activator.ToObservable();
+            var activator = target.Match(control).Activator;
+            Assert.NotNull(activator);
+            var observable = activator.ToObservable();
 
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
             control.Classes.Add("foo");
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
             control.Classes.Add("bar");
-            Assert.True(await activator.Take(1));
+            Assert.True(await observable.Take(1));
             control.Classes.Remove("bar");
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
         }
 
         [Fact]
@@ -128,6 +137,7 @@ namespace Avalonia.Base.UnitTests.Styling
 
             var target = default(Selector).Class("foo");
             var activator = target.Match(control).Activator;
+            Assert.NotNull(activator);
             var result = new List<bool>();
 
             using (activator.Subscribe(x => result.Add(x)))

--- a/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Descendent.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Descendent.cs
@@ -51,6 +51,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var selector = default(Selector).OfType<TestLogical1>().Class("foo").Descendant().OfType<TestLogical3>();
             var activator = selector.Match(child).Activator;
 
+            Assert.NotNull(activator);
             Assert.True(await activator.Take(1));
         }
 
@@ -69,6 +70,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var selector = default(Selector).OfType<TestLogical1>().Class("foo").Descendant().OfType<TestLogical3>();
             var activator = selector.Match(child).Activator;
 
+            Assert.NotNull(activator);
             Assert.False(await activator.Take(1));
         }
 
@@ -83,17 +85,19 @@ namespace Avalonia.Base.UnitTests.Styling
             child.LogicalParent = parent;
 
             var selector = default(Selector).OfType<TestLogical1>().Class("foo").Descendant().OfType<TestLogical3>();
-            var activator = selector.Match(child).Activator.ToObservable();
+            var activator = selector.Match(child).Activator;
+            Assert.NotNull(activator);
+            var observable = activator.ToObservable();
 
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
             parent.Classes.Add("foo");
-            Assert.True(await activator.Take(1));
+            Assert.True(await observable.Take(1));
             grandparent.Classes.Add("foo");
-            Assert.True(await activator.Take(1));
+            Assert.True(await observable.Take(1));
             parent.Classes.Remove("foo");
-            Assert.True(await activator.Take(1));
+            Assert.True(await observable.Take(1));
             grandparent.Classes.Remove("foo");
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
         }
 
         [Fact]
@@ -106,7 +110,7 @@ namespace Avalonia.Base.UnitTests.Styling
 
         public abstract class TestLogical : Control
         {
-            public ILogical LogicalParent
+            public ILogical? LogicalParent
             {
                 get => Parent;
                 set => ((ISetLogicalParent)this).SetParent(value);

--- a/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Multiple.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Multiple.cs
@@ -41,6 +41,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var match = selector.Match(border);
 
             Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.NotNull(match.Activator);
             match.Activator.Subscribe(x => values.Add(x));
 
             Assert.Equal(new[] { false }, values);
@@ -103,6 +104,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var match = selector.Match(textBlock);
 
             Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.NotNull(match.Activator);
             match.Activator.Subscribe(x => values.Add(x));
 
             Assert.Equal(new[] { false }, values);
@@ -141,6 +143,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var match = selector.Match(border);
 
             Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.NotNull(match.Activator);
             match.Activator.Subscribe(x => values.Add(x));
 
             Assert.Equal(new[] { false }, values);
@@ -168,6 +171,7 @@ namespace Avalonia.Base.UnitTests.Styling
 
             var activator = match.Activator;
 
+            Assert.NotNull(activator);
             Assert.False(await activator.Take(1));
             control.Tag = "bar";
             Assert.False(await activator.Take(1));

--- a/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Nesting.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Nesting.cs
@@ -22,7 +22,7 @@ namespace Avalonia.Base.UnitTests.Styling
                 }
             };
 
-            var match = nested.Selector.Match(control, parent);
+            var match = nested.Selector!.Match(control, parent);
             Assert.Equal(SelectorMatchResult.NeverThisType, match.Result);
         }
 
@@ -41,7 +41,7 @@ namespace Avalonia.Base.UnitTests.Styling
                 }
             };
 
-            var match = nested.Selector.Match(control, parent);
+            var match = nested.Selector!.Match(control, parent);
             Assert.Equal(SelectorMatchResult.NeverThisType, match.Result);
         }
 
@@ -61,7 +61,7 @@ namespace Avalonia.Base.UnitTests.Styling
                 }
             };
 
-            var match = nested.Selector.Match(control, parent);
+            var match = nested.Selector!.Match(control, parent);
             Assert.Equal(SelectorMatchResult.NeverThisInstance, match.Result);
         }
 
@@ -89,7 +89,7 @@ namespace Avalonia.Base.UnitTests.Styling
                 }
             };
 
-            var match = nested.Selector.Match(control, parent);
+            var match = nested.Selector!.Match(control, parent);
             Assert.Equal(SelectorMatchResult.NeverThisType, match.Result);
         }
 
@@ -106,8 +106,9 @@ namespace Avalonia.Base.UnitTests.Styling
                 }
             };
 
-            var match = nested.Selector.Match(control, parent);
+            var match = nested.Selector!.Match(control, parent);
             Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.NotNull(match.Activator);
 
             var sink = new ActivatorSink(match.Activator);
 
@@ -140,8 +141,9 @@ namespace Avalonia.Base.UnitTests.Styling
                 }
             };
 
-            var match = nested.Selector.Match(control, parent);
+            var match = nested.Selector!.Match(control, parent);
             Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.NotNull(match.Activator);
 
             var sink = new ActivatorSink(match.Activator);
 
@@ -165,8 +167,9 @@ namespace Avalonia.Base.UnitTests.Styling
                 }
             };
 
-            var match = nested.Selector.Match(control, parent);
+            var match = nested.Selector!.Match(control, parent);
             Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.NotNull(match.Activator);
 
             var sink = new ActivatorSink(match.Activator);
 
@@ -191,7 +194,7 @@ namespace Avalonia.Base.UnitTests.Styling
                 }
             };
 
-            var match = nested.Selector.Match(control, parent);
+            var match = nested.Selector!.Match(control, parent);
             Assert.Equal(SelectorMatchResult.AlwaysThisInstance, match.Result);
         }
 
@@ -201,7 +204,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var control = new Control1();
             var style = new Style(x => x.Nesting().OfType<Control1>());
 
-            Assert.Throws<InvalidOperationException>(() => style.Selector.Match(control, null));
+            Assert.Throws<InvalidOperationException>(() => style.Selector!.Match(control, null));
         }
 
         [Fact]
@@ -217,7 +220,7 @@ namespace Avalonia.Base.UnitTests.Styling
                 }
             };
 
-            Assert.Throws<InvalidOperationException>(() => nested.Selector.Match(control, parent));
+            Assert.Throws<InvalidOperationException>(() => nested.Selector!.Match(control, parent));
         }
 
         [Fact]
@@ -272,8 +275,9 @@ namespace Avalonia.Base.UnitTests.Styling
                 }
             };
 
-            var match = nested.Selector.Match(control, parent);
+            var match = nested.Selector!.Match(control, parent);
             Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.NotNull(match.Activator);
 
             var sink = new ActivatorSink(match.Activator);
 

--- a/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Not.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Not.cs
@@ -45,6 +45,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var match = target.Match(control);
 
             Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.NotNull(match.Activator);
             Assert.False(await match.Activator.Take(1));
         }
 
@@ -60,6 +61,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var match = target.Match(control);
 
             Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.NotNull(match.Activator);
             Assert.True(await match.Activator.Take(1));
         }
 
@@ -75,6 +77,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var match = target.Match(control);
 
             Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.NotNull(match.Activator);
             Assert.True(await match.Activator.Take(1));
         }
 

--- a/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_PropertyEquals.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_PropertyEquals.cs
@@ -17,13 +17,13 @@ namespace Avalonia.Base.UnitTests.Styling
 
         class Auth
         {
-            public readonly static AttachedProperty<string> NameProperty =
-                AvaloniaProperty.RegisterAttached<Auth, AvaloniaObject, string>("Name");
+            public readonly static AttachedProperty<string?> NameProperty =
+                AvaloniaProperty.RegisterAttached<Auth, AvaloniaObject, string?>("Name");
 
-            public static string GetName(AvaloniaObject avaloniaObject) =>
+            public static string? GetName(AvaloniaObject avaloniaObject) =>
                 avaloniaObject.GetValue(NameProperty);
 
-            public static void SetName(AvaloniaObject avaloniaObject, string value) =>
+            public static void SetName(AvaloniaObject avaloniaObject, string? value) =>
                 avaloniaObject.SetValue(NameProperty, value);
         }
 
@@ -39,16 +39,19 @@ namespace Avalonia.Base.UnitTests.Styling
                     _ => null
                 };
             }).Parse("TextBlock[(Grid.Column)=1]");
-            
+
+            Assert.NotNull(target);
 
             var control = new TextBlock();
-            var activator = target.Match(control).Activator.ToObservable();
+            var activator = target.Match(control).Activator;
+            Assert.NotNull(activator);
+            var observable = activator.ToObservable();
 
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
             Grid.SetColumn(control, 1);
-            Assert.True(await activator.Take(1));
+            Assert.True(await observable.Take(1));
             Grid.SetColumn(control, 0);
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
         }
 
         [Fact]
@@ -64,15 +67,19 @@ namespace Avalonia.Base.UnitTests.Styling
                 };
             }).Parse("TextBlock[(l|Auth.Name)=Admin]");
 
+            Assert.NotNull(target);
+
 
             var control = new TextBlock();
-            var activator = target.Match(control).Activator.ToObservable();
+            var activator = target.Match(control).Activator;
+            Assert.NotNull(activator);
+            var observable = activator.ToObservable();
 
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
             Auth.SetName(control, "Admin");
-            Assert.True(await activator.Take(1));
+            Assert.True(await observable.Take(1));
             Auth.SetName(control, null);
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
         }
 
         [Fact]
@@ -80,13 +87,15 @@ namespace Avalonia.Base.UnitTests.Styling
         {
             var control = new TextBlock();
             var target = default(Selector).PropertyEquals(TextBlock.TextProperty, "foo");
-            var activator = target.Match(control).Activator.ToObservable();
+            var activator = target.Match(control).Activator;
+            Assert.NotNull(activator);
+            var observable = activator.ToObservable();
 
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
             control.Text = "foo";
-            Assert.True(await activator.Take(1));
+            Assert.True(await observable.Take(1));
             control.Text = null;
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
         }
 
         [Theory]
@@ -97,13 +106,15 @@ namespace Avalonia.Base.UnitTests.Styling
         {
             var control = new TextBlock();
             var target = default(Selector).PropertyEquals(TextBlock.TagProperty, literal);
-            var activator = target.Match(control).Activator.ToObservable();
+            var activator = target.Match(control).Activator;
+            Assert.NotNull(activator);
+            var observable = activator.ToObservable();
 
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
             control.Tag = value;
-            Assert.True(await activator.Take(1));
+            Assert.True(await observable.Take(1));
             control.Tag = null;
-            Assert.False(await activator.Take(1));
+            Assert.False(await observable.Take(1));
         }
 
         [Fact]

--- a/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Template.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Template.cs
@@ -87,6 +87,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var selector = default(Selector).OfType(styleKey).Class("foo").Template().OfType<Border>();
             var activator = selector.Match(border).Activator;
 
+            Assert.NotNull(activator);
             Assert.True(await activator.Take(1));
         }
 
@@ -99,6 +100,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var selector = default(Selector).OfType(typeof(TestTemplatedControl)).Class("foo").Template().OfType<Border>();
             var activator = selector.Match(border).Activator;
 
+            Assert.NotNull(activator);
             Assert.False(await activator.Take(1));
         }
 
@@ -109,6 +111,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var border = (Border)target.VisualChildren.Single();
             var selector = default(Selector).OfType(typeof(TestTemplatedControl)).Class("foo").Template().OfType<Border>();
             var activator = selector.Match(border).Activator;
+            Assert.NotNull(activator);
 
             using (activator.Subscribe(_ => { }))
             {

--- a/tests/Avalonia.Base.UnitTests/Styling/StyledElementTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/StyledElementTests.cs
@@ -147,7 +147,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var border = new Border { Child = canvas };
             var raised = 0;
 
-            void Attached(object sender, LogicalTreeAttachmentEventArgs e)
+            void Attached(object? sender, LogicalTreeAttachmentEventArgs e)
             {
                 Assert.Same(border, e.Source);
                 ++raised;
@@ -169,7 +169,7 @@ namespace Avalonia.Base.UnitTests.Styling
             var border = new Border { Child = canvas };
             var raised = 0;
 
-            void Attached(object sender, LogicalTreeAttachmentEventArgs e)
+            void Attached(object? sender, LogicalTreeAttachmentEventArgs e)
             {
                 Assert.Same(root, e.Parent);
                 ++raised;
@@ -406,8 +406,8 @@ namespace Avalonia.Base.UnitTests.Styling
                 }
             };
 
-            var called = new List<string>();
-            void Record(object sender, EventArgs e) => called.Add(((StyledElement)sender).Name);
+            var called = new List<string?>();
+            void Record(object? sender, EventArgs e) => called.Add(((StyledElement)sender!).Name);
 
             root.DataContextChanged += Record;
 
@@ -449,9 +449,9 @@ namespace Avalonia.Base.UnitTests.Styling
 
             foreach (IDataContextEvents c in root.GetSelfAndLogicalDescendants())
             {
-                c.DataContextBeginUpdate += (s, e) => called.Add("begin " + ((StyledElement)s).Name);
-                c.DataContextChanged += (s, e) => called.Add("changed " + ((StyledElement)s).Name);
-                c.DataContextEndUpdate += (s, e) => called.Add("end " + ((StyledElement)s).Name);
+                c.DataContextBeginUpdate += (s, e) => called.Add("begin " + ((StyledElement)s!).Name);
+                c.DataContextChanged += (s, e) => called.Add("changed " + ((StyledElement)s!).Name);
+                c.DataContextEndUpdate += (s, e) => called.Add("end " + ((StyledElement)s!).Name);
             }
 
             root.DataContext = "foo";
@@ -501,11 +501,11 @@ namespace Avalonia.Base.UnitTests.Styling
 
             var called = new List<string>();
 
-            foreach (IDataContextEvents c in new[] { children[0], children[0].Child, children[1] })
+            foreach (var c in new[] { children[0], (IDataContextEvents)children[0].Child!, children[1] })
             {
-                c.DataContextBeginUpdate += (s, e) => called.Add("begin " + ((StyledElement)s).Name);
-                c.DataContextChanged += (s, e) => called.Add("changed " + ((StyledElement)s).Name);
-                c.DataContextEndUpdate += (s, e) => called.Add("end " + ((StyledElement)s).Name);
+                c.DataContextBeginUpdate += (s, e) => called.Add("begin " + ((StyledElement)s!).Name);
+                c.DataContextChanged += (s, e) => called.Add("changed " + ((StyledElement)s!).Name);
+                c.DataContextEndUpdate += (s, e) => called.Add("end " + ((StyledElement)s!).Name);
             }
 
             root.Children.AddRange(children);
@@ -624,17 +624,17 @@ namespace Avalonia.Base.UnitTests.Styling
 
         private interface IDataContextEvents
         {
-            event EventHandler DataContextBeginUpdate;
-            event EventHandler DataContextChanged;
-            event EventHandler DataContextEndUpdate;
+            event EventHandler? DataContextBeginUpdate;
+            event EventHandler? DataContextChanged;
+            event EventHandler? DataContextEndUpdate;
         }
 
         private class TestControl : Decorator, IDataContextEvents
         {
-            public event EventHandler DataContextBeginUpdate;
-            public event EventHandler DataContextEndUpdate;
+            public event EventHandler? DataContextBeginUpdate;
+            public event EventHandler? DataContextEndUpdate;
 
-            public new AvaloniaObject InheritanceParent => base.InheritanceParent;
+            public new AvaloniaObject? InheritanceParent => base.InheritanceParent;
 
             protected override void OnDataContextBeginUpdate()
             {
@@ -651,8 +651,8 @@ namespace Avalonia.Base.UnitTests.Styling
 
         private class TestStackPanel : StackPanel, IDataContextEvents
         {
-            public event EventHandler DataContextBeginUpdate;
-            public event EventHandler DataContextEndUpdate;
+            public event EventHandler? DataContextBeginUpdate;
+            public event EventHandler? DataContextEndUpdate;
 
             protected override void OnDataContextBeginUpdate()
             {

--- a/tests/Avalonia.Base.UnitTests/Styling/TestObserver.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/TestObserver.cs
@@ -6,11 +6,11 @@ namespace Avalonia.Base.UnitTests.Styling
     {
         private bool _hasValue;
 
-        private T _value;
+        private T _value = default!;
 
         public bool Completed { get; private set; }
 
-        public Exception Error { get; private set; }
+        public Exception? Error { get; private set; }
 
         public T GetValue()
         {

--- a/tests/Avalonia.Base.UnitTests/TestVisual.cs
+++ b/tests/Avalonia.Base.UnitTests/TestVisual.cs
@@ -17,11 +17,11 @@ namespace Avalonia.Base.UnitTests
 
     public class TestVisual : Visual
     {
-        public Visual Child
+        public Visual? Child
         {
             get
             {
-                return ((Visual)this).VisualChildren.FirstOrDefault();
+                return VisualChildren.FirstOrDefault();
             }
 
             set

--- a/tests/Avalonia.Base.UnitTests/Utilities/DelegateCommand.cs
+++ b/tests/Avalonia.Base.UnitTests/Utilities/DelegateCommand.cs
@@ -6,14 +6,14 @@ namespace Avalonia.Base.UnitTests.Utilities;
 internal class DelegateCommand : ICommand
 {
     private readonly Action _action;
-    private readonly Func<object, bool> _canExecute;
-    public DelegateCommand(Action action, Func<object, bool> canExecute = default)
+    private readonly Func<object?, bool> _canExecute;
+    public DelegateCommand(Action action, Func<object?, bool>? canExecute = null)
     {
         _action = action;
-        _canExecute = canExecute ?? new(_ => true);
+        _canExecute = canExecute ?? (_ => true);
     }
 
-    public event EventHandler CanExecuteChanged { add { } remove { } }
-    public bool CanExecute(object parameter) => _canExecute(parameter);
-    public void Execute(object parameter) => _action();
+    public event EventHandler? CanExecuteChanged { add { } remove { } }
+    public bool CanExecute(object? parameter) => _canExecute(parameter);
+    public void Execute(object? parameter) => _action();
 }

--- a/tests/Avalonia.Base.UnitTests/VisualTests.cs
+++ b/tests/Avalonia.Base.UnitTests/VisualTests.cs
@@ -30,13 +30,13 @@ namespace Avalonia.Base.UnitTests
         {
             var target = new TestVisual();
             var child = new TestVisual();
-            var parents = new List<Visual>();
+            var parents = new List<Visual?>();
 
             child.GetObservable(Visual.VisualParentProperty).Subscribe(x => parents.Add(x));
             target.AddChild(child);
             target.RemoveChild(child);
 
-            Assert.Equal(new Visual[] { null, target, null }, parents);
+            Assert.Equal([null, target, null], parents);
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace Avalonia.Base.UnitTests
 
             var result = children.Select(x => x.GetVisualParent()).ToList();
 
-            Assert.Equal(new Visual[] { null, null }, result);
+            Assert.Equal([null, null], result);
         }
 
         [Fact]

--- a/tests/Avalonia.Base.UnitTests/WeakEventHandlerManagerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/WeakEventHandlerManagerTests.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Avalonia.Utilities;
 using Xunit;
 
@@ -12,24 +8,24 @@ namespace Avalonia.Base.UnitTests
     {
         class EventSource
         {
-            public event EventHandler<EventArgs> Event;
+            public event EventHandler<EventArgs>? Event;
 
             public void Fire()
             {
-                Event?.Invoke(this, new EventArgs());
+                Event?.Invoke(this, EventArgs.Empty);
             }
         }
 
         class Subscriber
         {
-            private readonly Action _onEvent;
+            private readonly Action? _onEvent;
 
             public Subscriber(Action onEvent)
             {
                 _onEvent = onEvent;
             }
 
-            public void OnEvent(object sender, EventArgs ev)
+            public void OnEvent(object? sender, EventArgs ev)
             {
                 _onEvent?.Invoke();
             }

--- a/tests/Avalonia.Base.UnitTests/WeakEventTests.cs
+++ b/tests/Avalonia.Base.UnitTests/WeakEventTests.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Avalonia.Utilities;
 using Xunit;
 
@@ -12,11 +8,11 @@ namespace Avalonia.Base.UnitTests
     {
         class EventSource
         {
-            public event EventHandler Event;
+            public event EventHandler? Event;
 
             public void Fire()
             {
-                Event?.Invoke(this, new EventArgs());
+                Event?.Invoke(this, EventArgs.Empty);
             }
 
             public static readonly WeakEvent<EventSource, EventArgs> WeakEv = WeakEvent.Register<EventSource>(
@@ -26,14 +22,14 @@ namespace Avalonia.Base.UnitTests
 
         class Subscriber : IWeakEventSubscriber<EventArgs>
         {
-            private readonly Action _onEvent;
+            private readonly Action? _onEvent;
 
-            public Subscriber(Action onEvent)
+            public Subscriber(Action? onEvent)
             {
                 _onEvent = onEvent;
             }
 
-            public void OnEvent(object sender, WeakEvent ev, EventArgs args)
+            public void OnEvent(object? sender, WeakEvent ev, EventArgs args)
             {
                 _onEvent?.Invoke();
             }

--- a/tests/Avalonia.Markup.UnitTests/Avalonia.Markup.UnitTests.csproj
+++ b/tests/Avalonia.Markup.UnitTests/Avalonia.Markup.UnitTests.csproj
@@ -11,6 +11,7 @@
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\Microsoft.Reactive.Testing.props" />
   <Import Project="..\..\build\SharedVersion.props" />
+  <Import Project="..\..\build\NullableEnable.props" />
   <ItemGroup>
     <ProjectReference Include="..\..\src\Markup\Avalonia.Markup\Avalonia.Markup.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Base\Avalonia.Base.csproj" />

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
@@ -88,9 +88,9 @@ namespace Avalonia.Markup.UnitTests.Data
 
         private class DummyObject : ICloneable
         {
-            private readonly string _val;
+            private readonly string? _val;
 
-            public DummyObject(string val)
+            public DummyObject(string? val)
             {
                 _val = val;
             }
@@ -105,7 +105,7 @@ namespace Avalonia.Markup.UnitTests.Data
                 return string.Equals(_val, other._val);
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 if (ReferenceEquals(null, obj))
                     return false;
@@ -294,7 +294,7 @@ namespace Avalonia.Markup.UnitTests.Data
             };
 
             var child = new Control();
-            var values = new List<object>();
+            var values = new List<object?>();
 
             child.GetObservable(Control.DataContextProperty).Subscribe(x => values.Add(x));
             child.Bind(Control.DataContextProperty, new Binding("Foo"));
@@ -717,7 +717,7 @@ namespace Avalonia.Markup.UnitTests.Data
 
         private class NullableValuesViewModel : INotifyPropertyChanged
         {
-            public event PropertyChangedEventHandler PropertyChanged;
+            public event PropertyChangedEventHandler? PropertyChanged;
 
             private double? _nullableDouble;
             public double? NullableDouble
@@ -739,7 +739,7 @@ namespace Avalonia.Markup.UnitTests.Data
             private bool _boolValue;
             private double _value;
 
-            public event PropertyChangedEventHandler PropertyChanged;
+            public event PropertyChangedEventHandler? PropertyChanged;
 
             public bool BoolValue
             {
@@ -815,10 +815,10 @@ namespace Avalonia.Markup.UnitTests.Data
 
         public class Source : INotifyPropertyChanged
         {
-            private PropertyChangedEventHandler _propertyChanged;
-            private string _foo;
+            private PropertyChangedEventHandler? _propertyChanged;
+            private string? _foo;
 
-            public string Foo
+            public string? Foo
             {
                 get => _foo;
                 set
@@ -834,7 +834,7 @@ namespace Avalonia.Markup.UnitTests.Data
 
             public int SubscriberCount { get; private set; }
 
-            public event PropertyChangedEventHandler PropertyChanged
+            public event PropertyChangedEventHandler? PropertyChanged
             {
                 add { _propertyChanged += value; ++SubscriberCount; }
                 remove { _propertyChanged += value; --SubscriberCount; }
@@ -848,9 +848,9 @@ namespace Avalonia.Markup.UnitTests.Data
 
         public class WeakRefSource : INotifyPropertyChanged
         {
-            private WeakReference<object> _foo;
+            private WeakReference<object?>? _foo;
 
-            public object Foo
+            public object? Foo
             {
                 get
                 {
@@ -859,7 +859,7 @@ namespace Avalonia.Markup.UnitTests.Data
                         return null;
                     }
 
-                    if (_foo.TryGetTarget(out object target))
+                    if (_foo.TryGetTarget(out var target))
                     {
                         if (target is ICloneable cloneable)
                         {
@@ -873,13 +873,13 @@ namespace Avalonia.Markup.UnitTests.Data
                 }
                 set
                 {
-                    _foo = new WeakReference<object>(value);
+                    _foo = new WeakReference<object?>(value);
 
                     RaisePropertyChanged();
                 }
             }
 
-            public event PropertyChangedEventHandler PropertyChanged;
+            public event PropertyChangedEventHandler? PropertyChanged;
 
             private void RaisePropertyChanged([CallerMemberName] string prop = "")
             {
@@ -895,15 +895,15 @@ namespace Avalonia.Markup.UnitTests.Data
 
         private class TestControl : Control
         {
-            public static readonly DirectProperty<TestControl, object> ValueProperty =
-                AvaloniaProperty.RegisterDirect<TestControl, object>(
+            public static readonly DirectProperty<TestControl, object?> ValueProperty =
+                AvaloniaProperty.RegisterDirect<TestControl, object?>(
                     nameof(Value),
                     o => o.Value,
                     (o, v) => o.Value = v);
 
-            private object _value;
+            private object? _value;
 
-            public object Value
+            public object? Value
             {
                 get => _value;
                 set => SetAndRaise(ValueProperty, ref _value, value);

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Converters.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Converters.cs
@@ -25,9 +25,9 @@ namespace Avalonia.Markup.UnitTests.Data
                 Converter = StringConverters.IsNullOrEmpty,
             };
 
-            var expressionObserver = (BindingExpression)target.Initiate(
-                textBlock,
-                TextBlock.TextProperty).Expression;
+            var instancedBinding = target.Initiate(textBlock, TextBlock.TextProperty);
+            Assert.NotNull(instancedBinding);
+            var expressionObserver = Assert.IsType<BindingExpression>(instancedBinding.Expression);
 
             Assert.Same(StringConverters.IsNullOrEmpty, expressionObserver.Converter);
         }

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_ElementName.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_ElementName.cs
@@ -38,7 +38,7 @@ namespace Avalonia.Markup.UnitTests.Data
             {
                 ElementName = "source",
                 Path = "Text",
-                NameScope = new WeakReference<INameScope>(NameScope.GetNameScope(root))
+                NameScope = new WeakReference<INameScope?>(NameScope.GetNameScope(root))
             };
 
             target.Bind(TextBox.TextProperty, binding);
@@ -75,7 +75,7 @@ namespace Avalonia.Markup.UnitTests.Data
             var binding = new Binding
             {
                 ElementName = "source",
-                NameScope = new WeakReference<INameScope>(NameScope.GetNameScope(root))
+                NameScope = new WeakReference<INameScope?>(NameScope.GetNameScope(root))
             };
 
             target.Bind(ContentControl.ContentProperty, binding);
@@ -108,7 +108,7 @@ namespace Avalonia.Markup.UnitTests.Data
             {
                 ElementName = "source",
                 Path = "Text",
-                NameScope = new WeakReference<INameScope>(NameScope.GetNameScope(root))
+                NameScope = new WeakReference<INameScope?>(NameScope.GetNameScope(root))
             };
 
             target.Bind(TextBox.TextProperty, binding);
@@ -146,7 +146,7 @@ namespace Avalonia.Markup.UnitTests.Data
             var binding = new Binding
             {
                 ElementName = "source",
-                NameScope = new WeakReference<INameScope>(NameScope.GetNameScope(root))
+                NameScope = new WeakReference<INameScope?>(NameScope.GetNameScope(root))
             };
 
             target.Bind(ContentControl.ContentProperty, binding);

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Logging.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Logging.cs
@@ -2,14 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Avalonia.Controls;
-using Avalonia.Controls.Converters;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Data.Core;
-using Avalonia.Data.Core.Plugins;
 using Avalonia.Input;
 using Avalonia.Logging;
-using Avalonia.LogicalTree;
 using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings;
 using Avalonia.Reactive;
@@ -485,6 +482,6 @@ namespace Avalonia.Markup.UnitTests.Data
             }
         }
 
-        private record LogMessage(LogEventLevel level, string area, object source, string messageTemplate, params object[] propertyValues);
+        private record LogMessage(LogEventLevel level, string area, object? source, string messageTemplate, params object?[] propertyValues);
     }
 }

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Source.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Source.cs
@@ -25,9 +25,9 @@ namespace Avalonia.Markup.UnitTests.Data
         
         public class Source : INotifyPropertyChanged
         {
-            private string _foo;
+            private string? _foo;
 
-            public string Foo
+            public string? Foo
             {
                 get => _foo;
                 set
@@ -37,7 +37,7 @@ namespace Avalonia.Markup.UnitTests.Data
                 }
             }
 
-            public event PropertyChangedEventHandler PropertyChanged;
+            public event PropertyChangedEventHandler? PropertyChanged;
 
             private void RaisePropertyChanged([CallerMemberName] string prop = "")
             {

--- a/tests/Avalonia.Markup.UnitTests/Data/DynamicReflectableType.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/DynamicReflectableType.cs
@@ -34,7 +34,7 @@ class DynamicReflectableType : IReflectableType, INotifyPropertyChanged, IEnumer
         }
     }
     
-    public event PropertyChangedEventHandler PropertyChanged;
+    public event PropertyChangedEventHandler? PropertyChanged;
     public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
     {
         return _dic.GetEnumerator();
@@ -48,8 +48,8 @@ class DynamicReflectableType : IReflectableType, INotifyPropertyChanged, IEnumer
 
     class FakeTypeInfo : TypeInfo
     {
-        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types,
-            ParameterModifier[] modifiers)
+        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder? binder, Type? returnType, Type[]? types,
+            ParameterModifier[]? modifiers)
         {
             var propInfo = new Mock<PropertyInfo>();
             propInfo.SetupGet(x => x.Name).Returns(name);
@@ -83,16 +83,16 @@ class DynamicReflectableType : IReflectableType, INotifyPropertyChanged, IEnumer
             throw new NotSupportedException();
         }
 
-        public override Module Module { get; }
-        public override string Namespace { get; }
-        public override string Name { get; }
+        public override Module Module => throw new NotSupportedException();
+        public override string? Namespace => null;
+        public override string Name => "";
         protected override TypeAttributes GetAttributeFlagsImpl()
         {
             throw new NotSupportedException();
         }
 
-        protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention,
-            Type[] types, ParameterModifier[] modifiers)
+        protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention,
+            Type[] types, ParameterModifier[]? modifiers)
         {
             throw new NotSupportedException();
         }
@@ -132,8 +132,8 @@ class DynamicReflectableType : IReflectableType, INotifyPropertyChanged, IEnumer
             throw new NotSupportedException();
         }
 
-        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention,
-            Type[] types, ParameterModifier[] modifiers)
+        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention,
+            Type[]? types, ParameterModifier[]? modifiers)
         {
             throw new NotSupportedException();
         }
@@ -148,13 +148,13 @@ class DynamicReflectableType : IReflectableType, INotifyPropertyChanged, IEnumer
             throw new NotSupportedException();
         }
 
-        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args,
-            ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
+        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object?[]? args,
+            ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters)
         {
             throw new NotSupportedException();
         }
 
-        public override Type UnderlyingSystemType { get; }
+        public override Type UnderlyingSystemType => throw new NotSupportedException();
 
         protected override bool IsArrayImpl()
         {
@@ -181,11 +181,11 @@ class DynamicReflectableType : IReflectableType, INotifyPropertyChanged, IEnumer
             throw new NotSupportedException();
         }
 
-        public override Assembly Assembly { get; }
-        public override string AssemblyQualifiedName { get; }
-        public override Type BaseType { get; }
-        public override string FullName { get; }
-        public override Guid GUID { get; }
+        public override Assembly Assembly => throw new NotSupportedException();
+        public override string? AssemblyQualifiedName => null;
+        public override Type? BaseType => null;
+        public override string? FullName => null;
+        public override Guid GUID => Guid.Empty;
 
         
 

--- a/tests/Avalonia.Markup.UnitTests/Data/MultiBindingTests_Converters.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/MultiBindingTests_Converters.cs
@@ -87,7 +87,7 @@ namespace Avalonia.Markup.UnitTests.Data
 
         private class SumOfDoublesConverter : IMultiValueConverter
         {
-            public object Convert(IList<object> values, Type targetType, object parameter, CultureInfo culture)
+            public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
             {
                 return values.OfType<double>().Sum();
             }

--- a/tests/Avalonia.Markup.UnitTests/Data/TemplateBindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/TemplateBindingTests.cs
@@ -303,7 +303,7 @@ namespace Avalonia.Markup.UnitTests.Data
 
         private class PrefixConverter : IValueConverter
         {
-            public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
             {
                 if (value != null && parameter != null)
                 {
@@ -313,12 +313,12 @@ namespace Avalonia.Markup.UnitTests.Data
                 return null;
             }
 
-            public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
             {
                 if (value != null && parameter != null)
                 {
-                    var s = value.ToString();
-                    var prefix = parameter.ToString();
+                    var s = value.ToString() ?? string.Empty;
+                    var prefix = parameter.ToString() ?? string.Empty;
 
                     if (s.StartsWith(prefix) == true)
                     {
@@ -334,9 +334,9 @@ namespace Avalonia.Markup.UnitTests.Data
 
         private class MultiConverter : IMultiValueConverter
         {
-            public List<object> Values { get; } = new();
+            public List<object?> Values { get; } = new();
 
-            public object Convert(IList<object> values, Type targetType, object parameter, CultureInfo culture)
+            public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
             {
                 Values.AddRange(values);
                 return values.FirstOrDefault();

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionNodeFactoryTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionNodeFactoryTests.cs
@@ -17,6 +17,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var result = Parse("Foo");
 
+            Assert.NotNull(result);
             AssertIsProperty(result[0], "Foo");
         }
 
@@ -25,6 +26,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var result = Parse("_Foo");
 
+            Assert.NotNull(result);
             AssertIsProperty(result[0], "_Foo");
         }
 
@@ -33,6 +35,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var result = Parse("F0o");
 
+            Assert.NotNull(result);
             AssertIsProperty(result[0], "F0o");
         }
 
@@ -49,6 +52,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var result = Parse("Foo.Bar.Baz");
 
+            Assert.NotNull(result);
             Assert.Equal(3, result.Count);
             AssertIsProperty(result[0], "Foo");
             AssertIsProperty(result[1], "Bar");
@@ -60,6 +64,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var result = Parse("!Foo.Bar.Baz");
 
+            Assert.NotNull(result);
             Assert.Equal(4, result.Count);
             AssertIsProperty(result[0], "Foo");
             AssertIsProperty(result[1], "Bar");
@@ -72,6 +77,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var result = Parse("!!Foo.Bar.Baz");
 
+            Assert.NotNull(result);
             Assert.Equal(5, result.Count);
             AssertIsProperty(result[0], "Foo");
             AssertIsProperty(result[1], "Bar");
@@ -85,6 +91,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var result = Parse("Foo[15]");
 
+            Assert.NotNull(result);
             Assert.Equal(2, result.Count);
             AssertIsProperty(result[0], "Foo");
             AssertIsIndexer(result[1], "15");
@@ -96,6 +103,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var result = Parse("Foo[Key]");
 
+            Assert.NotNull(result);
             Assert.Equal(2, result.Count);
             AssertIsProperty(result[0], "Foo");
             AssertIsIndexer(result[1], "Key");
@@ -107,6 +115,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var result = Parse("Foo[15,6]");
 
+            Assert.NotNull(result);
             Assert.Equal(2, result.Count);
             AssertIsProperty(result[0], "Foo");
             AssertIsIndexer(result[1], "15", "6");
@@ -117,6 +126,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var result = Parse("Foo[5, 16]");
 
+            Assert.NotNull(result);
             Assert.Equal(2, result.Count);
             AssertIsProperty(result[0], "Foo");
             AssertIsIndexer(result[1], "5", "16");
@@ -127,6 +137,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var result = Parse("Foo[15][16]");
 
+            Assert.NotNull(result);
             Assert.Equal(3, result.Count);
             AssertIsProperty(result[0], "Foo");
             AssertIsIndexer(result[1], "15");
@@ -138,6 +149,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var result = Parse("Foo.Bar[5, 6].Baz");
 
+            Assert.NotNull(result);
             Assert.Equal(4, result.Count);
             AssertIsProperty(result[0], "Foo");
             AssertIsProperty(result[1], "Bar");
@@ -150,6 +162,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var result = Parse("Foo^");
 
+            Assert.NotNull(result);
             Assert.Equal(2, result.Count);
             Assert.IsType<DynamicPluginStreamNode>(result[1]);
         }
@@ -166,7 +179,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
             Assert.Equal(e.Arguments.Cast<string>().ToArray(), args);
         }
 
-        private static List<ExpressionNode> Parse(string path)
+        private static List<ExpressionNode>? Parse(string path)
         {
             var reader = new CharacterReader(path.AsSpan());
             var (astNodes, sourceMode) = BindingExpressionGrammar.Parse(ref reader);

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AttachedProperty.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AttachedProperty.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
 {
     public class ExpressionObserverBuilderTests_AttachedProperty : ScopedTestBase
     {
-        private readonly Func<string, string, Type> _typeResolver;
+        private readonly Func<string?, string, Type?> _typeResolver;
 
         public ExpressionObserverBuilderTests_AttachedProperty()
         {
@@ -87,7 +87,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var data = new Class1();
             var target = Build(data, "(Owner.Foo)", typeResolver: _typeResolver);
-            var result = new List<object>();
+            var result = new List<object?>();
 
             var sub = target.Subscribe(x => result.Add(x));
             data.SetValue(Owner.FooProperty, "bar");
@@ -111,7 +111,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
             };
 
             var target = Build(data, "Next.(Owner.Foo)", typeResolver: _typeResolver);
-            var result = new List<object>();
+            var result = new List<object?>();
 
             var sub = target.Subscribe(x => result.Add(x));
             data.Next.SetValue(Owner.FooProperty, "bar");
@@ -126,15 +126,15 @@ namespace Avalonia.Markup.UnitTests.Parsers
         [Fact]
         public void Should_Not_Keep_Source_Alive()
         {
-            Func<Tuple<IObservable<object>, WeakReference>> run = () =>
+            var run = () =>
             {
                 var source = new Class1();
                 var target = Build(source, "(Owner.Foo)", typeResolver: _typeResolver);
-                return Tuple.Create(target, new WeakReference(source));
+                return (target, source: new WeakReference(source));
             };
 
             var result = run();
-            result.Item1.Subscribe(x => { });
+            result.target.Subscribe(x => { });
 
             // Mono trickery
             GC.Collect(2);
@@ -142,7 +142,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
             GC.WaitForPendingFinalizers();
             GC.Collect(2);
 
-            Assert.Null(result.Item2.Target);
+            Assert.Null(result.source.Target);
         }
 
         [Fact]
@@ -161,7 +161,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
             Assert.Throws<ExpressionParseException>(() => Build(data, "(Owner.Foo.Bar)", typeResolver: _typeResolver));
         }
 
-        private static IObservable<object> Build(object source, string path, Func<string, string, Type> typeResolver)
+        private static IObservable<object?> Build(object source, string path, Func<string?, string, Type?> typeResolver)
         {
             var r = new CharacterReader(path);
             var grammar = BindingExpressionGrammar.Parse(ref r).Nodes;

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AvaloniaProperty.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AvaloniaProperty.cs
@@ -36,7 +36,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var data = new Class1();
             var target = Build(data, "Foo");
-            var result = new List<object>();
+            var result = new List<object?>();
 
             var sub = target.ToObservable().Subscribe(x => result.Add(x));
             data.SetValue(Class1.FooProperty, "bar");

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Indexer.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Indexer.cs
@@ -159,7 +159,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var data = new { Foo = new AvaloniaList<string> { "foo", "bar" } };
             var target = BuildAsObservable(data, "Foo[2]");
-            var result = new List<object>();
+            var result = new List<object?>();
 
             using (var sub = target.Subscribe(x => result.Add(BindingNotification.ExtractValue(x))))
             {
@@ -180,7 +180,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var data = new { Foo = new AvaloniaList<string> { "foo", "bar" } };
             var target = BuildAsObservable(data, "Foo[0]");
-            var result = new List<object>();
+            var result = new List<object?>();
 
             using (var sub = target.Subscribe(x => result.Add(x)))
             {
@@ -201,7 +201,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var data = new { Foo = new AvaloniaList<string> { "foo", "bar" } };
             var target = BuildAsObservable(data, "Foo[1]");
-            var result = new List<object>();
+            var result = new List<object?>();
 
             using (var sub = target.Subscribe(x => result.Add(x)))
             {
@@ -225,7 +225,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
             // as AvaloniaList as it implements PropertyChanged as an explicit interface event.
             var data = new { Foo = new ObservableCollection<string> { "foo", "bar" } };
             var target = BuildAsObservable(data, "Foo[1]");
-            var result = new List<object>();
+            var result = new List<object?>();
 
             var sub = target.Subscribe(x => result.Add(x));
             data.Foo.Move(0, 1);
@@ -241,7 +241,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var data = new { Foo = new AvaloniaList<string> { "foo", "bar" } };
             var target = BuildAsObservable(data, "Foo[1]");
-            var result = new List<object>();
+            var result = new List<object?>();
 
             var sub = target.Subscribe(x => result.Add(BindingNotification.ExtractValue(x)));
             data.Foo.Clear();
@@ -260,7 +260,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
             data.Foo["baz"] = "qux";
 
             var target = BuildAsObservable(data, "Foo[foo]");
-            var result = new List<object>();
+            var result = new List<object?>();
 
             using (var sub = target.Subscribe(x => result.Add(x)))
             {
@@ -368,7 +368,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
             Assert.Equal(data[1], value);
         }
 
-        private static BindingExpression Build(object source, string path, Func<string, string, Type> typeResolver = null)
+        private static BindingExpression Build(object source, string path, Func<string?, string, Type>? typeResolver = null)
         {
             var r = new CharacterReader(path);
             var grammar = BindingExpressionGrammar.Parse(ref r).Nodes;
@@ -376,7 +376,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
             return new BindingExpression(source, nodes, AvaloniaProperty.UnsetValue);
         }
 
-        private static IObservable<object> BuildAsObservable(object source, string path, Func<string, string, Type> typeResolver = null)
+        private static IObservable<object?> BuildAsObservable(object source, string path, Func<string?, string, Type>? typeResolver = null)
         {
             return Build(source, path, typeResolver).ToObservable();
         }

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Method.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Method.cs
@@ -62,7 +62,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
             var observer = Build(data, nameof(TestObject.MethodWithReturnAndParameter));
             var result = await observer.Take(1);
 
-            var callback = (Func<object, int>)result;
+            var callback = (Func<object, int>)result!;
 
             Assert.Equal(1, callback(1));
 
@@ -70,7 +70,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         }
 
 
-        private static IObservable<object> Build(object source, string path)
+        private static IObservable<object?> Build(object source, string path)
         {
             var r = new CharacterReader(path);
             var grammar = BindingExpressionGrammar.Parse(ref r).Nodes;

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Negation.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_Negation.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
             var target = BuildAsObservable(data, "!Foo");
             var result = await target.Take(1);
 
-            Assert.True((bool)result);
+            Assert.True((bool)result!);
 
             GC.KeepAlive(data);
         }
@@ -35,7 +35,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
             var target = BuildAsObservable(data, "!Foo");
             var result = await target.Take(1);
 
-            Assert.False((bool)result);
+            Assert.False((bool)result!);
 
             GC.KeepAlive(data);
         }
@@ -47,7 +47,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
             var target = BuildAsObservable(data, "!Foo");
             var result = await target.Take(1);
 
-            Assert.True((bool)result);
+            Assert.True((bool)result!);
 
             GC.KeepAlive(data);
         }
@@ -59,7 +59,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
             var target = BuildAsObservable(data, "!Foo");
             var result = await target.Take(1);
 
-            Assert.False((bool)result);
+            Assert.False((bool)result!);
 
             GC.KeepAlive(data);
         }
@@ -165,19 +165,19 @@ namespace Avalonia.Markup.UnitTests.Parsers
                 enableDataValidation: enableDataValidation);
         }
 
-        private static IObservable<object> BuildAsObservable(object source, string path, bool enableDataValidation = false)
+        private static IObservable<object?> BuildAsObservable(object source, string path, bool enableDataValidation = false)
         {
             return Build(source, path, enableDataValidation).ToObservable();
         }
 
         private class Test : INotifyDataErrorInfo
         {
-            private string _dataValidationError;
+            private string? _dataValidationError;
 
             public bool Foo { get; set; }
-            public object Bar { get; set; }
+            public object? Bar { get; set; }
 
-            public string DataValidationError
+            public string? DataValidationError
             {
                 get => _dataValidationError;
                 set
@@ -191,11 +191,11 @@ namespace Avalonia.Markup.UnitTests.Parsers
             }
             public bool HasErrors => !string.IsNullOrWhiteSpace(DataValidationError);
 
-            public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
+            public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
 
-            public IEnumerable GetErrors(string propertyName)
+            public IEnumerable GetErrors(string? propertyName)
             {
-                return DataValidationError is object ? new[] { DataValidationError } : null;
+                return DataValidationError is not null ? new[] { DataValidationError } : [];
             }
         }
     }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Avalonia.Markup.Xaml.UnitTests.csproj
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Avalonia.Markup.Xaml.UnitTests.csproj
@@ -11,6 +11,7 @@
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\Microsoft.Reactive.Testing.props" />
   <Import Project="..\..\build\SharedVersion.props" />
+  <Import Project="..\..\build\NullableEnable.props" />
   <ItemGroup>
     <ProjectReference Include="..\..\src\Markup\Avalonia.Markup.Xaml.Loader\Avalonia.Markup.Xaml.Loader.csproj" />
     <ProjectReference Include="..\..\src\Markup\Avalonia.Markup.Xaml\Avalonia.Markup.Xaml.csproj" />

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Converters/AvaloniaPropertyConverterTest.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Converters/AvaloniaPropertyConverterTest.cs
@@ -85,8 +85,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.Converters
         }
 
 
-        
-        private ITypeDescriptorContext CreateContext(Style style = null)
+
+        private ITypeDescriptorContext CreateContext(Style? style = null)
         {
             var tdMock = new Mock<ITypeDescriptorContext>();
             var tr = new Mock<IXamlTypeResolver>();
@@ -99,8 +99,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.Converters
                 .Returns(ps.Object);
 
             ps.SetupGet(v => v.Parents)
-                .Returns(new object[] {style});
-            
+                .Returns(style is null? [] : [style]);
+
             tr.Setup(v => v.Resolve(nameof(Class1)))
                 .Returns(typeof(Class1));
             tr.Setup(v => v.Resolve(nameof(AttachedOwner)))

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Converters/ConverterTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Converters/ConverterTests.cs
@@ -12,12 +12,13 @@ namespace Avalonia.Markup.Xaml.UnitTests.Converters
             var parsed = AvaloniaRuntimeXamlLoader.Parse<TestClassWithUri>(
                 $"<{testClass.Name} xmlns='clr-namespace:{testClass.Namespace}' Uri='/test'/>", testClass.Assembly);
 
+            Assert.NotNull(parsed.Uri);
             Assert.False(parsed.Uri.IsAbsoluteUri);
         }
     }
     
     public class TestClassWithUri
     {
-        public Uri Uri { get; set; }
+        public Uri? Uri { get; set; }
     }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Converters/GeometryTypeConverterTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Converters/GeometryTypeConverterTests.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Converters
     {
         public class StringDataViewModel
         {
-            public string PathData { get; set; } 
+            public string? PathData { get; set; }
         }
 
         public class IntDataViewModel
@@ -37,7 +37,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Converters
     <Path Name='path' Data='{Binding PathData}' Height='10' Width='10'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var path = window.FindControl<Path>("path");
+                var path = window.GetControl<Path>("path");
                 window.DataContext = vm;
                 Assert.Equal(nullData, path.Data is null);
             }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Converters/MultiValueConverterTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Converters/MultiValueConverterTests.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Converters
     </TextBlock>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = window.FindControl<TextBlock>("textBlock");
+                var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 window.ApplyTemplate();
 
@@ -50,7 +50,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Converters
     {
         public static readonly TestMultiValueConverter Instance = new TestMultiValueConverter();
 
-        public object Convert(IList<object> values, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
         {
             if (values[0] is int i && values[1] is int j)
             {

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Converters/PointsListTypeConverterTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Converters/PointsListTypeConverterTests.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Converters
         {
             var conv = new PointsListTypeConverter();
 
-            var points = (IList<Point>)conv.ConvertFrom(input);
+            var points = (IList<Point>)conv.ConvertFrom(input)!;
 
             Assert.Equal(2, points.Count);
             Assert.Equal(new Point(1, 2), points[0]);

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Converters/ValueConverterTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Converters/ValueConverterTests.cs
@@ -22,7 +22,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Converters
     <TextBlock Name='textBlock' Text='{Binding Converter={x:Static c:TestConverter.Instance}, FallbackValue=bar}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = window.FindControl<TextBlock>("textBlock");
+                var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 window.ApplyTemplate();
 
@@ -42,7 +42,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Converters
     {
         public static readonly TestConverter Instance = new TestConverter();
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             if (value is int i)
             {
@@ -62,7 +62,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Converters
             return "(default)";
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
     <TextBlock Name='textBlock' Text='{Binding}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = window.FindControl<TextBlock>("textBlock");
+                var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 window.DataContext = "foo";
                 window.ApplyTemplate();
@@ -47,7 +47,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
     <TextBlock Name='textBlock' Text='{Binding}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = window.FindControl<TextBlock>("textBlock");
+                var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 window.ApplyTemplate();
 
@@ -87,7 +87,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
     </TextBox>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBox = window.FindControl<TextBox>("textBox");
+                var textBox = window.GetControl<TextBox>("textBox");
 
                 window.ApplyTemplate();
                 textBox.ApplyTemplate();
@@ -109,7 +109,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
     <Border Background='{Binding HexString}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var border = (Border)window.Content;
+                var border = (Border)window.Content!;
                 window.DataContext = new { HexString = "#ff0000" };
 
                 window.ApplyTemplate();
@@ -124,7 +124,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
     {
         public static ConcatConverter Instance { get; } = new ConcatConverter();
 
-        public object Convert(IList<object> values, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
         {
             return string.Join(",", values);
         }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_Method.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_Method.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
     <Button Name='button' Command='{Binding Method}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
                 var vm = new ViewModel();
 
                 button.DataContext = vm;
@@ -45,7 +45,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
     <Button Name='button' Command='{Binding Method1}' CommandParameter='5'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
                 var vm = new ViewModel();
 
                 button.DataContext = vm;
@@ -69,7 +69,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
     <TextBlock Name='textBlock' Text='{Binding Method}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = window.FindControl<TextBlock>("textBlock");
+                var textBlock = window.GetControl<TextBlock>("textBlock");
                 var vm = new ViewModel();
 
                 textBlock.DataContext = vm;
@@ -83,7 +83,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
         [Theory]
         [InlineData(null, "Not called")]
         [InlineData("A", "Do A")]
-        public void Binding_Method_With_Parameter_To_Command_CanExecute(object commandParameter, string result)
+        public void Binding_Method_With_Parameter_To_Command_CanExecute(object? commandParameter, string result)
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
@@ -94,7 +94,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
     <Button Name='button' Command='{Binding Do}' CommandParameter='{Binding Parameter, Mode=OneTime}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
                 var vm = new ViewModel()
                 {
                     Parameter = commandParameter
@@ -121,7 +121,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
     <Button Name='button' Command='{Binding Do}' CommandParameter='{Binding Parameter, Mode=OneWay}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
                 var vm = new ViewModel()
                 {
                     Parameter = null,
@@ -153,7 +153,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
     <Button Name='button' Command='{Binding Method3}' CommandParameter='5'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
                 var vm = new ViewModel();
 
                 button.DataContext = vm;
@@ -168,9 +168,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
         {
             using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
 
-            WeakReference<ViewModel> MakeRef()
+            WeakReference<ViewModel?> MakeRef()
             {
-                var weakVm = new WeakReference<ViewModel>(null);
+                var weakVm = new WeakReference<ViewModel?>(null);
                 {
                     var vm = new ViewModel()
                     {
@@ -189,7 +189,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
                 }
                 return weakVm;
             }
-            bool IsAlive(WeakReference<ViewModel> @ref)
+            bool IsAlive(WeakReference<ViewModel?> @ref)
             {
                 return @ref.TryGetTarget(out var instance)
                     && instance is null == false;
@@ -219,7 +219,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
 
         private class ViewModel : INotifyPropertyChanged
         {
-            public event PropertyChangedEventHandler PropertyChanged;
+            public event PropertyChangedEventHandler? PropertyChanged;
 
             public string Method() => Value = "Called";
             public string Method1(object i) => Value = $"Called {i}";
@@ -228,8 +228,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
             public string Method3(object obj) => Value = $"Called Method with parameter of object type. Argument value is {obj}";
             public string Value { get; private set; } = "Not called";
 
-            object _parameter;
-            public object Parameter
+            private object? _parameter;
+            public object? Parameter
             {
                 get => _parameter;
                 set

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_TemplatedParent.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_TemplatedParent.cs
@@ -28,7 +28,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
     </Button>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
                 button.ApplyTemplate();
@@ -60,7 +60,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
     </Button>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 button.Tag = new GridLength(5, GridUnitType.Star);
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/BindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/BindingExtensionTests.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = window.FindControl<TextBlock>("textBlock");
+                var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 window.Show();
 
@@ -51,7 +51,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = window.FindControl<TextBlock>("textBlock");
+                var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 window.DataContext = new FooBar();
                 window.Show();
@@ -72,7 +72,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = window.FindControl<TextBlock>("textBlock");
+                var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 window.DataContext = new FooBar();
                 window.Show();
@@ -94,7 +94,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
     <ContentControl Content='{Binding $parent.((local:TestDataContext)DataContext).StringProperty}' Name='contentControl' />
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var contentControl = window.FindControl<ContentControl>("contentControl");
+                var contentControl = window.GetControl<ContentControl>("contentControl");
 
                 var dataContext = new TestDataContext
                 {
@@ -120,7 +120,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
     <ContentControl Content='{Binding $parent.((local:TestDataContext)DataContext)}' Name='contentControl' />
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var contentControl = window.FindControl<ContentControl>("contentControl");
+                var contentControl = window.GetControl<ContentControl>("contentControl");
 
                 var dataContext = "foo";
 
@@ -131,7 +131,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
         private class FooBar
         {
-            public object Foo { get; } = null;
+            public object? Foo { get; } = null;
         }
 
         private static IDisposable StyledWindow(params (string, string)[] assets)

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/DynamicResourceExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/DynamicResourceExtensionTests.cs
@@ -29,11 +29,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
-            var brush = (ISolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
@@ -51,7 +51,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
@@ -76,11 +76,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
-            var brush = (ISolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
@@ -104,11 +104,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
-            var brush = (ISolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
@@ -136,11 +136,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
-            var brush = (ISolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
@@ -149,7 +149,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         {
             using (StyledWindow())
             {
-                Application.Current.Resources.Add("brush", new SolidColorBrush(0xff506070));
+                Application.Current!.Resources.Add("brush", new SolidColorBrush(0xff506070));
 
                 var xaml = @"
 <Window xmlns='https://github.com/avaloniaui'
@@ -158,9 +158,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var border = window.FindControl<Border>("border");
+                var border = window.GetControl<Border>("border");
 
-                var brush = (SolidColorBrush)border.Background;
+                var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
@@ -170,7 +170,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
-                Application.Current.Resources.Add("brush", new SolidColorBrush(0xff506070));
+                Application.Current!.Resources.Add("brush", new SolidColorBrush(0xff506070));
 
                 var xaml = @"
 <UserControl xmlns='https://github.com/avaloniaui'
@@ -179,14 +179,14 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
                 var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var border = userControl.FindControl<Border>("border");
+                var border = userControl.GetControl<Border>("border");
 
                 // We don't actually know where the global styles are until we attach the control
                 // to a window, as Window has StylingParent set to Application.
                 var window = new Window { Content = userControl };
                 window.Show();
 
-                var brush = (SolidColorBrush)border.Background;
+                var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
@@ -211,8 +211,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
-                var brush = (ISolidColorBrush)button.Background;
+                var button = window.GetControl<Button>("button");
+                var brush = Assert.IsAssignableFrom<ISolidColorBrush>(button.Background);
 
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
@@ -240,8 +240,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
-                var brush = (ISolidColorBrush)button.Background;
+                var button = window.GetControl<Button>("button");
+                var brush = Assert.IsAssignableFrom<ISolidColorBrush>(button.Background);
 
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
@@ -276,8 +276,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             {
                 var compiled = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
                 var window = Assert.IsType<Window>(compiled[1]);
-                var border = window.FindControl<Border>("border");
-                var brush = (ISolidColorBrush)border.Background;
+                var border = window.GetControl<Border>("border");
+                var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
 
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
@@ -316,12 +316,12 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             {
                 var compiled = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
                 var window = Assert.IsType<Window>(compiled[1]);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.Show();
 
                 var border = (Border)button.GetVisualChildren().Single();
-                var brush = (ISolidColorBrush)border.Background;
+                var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
 
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
@@ -342,11 +342,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
-            var brush = (SolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
@@ -363,7 +363,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Application>";
 
             var application = (Application)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var brush = (SolidColorBrush)application.Resources["brush"];
+            var brush = Assert.IsAssignableFrom<SolidColorBrush>(application.Resources["brush"]);
 
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
@@ -384,7 +384,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var listBox = userControl.FindControl<ListBox>("listBox");
+            var listBox = userControl.GetControl<ListBox>("listBox");
 
             DelayedBinding.ApplyBindings(listBox);
 
@@ -401,7 +401,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
@@ -409,7 +409,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
             userControl.Resources.Add("brush", new SolidColorBrush(0xff506070));
 
-            var brush = (SolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
             Assert.NotNull(brush);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
@@ -424,7 +424,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
@@ -432,7 +432,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
             userControl.Styles.Resources.Add("brush", new SolidColorBrush(0xff506070));
 
-            var brush = (SolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
             Assert.NotNull(brush);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
@@ -451,7 +451,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
@@ -459,7 +459,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
             ((Style)userControl.Styles[0]).Resources.Add("brush", new SolidColorBrush(0xff506070));
 
-            var brush = (SolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
             Assert.NotNull(brush);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
@@ -481,7 +481,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
@@ -489,7 +489,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
             ((IResourceDictionary)userControl.Resources.MergedDictionaries[0]).Add("brush", new SolidColorBrush(0xff506070));
 
-            var brush = (SolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
             Assert.NotNull(brush);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
@@ -504,7 +504,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
@@ -517,7 +517,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
             userControl.Resources.MergedDictionaries.Add(dictionary);
 
-            var brush = (SolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
             Assert.NotNull(brush);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
@@ -536,7 +536,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
@@ -549,7 +549,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
             ((Style)userControl.Styles[0]).Resources.MergedDictionaries.Add(dictionary);
 
-            var brush = (SolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
             Assert.NotNull(brush);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
@@ -588,8 +588,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             {
                 var compiled = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
                 var window = Assert.IsType<Window>(compiled[2]);
-                var border = window.FindControl<Border>("border");
-                var borderBrush = (ISolidColorBrush)border.Background;
+                var border = window.GetControl<Border>("border");
+                var borderBrush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
 
                 Assert.NotNull(borderBrush);
                 Assert.Equal(0xffff0000, borderBrush.Color.ToUInt32());
@@ -628,8 +628,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             {
                 var compiled = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
                 var window = Assert.IsType<Window>(compiled[2]);
-                var border = window.FindControl<Border>("border");
-                var borderBrush = (ISolidColorBrush)border.Background;
+                var border = window.GetControl<Border>("border");
+                var borderBrush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
 
                 Assert.NotNull(borderBrush);
                 Assert.Equal(0xffff0000, borderBrush.Color.ToUInt32());
@@ -652,11 +652,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var border = window.FindControl<Border>("border");
+                var border = window.GetControl<Border>("border");
 
                 DelayedBinding.ApplyBindings(border);
 
-                var brush = (ISolidColorBrush)border.Background;
+                var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
 
                 window.Content = null;
@@ -665,7 +665,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
                 window.Content = border;
 
-                brush = (ISolidColorBrush)border.Background;
+                brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
@@ -684,11 +684,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
-            var brush = (SolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
             Assert.Equal(0u, brush.Color.ToUInt32());
 
             brush.GetObservable(SolidColorBrush.ColorProperty).Subscribe(_ => { });
@@ -730,11 +730,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
-            var brush = (SolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
             Assert.Equal(0u, brush.Color.ToUInt32());
 
             brush.GetObservable(SolidColorBrush.ColorProperty).Subscribe(_ => { });
@@ -774,11 +774,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             DelayedBinding.ApplyBindings(border);
 
-            var brush = (SolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
             Assert.Equal(0u, brush.Color.ToUInt32());
 
             using (UnitTestApplication.Start(TestServices.StyledWindow))
@@ -812,9 +812,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
-            var brush = (ISolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
@@ -848,7 +848,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
             var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = window.FindControl<Border>("border");
+            var border = window.GetControl<Border>("border");
 
             Assert.Equal("bar", border.Tag);
 
@@ -887,7 +887,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
             var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = window.FindControl<Border>("border");
+            var border = window.GetControl<Border>("border");
 
             Assert.Equal("bar", border.Tag);
 
@@ -919,7 +919,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
             window.Show();
 
-            Assert.Equal(Colors.Blue, ((ISolidColorBrush)target.Background).Color);
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(target.Background);
+            Assert.Equal(Colors.Blue, brush.Color);
 
             window.Content = null;
         }
@@ -995,7 +996,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
     {
         public override bool HasResources => true;
         public List<object> RequestedResources { get; } = new List<object>();
-        public override bool TryGetResource(object key, ThemeVariant themeVariant, out object value)
+        public override bool TryGetResource(object key, ThemeVariant? themeVariant, out object value)
         {
             RequestedResources.Add(key);
             value = key;

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/OptionsMarkupExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/OptionsMarkupExtensionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Disposables;
 using System.Runtime.InteropServices;
 using Avalonia.Controls;
@@ -11,7 +12,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;
 
 public class OptionsMarkupExtensionTests : XamlTestBase
 {
-    public static Func<object, bool> RaisedOption;
+    public static Func<object, bool>? RaisedOption;
     public static int? ObjectsCreated;
 
     [Fact]
@@ -420,7 +421,7 @@ public class OptionsMarkupExtensionTests : XamlTestBase
 </UserControl>";
 
         var window = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-        var textBlock = window.FindControl<TextBlock>("textBlock");
+        var textBlock = window.GetControl<TextBlock>("textBlock");
 
         Assert.Equal(expected, textBlock.Text);
     }
@@ -471,6 +472,7 @@ public class OptionsMarkupExtensionTests : XamlTestBase
         Assert.True(textBlock.IsVisible);
     }
 
+    [MemberNotNull(nameof(RaisedOption))]
     private static IDisposable SetupTestGlobals(object acceptedOption)
     {
         RaisedOption = o => o.Equals(acceptedOption);
@@ -513,24 +515,24 @@ public class OptionsMarkupExtensionBase<TReturn, TOn> : IAddChild<TOn>
     where TOn : On<TReturn>
 {
     [MarkupExtensionOption("option 1")]
-    public TReturn OptionA { get; set; }
+    public TReturn? OptionA { get; set; }
 
     [MarkupExtensionOption("option 2")]
-    public TReturn OptionB { get; set; }
+    public TReturn? OptionB { get; set; }
 
     [MarkupExtensionOption(3)]
-    public TReturn OptionNumber { get; set; }
+    public TReturn? OptionNumber { get; set; }
 
     [Content]
     [MarkupExtensionDefaultOption]
-    public TReturn Default { get; set; }
+    public TReturn? Default { get; set; }
 
     public bool ShouldProvideOption(IServiceProvider serviceProvider, string option)
     {
-        return OptionsMarkupExtensionTests.RaisedOption(option);
+        return OptionsMarkupExtensionTests.RaisedOption!(option);
     }
 
-    public TReturn ProvideValue(IServiceProvider serviceProvider) { throw null; }
+    public TReturn ProvideValue(IServiceProvider serviceProvider) { throw null!; }
 
     public void AddChild(TOn child) {}
 }
@@ -538,21 +540,21 @@ public class OptionsMarkupExtensionBase<TReturn, TOn> : IAddChild<TOn>
 public class OptionsMarkupExtensionNoServiceProvider
 {
     [MarkupExtensionOption(1)]
-    public object OptionA { get; set; }
+    public object? OptionA { get; set; }
 
     [MarkupExtensionOption(2)]
-    public object OptionB { get; set; }
+    public object? OptionB { get; set; }
 
     [Content]
     [MarkupExtensionDefaultOption]
-    public object Default { get; set; }
+    public object? Default { get; set; }
 
     public static bool ShouldProvideOption(int option)
     {
-        return OptionsMarkupExtensionTests.RaisedOption(option);
+        return OptionsMarkupExtensionTests.RaisedOption!(option);
     }
 
-    public object ProvideValue(IServiceProvider serviceProvider) { throw null; }
+    public object ProvideValue(IServiceProvider serviceProvider) { throw null!; }
 }
 
 public class OptionsMarkupExtensionMinimal
@@ -562,7 +564,7 @@ public class OptionsMarkupExtensionMinimal
 
     public static bool ShouldProvideOption(double option) => option > 0;
 
-    public object ProvideValue() { throw null; }
+    public object ProvideValue() { throw null!; }
 }
 
 public class OptionsMarkupExtensionWithProperty
@@ -574,29 +576,29 @@ public class OptionsMarkupExtensionWithProperty
 
     public bool ShouldProvideOption(int option) => option == Property;
 
-    public object ProvideValue() { throw null; }
+    public object ProvideValue() { throw null!; }
 }
 
 public class OptionsMarkupExtensionWithGeneric<TResult>
 {
     [MarkupExtensionOption("option 1")]
-    public TResult OptionA { get; set; }
+    public TResult? OptionA { get; set; }
 
     [Content]
     [MarkupExtensionDefaultOption]
-    public TResult Default { get; set; }
+    public TResult? Default { get; set; }
 
     public bool ShouldProvideOption(string option)
     {
-        return OptionsMarkupExtensionTests.RaisedOption(option);
+        return OptionsMarkupExtensionTests.RaisedOption!(option);
     }
 
-    public TResult ProvideValue() { throw null; }
+    public TResult ProvideValue() { throw null!; }
 }
 
 public class ChildObject
 {
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public ChildObject()
     {

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/StaticResourceExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/StaticResourceExtensionTests.cs
@@ -27,9 +27,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
-            var brush = (ISolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
@@ -47,7 +47,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
             Assert.Equal(5, Grid.GetColumn(border));
         }
@@ -70,9 +70,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
-            var brush = (ISolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
@@ -81,7 +81,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         {
             using (StyledWindow())
             {
-                Application.Current.Resources.Add("brush", new SolidColorBrush(0xff506070));
+                Application.Current!.Resources.Add("brush", new SolidColorBrush(0xff506070));
 
                 var xaml = @"
 <Window xmlns='https://github.com/avaloniaui'
@@ -90,9 +90,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var border = window.FindControl<Border>("border");
+                var border = window.GetControl<Border>("border");
 
-                var brush = (SolidColorBrush)border.Background;
+                var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
@@ -117,9 +117,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
-            var brush = (ISolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
@@ -147,9 +147,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
-            var brush = (ISolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
@@ -158,7 +158,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
-                Application.Current.Resources.Add("brush", new SolidColorBrush(0xff506070));
+                Application.Current!.Resources.Add("brush", new SolidColorBrush(0xff506070));
 
                 var xaml = @"
 <UserControl xmlns='https://github.com/avaloniaui'
@@ -167,14 +167,14 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
                 var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var border = userControl.FindControl<Border>("border");
+                var border = userControl.GetControl<Border>("border");
 
                 // We don't actually know where the global styles are until we attach the control
                 // to a window, as Window has StylingParent set to Application.
                 var window = new Window { Content = userControl };
                 window.Show();
 
-                var brush = (SolidColorBrush)border.Background;
+                var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
@@ -199,8 +199,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
-                var brush = (ISolidColorBrush)button.Background;
+                var button = window.GetControl<Button>("button");
+                var brush = Assert.IsAssignableFrom<ISolidColorBrush>(button.Background);
 
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
@@ -228,8 +228,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
-                var brush = (ISolidColorBrush)button.Background;
+                var button = window.GetControl<Button>("button");
+                var brush = Assert.IsAssignableFrom<ISolidColorBrush>(button.Background);
 
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
@@ -265,8 +265,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             {
                 var compiled = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
                 var window = Assert.IsType<Window>(compiled[1]);
-                var border = window.FindControl<Border>("border");
-                var brush = (ISolidColorBrush)border.Background;
+                var border = window.GetControl<Border>("border");
+                var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
 
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
@@ -287,9 +287,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
-            var brush = (SolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<SolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
@@ -306,7 +306,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Styles>";
 
             var styles = (Styles)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var brush = (SolidColorBrush)styles.Resources["brush"];
+            var brush = Assert.IsAssignableFrom<SolidColorBrush>(styles.Resources["brush"]);
 
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
@@ -345,12 +345,12 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             {
                 var compiled = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
                 var window = Assert.IsType<Window>(compiled[1]);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.Show();
 
                 var border = (Border)button.GetVisualChildren().Single();
-                var brush = (ISolidColorBrush)border.Background;
+                var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
 
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
@@ -372,7 +372,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var listBox = userControl.FindControl<ListBox>("listBox");
+            var listBox = userControl.GetControl<ListBox>("listBox");
 
             Assert.NotNull(listBox.ItemTemplate);
         }
@@ -394,7 +394,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = window.FindControl<TextBlock>("textBlock");
+                var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 window.DataContext = "foo";
                 window.ApplyTemplate();
@@ -425,7 +425,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
 
                 window.DataContext = "foo";
-                var presenter = window.FindControl<ContentPresenter>("presenter");
+                var presenter = window.GetControl<ContentPresenter>("presenter");
 
                 window.Show();
 
@@ -522,14 +522,14 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
-            var brush = (ISolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
 
             userControl.Content = null;
 
-            brush = (ISolidColorBrush)border.Background;
+            brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
@@ -547,9 +547,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </UserControl>";
 
             var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-            var border = userControl.FindControl<Border>("border");
+            var border = userControl.GetControl<Border>("border");
 
-            var brush = (ISolidColorBrush)border.Background;
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(border.Background);
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
@@ -573,8 +573,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
-                var brush = (ISolidColorBrush)button.Background;
+                var button = window.GetControl<Button>("button");
+                var brush = Assert.IsAssignableFrom<ISolidColorBrush>(button.Background);
 
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/TestValueConverter.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/TestValueConverter.cs
@@ -6,14 +6,14 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 {
     public class TestValueConverter : IValueConverter
     {
-        public string Append { get; set; }
+        public string? Append { get; set; }
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            return value.ToString() + Append;
+            return value + Append;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/SetterTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/SetterTests.cs
@@ -24,6 +24,7 @@ public class SetterTests : XamlTestBase
             var animation = (Animation.Animation)AvaloniaRuntimeXamlLoader.Load(xaml);
             var setter = (Setter)animation.Children[0].Setters[0];
 
+            Assert.NotNull(setter.Property);
             Assert.Equal(typeof(ContentControl), setter.Property.OwnerType);
         }
     }
@@ -45,6 +46,7 @@ public class SetterTests : XamlTestBase
             var animation = (Animation.Animation)AvaloniaRuntimeXamlLoader.Load(xaml);
             var setter = (Setter)animation.Children[0].Setters[0];
 
+            Assert.NotNull(setter.Property);
             Assert.Equal(typeof(ContentControl), setter.Property.OwnerType);
         }
     }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/StyleTests.cs
@@ -103,7 +103,7 @@ namespace Avalonia.Markup.Xaml.UnitTests
 
         private class Data
         {
-            public string Foo { get; set; }
+            public string? Foo { get; set; }
         }
     }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/TestViewModel.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/TestViewModel.cs
@@ -4,9 +4,9 @@ namespace Avalonia.Markup.Xaml.UnitTests
 {
     public class TestViewModel : NotifyingBase
     {
-        private string _string;
+        private string? _string;
         private int _integer;
-        private TestViewModel _child;
+        private TestViewModel? _child;
         private bool _boolean;
 
         public int Integer
@@ -19,7 +19,7 @@ namespace Avalonia.Markup.Xaml.UnitTests
             }
         }
 
-        public string String
+        public string? String
         {
             get => _string;
             set
@@ -29,7 +29,7 @@ namespace Avalonia.Markup.Xaml.UnitTests
             }
         }
 
-        public TestViewModel Child
+        public TestViewModel? Child
         {
             get => _child;
             set

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/AvaloniaIntrinsicsTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/AvaloniaIntrinsicsTests.cs
@@ -142,11 +142,11 @@ public class TestIntrinsicsControl : Control
     public Color ColorProperty { get; set; }
     public RelativePoint RelativePointProperty { get; set; }
     public GridLength GridLengthProperty { get; set; }
-    public IBrush IBrushProperty { get; set; }
-    public TextTrimming TextTrimmingProperty { get; set; }
-    public TextDecorationCollection TextDecorationCollectionProperty { get; set; }
+    public IBrush? IBrushProperty { get; set; }
+    public TextTrimming? TextTrimmingProperty { get; set; }
+    public TextDecorationCollection? TextDecorationCollectionProperty { get; set; }
     public WindowTransparencyLevel WindowTransparencyLevelProperty { get; set; }
-    public Uri UriProperty { get; set; }
-    public ThemeVariant ThemeVariantProperty { get; set; }
-    public Points PointsProperty { get; set; }
+    public Uri? UriProperty { get; set; }
+    public ThemeVariant? ThemeVariantProperty { get; set; }
+    public Points? PointsProperty { get; set; }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
@@ -66,7 +66,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             var target = AvaloniaRuntimeXamlLoader.Parse<UserControl>(xaml);
 
-            Assert.Equal(2, Grid.GetColumn((TestControl)target.Content));
+            Assert.Equal(2, Grid.GetColumn((TestControl)target.Content!));
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             Assert.NotNull(target);
 
-            var txt = (TextBlock)target.Build(null);
+            var txt = (TextBlock)target.Build(null)!;
 
             Assert.Equal("Foo", txt.Text);
         }
@@ -154,7 +154,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </UserControl>";
 
             var control = AvaloniaRuntimeXamlLoader.Parse<UserControl>(xaml);
-            var button = control.FindControl<Button>("button");
+            var button = control.GetControl<Button>("button");
 
             Assert.Equal("Foo", button.Content);
         }
@@ -174,7 +174,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
                 var control = AvaloniaRuntimeXamlLoader.Parse<Window>(xaml);
 
-                var itemsControl = control.FindControl<ItemsControl>("items");
+                var itemsControl = control.GetControl<ItemsControl>("items");
 
                 Assert.NotNull(itemsControl);
 
@@ -198,12 +198,12 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             var control = AvaloniaRuntimeXamlLoader.Parse<UserControl>(xaml);
 
-            var panel = control.FindControl<Panel>("panel");
+            var panel = control.GetControl<Panel>("panel");
 
             Assert.Equal(2, panel.Children.Count);
 
-            var foo = control.FindControl<ContentControl>("Foo");
-            var bar = control.FindControl<ContentControl>("Bar");
+            var foo = control.GetControl<ContentControl>("Foo");
+            var bar = control.GetControl<ContentControl>("Bar");
 
             Assert.Contains(foo, panel.Children);
             Assert.Contains(bar, panel.Children);
@@ -321,7 +321,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </UserControl>";
 
             var control = AvaloniaRuntimeXamlLoader.Parse<UserControl>(xaml);
-            var button = control.FindControl<Button>("button");
+            var button = control.GetControl<Button>("button");
 
             Assert.Equal("Foo", button.Content);
         }
@@ -341,9 +341,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
             var xaml = @"<UserControl xmlns='https://github.com/avaloniaui' Background='White' />";
 
             var control = AvaloniaRuntimeXamlLoader.Parse<UserControl>(xaml);
-            var bk = control.Background;
-            Assert.IsType<ImmutableSolidColorBrush>(bk);
-            Assert.Equal(Colors.White, (bk as ISolidColorBrush).Color);
+            var brush = Assert.IsType<ImmutableSolidColorBrush>(control.Background);
+            Assert.Equal(Colors.White, brush.Color);
         }
 
         [Fact]
@@ -369,7 +368,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
             Assert.Equal(2, setters.Length);
 
             Assert.Equal(TextBlock.BackgroundProperty, setters[0].Property);
-            Assert.Equal(Brushes.White.Color, ((ISolidColorBrush)setters[0].Value).Color);
+            Assert.Equal(Brushes.White.Color, ((ISolidColorBrush)setters[0].Value!).Color);
 
             Assert.Equal(TextBlock.WidthProperty, setters[1].Property);
             Assert.Equal(100.0, setters[1].Value);
@@ -541,7 +540,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
                 Assert.NotNull(target.Content);
 
-                var itemsControl = target.FindControl<ItemsControl>("itemsControl");
+                var itemsControl = target.GetControl<ItemsControl>("itemsControl");
 
                 var items = new string[] { "Foo", "Bar" };
 
@@ -636,7 +635,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             var control = new ContentControl();
 
-            var result = (ContentPresenter)template.Build(control).Result;
+            var result = (ContentPresenter)template.Build(control)!.Result;
 
             Assert.NotNull(result);
         }
@@ -653,7 +652,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Window>";
 
                 var window = AvaloniaRuntimeXamlLoader.Parse<Window>(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 Assert.Equal("Foo", button.Content);
             }
@@ -672,7 +671,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Window>";
 
                 var window = AvaloniaRuntimeXamlLoader.Parse<Window>(xaml);
-                var tracker = (InitializationOrderTracker)window.Content;
+                var tracker = (InitializationOrderTracker)window.Content!;
 
                 var attached = tracker.Order.IndexOf("AttachedToLogicalTree");
                 var widthChanged = tracker.Order.IndexOf("Property Width Changed");
@@ -696,7 +695,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Window>";
 
                 var window = AvaloniaRuntimeXamlLoader.Parse<Window>(xaml);
-                var tracker = (InitializationOrderTracker)window.Content;
+                var tracker = (InitializationOrderTracker)window.Content!;
 
                 var attached = tracker.Order.IndexOf("AttachedToLogicalTree");
                 var endInit = tracker.Order.IndexOf("EndInit 0");
@@ -722,7 +721,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
 
                 var window = AvaloniaRuntimeXamlLoader.Parse<Window>(xaml);
-                var tracker = (InitializationOrderTracker)window.Content;
+                var tracker = (InitializationOrderTracker)window.Content!;
 
                 //ensure binding is set and operational first
                 Assert.Equal(100.0, tracker.Tag);
@@ -750,7 +749,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Window>";
 
                 var window = AvaloniaRuntimeXamlLoader.Parse<Window>(xaml);
-                var tracker = (InitializationOrderTracker)window.Content;
+                var tracker = (InitializationOrderTracker)window.Content!;
 
                 Assert.Equal(0, tracker.InitState);
             }
@@ -775,7 +774,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             Assert.NotNull(template);
 
-            var txt = (TextBlock)template.Build(null);
+            var txt = (TextBlock)template.Build(null)!;
 
             Assert.Equal((object)NonControl.StringProperty, txt.Tag);
         }
@@ -791,7 +790,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Window>";
 
                 var window = AvaloniaRuntimeXamlLoader.Parse<Window>(xaml);
-                var listBox = (ListBox)window.Content;
+                var listBox = (ListBox)window.Content!;
 
                 var vm = new SelectedItemsViewModel()
                 {
@@ -819,7 +818,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Window>";
 
                 var window = AvaloniaRuntimeXamlLoader.Parse<Window>(xaml);
-                var textBlock = (TextBlock)window.Content;
+                var textBlock = (TextBlock)window.Content!;
 
                 Assert.Equal("Hello World!", textBlock.Text);
             }
@@ -836,7 +835,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Window>";
 
                 var window = AvaloniaRuntimeXamlLoader.Parse<Window>(xaml);
-                var slider = (Slider)window.Content;
+                var slider = (Slider)window.Content!;
 
                 Assert.Equal(0, slider.Minimum);
                 Assert.Equal(1000, slider.Maximum);
@@ -944,9 +943,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
         private class SelectedItemsViewModel : INotifyPropertyChanged
         {
-            public string[] Items { get; set; }
+            public string[]? Items { get; set; }
 
-            public event PropertyChangedEventHandler PropertyChanged;
+            public event PropertyChangedEventHandler? PropertyChanged;
 
             private IList _selectedItems = new AvaloniaList<string>();
 
@@ -964,7 +963,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
     public class ObjectWithAddChild : IAddChild
     {
-        public object Child { get; set; }
+        public object? Child { get; set; }
 
         void IAddChild.AddChild(object child)
         {
@@ -979,16 +978,16 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
             Test1 = param;
         }
         
-        public string Test1 { get; set; }
+        public string? Test1 { get; set; }
         
-        public string Test2 { get; set; }
+        public string? Test2 { get; set; }
     }
 
     public class ObjectWithAddChildOfT : IAddChild, IAddChild<string>
     {
-        public string Text { get; set; }
+        public string? Text { get; set; }
 
-        public object Child { get; set; }
+        public object? Child { get; set; }
 
         void IAddChild.AddChild(object child)
         {
@@ -1003,11 +1002,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
     public class BasicTestsAttachedPropertyHolder
     {
-        public static AvaloniaProperty<string> FooProperty =
-            AvaloniaProperty.RegisterAttached<BasicTestsAttachedPropertyHolder, AvaloniaObject, string>("Foo");
+        public static AvaloniaProperty<string?> FooProperty =
+            AvaloniaProperty.RegisterAttached<BasicTestsAttachedPropertyHolder, AvaloniaObject, string?>("Foo");
 
-        public static void SetFoo(AvaloniaObject target, string value) => target.SetValue(FooProperty, value);
-        public static string GetFoo(AvaloniaObject target) => (string)target.GetValue(FooProperty);
+        public static void SetFoo(AvaloniaObject target, string? value) => target.SetValue(FooProperty, value);
+        public static string? GetFoo(AvaloniaObject target) => (string?)target.GetValue(FooProperty);
 
     }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BindingTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BindingTests.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <Button Name='button' Content='{Binding Foo}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 button.DataContext = new { Foo = "foo" };
                 window.ApplyTemplate();
@@ -49,7 +49,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Button>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 button.DataContext = new { Foo = "foo" };
                 window.ApplyTemplate();
@@ -74,9 +74,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Button>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
-                Assert.Same(button, ((NonControl)button.Tag).Control);
+                Assert.Same(button, ((NonControl)button.Tag!).Control);
             }
         }
 
@@ -96,11 +96,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Button>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 button.DataContext = new { Foo = "foo" };
 
-                Assert.Equal("foo", ((NonControl)button.Tag).String);
+                Assert.Equal("foo", ((NonControl)button.Tag!).String);
             }
         }
 
@@ -134,11 +134,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <Border DataContext='{Binding Foo}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var border = (Border)window.Content;
+                var border = (Border)window.Content!;
 
                 window.DataContext = new { Foo = "foo" };
                 window.ApplyTemplate();
-                window.Presenter.ApplyTemplate();
+                window.Presenter!.ApplyTemplate();
 
                 Assert.Equal("foo", border.DataContext);
             }
@@ -157,7 +157,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Window>";
 
                 var window = AvaloniaRuntimeXamlLoader.Parse<ContentControl>(xaml);
-                var textBlock = (TextBlock)window.Content;
+                var textBlock = (TextBlock)window.Content!;
 
                 textBlock.Tag = "foo";
 
@@ -180,7 +180,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </TextBlock>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = (TextBlock)window.Content;
+                var textBlock = (TextBlock)window.Content!;
 
                 window.ApplyTemplate();
 
@@ -206,10 +206,10 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <Button Name='button' />
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
-                window.Presenter.ApplyTemplate();
+                window.Presenter!.ApplyTemplate();
 
                 Assert.True(button.IsVisible);
 
@@ -230,7 +230,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <TextBlock Name='textblock' Text='{Binding Observable^}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = (TextBlock)window.Content;
+                var textBlock = (TextBlock)window.Content!;
                 var observable = new BehaviorSubject<string>("foo");
 
                 window.DataContext = new { Observable = observable };
@@ -254,7 +254,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <TextBlock local:AttachedPropertyOwner.Double='{Binding}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = (TextBlock)window.Content;
+                var textBlock = (TextBlock)window.Content!;
 
                 window.DataContext = 5.6;
                 window.ApplyTemplate();
@@ -275,7 +275,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <local:TestControl Double='{Binding}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var testControl = (TestControl)window.Content;
+                var testControl = (TestControl)window.Content!;
 
                 window.DataContext = 5.6;
                 window.ApplyTemplate();
@@ -296,7 +296,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <TextBlock local:TestControl.Double='{Binding}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = (TextBlock)window.Content;
+                var textBlock = (TextBlock)window.Content!;
 
                 window.DataContext = 5.6;
                 window.ApplyTemplate();
@@ -322,7 +322,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <TextBlock/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = (TextBlock)window.Content;
+                var textBlock = (TextBlock)window.Content!;
 
                 window.DataContext = 5.6;
                 window.ApplyTemplate();
@@ -347,7 +347,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <TextBlock Name='textBlock' Text=""{Binding Foo, StringFormat=" + fmt + @"}""/> 
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml); 
-                var textBlock = window.FindControl<TextBlock>("textBlock"); 
+                var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 textBlock.DataContext = new { Foo = "world" };
                 window.ApplyTemplate(); 
@@ -377,7 +377,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </TextBlock> 
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = window.FindControl<TextBlock>("textBlock");
+                var textBlock = window.GetControl<TextBlock>("textBlock");
 
                 textBlock.DataContext = new WindowViewModel();
                 window.ApplyTemplate();
@@ -514,46 +514,46 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
             }
         }
 
-        public static IEnumerable<object[]> NegationData()
+        public static IEnumerable<object?[]> NegationData()
         {
-            yield return new object[] { true, false };
-            yield return new object[] { false, true };
-            yield return new object[] { null, true };
-            yield return new object[] { new object(), null };
-            yield return new object[] { "foo", null };
-            yield return new object[] { "true", false };
-            yield return new object[] { "false", true };
-            yield return new object[] { 0, true };
-            yield return new object[] { 1, false };
-            yield return new object[] { 2, false };
-            yield return new object[] { -1, false };
-            yield return new object[] { 0.0, true };
-            yield return new object[] { 1.0, false };
-            yield return new object[] { 2.0, false };
-            yield return new object[] { -1.0, false };
-            yield return new object[] { double.NaN, false };
-            yield return new object[] { double.PositiveInfinity, false };
-            yield return new object[] { double.NegativeInfinity, false };
+            yield return [true, false];
+            yield return [false, true];
+            yield return [null, true];
+            yield return [new object(), null];
+            yield return ["foo", null];
+            yield return ["true", false];
+            yield return ["false", true];
+            yield return [0, true];
+            yield return [1, false];
+            yield return [2, false];
+            yield return [-1, false];
+            yield return [0.0, true];
+            yield return [1.0, false];
+            yield return [2.0, false];
+            yield return [-1.0, false];
+            yield return [double.NaN, false];
+            yield return [double.PositiveInfinity, false];
+            yield return [double.NegativeInfinity, false];
         }
 
         private class WindowViewModel
         {
             public bool ShowInTaskbar { get; set; }
-            public string Greeting1 { get; set; } = "Hello";
-            public string Greeting2 { get; set; } = "World";
-            public object Object { get; set; }
+            public string? Greeting1 { get; set; } = "Hello";
+            public string? Greeting2 { get; set; } = "World";
+            public object? Object { get; set; }
         }
 
         public class CultureAppender : IValueConverter
         {
             public static CultureAppender Instance { get; } = new CultureAppender();
 
-            public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
             {
                 return $"{value}+{culture}";
             }
 
-            public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
             {
                 throw new NotImplementedException();
             }
@@ -572,7 +572,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <Button Name='button' Classes.MyClass='{Binding Foo}' Classes.MySecondClass='True' Classes='foo bar'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 button.DataContext = new { Foo = true };
                 window.ApplyTemplate();

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BindingTests_RelativeSource.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BindingTests_RelativeSource.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <Button Name='button' Content='{Binding Foo, RelativeSource={RelativeSource DataContext}}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 button.DataContext = new { Foo = "foo" };
                 window.ApplyTemplate();
@@ -40,7 +40,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <Button Name='button' Content='{Binding Name, RelativeSource={RelativeSource Self}}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
 
@@ -64,10 +64,10 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Border>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
-                window.Presenter.ApplyTemplate();
+                window.Presenter!.ApplyTemplate();
 
                 Assert.Equal("border2", button.Content);
             }
@@ -89,7 +89,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Border>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
 
@@ -113,8 +113,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Border>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var contentControl = window.FindControl<ContentControl>("contentControl");
-                var button = window.FindControl<Button>("button");
+                var contentControl = window.GetControl<ContentControl>("contentControl");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
                 
@@ -138,10 +138,10 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Border>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
-                window.Presenter.ApplyTemplate();
+                window.Presenter!.ApplyTemplate();
 
                 Assert.Equal("border1", button.Content);
             }
@@ -163,9 +163,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </ContentControl>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var contentControl1 = window.FindControl<ContentControl>("contentControl1");
-                var contentControl2 = window.FindControl<ContentControl>("contentControl2");
-                var button = window.FindControl<Button>("button");
+                var contentControl1 = window.GetControl<ContentControl>("contentControl1");
+                var contentControl2 = window.GetControl<ContentControl>("contentControl2");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
 
@@ -189,7 +189,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Border>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
 
@@ -213,7 +213,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Border>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
 
@@ -237,7 +237,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Border>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
 
@@ -258,10 +258,10 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
   <Button Name='button' Content='{Binding Title, RelativeSource={RelativeSource AncestorType=local:TestWindow}}'/>
 </local:TestWindow>";
                 var window = (TestWindow)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
-                window.Presenter.ApplyTemplate();
+                window.Presenter!.ApplyTemplate();
 
                 Assert.Equal("title", button.Content);
             }
@@ -283,7 +283,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Border>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
 
@@ -308,7 +308,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Border>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 window.ApplyTemplate();
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ControlBindingTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ControlBindingTests.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <ProgressBar Maximum='10' Value='{Binding Value, FallbackValue=3}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var progressBar = (ProgressBar)window.Content;
+                var progressBar = (ProgressBar)window.Content!;
 
                 window.DataContext = new { Value = "foo" };
                 window.ApplyTemplate();
@@ -52,8 +52,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </DockPanel>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var strip = window.FindControl<TabStrip>("strip");
-                var carousel = window.FindControl<Carousel>("carousel");
+                var strip = window.GetControl<TabStrip>("strip");
+                var carousel = window.GetControl<Carousel>("carousel");
 
                 window.DataContext = new ItemsViewModel
                 {
@@ -73,13 +73,13 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
         private class ItemsViewModel
         {
-            public IList<ItemViewModel> Items { get; set; }
+            public IList<ItemViewModel>? Items { get; set; }
         }
 
         private class ItemViewModel
         {
-            public string Header { get; set; }
-            public string Detail { get; set; }
+            public string? Header { get; set; }
+            public string? Detail { get; set; }
         }
     }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ControlTemplateTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ControlTemplateTests.cs
@@ -43,11 +43,14 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Button>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = (Button)window.Content;
+                var button = (Button)window.Content!;
 
                 window.ApplyTemplate();
                 button.ApplyTemplate();
                 var listBoxHierarchyLine = button.GetVisualChildren().ElementAt(0) as ListBoxHierarchyLine;
+                Assert.NotNull(listBoxHierarchyLine);
+                Assert.NotNull(listBoxHierarchyLine.LineDashStyle);
+                Assert.NotNull(listBoxHierarchyLine.LineDashStyle.Dashes);
                 Assert.Equal(1, listBoxHierarchyLine.LineDashStyle.Offset);
                 Assert.Equal(2, listBoxHierarchyLine.LineDashStyle.Dashes.Count);
                 Assert.Equal(2, listBoxHierarchyLine.LineDashStyle.Dashes[0]);
@@ -74,12 +77,12 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Button>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = (Button)window.Content;
+                var button = (Button)window.Content!;
 
                 window.ApplyTemplate();
                 button.ApplyTemplate();
 
-                var presenter = button.Presenter;
+                var presenter = button.Presenter!;
                 Assert.Equal(Brushes.Red, presenter.Background);
 
                 var diagnostic = presenter.GetDiagnostic(Button.BackgroundProperty);
@@ -108,12 +111,13 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <Button/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = (Button)window.Content;
+                var button = (Button)window.Content!;
 
                 window.ApplyTemplate();
                 button.ApplyTemplate();
 
                 var presenter = button.Presenter;
+                Assert.NotNull(presenter);
                 Assert.Equal(Brushes.Red, presenter.Background);
 
                 var diagnostic = presenter.GetDiagnostic(Button.BackgroundProperty);
@@ -139,12 +143,13 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Button>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = (Button)window.Content;
+                var button = (Button)window.Content!;
 
                 window.ApplyTemplate();
                 button.ApplyTemplate();
 
                 var presenter = button.Presenter;
+                Assert.NotNull(presenter);
                 Assert.Equal(Dock.Top, DockPanel.GetDock(presenter));
 
                 var diagnostic = presenter.GetDiagnostic(DockPanel.DockProperty);
@@ -173,12 +178,13 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Button>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = (Button)window.Content;
+                var button = (Button)window.Content!;
 
                 window.ApplyTemplate();
                 button.ApplyTemplate();
 
                 var presenter = button.Presenter;
+                Assert.NotNull(presenter);
                 Assert.Equal(Brushes.Red, presenter.Background);
 
                 var diagnostic = presenter.GetDiagnostic(Button.BackgroundProperty);
@@ -207,12 +213,13 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Button>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = (Button)window.Content;
+                var button = (Button)window.Content!;
 
                 window.ApplyTemplate();
                 button.ApplyTemplate();
 
                 var presenter = button.Presenter;
+                Assert.NotNull(presenter);
                 Assert.Equal(Brushes.Red, presenter.Background);
 
                 var diagnostic = presenter.GetDiagnostic(Button.BackgroundProperty);
@@ -238,12 +245,13 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </Button>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = (Button)window.Content;
+                var button = (Button)window.Content!;
 
                 window.ApplyTemplate();
                 button.ApplyTemplate();
 
                 var presenter = button.Presenter;
+                Assert.NotNull(presenter);
                 Assert.Equal("Foo", presenter.Content);
 
                 var diagnostic = presenter.GetDiagnostic(ContentPresenter.ContentProperty);
@@ -263,7 +271,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 ";
             var template = AvaloniaRuntimeXamlLoader.Parse<ControlTemplate>(xaml);
 
-            var parent = (ContentControl)template.Build(new ContentControl()).Result;
+            var parent = (ContentControl)template.Build(new ContentControl())!.Result;
 
             Assert.Equal("parent", parent.Name);
 
@@ -288,7 +296,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             Assert.Equal(typeof(ContentControl), template.TargetType);
 
-            Assert.IsType(typeof(ContentPresenter), template.Build(new ContentControl()).Result);
+            Assert.IsType(typeof(ContentPresenter), template.Build(new ContentControl())!.Result);
         }
 
         [Fact]
@@ -305,7 +313,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             Assert.Equal(typeof(ContentControl), template.TargetType);
 
-            Assert.IsType(typeof(ContentPresenter), template.Build(new ContentControl()).Result);
+            Assert.IsType(typeof(ContentPresenter), template.Build(new ContentControl())!.Result);
         }
 
 
@@ -322,7 +330,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 ";
             var template = AvaloniaRuntimeXamlLoader.Parse<ControlTemplate>(xaml);
 
-            var panel = (Panel)template.Build(new ContentControl()).Result;
+            var panel = (Panel)template.Build(new ContentControl())!.Result;
 
             Assert.Equal(2, panel.Children.Count);
 
@@ -439,8 +447,6 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
             Assert.Equal(RuntimeXamlDiagnosticSeverity.Info, warning.Severity);
             Assert.Contains("'PART_MainContentBorder'", warning.Title);
         }
-
-#nullable enable
 
         [Fact]
         public void Custom_ControlTemplate_Allows_TemplateBindings()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/DataTemplateTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/DataTemplateTests.cs
@@ -28,11 +28,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <ContentControl Name='target' Content='Foo'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var target = window.FindControl<ContentControl>("target");
+                var target = window.GetControl<ContentControl>("target");
 
                 window.ApplyTemplate();
                 target.ApplyTemplate();
-                target.Presenter.UpdateChild();
+                target.Presenter!.UpdateChild();
 
                 Assert.Null(target.Presenter.Child);
             }
@@ -55,11 +55,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <ContentControl Name='target' Content='Foo'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var target = window.FindControl<ContentControl>("target");
+                var target = window.GetControl<ContentControl>("target");
 
                 window.ApplyTemplate();
                 target.ApplyTemplate();
-                target.Presenter.UpdateChild();
+                target.Presenter!.UpdateChild();
 
                 Assert.IsType<Canvas>(target.Presenter.Child);
             }
@@ -83,15 +83,15 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </ItemsControl>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var itemsControl = window.FindControl<ItemsControl>("itemsControl");
+                var itemsControl = window.GetControl<ItemsControl>("itemsControl");
 
                 window.DataContext = new[] { "item1", "item2" };
 
                 window.ApplyTemplate();
                 itemsControl.ApplyTemplate();
-                itemsControl.Presenter.ApplyTemplate();
+                itemsControl.Presenter!.ApplyTemplate();
 
-                Assert.Equal(2, itemsControl.Presenter.Panel.Children.Count);
+                Assert.Equal(2, itemsControl.Presenter.Panel!.Children.Count);
             }
         }
 
@@ -112,12 +112,12 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <ContentControl Name='target' Content='Foo'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var target = window.FindControl<ContentControl>("target");
+                var target = window.GetControl<ContentControl>("target");
                 var template = (DataTemplate)window.DataTemplates.First();
                 
                 window.ApplyTemplate();
                 target.ApplyTemplate();
-                target.Presenter.UpdateChild();
+                target.Presenter!.UpdateChild();
                 
                 Assert.Equal(typeof(string), template.DataType);
                 Assert.IsType<Canvas>(target.Presenter.Child);
@@ -141,11 +141,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <ContentControl Name='target' Content='Foo'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var target = window.FindControl<ContentControl>("target");
+                var target = window.GetControl<ContentControl>("target");
 
                 window.ApplyTemplate();
                 target.ApplyTemplate();
-                target.Presenter.UpdateChild();
+                target.Presenter!.UpdateChild();
 
                 Assert.IsType<Canvas>(target.Presenter.Child);
             }
@@ -171,13 +171,13 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </ContentControl>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var target = window.FindControl<ContentControl>("target");
+                var target = window.GetControl<ContentControl>("target");
                 
                 window.ApplyTemplate();
                 target.ApplyTemplate();
-                target.Presenter.UpdateChild();
+                target.Presenter!.UpdateChild();
 
-                var dataTemplate = (CustomDataTemplate)target.ContentTemplate;
+                var dataTemplate = (CustomDataTemplate)target.ContentTemplate!;
                 Assert.Null(dataTemplate.FancyDataType);
             }
         }
@@ -198,7 +198,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <ContentControl Name='target' Content='{Binding Child}'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var target = window.FindControl<ContentControl>("target");
+                var target = window.GetControl<ContentControl>("target");
 
                 var viewModel = new TestViewModel
                 {
@@ -217,9 +217,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
                 window.ApplyTemplate();
                 target.ApplyTemplate();
-                target.Presenter.UpdateChild();
+                target.Presenter!.UpdateChild();
 
-                var canvas = (Canvas)target.Presenter.Child;
+                var canvas = (Canvas)target.Presenter.Child!;
                 Assert.Same(viewModel, target.DataContext);
                 Assert.Same(viewModel.Child, target.Presenter.DataContext);
                 Assert.Same(viewModel.Child.Child, canvas.DataContext);

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/DesignModeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/DesignModeTests.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml;
 
 public class DesignModeTests : XamlTestBase
 {
-    public static object SomeStaticProperty { get; set; }
+    public static object? SomeStaticProperty { get; set; }
 
     [Fact]
     public void Design_Mode_PreviewWith_Should_Be_Ignored_Without_Design_Mode()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/EventTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/EventTests.cs
@@ -51,7 +51,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             Assert.NotNull(target);
 
-            target.RaiseEvent(new TappedEventArgs(Gestures.DoubleTappedEvent, default));
+            target.RaiseEvent(new TappedEventArgs(Gestures.DoubleTappedEvent, null!));
 
             Assert.True(host.WasTapped);
         }
@@ -75,7 +75,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             AvaloniaRuntimeXamlLoader.Load(xaml, rootInstance: host);
 
-            var target = host.FindControl<Button>("target");
+            var target = host.GetControl<Button>("target");
             target.RaiseEvent(new RoutedEventArgs
             {
                 RoutedEvent = Button.ClickEvent,

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/GenericTemplateTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/GenericTemplateTests.cs
@@ -11,19 +11,19 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     public class SampleTemplatedObject : StyledElement
     {
         [Content] public List<SampleTemplatedObject> Content { get; set; } = new List<SampleTemplatedObject>();
-        public string Foo { get; set; }
+        public string? Foo { get; set; }
     }
     
     public class SampleTemplatedObjectTemplate
     {
         [Content]
         [TemplateContent(TemplateResultType = typeof(SampleTemplatedObject))]
-        public object Content { get; set; }
+        public object? Content { get; set; }
     }
 
     public class SampleTemplatedObjectContainer
     {
-        public SampleTemplatedObjectTemplate Template { get; set; }
+        public SampleTemplatedObjectTemplate? Template { get; set; }
     }
     
     public class GenericTemplateTests : XamlTestBase
@@ -50,7 +50,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
                 var container =
                     (SampleTemplatedObjectContainer)AvaloniaRuntimeXamlLoader.Load(xaml,
                         typeof(GenericTemplateTests).Assembly);
-                var res = TemplateContent.Load<SampleTemplatedObject>(container.Template.Content);
+                var res = TemplateContent.Load<SampleTemplatedObject>(container.Template!.Content)!;
                 Assert.Equal(res.Result, res.NameScope.Find("root"));
                 Assert.Equal(res.Result.Content[0], res.NameScope.Find("child1"));
                 Assert.Equal(res.Result.Content[1], res.NameScope.Find("child2"));

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/IgnoredDirectivesTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/IgnoredDirectivesTests.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <TextBlock x:Name='target' x:FieldModifier='Public' Text='Foo'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var target = window.FindControl<TextBlock>("target");
+                var target = window.GetControl<TextBlock>("target");
 
                 window.ApplyTemplate();
                 target.ApplyTemplate();

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/RelativePanelTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/RelativePanelTests.cs
@@ -96,7 +96,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
                 {
-                    var panel = window.FindControl<RelativePanel>("TestRelativePanel");
+                    var panel = window.GetControl<RelativePanel>("TestRelativePanel");
 
                     panel.DataContext = new
                     {
@@ -106,7 +106,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
                 window.ApplyTemplate();
                 window.Show();
                     
-                var sv = window.FindControl<ScrollViewer>("TestArea");
+                var sv = window.GetControl<ScrollViewer>("TestArea");
                 Assert.True(sv.Viewport.Width < sv.Bounds.Width);
                 Assert.True(sv.Viewport.Height < sv.Bounds.Height);
             }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ResourceDictionaryTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ResourceDictionaryTests.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
   <SolidColorBrush x:Key='RedBrush' Color='{StaticResource Red}'/>
 </ResourceDictionary>";
                 var resources = (ResourceDictionary)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var brush = (SolidColorBrush)resources["RedBrush"];
+                var brush = (SolidColorBrush)resources["RedBrush"]!;
 
                 Assert.Equal(Colors.Red, brush.Color);
             }
@@ -59,7 +59,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
                 var loaded = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
                 var window = Assert.IsType<Window>(loaded[1]);
-                var button = window.FindControl<Button>("button");
+                var button = window.GetControl<Button>("button");
 
                 var brush = Assert.IsType<SolidColorBrush>(button.Background);
                 Assert.Equal(Colors.Red, brush.Color);
@@ -418,7 +418,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <ResourceDictionary x:Key='NotAThemeVariantKey' />
 </ResourceDictionary>";
                 var resources = (ResourceDictionary)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var nested = (ResourceDictionary)resources["NotAThemeVariantKey"];
+                var nested = (ResourceDictionary?)resources["NotAThemeVariantKey"];
 
                 Assert.NotNull(nested);
             }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleIncludeTests.cs
@@ -301,7 +301,7 @@ public class StyleIncludeTests : XamlTestBase
                 return diagnostic.Severity;
             } 
         });
-        Assert.IsAssignableFrom<IStyle>(((ResourceDictionary)control.Resources)!.MergedDictionaries[0]);
+        Assert.IsAssignableFrom<IStyle>(((ResourceDictionary)control.Resources).MergedDictionaries[0]);
         var warning = Assert.Single(diagnostics);
         Assert.Equal(RuntimeXamlDiagnosticSeverity.Warning, warning.Severity);
     }
@@ -319,10 +319,11 @@ public class StyleIncludeTests : XamlTestBase
         };
 
         var loaded = Assert.IsType<StyleWithServiceProvider>(styleInclude.Loaded);
+        Assert.NotNull(loaded.ServiceProvider);
         
         Assert.Equal(
-            sp.GetService<IAvaloniaXamlIlParentStackProvider>().Parents, 
-            loaded.ServiceProvider.GetService<IAvaloniaXamlIlParentStackProvider>().Parents);
+            sp.GetRequiredService<IAvaloniaXamlIlParentStackProvider>().Parents,
+            loaded.ServiceProvider.GetRequiredService<IAvaloniaXamlIlParentStackProvider>().Parents);
     }
 }
 
@@ -332,7 +333,7 @@ public class TestServiceProvider :
     IAvaloniaXamlIlEagerParentStackProvider
 {
     private IServiceProvider _root = XamlIlRuntimeHelpers.CreateRootServiceProviderV2();
-    public object GetService(Type serviceType)
+    public object? GetService(Type serviceType)
     {
         if (serviceType == typeof(IUriContext))
         {
@@ -345,9 +346,9 @@ public class TestServiceProvider :
         return _root.GetService(serviceType);
     }
 
-    public Uri BaseUri { get; set; }
+    public Uri BaseUri { get; set; } = null!;
     public List<object> ParentsStack { get; set; } = [new ContentControl()];
     IEnumerable<object> IAvaloniaXamlIlParentStackProvider.Parents => ParentsStack.AsEnumerable().Reverse();
     IReadOnlyList<object> IAvaloniaXamlIlEagerParentStackProvider.DirectParentsStack => ParentsStack;
-    IAvaloniaXamlIlEagerParentStackProvider IAvaloniaXamlIlEagerParentStackProvider.ParentProvider => null;
+    IAvaloniaXamlIlEagerParentStackProvider? IAvaloniaXamlIlEagerParentStackProvider.ParentProvider => null;
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -35,7 +35,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </UserControl.Styles>
 </UserControl>";
                 var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var color = (Color)((Style)userControl.Styles[0]).Resources["color"];
+                var color = (Color)((Style)userControl.Styles[0]).Resources["color"]!;
 
                 Assert.Equal(0xff506070, color.ToUInt32());
             }
@@ -58,7 +58,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </UserControl.Styles>
 </UserControl>";
                 var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var dataTemplate = (DataTemplate)((Style)userControl.Styles[0]).Resources["dataTemplate"];
+                var dataTemplate = (DataTemplate?)((Style)userControl.Styles[0]).Resources["dataTemplate"];
 
                 Assert.NotNull(dataTemplate);
             }
@@ -83,7 +83,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </UserControl.Styles>
 </UserControl>";
                 var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var controlTemplate = (ControlTemplate)((Style)userControl.Styles[0]).Resources["controlTemplate"];
+                var controlTemplate = (ControlTemplate?)((Style)userControl.Styles[0]).Resources["controlTemplate"];
 
                 Assert.NotNull(controlTemplate);
                 Assert.Equal(typeof(Button), controlTemplate.TargetType);
@@ -107,7 +107,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </UserControl.Styles>
 </UserControl>";
                 var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var brush = (ISolidColorBrush)((Style)userControl.Styles[0]).Resources["brush"];
+                var brush = (ISolidColorBrush)((Style)userControl.Styles[0]).Resources["brush"]!;
 
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
@@ -135,7 +135,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var target = window.Find<ContentControl>("target");
+                var target = window.Get<ContentControl>("target");
 
                 Assert.IsType<TextBlock>(target.Content);
                 Assert.Equal("Hello World!", ((TextBlock)target.Content).Text);
@@ -166,7 +166,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Window>";
 
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var target = window.Find<TextBlock>("target");
+                var target = window.Get<TextBlock>("target");
 
                 Assert.NotNull(target.FocusAdorner);
             }
@@ -189,7 +189,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <TextBlock/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var textBlock = (TextBlock)window.Content;
+                var textBlock = (TextBlock)window.Content!;
 
                 window.ApplyTemplate();
 
@@ -217,7 +217,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
                 Assert.Equal(
                     "Property 'Button.IsDefault' is not registered on 'Avalonia.Controls.TextBlock'.",
-                    ex.InnerException.Message);
+                    ex.InnerException?.Message);
             }
         }
 
@@ -240,11 +240,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </StackPanel>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var foo = window.FindControl<Border>("foo");
-                var notFoo = window.FindControl<Border>("notFoo");
+                var foo = window.GetControl<Border>("foo");
+                var notFoo = window.GetControl<Border>("notFoo");
 
                 Assert.Null(foo.Background);
-                Assert.Equal(Colors.Red, ((ISolidColorBrush)notFoo.Background).Color);
+                Assert.Equal(Colors.Red, ((ISolidColorBrush)notFoo.Background!).Color);
             }
         }
 
@@ -267,8 +267,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </StackPanel>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var b1 = window.FindControl<Border>("b1");
-                var b2 = window.FindControl<Border>("b2");
+                var b1 = window.GetControl<Border>("b1");
+                var b2 = window.GetControl<Border>("b2");
 
                 Assert.Equal(Brushes.Red, b1.Background);
                 Assert.Null(b2.Background);
@@ -295,9 +295,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
 
-                var parent = window.FindControl<StackPanel>("parent");
-                var b1 = window.FindControl<Border>("b1");
-                var b2 = window.FindControl<Border>("b2");
+                var parent = window.GetControl<StackPanel>("parent");
+                var b1 = window.GetControl<Border>("b1");
+                var b2 = window.GetControl<Border>("b2");
 
                 Assert.Null(b1.Background);
                 Assert.Equal(Brushes.Red, b2.Background);
@@ -334,9 +334,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
 
-                var parent = window.FindControl<StackPanel>("parent");
-                var b1 = window.FindControl<Border>("b1");
-                var b2 = window.FindControl<Border>("b2");
+                var parent = window.GetControl<StackPanel>("parent");
+                var b1 = window.GetControl<Border>("b1");
+                var b2 = window.GetControl<Border>("b2");
 
                 Assert.Equal(Brushes.Red, b1.Background);
                 Assert.Null(b2.Background);
@@ -374,12 +374,12 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
                     Brushes.Red, Brushes.Green, Brushes.Blue
                 };
 
-                var list = window.FindControl<ListBox>("list");
+                var list = window.GetControl<ListBox>("list");
                 list.ItemsSource = collection;
 
                 window.Show();
 
-                IEnumerable<IBrush> GetColors() => list.GetRealizedContainers().Cast<ListBoxItem>().Select(t => t.Background);
+                IEnumerable<IBrush?> GetColors() => list.GetRealizedContainers().Cast<ListBoxItem>().Select(t => t.Background);
 
                 Assert.Equal(new[] { Brushes.Transparent, Brushes.Green, Brushes.Transparent }, GetColors());
 
@@ -416,9 +416,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </StackPanel>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var foo = window.FindControl<Border>("foo");
-                var bar = window.FindControl<Border>("bar");
-                var baz = window.FindControl<Border>("baz");
+                var foo = window.GetControl<Border>("foo");
+                var bar = window.GetControl<Border>("bar");
+                var baz = window.GetControl<Border>("baz");
 
                 Assert.Equal(Brushes.Red, foo.Background);
                 Assert.Equal(Brushes.Red, bar.Background);
@@ -446,9 +446,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </StackPanel>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var button = window.FindControl<Button>("button");
-                var carousel = window.FindControl<Carousel>("carousel");
-                var listBox = window.FindControl<ListBox>("listBox");
+                var button = window.GetControl<Button>("button");
+                var carousel = window.GetControl<Carousel>("carousel");
+                var listBox = window.GetControl<ListBox>("listBox");
 
                 Assert.Equal(Brushes.Red, button.Background);
                 Assert.Equal(Brushes.Red, carousel.Background);
@@ -483,18 +483,21 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     <Border/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var border = (Border)window.Content;
+                var border = (Border)window.Content!;
 
+                Assert.NotNull(border.Transitions);
                 Assert.Equal(1, border.Transitions.Count);
                 Assert.Equal(Border.WidthProperty, border.Transitions[0].Property);
 
                 border.Classes.Add("foo");
 
+                Assert.NotNull(border.Transitions);
                 Assert.Equal(1, border.Transitions.Count);
                 Assert.Equal(Border.HeightProperty, border.Transitions[0].Property);
 
                 border.Classes.Remove("foo");
 
+                Assert.NotNull(border.Transitions);
                 Assert.Equal(1, border.Transitions.Count);
                 Assert.Equal(Border.WidthProperty, border.Transitions[0].Property);
             }
@@ -518,9 +521,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </StackPanel>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var foo = window.FindControl<Border>("foo");
+                var foo = window.GetControl<Border>("foo");
 
-                Assert.Equal(Colors.Red, ((ISolidColorBrush)foo.Background).Color);
+                Assert.Equal(Colors.Red, ((ISolidColorBrush)foo.Background!).Color);
             }
         }
 
@@ -542,13 +545,13 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </StackPanel>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var foo = window.FindControl<Border>("foo");
+                var foo = window.GetControl<Border>("foo");
 
                 Assert.Null(foo.Background);
 
                 ((IPseudoClasses)foo.Classes).Add(":foo-bar");
 
-                Assert.Equal(Colors.Red, ((ISolidColorBrush)foo.Background).Color);
+                Assert.Equal(Colors.Red, ((ISolidColorBrush)foo.Background!).Color);
             }
         }
 
@@ -572,13 +575,13 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     </StackPanel>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
-                var foo = window.FindControl<Border>("foo");
+                var foo = window.GetControl<Border>("foo");
 
                 Assert.Null(foo.Background);
 
                 foo.Classes.Add("foo");
 
-                Assert.Equal(Colors.Red, ((ISolidColorBrush)foo.Background).Color);
+                Assert.Equal(Colors.Red, ((ISolidColorBrush)foo.Background!).Color);
             }
         }
         

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleWithServiceProvider.xaml.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleWithServiceProvider.xaml.cs
@@ -6,9 +6,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml;
 
 public class StyleWithServiceProvider : Style
 {
-    public IServiceProvider ServiceProvider { get; }
+    public IServiceProvider? ServiceProvider { get; }
 
-    public StyleWithServiceProvider(IServiceProvider sp = null)
+    public StyleWithServiceProvider(IServiceProvider? sp = null)
     {
         ServiceProvider = sp;
         AvaloniaXamlLoader.Load(sp, this);

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ThemeDictionariesTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ThemeDictionariesTests.cs
@@ -43,12 +43,12 @@ public class ThemeDictionariesTests : XamlTestBase
 </ThemeVariantScope>");
         var border = (Border)themeVariantScope.Child!;
         
-        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background!).Color);
 
         var themeVariantKey = new string(['D', 'a', 'r', 'k']); // Ensure that a non-interned string works
         themeVariantScope.RequestedThemeVariant = new ThemeVariant(themeVariantKey, null);
 
-        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background!).Color);
     }
     
     [Fact]
@@ -72,11 +72,11 @@ public class ThemeDictionariesTests : XamlTestBase
         
         DelayedBinding.ApplyBindings(border);
         
-        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background!).Color);
 
         themeVariantScope.RequestedThemeVariant = ThemeVariant.Dark;
 
-        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background!).Color);
     }
 
     [Fact]
@@ -104,11 +104,11 @@ public class ThemeDictionariesTests : XamlTestBase
 </ThemeVariantScope>");
         var border = (Border)themeVariantScope.Child!;
         
-        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background!).Color);
 
         themeVariantScope.RequestedThemeVariant = ThemeVariant.Dark;
 
-        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background!).Color);
     }
 
     [Fact]
@@ -134,14 +134,14 @@ public class ThemeDictionariesTests : XamlTestBase
 </ResourceDictionary>");
         
         themeVariantScope.Resources.MergedDictionaries.Add(resources);
-        var geo = (GeometryDrawing)themeVariantScope.FindResource("Geo");
+        var geo = (GeometryDrawing?)themeVariantScope.FindResource("Geo");
         
         Assert.NotNull(geo);
-        Assert.Equal(Colors.White, ((ISolidColorBrush)geo.Brush)!.Color);
+        Assert.Equal(Colors.White, ((ISolidColorBrush)geo.Brush!).Color);
 
         themeVariantScope.RequestedThemeVariant = ThemeVariant.Dark;
         
-        Assert.Equal(Colors.Black, ((ISolidColorBrush)geo.Brush)!.Color);
+        Assert.Equal(Colors.Black, ((ISolidColorBrush)geo.Brush!).Color);
     }
 
     [Fact]
@@ -170,11 +170,11 @@ public class ThemeDictionariesTests : XamlTestBase
 </ThemeVariantScope>");
         var border = (Border)themeVariantScope.Child!;
         
-        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background!).Color);
 
         themeVariantScope.RequestedThemeVariant = ThemeVariant.Dark;
 
-        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background!).Color);
     }
 
     [Fact]
@@ -214,11 +214,11 @@ public class ThemeDictionariesTests : XamlTestBase
 </ThemeVariantScope>");
         var border = (Border)themeVariantScope.Child!;
         
-        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background!).Color);
 
         themeVariantScope.RequestedThemeVariant = ThemeVariant.Dark;
 
-        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background!).Color);
     }
     
     [Fact]
@@ -381,7 +381,7 @@ public class ThemeDictionariesTests : XamlTestBase
             var border = (Border)themeVariantScope.Child!;
 
             themeVariantScope.RequestedThemeVariant = ThemeVariant.Light;
-            Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background)!.Color);
+            Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background!).Color);
         }
     }
     
@@ -409,11 +409,11 @@ public class ThemeDictionariesTests : XamlTestBase
 </ThemeVariantScope>");
         var border = (Border)themeVariantScope.Child!;
         
-        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background!).Color);
 
         themeVariantScope.RequestedThemeVariant = ThemeVariant.Dark;
 
-        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background!).Color);
     }
     
     [Fact]
@@ -446,11 +446,11 @@ public class ThemeDictionariesTests : XamlTestBase
 </ThemeVariantScope>");
         var border = (Border)themeVariantScope.Child!;
         
-        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background!).Color);
 
         themeVariantScope.RequestedThemeVariant = ThemeVariant.Dark;
 
-        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background!).Color);
     }
     
     [Fact]
@@ -479,11 +479,11 @@ public class ThemeDictionariesTests : XamlTestBase
 </ThemeVariantScope>");
         var border = (Border)themeVariantScope.Child!;
         
-        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.White, ((ISolidColorBrush)border.Background!).Color);
 
         themeVariantScope.RequestedThemeVariant = ThemeVariant.Dark;
 
-        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background!).Color);
     }
     
     [Fact]
@@ -519,11 +519,11 @@ public class ThemeDictionariesTests : XamlTestBase
 </ThemeVariantScope>");
         var border = (Border)themeVariantScope.Child!;
         
-        Assert.Equal(Colors.Red, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.Red, ((ISolidColorBrush)border.Background!).Color);
 
         themeVariantScope.RequestedThemeVariant = ThemeVariant.Dark;
 
-        Assert.Equal(Colors.Red, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.Red, ((ISolidColorBrush)border.Background!).Color);
     }
 
     [Fact]
@@ -556,7 +556,7 @@ public class ThemeDictionariesTests : XamlTestBase
 
         themeVariantScope.RequestedThemeVariant = Custom;
         
-        Assert.Equal(Colors.Pink, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.Pink, ((ISolidColorBrush)border.Background!).Color);
     }
     
     [Fact]
@@ -581,7 +581,7 @@ public class ThemeDictionariesTests : XamlTestBase
         
         themeVariantScope.RequestedThemeVariant = new ThemeVariant("Custom", ThemeVariant.Dark);
 
-        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background!).Color);
     }
     
     [Fact]
@@ -612,7 +612,7 @@ public class ThemeDictionariesTests : XamlTestBase
 </ThemeVariantScope>");
         var border = (Border)themeVariantScope.Child!;
 
-        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background)!.Color);
+        Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background!).Color);
     }
     
     [Fact]

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/XamlIlTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/XamlIlTests.cs
@@ -31,6 +31,7 @@ namespace Avalonia.Markup.Xaml.UnitTests
     </Transitions>
   </Grid.Transitions>
 </Grid>");
+            Assert.NotNull(parsed.Transitions);
             Assert.Equal(1, parsed.Transitions.Count);
             Assert.Equal(Visual.OpacityProperty, parsed.Transitions[0].Property);
         }
@@ -101,13 +102,13 @@ namespace Avalonia.Markup.Xaml.UnitTests
 
 </Window>
 ");
-                var btn = ((Button)parsed.Content);
+                var btn = (Button)parsed.Content!;
                 btn.ApplyTemplate();
                 var canvas = (Canvas)btn.GetVisualChildren().First()
                     .VisualChildren.First()
                     .VisualChildren.First()
                     .VisualChildren.First();
-                Assert.Equal(Brushes.Red.Color, ((ISolidColorBrush)canvas.Background).Color);
+                Assert.Equal(Brushes.Red.Color, ((ISolidColorBrush)canvas.Background!).Color);
             }
         }
 
@@ -121,7 +122,10 @@ namespace Avalonia.Markup.Xaml.UnitTests
                 w.Show();
 
                 Dispatcher.UIThread.RunJobs();
-                var itemsPresenter = ((ItemsControl)w.Content).GetVisualChildren().FirstOrDefault();
+
+                var itemsPresenter = ((ItemsControl)w.Content!).GetVisualChildren().FirstOrDefault();
+                Assert.NotNull(itemsPresenter);
+
                 var item = itemsPresenter
                     .GetVisualChildren().First()
                     .GetVisualChildren().First()
@@ -168,7 +172,7 @@ namespace Avalonia.Markup.Xaml.UnitTests
 
 </Window>
 ");
-                var tb = ((TextBox)parsed.Content);
+                var tb = (TextBox)parsed.Content!;
                 parsed.Show();
                 tb.ApplyTemplate();
                 Assert.Equal(100, XamlIlBugTestsStaticClassWithAttachedProperty.GetTestInt(tb));
@@ -223,7 +227,7 @@ namespace Avalonia.Markup.Xaml.UnitTests
                 parsed.DataContext = new List<string>() {"Test"};
                 parsed.Show();
                 parsed.ApplyTemplate();
-                var cc = ((ContentControl)((StackPanel)parsed.Content).Children.Last());
+                var cc = (ContentControl)((StackPanel)parsed.Content!).Children.Last();
                 cc.ApplyTemplate();
                 var templated = cc.GetVisualDescendants().OfType<TextBlock>()
                     .First(x => x.Classes.Contains("target"));
@@ -425,10 +429,10 @@ namespace Avalonia.Markup.Xaml.UnitTests
 
     public class XamlIlBugTestsEventHandlerCodeBehind : Window
     {
-        public object SavedContext;
-        public void HandleDataContextChanged(object sender, EventArgs args)
+        public object? SavedContext;
+        public void HandleDataContextChanged(object? sender, EventArgs args)
         {
-            SavedContext = ((Control)sender).DataContext;
+            SavedContext = ((Control)sender!).DataContext;
         }
 
         public XamlIlBugTestsEventHandlerCodeBehind()
@@ -448,13 +452,13 @@ namespace Avalonia.Markup.Xaml.UnitTests
   </ItemsControl>
 </Window>
 ", typeof(XamlIlBugTestsEventHandlerCodeBehind).Assembly, this);
-            ((ItemsControl)Content).ItemsSource = new[] {"123"};
+            ((ItemsControl)Content!).ItemsSource = new[] {"123"};
         }
     }
     
     public class XamlIlClassWithCustomProperty : UserControl
     {
-        public string Test { get; set; }
+        public string? Test { get; set; }
 
         public XamlIlClassWithCustomProperty()
         {
@@ -464,7 +468,7 @@ namespace Avalonia.Markup.Xaml.UnitTests
 
     public class XamlIlBugTestsBrushToColorConverter : IMultiValueConverter
     {
-        public object Convert(IList<object> values, Type targetType, object parameter, CultureInfo culture)
+        public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
         {
             return (values[0] as ISolidColorBrush)?.Color;
         }
@@ -472,9 +476,9 @@ namespace Avalonia.Markup.Xaml.UnitTests
 
     public class XamlIlBugTestsDataContext : INotifyPropertyChanged
     {
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
-        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
@@ -496,19 +500,19 @@ namespace Avalonia.Markup.Xaml.UnitTests
 
         public static int GetTestInt(Control control)
         {
-            return (int)control.GetValue(TestIntProperty);
+            return (int)control.GetValue(TestIntProperty)!;
         }
     }
 
     public class XamlIlCheckClrPropertyInfoExtension
     {
-        public string ExpectedPropertyName { get; set; }
+        public string? ExpectedPropertyName { get; set; }
 
         public object ProvideValue(IServiceProvider prov)
         {
-            var pvt = prov.GetService<IProvideValueTarget>();
+            var pvt = prov.GetRequiredService<IProvideValueTarget>();
             var info = (ClrPropertyInfo)pvt.TargetProperty;
-            var v = (int)info.Get(pvt.TargetObject);
+            var v = (int)info.Get(pvt.TargetObject)!;
             return v + 1;
         }
     }
@@ -527,12 +531,12 @@ namespace Avalonia.Markup.Xaml.UnitTests
         
         public class MyTypeConverter : TypeConverter
         {
-            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
             {
                 return sourceType == typeof(string);
             }
 
-            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
             {
                 if (value is string s)
                     return s.Split([','], StringSplitOptions.RemoveEmptyEntries).Select(x => new MyType(x.Trim()));

--- a/tests/Avalonia.Skia.UnitTests/HitTesting.cs
+++ b/tests/Avalonia.Skia.UnitTests/HitTesting.cs
@@ -34,8 +34,8 @@ namespace Avalonia.Skia.UnitTests
                     }
                 };
 
-                services.AssertHitTest(10, 10, null, Array.Empty<object>());
-                services.AssertHitTest(50, 50, null, services.TopLevel.Content);
+                services.AssertHitTest(10, 10, null, Array.Empty<Visual>());
+                services.AssertHitTest(50, 50, null, (Visual)services.TopLevel.Content);
             }
         }
 
@@ -64,8 +64,8 @@ namespace Avalonia.Skia.UnitTests
                 };
                 
                 
-                services.AssertHitTest(50, 50, null, Array.Empty<object>());
-                services.AssertHitTest(1, 50, null, services.TopLevel.Content);
+                services.AssertHitTest(50, 50, null, Array.Empty<Visual>());
+                services.AssertHitTest(1, 50, null, (Visual)services.TopLevel.Content);
             }
         }
     }

--- a/tests/Avalonia.UnitTests/Avalonia.UnitTests.csproj
+++ b/tests/Avalonia.UnitTests/Avalonia.UnitTests.csproj
@@ -22,4 +22,5 @@
   <Import Project="..\..\build\HarfBuzzSharp.props" />
   <Import Project="..\..\build\XUnit.props" />
   <Import Project="..\..\build\SharedVersion.props" />
+  <Import Project="..\..\build\NullableEnable.props" />
 </Project>

--- a/tests/Avalonia.UnitTests/CompositorTestServices.cs
+++ b/tests/Avalonia.UnitTests/CompositorTestServices.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Controls.Embedding;
 using Avalonia.Controls.Platform.Surfaces;
@@ -34,7 +33,7 @@ public class CompositorTestServices : IDisposable
         _app.Dispose();
     }
 
-    public CompositorTestServices(Size? size = null, IPlatformRenderInterface renderInterface = null)
+    public CompositorTestServices(Size? size = null, IPlatformRenderInterface? renderInterface = null)
     {
         var services = TestServices.MockPlatformRenderInterface;
         if (renderInterface != null)
@@ -63,7 +62,7 @@ public class CompositorTestServices : IDisposable
             TopLevel.Prepare();
             TopLevel.StartRendering();
             RunJobs();
-            Renderer = ((CompositingRenderer)TopLevel.Renderer);
+            Renderer = TopLevel.Renderer;
             Renderer.CompositionTarget.Server.DebugEvents = Events;
         }
         catch
@@ -96,17 +95,17 @@ public class CompositorTestServices : IDisposable
         Events.Rects.Clear();
     }
 
-    public void AssertHitTest(double x, double y, Func<Visual, bool> filter, params object[] expected)
+    public void AssertHitTest(double x, double y, Func<Visual, bool>? filter, params Visual[] expected)
         => AssertHitTest(new Point(x, y), filter, expected);
 
-    public void AssertHitTest(Point pt, Func<Visual, bool> filter, params object[] expected)
+    public void AssertHitTest(Point pt, Func<Visual, bool>? filter, params Visual[] expected)
     {
         RunJobs();
         var tested = Renderer.HitTest(pt, TopLevel, filter);
         Assert.Equal(expected, tested);
     }
 
-    public void AssertHitTestFirst(Point pt, Func<Visual, bool> filter, object expected)
+    public void AssertHitTestFirst(Point pt, Func<Visual, bool>? filter, Visual? expected)
     {
         RunJobs();
         var tested = Renderer.HitTest(pt, TopLevel, filter).First();
@@ -138,7 +137,7 @@ public class CompositorTestServices : IDisposable
 
     public class ManualRenderTimer : IRenderTimer
     {
-        public event Action<TimeSpan> Tick;
+        public event Action<TimeSpan>? Tick;
         public bool RunsInBackground => false;
         public void TriggerTick() => Tick?.Invoke(TimeSpan.Zero);
     }
@@ -159,16 +158,15 @@ public class CompositorTestServices : IDisposable
         }
 
         public double DesktopScaling => 1;
-        public IPlatformHandle Handle { get; }
+        public IPlatformHandle? Handle => null;
         public Size ClientSize { get; }
-        public Size? FrameSize { get; }
         public double RenderScaling => 1;
         public IEnumerable<object> Surfaces { get; } = new[] { new DummyFramebufferSurface() };
-        public Action<RawInputEventArgs> Input { get; set; }
-        public Action<Rect> Paint { get; set; }
-        public Action<Size, WindowResizeReason> Resized { get; set; }
-        public Action<double> ScalingChanged { get; set; }
-        public Action<WindowTransparencyLevel> TransparencyLevelChanged { get; set; }
+        public Action<RawInputEventArgs>? Input { get; set; }
+        public Action<Rect>? Paint { get; set; }
+        public Action<Size, WindowResizeReason>? Resized { get; set; }
+        public Action<double>? ScalingChanged { get; set; }
+        public Action<WindowTransparencyLevel>? TransparencyLevelChanged { get; set; }
 
         class DummyFramebufferSurface : IFramebufferPlatformSurface
         {
@@ -184,10 +182,6 @@ public class CompositorTestServices : IDisposable
 
         public Compositor Compositor => _compositor;
 
-        public void Invalidate(Rect rect)
-        {
-        }
-
         public void SetInputRoot(IInputRoot inputRoot)
         {
         }
@@ -196,13 +190,13 @@ public class CompositorTestServices : IDisposable
 
         public PixelPoint PointToScreen(Point point) => new();
 
-        public void SetCursor(ICursorImpl cursor)
+        public void SetCursor(ICursorImpl? cursor)
         {
         }
 
-        public Action Closed { get; set; }
-        public Action LostFocus { get; set; }
-        public IMouseDevice MouseDevice { get; } = new MouseDevice();
+        public Action? Closed { get; set; }
+        public Action? LostFocus { get; set; }
+
         public IPopupImpl CreatePopup() => throw new NotImplementedException();
 
         public void SetTransparencyLevelHint(IReadOnlyList<WindowTransparencyLevel> transparencyLevel)
@@ -215,9 +209,9 @@ public class CompositorTestServices : IDisposable
         {
         }
 
-        public AcrylicPlatformCompensationLevels AcrylicCompensationLevels { get; }
+        public AcrylicPlatformCompensationLevels AcrylicCompensationLevels => new(1, 1, 1);
         
-        public object TryGetFeature(Type featureType) => null;
+        public object? TryGetFeature(Type featureType) => null;
     }
 }
 

--- a/tests/Avalonia.UnitTests/HarfBuzzGlyphTypefaceImpl.cs
+++ b/tests/Avalonia.UnitTests/HarfBuzzGlyphTypefaceImpl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Avalonia.Media;
 using HarfBuzzSharp;
@@ -126,7 +127,7 @@ namespace Avalonia.UnitTests
             return Font.GetHorizontalGlyphAdvances(glyphIndices);
         }
 
-        public bool TryGetTable(uint tag, out byte[] table)
+        public bool TryGetTable(uint tag, [NotNullWhen(true)] out byte[]? table)
         {
             table = null;
             var blob = Face.ReferenceTable(tag);

--- a/tests/Avalonia.UnitTests/HarfBuzzTextShaperImpl.cs
+++ b/tests/Avalonia.UnitTests/HarfBuzzTextShaperImpl.cs
@@ -17,7 +17,6 @@ namespace Avalonia.UnitTests
         private static readonly ConcurrentDictionary<int, Language> s_cachedLanguage = new();
         public ShapedBuffer ShapeText(ReadOnlyMemory<char> text, TextShaperOptions options)
         {
-            var textSpan = text.Span;
             var typeface = options.Typeface;
             var fontRenderingEmSize = options.FontRenderingEmSize;
             var bidiLevel = options.BidiLevel;
@@ -168,7 +167,7 @@ namespace Avalonia.UnitTests
                 return segment.Array.AsMemory();
             }
 
-            if (MemoryMarshal.TryGetMemoryManager(memory, out MemoryManager<char> memoryManager, out start, out length))
+            if (MemoryMarshal.TryGetMemoryManager(memory, out MemoryManager<char>? memoryManager, out start, out length))
             {
                 return memoryManager.Memory;
             }

--- a/tests/Avalonia.UnitTests/MockAssetLoader.cs
+++ b/tests/Avalonia.UnitTests/MockAssetLoader.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Text;
 using Avalonia.Platform;
 using Avalonia.Utilities;
+using Moq;
 
 namespace Avalonia.UnitTests
 {
@@ -18,27 +19,27 @@ namespace Avalonia.UnitTests
             _assets = assets.ToDictionary(x => new Uri(x.Item1, UriKind.RelativeOrAbsolute), x => x.Item2);
         }
 
-        public bool Exists(Uri uri, Uri baseUri = null)
+        public bool Exists(Uri uri, Uri? baseUri = null)
         {
             return _assets.ContainsKey(uri);
         }
 
-        public Stream Open(Uri uri, Uri baseUri = null)
+        public Stream Open(Uri uri, Uri? baseUri = null)
         {
             return new MemoryStream(Encoding.UTF8.GetBytes(_assets[uri]));
         }
 
-        public (Stream stream, Assembly assembly) OpenAndGetAssembly(Uri uri, Uri baseUri = null)
+        public (Stream stream, Assembly assembly) OpenAndGetAssembly(Uri uri, Uri? baseUri = null)
         {
-            return (Open(uri, baseUri), (Assembly)null);
+            return (Open(uri, baseUri), Mock.Of<Assembly>());
         }
 
-        public Assembly GetAssembly(Uri uri, Uri baseUri = null)
+        public Assembly? GetAssembly(Uri uri, Uri? baseUri = null)
         {
             return null;
         }
 
-        public IEnumerable<Uri> GetAssets(Uri uri, Uri baseUri)
+        public IEnumerable<Uri> GetAssets(Uri uri, Uri? baseUri)
         {
             var absPath = uri.GetUnescapeAbsolutePath();
             return _assets.Keys.Where(

--- a/tests/Avalonia.UnitTests/MockWindowingPlatform.cs
+++ b/tests/Avalonia.UnitTests/MockWindowingPlatform.cs
@@ -11,12 +11,12 @@ namespace Avalonia.UnitTests
     public class MockWindowingPlatform : IWindowingPlatform
     {
         private static readonly Size s_screenSize = new Size(1280, 1024);
-        private readonly Func<IWindowImpl> _windowImpl;
-        private readonly Func<IWindowBaseImpl, IPopupImpl> _popupImpl;
+        private readonly Func<IWindowImpl>? _windowImpl;
+        private readonly Func<IWindowBaseImpl, IPopupImpl>? _popupImpl;
 
         public MockWindowingPlatform(
-            Func<IWindowImpl> windowImpl = null,
-            Func<IWindowBaseImpl, IPopupImpl> popupImpl = null )
+            Func<IWindowImpl>? windowImpl = null,
+            Func<IWindowBaseImpl, IPopupImpl>? popupImpl = null )
         {
             _windowImpl = windowImpl;
             _popupImpl = popupImpl;
@@ -34,7 +34,7 @@ namespace Avalonia.UnitTests
             windowImpl.Setup(x => x.MaxAutoSizeHint).Returns(s_screenSize);
             windowImpl.Setup(x => x.DesktopScaling).Returns(1);
             windowImpl.Setup(x => x.RenderScaling).Returns(1);
-            windowImpl.Setup(r => r.TryGetFeature(It.IsAny<Type>())).Returns(null);
+            windowImpl.Setup(r => r.TryGetFeature(It.IsAny<Type>())).Returns((object?)null);
             windowImpl.Setup(x => x.TryGetFeature(It.Is<Type>(t => t == typeof(IScreenImpl)))).Returns(CreateScreenMock().Object);
 
             windowImpl.Setup(x => x.CreatePopup()).Returns(() =>
@@ -113,7 +113,7 @@ namespace Avalonia.UnitTests
 
 
 
-            popupImpl.Setup(r => r.TryGetFeature(It.IsAny<Type>())).Returns(null);
+            popupImpl.Setup(r => r.TryGetFeature(It.IsAny<Type>())).Returns((object?)null);
             popupImpl.Setup(x => x.Dispose()).Callback(() =>
             {
                 popupImpl.Object.Closed?.Invoke();
@@ -158,7 +158,7 @@ namespace Avalonia.UnitTests
             throw new NotImplementedException();
         }
 
-        public ITrayIconImpl CreateTrayIcon()
+        public ITrayIconImpl? CreateTrayIcon()
         {
             return null;
         }

--- a/tests/Avalonia.UnitTests/ModuleInitializer.cs
+++ b/tests/Avalonia.UnitTests/ModuleInitializer.cs
@@ -14,12 +14,12 @@ namespace Avalonia.Base.UnitTests
 
         private class ThrowListener : TextWriterTraceListener
         {
-            public override void Fail(string message)
+            public override void Fail(string? message)
             {
                 throw new Exception("Assertion Failed. " + message);
             }
 
-            public override void Fail(string message, string detailMessage)
+            public override void Fail(string? message, string? detailMessage)
             {
                 throw new Exception("Assertion Failed. " + message + detailMessage);
             }

--- a/tests/Avalonia.UnitTests/MouseTestHelper.cs
+++ b/tests/Avalonia.UnitTests/MouseTestHelper.cs
@@ -11,7 +11,7 @@ namespace Avalonia.UnitTests
         private ulong Timestamp() => _nextStamp++;
 
         private RawInputModifiers _pressedButtons;
-        public IInputElement Captured => _pointer.Captured;
+        public IInputElement? Captured => _pointer.Captured;
 
         private RawInputModifiers Convert(MouseButton mouseButton)
         {
@@ -141,7 +141,7 @@ namespace Avalonia.UnitTests
         private Point MidpointRelativeToRoot(Interactive element)
         {
             var root = GetRoot(element);
-            return element.TranslatePoint(new(element.Bounds.Width / 2, element.Bounds.Height / 2), root).Value;
+            return element.TranslatePoint(new(element.Bounds.Width / 2, element.Bounds.Height / 2), root).GetValueOrDefault();
         }
     }
 }

--- a/tests/Avalonia.UnitTests/TestLogSink.cs
+++ b/tests/Avalonia.UnitTests/TestLogSink.cs
@@ -7,9 +7,9 @@ namespace Avalonia.UnitTests
     public delegate void LogCallback(
         LogEventLevel level,
         string area,
-        object source,
+        object? source,
         string messageTemplate,
-        params object[] propertyValues);
+        params object?[] propertyValues);
 
     public class TestLogSink : ILogSink
     {
@@ -32,13 +32,13 @@ namespace Avalonia.UnitTests
             return true;
         }
 
-        public void Log(LogEventLevel level, string area, object source, string messageTemplate)
+        public void Log(LogEventLevel level, string area, object? source, string messageTemplate)
         {
             _callback(level, area, source, messageTemplate);
         }
 
-        public void Log(LogEventLevel level, string area, object source, string messageTemplate,
-            params object[] propertyValues)
+        public void Log(LogEventLevel level, string area, object? source, string messageTemplate,
+            params object?[] propertyValues)
         {
             _callback(level, area, source, messageTemplate, propertyValues);
         }

--- a/tests/Avalonia.UnitTests/TestServices.cs
+++ b/tests/Avalonia.UnitTests/TestServices.cs
@@ -69,25 +69,28 @@ namespace Avalonia.UnitTests
             fontManagerImpl: new HarfBuzzFontManagerImpl(),
             textShaperImpl: new HarfBuzzTextShaperImpl());
         
-        public TestServices(
-            IAssetLoader assetLoader = null,
-            IInputManager inputManager = null,
-            Func<IKeyboardDevice> keyboardDevice = null,
-            Func<IKeyboardNavigationHandler> keyboardNavigation = null,
-            Func<IMouseDevice> mouseDevice = null,
-            IRuntimePlatform platform = null,
-            IPlatformRenderInterface renderInterface = null,
-            IRenderTimer renderLoop = null,
-            ICursorFactory standardCursorFactory = null,
-            Func<IStyle> theme = null,
-            IDispatcherImpl dispatcherImpl = null,
-            IFontManagerImpl fontManagerImpl = null,
-            ITextShaperImpl textShaperImpl = null,
-            IWindowImpl windowImpl = null,
-            IWindowingPlatform windowingPlatform = null)
+        internal TestServices(
+            IAssetLoader? assetLoader = null,
+            IInputManager? inputManager = null,
+            IGlobalClock? globalClock = null,
+            Func<IKeyboardDevice?>? keyboardDevice = null,
+            Func<IKeyboardNavigationHandler?>? keyboardNavigation = null,
+            Func<IMouseDevice?>? mouseDevice = null,
+            IRuntimePlatform? platform = null,
+            IPlatformRenderInterface? renderInterface = null,
+            ICursorFactory? standardCursorFactory = null,
+            Func<IStyle>? theme = null,
+            IDispatcherImpl? dispatcherImpl = null,
+            IFontManagerImpl? fontManagerImpl = null,
+            ITextShaperImpl? textShaperImpl = null,
+            IWindowImpl? windowImpl = null,
+            IWindowingPlatform? windowingPlatform = null,
+            IAccessKeyHandler? accessKeyHandler = null)
         {
             AssetLoader = assetLoader;
             InputManager = inputManager;
+            GlobalClock = globalClock;
+            AccessKeyHandler = accessKeyHandler;
             KeyboardDevice = keyboardDevice;
             KeyboardNavigation = keyboardNavigation;
             MouseDevice = mouseDevice;
@@ -102,74 +105,48 @@ namespace Avalonia.UnitTests
             WindowingPlatform = windowingPlatform;
         }
 
-        internal TestServices(
-            IGlobalClock globalClock,
-            IAssetLoader assetLoader = null,
-            IInputManager inputManager = null,
-            Func<IKeyboardDevice> keyboardDevice = null,
-            Func<IKeyboardNavigationHandler> keyboardNavigation = null,
-            Func<IMouseDevice> mouseDevice = null,
-            IRuntimePlatform platform = null,
-            IPlatformRenderInterface renderInterface = null,
-            IRenderTimer renderLoop = null,
-            ICursorFactory standardCursorFactory = null,
-            Func<IStyle> theme = null,
-            IDispatcherImpl dispatcherImpl = null,
-            IFontManagerImpl fontManagerImpl = null,
-            ITextShaperImpl textShaperImpl = null,
-            IWindowImpl windowImpl = null,
-            IWindowingPlatform windowingPlatform = null,
-            IAccessKeyHandler accessKeyHandler = null
-            ) : this(assetLoader, inputManager, keyboardDevice,
-            keyboardNavigation,
-            mouseDevice, platform, renderInterface, renderLoop, standardCursorFactory, theme,
-            dispatcherImpl, fontManagerImpl, textShaperImpl, windowImpl, windowingPlatform)
-        {
-            GlobalClock = globalClock;
-            AccessKeyHandler = accessKeyHandler;
-        }
-
-        public IAssetLoader AssetLoader { get; }
-        public IInputManager InputManager { get; }
-        internal IGlobalClock GlobalClock { get; set; }
-        internal IAccessKeyHandler AccessKeyHandler { get; }
-        public Func<IKeyboardDevice> KeyboardDevice { get; }
-        public Func<IKeyboardNavigationHandler> KeyboardNavigation { get; }
-        public Func<IMouseDevice> MouseDevice { get; }
-        public IRuntimePlatform Platform { get; }
-        public IPlatformRenderInterface RenderInterface { get; }
-        public IFontManagerImpl FontManagerImpl { get; }
-        public ITextShaperImpl TextShaperImpl { get; }
-        public ICursorFactory StandardCursorFactory { get; }
-        public Func<IStyle> Theme { get; }
-        public IDispatcherImpl DispatcherImpl { get; }
-        public IWindowImpl WindowImpl { get; }
-        public IWindowingPlatform WindowingPlatform { get; }
+        public IAssetLoader? AssetLoader { get; }
+        public IInputManager? InputManager { get; }
+        internal IGlobalClock? GlobalClock { get; set; }
+        internal IAccessKeyHandler? AccessKeyHandler { get; }
+        public Func<IKeyboardDevice?>? KeyboardDevice { get; }
+        public Func<IKeyboardNavigationHandler?>? KeyboardNavigation { get; }
+        public Func<IMouseDevice?>? MouseDevice { get; }
+        public IRuntimePlatform? Platform { get; }
+        public IPlatformRenderInterface? RenderInterface { get; }
+        public IFontManagerImpl? FontManagerImpl { get; }
+        public ITextShaperImpl? TextShaperImpl { get; }
+        public ICursorFactory? StandardCursorFactory { get; }
+        public Func<IStyle>? Theme { get; }
+        public IDispatcherImpl? DispatcherImpl { get; }
+        public IWindowImpl? WindowImpl { get; }
+        public IWindowingPlatform? WindowingPlatform { get; }
 
         internal TestServices With(
-            IAssetLoader assetLoader = null,
-            IInputManager inputManager = null,
-            Func<IKeyboardDevice> keyboardDevice = null,
-            Func<IKeyboardNavigationHandler> keyboardNavigation = null,
-            Func<IMouseDevice> mouseDevice = null,
-            IRuntimePlatform platform = null,
-            IPlatformRenderInterface renderInterface = null,
-            IRenderTimer renderLoop = null,
-            IScheduler scheduler = null,
-            ICursorFactory standardCursorFactory = null,
-            Func<IStyle> theme = null,
-            IDispatcherImpl dispatcherImpl = null,
-            IFontManagerImpl fontManagerImpl = null,
-            ITextShaperImpl textShaperImpl = null,
-            IWindowImpl windowImpl = null,
-            IWindowingPlatform windowingPlatform = null,
-            IGlobalClock globalClock = null,
-            IAccessKeyHandler accessKeyHandler = null)
+            IAssetLoader? assetLoader = null,
+            IInputManager? inputManager = null,
+            IGlobalClock? globalClock = null,
+            IAccessKeyHandler? accessKeyHandler = null,
+            Func<IKeyboardDevice?>? keyboardDevice = null,
+            Func<IKeyboardNavigationHandler?>? keyboardNavigation = null,
+            Func<IMouseDevice?>? mouseDevice = null,
+            IRuntimePlatform? platform = null,
+            IPlatformRenderInterface? renderInterface = null,
+            IRenderTimer? renderLoop = null,
+            IScheduler? scheduler = null,
+            ICursorFactory? standardCursorFactory = null,
+            Func<IStyle>? theme = null,
+            IDispatcherImpl? dispatcherImpl = null,
+            IFontManagerImpl? fontManagerImpl = null,
+            ITextShaperImpl? textShaperImpl = null,
+            IWindowImpl? windowImpl = null,
+            IWindowingPlatform? windowingPlatform = null)
         {
             return new TestServices(
-                globalClock ?? GlobalClock,
                 assetLoader: assetLoader ?? AssetLoader,
                 inputManager: inputManager ?? InputManager,
+                globalClock: globalClock ?? GlobalClock,
+                accessKeyHandler: accessKeyHandler ?? AccessKeyHandler,
                 keyboardDevice: keyboardDevice ?? KeyboardDevice,
                 keyboardNavigation: keyboardNavigation ?? KeyboardNavigation,
                 mouseDevice: mouseDevice ?? MouseDevice,
@@ -181,9 +158,7 @@ namespace Avalonia.UnitTests
                 theme: theme ?? Theme,
                 dispatcherImpl: dispatcherImpl ?? DispatcherImpl,
                 windowingPlatform: windowingPlatform ?? WindowingPlatform,
-                windowImpl: windowImpl ?? WindowImpl,
-                accessKeyHandler: accessKeyHandler ?? AccessKeyHandler
-                );
+                windowImpl: windowImpl ?? WindowImpl);
         }
 
         private static IStyle CreateSimpleTheme()

--- a/tests/Avalonia.UnitTests/TouchTestHelper.cs
+++ b/tests/Avalonia.UnitTests/TouchTestHelper.cs
@@ -1,6 +1,5 @@
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.VisualTree;
 
 namespace Avalonia.UnitTests
 {
@@ -9,7 +8,7 @@ namespace Avalonia.UnitTests
         private readonly Pointer _pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Touch, true);
         private ulong _nextStamp = 1;
         private ulong Timestamp() => _nextStamp++;
-        public IInputElement Captured => _pointer.Captured;
+        public IInputElement? Captured => _pointer.Captured;
 
         public void Down(Interactive target, Point position = default, KeyModifiers modifiers = default)
         {

--- a/tests/Avalonia.UnitTests/UnitTestApplication.cs
+++ b/tests/Avalonia.UnitTests/UnitTestApplication.cs
@@ -21,7 +21,7 @@ namespace Avalonia.UnitTests
 
         }
 
-        public UnitTestApplication(TestServices services)
+        public UnitTestApplication(TestServices? services)
         {
             _services = services ?? new TestServices();
             AvaloniaLocator.CurrentMutable.BindToSelf<Application>(this);
@@ -33,11 +33,11 @@ namespace Avalonia.UnitTests
             AssetLoader.RegisterResUriParsers();
         }
 
-        public static new UnitTestApplication Current => (UnitTestApplication)Application.Current;
+        public static new UnitTestApplication Current => (UnitTestApplication)Application.Current!;
 
         public TestServices Services => _services;
 
-        public static IDisposable Start(TestServices services = null)
+        public static IDisposable Start(TestServices? services = null)
         {
             var scope = AvaloniaLocator.EnterScope();
             var oldContext = SynchronizationContext.Current;
@@ -50,7 +50,7 @@ namespace Avalonia.UnitTests
                     Dispatcher.UIThread.RunJobs();
                 }
 
-                ((ToolTipService)AvaloniaLocator.Current.GetService<IToolTipService>())?.Dispose();
+                (AvaloniaLocator.Current.GetService<IToolTipService>() as ToolTipService)?.Dispose();
                 (AvaloniaLocator.Current.GetService<FontManager>() as IDisposable)?.Dispose();
 
                 Dispatcher.ResetForUnitTests();
@@ -63,24 +63,24 @@ namespace Avalonia.UnitTests
         public override void RegisterServices()
         {
             AvaloniaLocator.CurrentMutable
-                .Bind<IAssetLoader>().ToConstant(Services.AssetLoader)
-                .Bind<IGlobalClock>().ToConstant(Services.GlobalClock)
+                .Bind<IAssetLoader?>().ToConstant(Services.AssetLoader)
+                .Bind<IGlobalClock?>().ToConstant(Services.GlobalClock)
                 .BindToSelf<IGlobalStyles>(this)
-                .Bind<IInputManager>().ToConstant(Services.InputManager)
-                .Bind<IToolTipService>().ToConstant(Services.InputManager == null ? null : new ToolTipService(Services.InputManager))
-                .Bind<IKeyboardDevice>().ToConstant(Services.KeyboardDevice?.Invoke())
-                .Bind<IMouseDevice>().ToConstant(Services.MouseDevice?.Invoke())
-                .Bind<IKeyboardNavigationHandler>().ToFunc(Services.KeyboardNavigation ?? (() => null))
-                .Bind<IRuntimePlatform>().ToConstant(Services.Platform)
-                .Bind<IPlatformRenderInterface>().ToConstant(Services.RenderInterface)
-                .Bind<IFontManagerImpl>().ToConstant(Services.FontManagerImpl)
-                .Bind<ITextShaperImpl>().ToConstant(Services.TextShaperImpl)
-                .Bind<IDispatcherImpl>().ToConstant(Services.DispatcherImpl)
-                .Bind<ICursorFactory>().ToConstant(Services.StandardCursorFactory)
-                .Bind<IWindowingPlatform>().ToConstant(Services.WindowingPlatform)
+                .Bind<IInputManager?>().ToConstant(Services.InputManager)
+                .Bind<IToolTipService?>().ToConstant(Services.InputManager == null ? null : new ToolTipService(Services.InputManager))
+                .Bind<IKeyboardDevice?>().ToConstant(Services.KeyboardDevice?.Invoke())
+                .Bind<IMouseDevice?>().ToConstant(Services.MouseDevice?.Invoke())
+                .Bind<IKeyboardNavigationHandler?>().ToFunc(Services.KeyboardNavigation ?? (() => null))
+                .Bind<IRuntimePlatform?>().ToConstant(Services.Platform)
+                .Bind<IPlatformRenderInterface?>().ToConstant(Services.RenderInterface)
+                .Bind<IFontManagerImpl?>().ToConstant(Services.FontManagerImpl)
+                .Bind<ITextShaperImpl?>().ToConstant(Services.TextShaperImpl)
+                .Bind<IDispatcherImpl?>().ToConstant(Services.DispatcherImpl)
+                .Bind<ICursorFactory?>().ToConstant(Services.StandardCursorFactory)
+                .Bind<IWindowingPlatform?>().ToConstant(Services.WindowingPlatform)
                 .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>()
                 .Bind<IPlatformSettings>().ToSingleton<DefaultPlatformSettings>()
-                .Bind<IAccessKeyHandler>().ToConstant(Services.AccessKeyHandler)
+                .Bind<IAccessKeyHandler?>().ToConstant(Services.AccessKeyHandler)
                 ;
             
             // This is a hack to make tests work, we need to refactor the way font manager is registered


### PR DESCRIPTION
## What does the pull request do?
This PR enables nullable reference types in the following projects:
 - `Avalonia.UnitTests`
 - `Avalonia.Base.UnitTests`
 - `Avalonia.Markup.UnitTests`
 - `Avalonia.Markup.Xaml.UnitTests`