### PR TITLE
Update NUnit to v4

### DIFF
--- a/src/Headless/Avalonia.Headless.NUnit/Avalonia.Headless.NUnit.csproj
+++ b/src/Headless/Avalonia.Headless.NUnit/Avalonia.Headless.NUnit.csproj
@@ -5,8 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Use lower minor version, as it is supposed to be compatible  -->
-    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Avalonia.Headless.NUnit.PerAssembly.UnitTests/Avalonia.Headless.NUnit.PerAssembly.UnitTests.csproj
+++ b/tests/Avalonia.Headless.NUnit.PerAssembly.UnitTests/Avalonia.Headless.NUnit.PerAssembly.UnitTests.csproj
@@ -12,8 +12,8 @@
   <Import Project="..\..\build\SharedVersion.props" />
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
   </ItemGroup>
 

--- a/tests/Avalonia.Headless.NUnit.PerTest.UnitTests/Avalonia.Headless.NUnit.PerTest.UnitTests.csproj
+++ b/tests/Avalonia.Headless.NUnit.PerTest.UnitTests/Avalonia.Headless.NUnit.PerTest.UnitTests.csproj
@@ -12,8 +12,8 @@
   <Import Project="..\..\build\SharedVersion.props" />
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
   </ItemGroup>
 

--- a/tests/Avalonia.Headless.UnitTests/AssertHelper.cs
+++ b/tests/Avalonia.Headless.UnitTests/AssertHelper.cs
@@ -1,0 +1,52 @@
+#nullable enable
+
+namespace Avalonia.Headless.UnitTests;
+
+internal static class AssertHelper
+{
+    public static void True(bool condition, string? message = null)
+    {
+#if NUNIT
+        Assert.That(condition, Is.True, message);
+#elif XUNIT
+        Assert.True(condition, message);
+#endif
+    }
+
+    public static void False(bool condition, string? message = null)
+    {
+#if NUNIT
+        Assert.That(condition, Is.False, message);
+#elif XUNIT
+        Assert.False(condition, message);
+#endif
+    }
+
+    public static void NotNull(object? value)
+    {
+#if NUNIT
+        Assert.That(value, Is.Not.Null);
+#elif XUNIT
+        Assert.NotNull(value);
+#endif
+    }
+
+    public static void Equal<T>(T expected, T actual)
+    {
+#if NUNIT
+        Assert.That(expected, Is.EqualTo(actual));
+#elif XUNIT
+        Assert.Equal(expected, actual);
+#endif
+    }
+
+    public static void Same(object? expected, object? actual)
+    {
+#if NUNIT
+        Assert.That(expected, Is.SameAs(actual));
+#elif XUNIT
+        Assert.Same(expected, actual);
+#endif
+    }
+
+}

--- a/tests/Avalonia.Headless.UnitTests/InputTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/InputTests.cs
@@ -34,13 +34,13 @@ public class InputTests
     }
     
 #if NUNIT
-    [AvaloniaTest, Timeout(10000)]
+    [AvaloniaTest]
 #elif XUNIT
     [AvaloniaFact]
 #endif
     public void Should_Click_Button_On_Window()
     {
-        Assert.True(_setupApp == Application.Current);
+        AssertHelper.Same(_setupApp, Application.Current);
         var buttonClicked = false;
         var button = new Button
         {
@@ -56,11 +56,11 @@ public class InputTests
         _window.MouseDown(new Point(50, 50), MouseButton.Left);
         _window.MouseUp(new Point(50, 50), MouseButton.Left);
 
-        Assert.True(buttonClicked);
+        AssertHelper.True(buttonClicked);
     }
     
 #if NUNIT
-    [AvaloniaTest, Timeout(10000)]
+    [AvaloniaTest]
 #elif XUNIT
     [AvaloniaFact]
 #endif
@@ -69,11 +69,11 @@ public class InputTests
         var newWindowPosition = new PixelPoint(100, 150);
         _window.Position = newWindowPosition;
         _window.Show();
-        Assert.True(_window.Position == newWindowPosition);
+        AssertHelper.Equal(newWindowPosition, _window.Position);
     }
 
 #if NUNIT
-    [AvaloniaTest, Timeout(10000)]
+    [AvaloniaTest]
 #elif XUNIT
     [AvaloniaFact]
 #endif
@@ -100,7 +100,7 @@ public class InputTests
         _window.MouseDown(translatePoint.Value, MouseButton.Left, RawInputModifiers.None);
         _window.MouseUp(translatePoint.Value, MouseButton.Left, RawInputModifiers.None);
 
-        Assert.True(clickCount == 1);
+        AssertHelper.Equal(1, clickCount);
     }
 
 #if NUNIT
