### PR TITLE
Fixed broken accessibility properties in ScrollBar control

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/ThumbAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ThumbAutomationPeer.cs
@@ -8,6 +8,5 @@ namespace Avalonia.Controls.Automation.Peers
         public ThumbAutomationPeer(Thumb owner) : base(owner) { }
         protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Thumb;
         protected override bool IsContentElementCore() => false;
-        protected override string? GetNameCore() => "Position";
     }
 }

--- a/src/Avalonia.Controls/Automation/Peers/ThumbAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ThumbAutomationPeer.cs
@@ -8,5 +8,6 @@ namespace Avalonia.Controls.Automation.Peers
         public ThumbAutomationPeer(Thumb owner) : base(owner) { }
         protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Thumb;
         protected override bool IsContentElementCore() => false;
+        protected override string? GetNameCore() => "Position";
     }
 }

--- a/src/Avalonia.Themes.Fluent/Controls/ScrollBar.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ScrollBar.xaml
@@ -137,7 +137,8 @@
                               Grid.Row="0"
                               Focusable="False"
                               MinWidth="{DynamicResource ScrollBarSize}"
-                              Height="{DynamicResource ScrollBarSize}">
+                              Height="{DynamicResource ScrollBarSize}"
+                              AutomationProperties.Name="Line up">
                   <PathIcon Data="M 19.091797 14.970703 L 10 5.888672 L 0.908203 14.970703 L 0.029297 14.091797 L 10 4.111328 L 19.970703 14.091797 Z"
                             Width="{DynamicResource ScrollBarButtonArrowIconFontSize}"
                             Height="{DynamicResource ScrollBarButtonArrowIconFontSize}"/>
@@ -155,13 +156,15 @@
                     <RepeatButton Name="PART_PageUpButton"
                                   Classes="largeIncrease"
                                   Theme="{StaticResource FluentScrollBarPageButton}"
-                                  Focusable="False" />
+                                  Focusable="False"
+                                  AutomationProperties.Name="Page up"/>
                   </Track.DecreaseButton>
                   <Track.IncreaseButton>
                     <RepeatButton Name="PART_PageDownButton"
                                   Classes="largeIncrease"
                                   Theme="{StaticResource FluentScrollBarPageButton}"
-                                  Focusable="False" />
+                                  Focusable="False"
+                                  AutomationProperties.Name="Page down"/>
                   </Track.IncreaseButton>
                   <Thumb Theme="{StaticResource FluentScrollBarThumb}"
                          Width="{DynamicResource ScrollBarSize}"
@@ -176,7 +179,8 @@
                               Grid.Row="2"
                               Focusable="False"
                               MinWidth="{DynamicResource ScrollBarSize}"
-                              Height="{DynamicResource ScrollBarSize}">
+                              Height="{DynamicResource ScrollBarSize}"
+                              AutomationProperties.Name="Line down">
                   <PathIcon Data="M 18.935547 4.560547 L 19.814453 5.439453 L 10 15.253906 L 0.185547 5.439453 L 1.064453 4.560547 L 10 13.496094 Z"
                             Width="{DynamicResource ScrollBarButtonArrowIconFontSize}"
                             Height="{DynamicResource ScrollBarButtonArrowIconFontSize}"/>
@@ -215,7 +219,8 @@
                               Grid.Column="0"
                               Focusable="False"
                               MinHeight="{DynamicResource ScrollBarSize}"
-                              Width="{DynamicResource ScrollBarSize}">
+                              Width="{DynamicResource ScrollBarSize}"
+                              AutomationProperties.Name="Column left">
                   <PathIcon Data="M 14.091797 19.970703 L 4.111328 10 L 14.091797 0.029297 L 14.970703 0.908203 L 5.888672 10 L 14.970703 19.091797 Z"
                             Width="{DynamicResource ScrollBarButtonArrowIconFontSize}"
                             Height="{DynamicResource ScrollBarButtonArrowIconFontSize}"/>
@@ -232,13 +237,15 @@
                     <RepeatButton Name="PART_PageUpButton"
                                   Classes="largeIncrease"
                                   Theme="{StaticResource FluentScrollBarPageButton}"
-                                  Focusable="False" />
+                                  Focusable="False"
+                                  AutomationProperties.Name="Page left"/>
                   </Track.DecreaseButton>
                   <Track.IncreaseButton>
                     <RepeatButton Name="PART_PageDownButton"
                                   Classes="largeIncrease"
                                   Theme="{StaticResource FluentScrollBarPageButton}"
-                                  Focusable="False" />
+                                  Focusable="False"
+                                  AutomationProperties.Name="Page right"/>
                   </Track.IncreaseButton>
                   <Thumb Theme="{StaticResource FluentScrollBarThumb}"
                          Height="{DynamicResource ScrollBarSize}"
@@ -253,7 +260,8 @@
                               Grid.Column="2"
                               Focusable="False"
                               MinHeight="{DynamicResource ScrollBarSize}"
-                              Width="{DynamicResource ScrollBarSize}">
+                              Width="{DynamicResource ScrollBarSize}"
+                              AutomationProperties.Name="Column right">
                   <PathIcon Data="M 5.029297 19.091797 L 14.111328 10 L 5.029297 0.908203 L 5.908203 0.029297 L 15.888672 10 L 5.908203 19.970703 Z"
                             Width="{DynamicResource ScrollBarButtonArrowIconFontSize}"
                             Height="{DynamicResource ScrollBarButtonArrowIconFontSize}"/>

