### PR TITLE
Fixed intermediate points sorting for mouse (again)

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -1118,9 +1118,6 @@ namespace Avalonia.Win32
                     var x = mp.x > 32767 ? mp.x - 65536 : mp.x;
                     var y = mp.y > 32767 ? mp.y - 65536 : mp.y;
 
-                    if(mp.time <= prevMovePoint.time || mp.time >= movePoint.time)
-                        continue;
-
                     s_sortedPoints.Add(new InternalPoint
                     {
                         Time = mp.time,
@@ -1133,6 +1130,9 @@ namespace Avalonia.Win32
 
                 foreach (var p in s_sortedPoints)
                 {
+                    if(p.Time <= prevMovePoint.time || p.Time >= movePoint.time)
+                        continue;
+
                     var client = PointToClient(p.Pt);
 
                     s_intermediatePointsPooledList.Add(new RawPointerPoint


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Mouse Intermediate points are not returned in order on Windows. I already pushed one fix to this some time ago https://github.com/AvaloniaUI/Avalonia/pull/20075, and it solves _most_ of the cases. However I found out, that on significantly higher pauses between events, Windows still manages to slip past equal timestamps for 2 different pointer positions. And of course, not in order (good job Microsoft)

## What is the current behavior?

Points are not in order, when fps are low.

https://github.com/user-attachments/assets/f5d4cfc7-497b-4353-b0e3-b1bd9aea94ce

To test set:
```xaml
 <local:PointerCanvas x:Name="PressureCanvas"
                             ...
                             ThreadSleep="50" />
```

In `PointersPage.xaml`

## What is the updated/expected behavior with this PR?

Points are in order, no weird lines on PointerCanvas

## How was the solution implemented (if it's not obvious)?

Discarding packets is now done after time sorting, so time comparision is correct. Discarding early didn't work correctly, because points were not in timestamp order.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
