### PR TITLE
Fix NuGet warnings

### DIFF
--- a/build/AnalyzerProject.targets
+++ b/build/AnalyzerProject.targets
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <EnforceExtendedAnalyzerRules Condition="'$(EnforceExtendedAnalyzerRules)' == ''">true</EnforceExtendedAnalyzerRules>
     <IsRoslynComponent Condition="'$(IsRoslynComponent)' == ''">true</IsRoslynComponent>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);RS2008</NoWarn>
   </PropertyGroup>
 

--- a/nukebuild/.editorconfig
+++ b/nukebuild/.editorconfig
@@ -6,12 +6,3 @@ root = false
 # C# files
 [*.cs]
 dotnet_style_require_accessibility_modifiers = never
-
-[{il-repack,Numerge}/**/*.cs]
-dotnet_diagnostic.CA1304.severity = none
-dotnet_diagnostic.CA1815.severity = none
-dotnet_diagnostic.CA1820.severity = none
-dotnet_diagnostic.CA1825.severity = none
-dotnet_diagnostic.CA1829.severity = none
-dotnet_diagnostic.CA1847.severity = none
-dotnet_diagnostic.SYSLIB0017.severity = none

--- a/nukebuild/_build.csproj
+++ b/nukebuild/_build.csproj
@@ -4,7 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace></RootNamespace>
     <IsPackable>False</IsPackable>
-    <NoWarn>$(NoWarn);CS0649;CS0169;SYSLIB0011</NoWarn>
+    <NoWarn>$(NoWarn);CS0649;CA1847</NoWarn>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
     <TargetFramework>$(AvsCurrentTargetFramework)</TargetFramework>
     <!-- See https://github.com/nuke-build/nuke/issues/818 -->

--- a/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
+++ b/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
@@ -6,6 +6,7 @@
       <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
       <DefineConstants>$(DefineConstants);BUILDTASK;XAMLX_CECIL_INTERNAL;XAMLX_INTERNAL</DefineConstants>
       <CopyLocalLockFileAssemblies Condition="$(TargetFramework) == 'netstandard2.0'">true</CopyLocalLockFileAssemblies>
+      <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
       <NoWarn>$(NoWarn);NU1605;CS8632</NoWarn>
       <DebugType>embedded</DebugType>
       <IncludeSymbols>false</IncludeSymbols>


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the [NU5128](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128) warning for our analyzers and build tasks packages.
These packages don't have any dependency. As a result, dependencies are suppressed using `SuppressDependenciesWhenPacking`. Numerge has been updated to handle this case.

The performance warning `CA1847` coming from Numerge has also been suppressed. It was ignored in `.editorconfig` previously, but that broke when the submodule got moved to the `external` folder.