--- a/src/Avalonia.Themes.Fluent/Controls/ScrollBar.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ScrollBar.xaml
@@ -170,7 +170,8 @@
                          Width="{DynamicResource ScrollBarSize}"
                          MinHeight="{DynamicResource ScrollBarSize}"
                          RenderTransform="{DynamicResource VerticalSmallScrollThumbScaleTransform}"
-                         RenderTransformOrigin="100%,50%" />
+                         RenderTransformOrigin="100%,50%"
+                         AutomationProperties.Name="Position"/>
                 </Track>
 
                 <RepeatButton Name="PART_LineDownButton"
@@ -251,7 +252,8 @@
                          Height="{DynamicResource ScrollBarSize}"
                          MinWidth="{DynamicResource ScrollBarSize}"
                          RenderTransform="{DynamicResource HorizontalSmallScrollThumbScaleTransform}"
-                         RenderTransformOrigin="50%,100%" />
+                         RenderTransformOrigin="50%,100%"
+                         AutomationProperties.Name="Position"/>
                 </Track>
 
                 <RepeatButton Name="PART_LineDownButton"

--- a/src/Avalonia.Themes.Simple/Controls/ScrollBar.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ScrollBar.xaml
@@ -18,7 +18,8 @@
                             MinWidth="{DynamicResource ScrollBarThickness}"
                             VerticalAlignment="Center"
                             Classes="repeat"
-                            Focusable="False">
+                            Focusable="False"
+                            AutomationProperties.Name="Column left">
                 <Path Data="M 4 0 L 4 8 L 0 4 Z" />
               </RepeatButton>
               <Track Grid.Row="1"
@@ -33,14 +34,17 @@
                 <Track.DecreaseButton>
                   <RepeatButton Name="PART_PageUpButton"
                                 Classes="repeattrack"
-                                Focusable="False" />
+                                Focusable="False"
+                                AutomationProperties.Name="Page left"/>
                 </Track.DecreaseButton>
                 <Track.IncreaseButton>
                   <RepeatButton Name="PART_PageDownButton"
                                 Classes="repeattrack"
-                                Focusable="False" />
+                                Focusable="False"
+                                AutomationProperties.Name="Page right"/>
                 </Track.IncreaseButton>
-                <Thumb Name="thumb" />
+                <Thumb Name="thumb"
+                       AutomationProperties.Name="Position"/>
               </Track>
               <RepeatButton Name="PART_LineDownButton"
                             Grid.Row="2"
@@ -48,7 +52,8 @@
                             MinWidth="{DynamicResource ScrollBarThickness}"
                             VerticalAlignment="Center"
                             Classes="repeat"
-                            Focusable="False">
+                            Focusable="False"
+                            AutomationProperties.Name="Column right">
                 <Path Data="M 0 0 L 4 4 L 0 8 Z" />
               </RepeatButton>
             </Grid>
@@ -68,7 +73,8 @@
                             MinHeight="{DynamicResource ScrollBarThickness}"
                             HorizontalAlignment="Center"
                             Classes="repeat"
-                            Focusable="False">
+                            Focusable="False"
+                            AutomationProperties.Name="Line up">
                 <Path Data="M 0 4 L 8 4 L 4 0 Z" />
               </RepeatButton>
               <Track Grid.Row="1"
@@ -84,14 +90,17 @@
                 <Track.DecreaseButton>
                   <RepeatButton Name="PART_PageUpButton"
                                 Classes="repeattrack"
-                                Focusable="False" />
+                                Focusable="False"
+                                AutomationProperties.Name="Page up"/>
                 </Track.DecreaseButton>
                 <Track.IncreaseButton>
                   <RepeatButton Name="PART_PageDownButton"
                                 Classes="repeattrack"
-                                Focusable="False" />
+                                Focusable="False"
+                                AutomationProperties.Name="Page down"/>
                 </Track.IncreaseButton>
-                <Thumb Name="thumb" />
+                <Thumb Name="thumb"
+                       AutomationProperties.Name="Position"/>
               </Track>
               <RepeatButton Name="PART_LineDownButton"
                             Grid.Row="2"
@@ -99,7 +108,8 @@
                             MinHeight="{DynamicResource ScrollBarThickness}"
                             HorizontalAlignment="Center"
                             Classes="repeat"
-                            Focusable="False">
+                            Focusable="False"
+                            AutomationProperties.Name="Line down">
                 <Path Data="M 0 0 L 4 4 L 8 0 Z" />
               </RepeatButton>
             </Grid>


### PR DESCRIPTION
## What does the pull request do?
This fixes the broken accessibility properties in the ScrollBar control on the Fluent and Simple themes.

## What is the current behavior?
The scroll bar control automation tree looked like this:

<img width="294" height="155" alt="image" src="https://github.com/user-attachments/assets/6fbe622b-2033-4a15-a49b-7eee936f636a" />

## What is the updated/expected behavior with this PR?
The scroll bar control automation tree now looks like this:

<img width="193" height="156" alt="image" src="https://github.com/user-attachments/assets/be68961c-c056-4d56-826e-c210e81f8fef" />

It would be nice to have the thumb control in the middle of the tree, but I'm not sure accessibility tools care too much about it, and the code to make it work like that feels a bit too complex to me.

## How was the solution implemented (if it's not obvious)?
This matches the behavior in Windows Explorer. It looks like Microsoft doesn't standardize the names for these controls, because in Windows Settings they are "Vertical Small Decrease", "Vertical Large Decrease" etc which feels overly verbose to me.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
