### PR TITLE
Fix NRE bug in TextShaperImpl.ShapeText on netstandard2.0

### DIFF
--- a/src/Skia/Avalonia.Skia/TextShaperImpl.cs
+++ b/src/Skia/Avalonia.Skia/TextShaperImpl.cs
@@ -44,7 +44,11 @@ namespace Avalonia.Skia
             var usedCulture = culture ?? CultureInfo.CurrentCulture;
 
 #if NETSTANDARD2_0
-            buffer.Language = s_cachedLanguage.GetOrAdd(usedCulture.LCID, _ => new Language(culture));
+            if (!s_cachedLanguage.TryGetValue(usedCulture.LCID, out var language))
+            {
+                language = s_cachedLanguage.GetOrAdd(usedCulture.LCID, new Language(usedCulture));
+            }
+            buffer.Language = language;
 #else
             buffer.Language = s_cachedLanguage.GetOrAdd(
                 usedCulture.LCID,
@@ -197,18 +201,18 @@ namespace Avalonia.Skia
             }
 
             var features = new Feature[options.FontFeatures.Count];
-            
+
             for (var i = 0; i < options.FontFeatures.Count; i++)
             {
                 var fontFeature = options.FontFeatures[i];
 
                 features[i] = new Feature(
-                    Tag.Parse(fontFeature.Tag), 
+                    Tag.Parse(fontFeature.Tag),
                     (uint)fontFeature.Value,
                     (uint)fontFeature.Start,
                     (uint)fontFeature.End);
             }
-            
+
             return features;
         }
     }

--- a/src/Skia/Avalonia.Skia/TextShaperImpl.cs
+++ b/src/Skia/Avalonia.Skia/TextShaperImpl.cs
@@ -201,18 +201,18 @@ namespace Avalonia.Skia
             }
 
             var features = new Feature[options.FontFeatures.Count];
-
+            
             for (var i = 0; i < options.FontFeatures.Count; i++)
             {
                 var fontFeature = options.FontFeatures[i];
 
                 features[i] = new Feature(
-                    Tag.Parse(fontFeature.Tag),
+                    Tag.Parse(fontFeature.Tag), 
                     (uint)fontFeature.Value,
                     (uint)fontFeature.Start,
                     (uint)fontFeature.End);
             }
-
+            
             return features;
         }
     }


### PR DESCRIPTION
## What does the pull request do?
Fixes a `NullReferenceException` bug in `TextShaperImpl.ShapeText` occurring when the `netstandard2.0` build of `Avalonia.Skia` is used.

## What is the current behavior?
Applications targeting .NET Framework crash on startup as a `NullReferenceException` is thrown. This happens because the `Language` object to be placed in the cache is created from an incorrect `CultureInfo` object (`culture`) in the `netstardard2.0` build.

For details, see #20364.

## What is the updated/expected behavior with this PR?

The `Language` object to cache is now created from the correct `CultureInfo` object (`usedCulture`).

## How was the solution implemented (if it's not obvious)?

The PR also makes some adjustments to avoid heap allocations which would happen if the factory overload of `ConcurrentDictionary<,>.GetOrAdd` were used. (This aligns with the motivation of the original change, see  #20175, point 3.)

Note: I tested this only manually as a unit test would require `Avalonia.Skia.UnitTests` to target some `netstandard2.0`-compatible runtime, but it runs only on `$(AvsCurrentTargetFramework)` currently. However, adding such a target framework would also require adding polyfills for some newer C# language features...

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
n/a

## Obsoletions / Deprecations
n/a

## Fixed issues
Fixes #20364
