### PR TITLE
Remove EnableUnsafeBinaryFormatterSerialization property

### DIFF
--- a/nukebuild/_build.csproj
+++ b/nukebuild/_build.csproj
@@ -7,8 +7,6 @@
     <NoWarn>$(NoWarn);CS0649;CS0169;SYSLIB0011</NoWarn>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
     <TargetFramework>$(AvsCurrentTargetFramework)</TargetFramework>
-    <!-- See https://github.com/nuke-build/nuke/issues/818 -->
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
+++ b/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
@@ -3,8 +3,6 @@
     <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableRuntimeMarshalling>true</EnableRuntimeMarshalling>
-    <!-- We still keep BinaryFormatter for WinForms compatibility. -->
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Numerics.Vectors" Version="4.6.1" />


### PR DESCRIPTION
## What does the pull request do?
This PR removes the `EnableUnsafeBinaryFormatterSerialization` property from csproj files:
 - `Avalonia.Win32`: `BinaryFormatter` was removed in https://github.com/AvaloniaUI/Avalonia/pull/20455.
 - `_build`: Nuke was updated to v10 in https://github.com/AvaloniaUI/Avalonia/pull/20345 which doesn't use the binary formatter anymore.