### PR TITLE
Fix for HarfBuzz was missing

### DIFF
--- a/src/Browser/Avalonia.Browser/Avalonia.Browser.csproj
+++ b/src/Browser/Avalonia.Browser/Avalonia.Browser.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="../../../packages/Avalonia/Avalonia.csproj" />
     <ProjectReference Include="../../Skia/Avalonia.Skia/Avalonia.Skia.csproj" />
+    <ProjectReference Include="../../HarfBuzz/Avalonia.HarfBuzz/Avalonia.HarfBuzz.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Browser/Avalonia.Browser/BrowserAppBuilder.cs
+++ b/src/Browser/Avalonia.Browser/BrowserAppBuilder.cs
@@ -157,9 +157,6 @@ public static class BrowserAppBuilder
             builder = builder.UseBrowser();
         }
         
-        // Ensure that HarfBuzz was correctly initiated; Otherwise the wasm-App will fail to load.
-        builder.UseHarfBuzz();
-
         return builder;
     }
 
@@ -169,6 +166,7 @@ public static class BrowserAppBuilder
         return builder
             .UseBrowserRuntimePlatformSubsystem()
             .UseWindowingSubsystem(BrowserWindowingPlatform.Register)
-            .UseSkia();
+            .UseSkia()
+            .UseHarfBuzz();
     }
 }

--- a/src/Browser/Avalonia.Browser/BrowserAppBuilder.cs
+++ b/src/Browser/Avalonia.Browser/BrowserAppBuilder.cs
@@ -156,6 +156,9 @@ public static class BrowserAppBuilder
         {
             builder = builder.UseBrowser();
         }
+        
+        // Ensure that HarfBuzz was correctly initiated; Otherwise the wasm-App will fail to load.
+        builder.UseHarfBuzz();
 
         return builder;
     }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
After #19852 was merged, the ControlCatalog.Browser-sample didn't start. 


## What is the current behavior?
Browser Apss cannot start. Instead it throws 

```
RentedList<TextRun> haven't been returned to the pool!
   at Avalonia.Media.TextFormatting.FormattingObjectPool.ListPool`1.VerifyAllReturned()
in src/Avalonia.Base/Media/TextFormatting/FormattingObjectPool.cs:line 101
   at Avalonia.Media.TextFormatting.FormattingObjectPool.VerifyAllReturned() 
in src/Avalonia.Base/Media/TextFormatting/FormattingObjectPool.cs:line 38
   at Avalonia.Media.TextFormatting.TextLayout.CreateTextLines() 
in src/Avalonia.Base/Media/TextFormatting/TextLayout.cs:line 671
   at Avalonia.Media.TextFormatting.TextLayout..ctor(ITextSource textSource, TextParagraphPropert…
```

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

WASM Apps starting w/o error

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Added `.UseHarfBuzz()` as now required and done for other platforms. Users shouldn't bother with it. 

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
