### PR TITLE
Android - Call default back callbacks when not handled.

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaActivity.cs
+++ b/src/Android/Avalonia.Android/AvaloniaActivity.cs
@@ -28,6 +28,7 @@ public class AvaloniaActivity : AppCompatActivity, IAvaloniaActivity
     private bool _contentViewSet;
     internal AvaloniaView? _view;
     private BackPressedCallback? _currentBackPressedCallback;
+    private bool _shouldNavigateBack;
 
     public Action<int, Result, Intent?>? ActivityResult { get; set; }
     public Action<int, string[], Permission[]>? RequestPermissionsResult { get; set; }
@@ -61,6 +62,20 @@ public class AvaloniaActivity : AppCompatActivity, IAvaloniaActivity
                     _view.Content = _content;
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Gets whether to call the default back handler after our back handler is called.
+    /// </summary>
+    internal bool ShouldNavigateBack
+    {
+        get
+        {
+            var goBack = _shouldNavigateBack;
+            _shouldNavigateBack = false;
+
+            return goBack;
         }
     }
 
@@ -208,6 +223,8 @@ public class AvaloniaActivity : AppCompatActivity, IAvaloniaActivity
         var eventArgs = new AndroidBackRequestedEventArgs();
 
         BackRequested?.Invoke(this, eventArgs);
+
+        _shouldNavigateBack = !eventArgs.Handled;
     }
 
     private class GlobalLayoutListener : Java.Lang.Object, ViewTreeObserver.IOnGlobalLayoutListener

--- a/src/Android/Avalonia.Android/BackPressedCallback.cs
+++ b/src/Android/Avalonia.Android/BackPressedCallback.cs
@@ -10,6 +10,14 @@ namespace Avalonia.Android
         public override void HandleOnBackPressed()
         {
             activity.OnBackInvoked();
+
+            if (activity.ShouldNavigateBack)
+            {
+                this.Enabled = false;
+                activity.OnBackPressedDispatcher?.OnBackPressed();
+            }
+
+            this.Enabled = true;
         }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
https://github.com/AvaloniaUI/Avalonia/issues/20398 switched to using the back callback api in Android 13. The change though, prevented the system from triggering the default back behavior if the app doesn't handle it. The workaround for that wasn't straightforward, so I left it as is.
This pr fixes that issue by disabling our callback, triggering the default back behavior, and enabling our callbacks again.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/20398
