### PR TITLE
Implement scene delegate for iOS

### DIFF
--- a/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Versioning;
 using Foundation;
 using Avalonia.Controls.ApplicationLifetimes;
 using UIKit;
@@ -27,6 +28,7 @@ namespace Avalonia.iOS
             add { _onActivated += value; }
             remove { _onActivated -= value; }
         }
+
         event EventHandler<ActivatedEventArgs> IAvaloniaAppDelegate.Deactivated
         {
             add { _onDeactivated += value; }
@@ -39,6 +41,17 @@ namespace Avalonia.iOS
         [Export("window")]
         public UIWindow? Window { get; set; }
 
+        [Export("application:configurationForConnectingSceneSession:options:")]
+        [SupportedOSPlatform("ios13.0")]
+        [SupportedOSPlatform("tvos13.0")]
+        [SupportedOSPlatform("maccatalyst")]
+        public UISceneConfiguration GetConfiguration(UIApplication application, UISceneSession connectingSceneSession, UISceneConnectionOptions options)
+        {
+            var config = new UISceneConfiguration(null, connectingSceneSession.Role);
+            config.DelegateType = typeof(AvaloniaSceneDelegate);
+            return config;
+        }
+
         [Export("application:didFinishLaunchingWithOptions:")]
         public bool FinishedLaunching(UIApplication application, NSDictionary? launchOptions)
         {
@@ -47,23 +60,21 @@ namespace Avalonia.iOS
 
             var lifetime = new SingleViewLifetime();
 
+            // In iOS 13+ the window is initialized in AvaloniaSceneDelegate instead.
             builder.AfterApplicationSetup(_ =>
             {
-                Window = new UIWindow();
-
-                var view = new AvaloniaView();
-                lifetime.View = view;
-                var controller = new DefaultAvaloniaViewController
+                if (!(OperatingSystem.IsIOSVersionAtLeast(13) ||
+                    OperatingSystem.IsTvOSVersionAtLeast(13) ||
+                    OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)))
                 {
-                    View = view
-                };
-                Window.RootViewController = controller;
-                view.InitWithController(controller);
+                    Window = new UIWindow();
+                    AvaloniaSceneDelegate.InitWindow(Window, lifetime);
+                }
             });
 
             builder.SetupWithLifetime(lifetime);
 
-            Window!.MakeKeyAndVisible();
+            Window?.MakeKeyAndVisible();
 
             return true;
         }

--- a/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
@@ -59,24 +59,25 @@ namespace Avalonia.iOS
             builder = CustomizeAppBuilder(builder);
 
             var lifetime = new SingleViewLifetime();
-
-            // In iOS 13+ the window is initialized in AvaloniaSceneDelegate instead.
-            builder.AfterApplicationSetup(_ =>
-            {
-                if (!(OperatingSystem.IsIOSVersionAtLeast(13) ||
-                    OperatingSystem.IsTvOSVersionAtLeast(13) ||
-                    OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)))
-                {
-                    Window = new UIWindow();
-                    AvaloniaSceneDelegate.InitWindow(Window, lifetime);
-                }
-            });
-
+            builder.AfterApplicationSetup(_ => CreateAndInitWindow(lifetime));
             builder.SetupWithLifetime(lifetime);
 
             Window?.MakeKeyAndVisible();
 
             return true;
+        }
+
+        private void CreateAndInitWindow(SingleViewLifetime lifetime)
+        {
+            if (OperatingSystem.IsIOSVersionAtLeast(13) ||
+                OperatingSystem.IsTvOSVersionAtLeast(13) ||
+                OperatingSystem.IsMacCatalyst())
+            {
+                return;
+            }
+
+            Window = new UIWindow();
+            AvaloniaSceneDelegate.InitWindow(Window, lifetime);
         }
 
         [Export("application:openURL:options:")]

--- a/src/iOS/Avalonia.iOS/AvaloniaSceneDelegate.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaSceneDelegate.cs
@@ -1,0 +1,36 @@
+﻿using Foundation;
+using UIKit;
+
+namespace Avalonia.iOS;
+
+internal sealed class AvaloniaSceneDelegate : UIResponder, IUIWindowSceneDelegate
+{
+    [Export("window")]
+    public UIWindow? Window { get; set; }
+
+    [Export("scene:willConnectToSession:options:")]
+    public void WillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
+    {
+        if (session.Configuration.Name is not null ||
+            scene is not UIWindowScene windowScene ||
+            Application.Current?.ApplicationLifetime is not SingleViewLifetime lifetime)
+        {
+            return;
+        }
+
+        Window = new UIWindow(windowScene);
+        InitWindow(Window, lifetime);
+
+        Window.MakeKeyAndVisible();
+    }
+
+    internal static void InitWindow(UIWindow window, SingleViewLifetime lifetime)
+    {
+        var view = new AvaloniaView();
+        lifetime.View = view;
+
+        var controller = new DefaultAvaloniaViewController { View = view };
+        window.RootViewController = controller;
+        view.InitWithController(controller);
+    }
+}

--- a/src/iOS/Avalonia.iOS/SingleViewLifetime.cs
+++ b/src/iOS/Avalonia.iOS/SingleViewLifetime.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 
 namespace Avalonia.iOS;
@@ -10,9 +8,9 @@ internal class SingleViewLifetime : ISingleViewApplicationLifetime, ISingleTopLe
     private Control? _mainView;
     private AvaloniaView? _view;
 
-    public AvaloniaView View
+    public AvaloniaView? View
     {
-        [return: MaybeNull] get => _view!;
+        get => _view;
         internal set
         {
             if (_view != null)
@@ -21,7 +19,7 @@ internal class SingleViewLifetime : ISingleViewApplicationLifetime, ISingleTopLe
                 _view.Dispose();
             }
             _view = value;
-            _view.Content = _mainView;
+            _view?.Content = _mainView;
         }
     }
 
@@ -33,10 +31,7 @@ internal class SingleViewLifetime : ISingleViewApplicationLifetime, ISingleTopLe
             if (_mainView != value)
             {
                 _mainView = value;
-                if (_view != null)
-                {
-                    _view.Content = _mainView;
-                }
+                _view?.Content = _mainView;
             }
         }
     }


### PR DESCRIPTION
## What does the pull request do?
This PR implement `IUIWindowSceneDelegate` for iOS, used to create the main window instead of `IUIApplicationDelegate`.

Not using the scene-based lifecycle (introduced in iOS 13) is a warning in recent iOS SDKs, and will be an error in iOS 27 and later. See [TN3187](https://developer.apple.com/documentation/technotes/tn3187-migrating-to-the-uikit-scene-based-life-cycle) for more information.

Note that this PR does not implement multiple scenes handling.

## Fixed issues
 - Fixes #19416
