### PR TITLE
Fix android wrong inset safe area padding value after resume

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
@@ -61,7 +61,6 @@ namespace Avalonia.Android
                 .Log(this, "InvalidationAwareSurfaceView Destroyed");
             ReleaseNativeWindowHandle();
             _size = new PixelSize(1, 1);
-            _scaling = 1;
         }
 
         public virtual void SurfaceRedrawNeeded(ISurfaceHolder holder)


### PR DESCRIPTION

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes an issue where `AndroidInsetsManager.SafeAreaPadding` is calculated incorrectly if a orientation change occurs while the app is resuming.

## What is the current behavior?
The Safe Area padding becomes incorrect after resuming the app with an auto-rotation.

Repro steps:
1. Launch an Avalonia app (e.g., the ControlCatalog sample) and rotate the device to landscape.
2. Switch to another app that doesn't support landscape (e.g., the Home screen on most phones). This forces the Android to rotate back to portrait mode.
3. Switch back to the Avalonia app.
4. The app restores and rotates back to landscape as expected, but the padding for the status bar, cutout, or navigation bar safe area is significantly larger than intended.

https://github.com/user-attachments/assets/dcfa5d99-10d7-4a8f-89ba-abae49a71010

## What is the updated/expected behavior with this PR?
No extra safe area padding.

https://github.com/user-attachments/assets/3a8e0b02-521b-4457-8f77-ac05fdf7b85f

## How was the solution implemented (if it's not obvious)?

When the app goes to background, the `SurfaceView` will be destroyed and Avalonia resets its cached scaling value to 1 (`InvalidationAwareSurfaceView._scaling`). The correct value will be set when app goes foreground and `SurfaceView` is created. The problems happens when Android delivers a new inset value before correct value is set, and this will happen if returning after an orientation change. Then the padding will be calculated using scaling 1, producing way too big padding.

This PR removes the logic that resets of cached `renderScaling` in `InvalidationAwareSurfaceView.SurfaceDestroyed` method, so the previous correct value is used. 

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
