### PR TITLE
Fixed accessibility with screen reader on TextBlocks with inlines

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/TextBlockAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TextBlockAutomationPeer.cs
@@ -16,7 +16,7 @@ namespace Avalonia.Automation.Peers
             return AutomationControlType.Text;
         }
 
-        protected override string? GetNameCore() => Owner.Text;
+        protected override string? GetNameCore() => Owner.Inlines?.Text ?? Owner.Text;
 
         protected override bool IsControlElementCore()
         {


### PR DESCRIPTION
## What does the pull request do?
This fixes accessibility for screen readers on TextBlock controls that have inline text defined rather than just a single string.

## What is the current behavior?
Currently, screen readers have trouble with `TextBlock` controls that have inlines.

For example, this works fine:
```xaml
<TextBlock>Hello, world!</TextBlock>
```
But this does not work and becomes invisible to screen readers:
```xaml
<TextBlock>Hello, <Run FontWeight="Bold">world</Run>!</TextBlock>
```

## What is the updated/expected behavior with this PR?
The text rendered by these controls should be visible to screen readers.

## How was the solution implemented (if it's not obvious)?
Initially I tested this with the following simple control, and that seems to work well.
```cs
internal class AccessibleTextBlockAutomationPeer(TextBlock owner) : TextBlockAutomationPeer(owner)
{
	protected override string? GetNameCore() => Owner.Inlines?.Text ?? Owner.Text;
}

public class AccessibleTextBlock : TextBlock
{
	protected override AutomationPeer OnCreateAutomationPeer()
		=> new AccessibleTextBlockAutomationPeer(this);
}
```

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
n/a

## Obsoletions / Deprecations
n/a

## Fixed issues
n/a