### PR TITLE
#20479 Fix dead lock after SetDataAsync from clipboard in X11Clipboar…

### DIFF
--- a/src/Avalonia.X11/Clipboard/X11Clipboard.cs
+++ b/src/Avalonia.X11/Clipboard/X11Clipboard.cs
@@ -281,6 +281,7 @@ namespace Avalonia.X11.Clipboard
                     PropertyMode.Replace, atoms, atoms.Length);
                 XConvertSelection(_x11.Display, _x11.Atoms.CLIPBOARD_MANAGER, _x11.Atoms.SAVE_TARGETS,
                     _avaloniaSaveTargetsAtom, _handle, IntPtr.Zero);
+                _storeAtomTcs.TrySetResult(true);
                 await _storeAtomTcs.Task;
             }
         }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Solve a deadlock when call Linux X11 Clipboard to SetTextAsync

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`board.SetTextAsync(text)` will create a dead lock on UOS system, e.g., UOS V20 1050/1060/1070

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
`board.SetTextAsync(text)` could not cause a dead lock

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
It's easy to reproduce but only on UOS System

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
Please check the code related with
```csharp
new TaskCompletionSource<T>()
```
must call `TrySetResult(T)` before return because there won't be a default value on UOS systems

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
Please check all code related with `new TaskCompletionSource<T>()`, must call `TrySetResult(T)` before return

## Fixed issues
Fixes #20479 
