### PR TITLE
Set XkbSetDetectableAutoRepeat to true

### DIFF
--- a/src/Avalonia.X11/X11Globals.cs
+++ b/src/Avalonia.X11/X11Globals.cs
@@ -41,6 +41,13 @@ namespace Avalonia.X11
             plat.Windows[_rootWindow] = OnRootWindowEvent;
             XSelectInput(_x11.Display, _rootWindow,
                 new IntPtr((int)(EventMask.StructureNotifyMask | EventMask.PropertyChangeMask)));
+            
+            if (_x11.HasXkb)
+            {
+                nint supportsDetectable = 0;
+                XkbSetDetectableAutoRepeat(_x11.Display, true, supportsDetectable);
+            }
+            
             _compositingAtom = XInternAtom(_x11.Display, "_NET_WM_CM_S" + _screenNumber, false);
             OnNewWindowManager();
             UpdateCompositingAtomOwner();


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Added xKbSetDetectableAutoRepeat to X11 Globals to prevent firing Key up and down when holding a key.


## What is the current behavior?

On X11, holding a key invokes Key Down and Key Up interchangeably.


## What is the updated/expected behavior with this PR?

Holding down a key should fire Key Down and releasing a key should invoke KeyUp


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues

https://github.com/AvaloniaUI/Avalonia/issues/19745