@@ -110,7 +110,7 @@ public class InputTests
     public void Dispose()
 #endif
     {
-        Assert.True(_setupApp == Application.Current);
+        AssertHelper.Same(_setupApp, Application.Current);
 
         Dispatcher.UIThread.VerifyAccess();
         _window.Close();

--- a/tests/Avalonia.Headless.UnitTests/IsolationTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/IsolationTests.cs
@@ -10,7 +10,7 @@ public class IsolationTests
     private static WeakReference<Dispatcher> s_previousDispatcherRef;
 
 #if NUNIT
-    [AvaloniaTheory, Timeout(10000)]
+    [AvaloniaTheory]
     [TestCase(1), TestCase(2), TestCase(3)]
 #elif XUNIT
     [AvaloniaTheory]
@@ -37,23 +37,23 @@ public class IsolationTests
                 GC.WaitForPendingFinalizers();
                 GC.Collect();
 
-                Assert.False(s_previousAppRef.TryGetTarget(out var previousApp),
+                AssertHelper.False(s_previousAppRef.TryGetTarget(out var previousApp),
                     "Previous Application instance should have been collected.");
-                Assert.False(s_previousDispatcherRef.TryGetTarget(out var previousDispatcher),
+                AssertHelper.False(s_previousDispatcherRef.TryGetTarget(out var previousDispatcher),
                     "Previous Dispatcher instance should have been collected.");
 
-                Assert.False(previousApp == currentApp);
-                Assert.False(previousDispatcher == currentDispatcher);
+                AssertHelper.False(previousApp == currentApp);
+                AssertHelper.False(previousDispatcher == currentDispatcher);
             }
             else if (isolationLevel == AvaloniaTestIsolationLevel.PerAssembly)
             {
-                Assert.True(s_previousAppRef.TryGetTarget(out var previousApp),
+                AssertHelper.True(s_previousAppRef.TryGetTarget(out var previousApp),
                     "Previous Application instance should still be alive.");
-                Assert.True(s_previousDispatcherRef.TryGetTarget(out var previousDispatcher),
+                AssertHelper.True(s_previousDispatcherRef.TryGetTarget(out var previousDispatcher),
                     "Previous Dispatcher instance should still be alive.");
 
-                Assert.True(previousApp == currentApp);
-                Assert.True(previousDispatcher == currentDispatcher);
+                AssertHelper.True(previousApp == currentApp);
+                AssertHelper.True(previousDispatcher == currentDispatcher);
             }
             else
             {

--- a/tests/Avalonia.Headless.UnitTests/LeakTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/LeakTests.cs
@@ -16,7 +16,7 @@ public class LeakTests
 
 #if NUNIT
     [TestCaseSource(nameof(TestData))]
-    [AvaloniaTest, Timeout(10000)]
+    [AvaloniaTest]
 #elif XUNIT
     [MemberData(nameof(TestData))]
     [AvaloniaTheory]
@@ -45,7 +45,7 @@ public class LeakTests
         // Either previous font manager is collected (IsAlive == false), or it is the same as current (shared isolation mode).
         if (s_previousFontManager is not null && s_previousFontManager.Target != fontManager.Target)
         {
-            Assert.False(s_previousFontManager.IsAlive);
+            AssertHelper.False(s_previousFontManager.IsAlive);
         }
 
         s_previousFontManager = fontManager;

--- a/tests/Avalonia.Headless.UnitTests/RenderingTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/RenderingTests.cs
@@ -1,18 +1,16 @@
 ﻿using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Avalonia.Controls;
-using Avalonia.Controls.Shapes;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Rendering.Composition;
-using Avalonia.Threading;
 
 namespace Avalonia.Headless.UnitTests;
 
 public class RenderingTests
 {
 #if NUNIT
-    [AvaloniaTest, Timeout(10000)]
+    [AvaloniaTest]
 #elif XUNIT
     [AvaloniaFact]
 #endif
@@ -37,11 +35,11 @@ public class RenderingTests
 
         var frame = window.CaptureRenderedFrame();
 
-        Assert.NotNull(frame);
+        AssertHelper.NotNull(frame);
     }
 
 #if NUNIT
-    [AvaloniaTest, Timeout(10000)]
+    [AvaloniaTest]
 #elif XUNIT
     [AvaloniaFact]
 #endif
@@ -73,11 +71,11 @@ public class RenderingTests
 
         var frame = window.CaptureRenderedFrame();
 
-        Assert.NotNull(frame);
+        AssertHelper.NotNull(frame);
     }
     
 #if NUNIT
-    [AvaloniaTest, Timeout(10000)]
+    [AvaloniaTest]
 #elif XUNIT
     [AvaloniaFact]
 #endif
@@ -104,11 +102,11 @@ public class RenderingTests
 
         var frame = window.CaptureRenderedFrame();
 
-        Assert.NotNull(frame);
+        AssertHelper.NotNull(frame);
     }
 
 #if NUNIT
-    [AvaloniaTest, Timeout(10000)]
+    [AvaloniaTest]
 #elif XUNIT
     [AvaloniaFact]
 #endif
@@ -136,13 +134,13 @@ public class RenderingTests
         window.Show();
 
         var frame = window.CaptureRenderedFrame();
-        Assert.NotNull(frame);
+        AssertHelper.NotNull(frame);
     }
 
 #if NUNIT
-    [AvaloniaTest, Timeout(10000)]
+    [AvaloniaTest]
 #elif XUNIT
-    [AvaloniaFact(Timeout = 10000)]
+    [AvaloniaFact]
 #endif
     public async Task Should_Render_To_A_Compositor_Snapshot_Capture()
     {
@@ -164,10 +162,8 @@ public class RenderingTests
         var compositionVisual = ElementComposition.GetElementVisual(window)!;
         var snapshot = await compositionVisual.Compositor.CreateCompositionVisualSnapshot(compositionVisual, 1);
 
-        Assert.NotNull(snapshot);
-        // ReSharper disable CompareOfFloatsByEqualityOperator
-        Assert.True(100 == snapshot.Size.Width);
-        Assert.True(100 == snapshot.Size.Height);
-        // ReSharper restore CompareOfFloatsByEqualityOperator
+        AssertHelper.NotNull(snapshot);
+        AssertHelper.Equal(100, snapshot.Size.Width);
+        AssertHelper.Equal(100, snapshot.Size.Height);
     }
 }

--- a/tests/Avalonia.Headless.UnitTests/ServicesTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/ServicesTests.cs
@@ -1,17 +1,11 @@
-using System;
-using System.Reactive.Disposables;
-using System.Threading;
 using Avalonia.Controls;
-using Avalonia.Input;
-using Avalonia.Layout;
-using Avalonia.Threading;
 
 namespace Avalonia.Headless.UnitTests;
 
 public class ServicesTests
 {
 #if NUNIT
-    [AvaloniaTest, Timeout(10000)]
+    [AvaloniaTest]
 #elif XUNIT
     [AvaloniaFact]
 #endif
@@ -19,11 +13,11 @@ public class ServicesTests
     {
         var window = new Window();
         var screens = window.Screens;
-        Assert.NotNull(screens);
+        AssertHelper.NotNull(screens);
 
         var currentScreenFromWindow = screens.ScreenFromWindow(window);
         var currentScreenFromVisual = screens.ScreenFromVisual(window);
 
-        Assert.True(ReferenceEquals(currentScreenFromWindow, currentScreenFromVisual));
+        AssertHelper.Same(currentScreenFromWindow, currentScreenFromVisual);
     }
 }

--- a/tests/Avalonia.Headless.UnitTests/ThreadingTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/ThreadingTests.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Headless.UnitTests;
 public class ThreadingTests
 {
 #if NUNIT
-    [AvaloniaTest, Timeout(10000)]
+    [AvaloniaTest]
 #elif XUNIT
     [AvaloniaFact]
 #endif
@@ -31,20 +31,20 @@ public class ThreadingTests
     }
     
 #if NUNIT
-    [AvaloniaTheory, Timeout(10000), TestCase(1), TestCase(10), TestCase(100)]
+    [AvaloniaTheory, TestCase(1), TestCase(10), TestCase(100)]
 #elif XUNIT
-    [AvaloniaTheory(Timeout = 10000), InlineData(1), InlineData(10), InlineData(100)]
+    [AvaloniaTheory, InlineData(1), InlineData(10), InlineData(100)]
 #endif
     public async Task DispatcherTimer_Works_On_The_Same_Thread(int interval)
     {
-        Assert.NotNull(SynchronizationContext.Current);
+        AssertHelper.NotNull(SynchronizationContext.Current);
         ValidateTestContext();
         var currentThread = Thread.CurrentThread;
 
         await Task.Delay(100);
 
         ValidateTestContext();
-        Assert.True(currentThread == Thread.CurrentThread);
+        AssertHelper.Same(currentThread, Thread.CurrentThread);
 
         var tcs = new TaskCompletionSource();
 
@@ -53,7 +53,7 @@ public class ThreadingTests
             try
             {
                 ValidateTestContext();
-                Assert.True(currentThread == Thread.CurrentThread);
+                AssertHelper.Same(currentThread, Thread.CurrentThread);
                 tcs.SetResult();
             }
             catch (Exception ex)
@@ -70,7 +70,7 @@ public class ThreadingTests
 #if NUNIT
         var testName = TestContext.CurrentContext.Test.Name;
         // Test.Name also includes parameters.
-        Assert.AreEqual(testName.Split('(').First(), runningMethodName); 
+        AssertHelper.Equal(testName.Split('(').First(), runningMethodName);
 #endif
     }
 }


### PR DESCRIPTION
## What does the pull request do?
This PR updates the supported version of NUnit for the headless platform from v3 to v4.
The corresponding unit tests have also been updated.

Notes:
- NUnit 4 is an update mostly compatible with v3, for better and for worse. There still isn't a nice overridable pipeline, but our reflection hacks still work.
 - Thread abort timeouts have been removed. They weren't working in modern .NET anyways, and NUnit v4 doesn't support them. This matches our xUnit tests which don't have any timeout.
 - An `AssertHelper` class has been introduced in our unit tests to abstract away from the difference between `xUnit` and `NUnit` asserts.
