### PR TITLE
Removed obsolete Windows clipboard format CF_TEXT.

### DIFF
--- a/src/Windows/Avalonia.Win32/ClipboardFormatRegistry.cs
+++ b/src/Windows/Avalonia.Win32/ClipboardFormatRegistry.cs
@@ -30,7 +30,6 @@ namespace Avalonia.Win32
         static ClipboardFormatRegistry()
         {
             AddDataFormat(DataFormat.Text, (ushort)UnmanagedMethods.ClipboardFormat.CF_UNICODETEXT);
-            AddDataFormat(DataFormat.Text, (ushort)UnmanagedMethods.ClipboardFormat.CF_TEXT);
             AddDataFormat(DataFormat.File, (ushort)UnmanagedMethods.ClipboardFormat.CF_HDROP);
             AddDataFormat(DibDataFormat, (ushort)UnmanagedMethods.ClipboardFormat.CF_DIB);
             AddDataFormat(DibV5DataFormat, (ushort)UnmanagedMethods.ClipboardFormat.CF_DIBV5);

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -2300,10 +2300,6 @@ namespace Avalonia.Win32.Interop
         public enum ClipboardFormat
         {
             /// <summary>
-            /// Text format. Each line ends with a carriage return/linefeed (CR-LF) combination. A null character signals the end of the data. Use this format for ANSI text.
-            /// </summary>
-            CF_TEXT = 1,
-            /// <summary>
             /// A handle to a bitmap
             /// </summary>
             CF_BITMAP = 2,


### PR DESCRIPTION
## What does the pull request do?
Removes interactions with `CF_TEXT` clipboard format on Windows.

Modern applications should only use `CF_UNICODETEXT`.

This allows Windows to do conversion between `CF_TEXT` and `CF_UNICODETEXT`. The conversion logic is rather complicated as described in the series of articles [Deep dive into Windows clipboard text conversion](https://devblogs.microsoft.com/oldnewthing/20251218-00/?p=111882).

## What is the current behavior?
Old applications, like [SpeQ Mathematics](https://speqmath.com/), that understand `CF_TEXT` but not `CF_UNICODETEXT` receive incorrect text.

## What is the updated/expected behavior with this PR?
Old applications receive text converted by Windows from `CF_UNICODETEXT`.

## Fixed issues
Fixes #19867

