### PR TITLE
Fix Android obsolete warnings

### DIFF
--- a/samples/ControlCatalog.Android/ControlCatalog.Android.csproj
+++ b/samples/ControlCatalog.Android/ControlCatalog.Android.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.17" />
+    <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Android/Avalonia.Android/Avalonia.Android.csproj
+++ b/src/Android/Avalonia.Android/Avalonia.Android.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />
     <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.7.1.1" />
-    <PackageReference Include="Xamarin.AndroidX.Window" Version="1.5.0" />
+    <PackageReference Include="Xamarin.AndroidX.Window" Version="1.5.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Avalonia.Base\Avalonia.Base.csproj" />

--- a/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
+++ b/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Android.OS;
 using AndroidX.Core.View.Accessibility;
@@ -157,7 +158,7 @@ namespace Avalonia.Android
             if (labeledBy is not null)
             {
                 GetOrCreateNodeInfoProvidersFromPeer(labeledBy, out int labeledById);
-                nodeInfo.SetLabeledBy(_view, labeledById);
+                nodeInfo.AddLabeledBy(_view, labeledById);
             }
 
             // UI debug metadata
@@ -181,7 +182,7 @@ namespace Avalonia.Android
                 _view.TopLevelImpl.PointToScreen(bounds.TopLeft),
                 _view.TopLevelImpl.PointToScreen(bounds.BottomRight)
                 );
-            nodeInfo.SetBoundsInParent(new(
+            nodeInfo.SetBoundsInScreen(new(
                 screenRect.X, screenRect.Y,
                 screenRect.Right, screenRect.Bottom
                 ));

--- a/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
+++ b/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
@@ -302,12 +302,17 @@ namespace Avalonia.Android.Platform
                     _activity.Window.AddFlags(WindowManagerFlags.DrawsSystemBarBackgrounds);
 
                     var androidColor = global::Android.Graphics.Color.Argb(color.A, color.R, color.G, color.B);
-                    _activity.Window.SetStatusBarColor(androidColor);
 
-                    if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+                    // Status and navigation bar colors can't be changed at all with API level >= 35
+                    if (!OperatingSystem.IsAndroidVersionAtLeast(35))
                     {
-                        // As we can only change the navigation bar's foreground api 26 and newer, we only change the background color if running on those versions
-                        _activity.Window.SetNavigationBarColor(androidColor);
+                        _activity.Window.SetStatusBarColor(androidColor);
+
+                        if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+                        {
+                            // As we can only change the navigation bar's foreground api 26 and newer, we only change the background color if running on those versions
+                            _activity.Window.SetNavigationBarColor(androidColor);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What does the pull request do?
This PR solves all remaining obsolete usages in `Avalonia.Android`:
 - `Window.SetStatusBarColor`/`SetNavigationBarColor` do nothing on API ≥ 35 (Android ≥ 15). Calls are suppressed in this case.
 - `AccessibilityNodeInfoCompat.AddLabeledBy` is used instead of `SetLabeledBy`.
 - `AccessibilityNodeInfoCompat.SetBoundsInScreen` is used instead of `SetBoundsInParent`. Coordinates were already in screen space, so it was likely an oversight.

`Xamarin.AndroidX` packages have been updated to their latest version as part of this PR.