### PR TITLE
Added property changed event for IToggleProvider

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/ToggleButtonAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ToggleButtonAutomationPeer.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Automation.Provider;
+using Avalonia.Controls.Automation;
 using Avalonia.Controls.Primitives;
 
 namespace Avalonia.Automation.Peers
@@ -8,19 +9,28 @@ namespace Avalonia.Automation.Peers
         public ToggleButtonAutomationPeer(ToggleButton owner)
             : base(owner)
         {
+            Owner.PropertyChanged += (a, e) =>
+            {
+                if (e.Property == ToggleButton.IsCheckedProperty)
+                {
+                    RaisePropertyChangedEvent(
+                        TogglePatternIdentifiers.ToggleStateProperty,
+                        ToState((bool?)e.OldValue),
+                        ToState((bool?)e.NewValue));
+                }
+            };
         }
 
         public new ToggleButton Owner => (ToggleButton)base.Owner;
 
-        ToggleState IToggleProvider.ToggleState
+        private ToggleState ToState(bool? value) => value switch
         {
-            get => Owner.IsChecked switch
-            {
-                true => ToggleState.On,
-                false => ToggleState.Off,
-                null => ToggleState.Indeterminate,
-            };
-        }
+            true => ToggleState.On,
+            false => ToggleState.Off,
+            null => ToggleState.Indeterminate,
+        };
+
+        ToggleState IToggleProvider.ToggleState => ToState(Owner.IsChecked);
 
         void IToggleProvider.Toggle()
         {

--- a/src/Avalonia.Controls/Automation/TogglePatternIdentifiers.cs
+++ b/src/Avalonia.Controls/Automation/TogglePatternIdentifiers.cs
@@ -1,0 +1,15 @@
+﻿using Avalonia.Automation.Provider;
+
+namespace Avalonia.Automation
+{
+    /// <summary>
+    /// Contains values used as identifiers by <see cref="IToggleProvider"/>.
+    /// </summary>
+    public static class TogglePatternIdentifiers
+    {
+        /// <summary>
+        /// Identifies the <see cref="IToggleProvider.ToggleState"/> property.
+        /// </summary>
+        public static AutomationProperty ToggleStateProperty { get; } = new AutomationProperty();
+    }
+}

--- a/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
+++ b/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
@@ -54,10 +54,8 @@ namespace Avalonia.Win32.Automation
             { SelectionPatternIdentifiers.IsSelectionRequiredProperty, UiaPropertyId.SelectionIsSelectionRequired },
             { SelectionPatternIdentifiers.SelectionProperty, UiaPropertyId.SelectionSelection },
             { SelectionItemPatternIdentifiers.IsSelectedProperty, UiaPropertyId.SelectionItemIsSelected },
-            {
-                SelectionItemPatternIdentifiers.SelectionContainerProperty,
-                UiaPropertyId.SelectionItemSelectionContainer
-            }
+            { SelectionItemPatternIdentifiers.SelectionContainerProperty, UiaPropertyId.SelectionItemSelectionContainer },
+            { TogglePatternIdentifiers.ToggleStateProperty, UiaPropertyId.ToggleToggleState },
         };
 
         private static ConditionalWeakTable<AutomationPeer, AutomationNode> s_nodes = new();


### PR DESCRIPTION
## What does the pull request do?
This implements the `TogglePattern.ToggleState` property changed event in `ToggleButtonAutomationPeer`.

## What is the current behavior?
The event is not emitted and can't be emitted by any `IToggleProvider`.

## What is the updated/expected behavior with this PR?
The event is emitted on Windows now, and other implementations can raise the event using `TogglePatternIdentifiers.ToggleStateProperty` when they implement `IToggleProvider`.

There are currently no property changed events called at all on Mac; that will have to wait on #20473, as that implements the functionality for it.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
