### PR TITLE
Fixed title bar appearing in content element accessibility tree

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/TitleBarAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TitleBarAutomationPeer.cs
@@ -10,7 +10,7 @@ internal class TitleBarAutomationPeer : ControlAutomationPeer
     {
     }
 
-    protected override bool IsContentElementCore() => true;
+    protected override bool IsContentElementCore() => false;
 
     protected override string GetClassNameCore()
     {


### PR DESCRIPTION
## What does the pull request do?
This makes sure the `titlebar` control does not appear in the content element tree.

## What is the current behavior?
The title bar is currently appearing in the "Content" tree, which is unusual; every other program on my computer only exposes it in the control tree. See also [UI AutomationTree Overview](https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-treeoverview).

## What is the updated/expected behavior with this PR?
The `titlebar` control now only shows up in the Control tree as expected.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
