### PR TITLE
Change CanSeek to true in BlobReadableStream

### DIFF
--- a/src/Browser/Avalonia.Browser/Storage/BlobReadableStream.cs
+++ b/src/Browser/Avalonia.Browser/Storage/BlobReadableStream.cs
@@ -24,7 +24,7 @@ internal class BlobReadableStream : Stream
 
     public override bool CanRead => true;
 
-    public override bool CanSeek => false;
+    public override bool CanSeek => true;
 
     public override bool CanWrite => false;
 


### PR DESCRIPTION
## What does the pull request do?
Changes CanSeek from false to true in BlobReadableStream.cs, as it has completely working Seek implementation.


## What is the current behavior?
Currently CanSeek returns false.


## What is the updated/expected behavior with this PR?
CanSeek returns true.

## How was the solution implemented (if it's not obvious)?

## Checklist

- [x] changed CanSeek from false to true

## Breaking changes
None known.

## Obsoletions / Deprecations
None.

## Fixed issues

Fixes [#18168](https://github.com/AvaloniaUI/Avalonia/issues/18168)

