### PR TITLE
Fix DatePicker to respect custom Width property

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/DatePicker.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/DatePicker.xaml
@@ -79,6 +79,8 @@
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="HorizontalAlignment" Value="Left" />
     <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="MinWidth" Value="{DynamicResource DatePickerThemeMinWidth}" />
+    <Setter Property="MaxWidth" Value="{DynamicResource DatePickerThemeMaxWidth}" />
     <Setter Property="Template">
       <ControlTemplate>
         <DataValidationErrors>
@@ -91,8 +93,7 @@
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="{TemplateBinding CornerRadius}"
                     IsEnabled="{TemplateBinding IsEnabled}"
-                    MinWidth="{DynamicResource DatePickerThemeMinWidth}"
-                    MaxWidth="{DynamicResource DatePickerThemeMaxWidth}"
+                    MaxWidth="{TemplateBinding MaxWidth}"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     TemplatedControl.IsTemplateFocusTarget="True">


### PR DESCRIPTION
## What does the pull request do?

Allows developers to set a custom `Width` on `DatePicker` without the content overflowing. Currently, the internal `Button` has a hardcoded `MinWidth` from `DatePickerThemeMinWidth` (296px) that cannot be overridden, preventing compact DatePickers in narrower layouts.

Related discussion: https://github.com/AvaloniaUI/Avalonia/discussions/15456

## What is the current behavior?

When setting `Width="200"` on a DatePicker, the content overflows because the internal Button enforces `MinWidth=296` regardless of the control's Width setting.

```xml
<DatePicker Width="200" />  <!-- Content overflows -->
```

<img width="222" height="57" alt="DateRange before" src="https://github.com/user-attachments/assets/1854c7ab-878c-4238-b532-c54896a7b156" />

## What is the updated/expected behavior with this PR?

Developers can now create compact DatePickers by setting `MinWidth="0"`:

```xml
<DatePicker Width="200" MinWidth="0" />  <!-- Content fits -->
```

<img width="223" height="59" alt="DateRange after" src="https://github.com/user-attachments/assets/fcff6a0b-6c82-44d8-8063-c73ecadf2bb6" />

Default behavior is unchanged - DatePickers without explicit MinWidth still use the theme default (296px).

## How was the solution implemented?

1. Added MinWidth and MaxWidth setters to the ControlTheme (preserves default appearance).
2. Removed MinWidth from internal Button, changed MaxWidth to use TemplateBinding.

This allows the Button to shrink when the DatePicker's MinWidth is overridden, while maintaining backward compatibility.

## How to test this new behavior:
Add to `samples/ControlCatalog/Pages/DateTimePickerPage.xaml`:

```xml
<TextBlock FontSize="18">A DatePicker with custom Width.</TextBlock>
<StackPanel Orientation="Vertical">
    <Border BorderBrush="Red" BorderThickness="2" Width="200" HorizontalAlignment="Left">
        <DatePicker Width="200" MinWidth="0" />
    </Border>
</StackPanel>
```

## Workaround (for developers waiting for this fix)

Until this PR is merged, you can override the theme resources locally:

```xml
<Grid>
    <Grid.Resources>
        <x:Double x:Key="DatePickerThemeMinWidth">0</x:Double>
        <x:Double x:Key="DatePickerThemeMaxWidth">1000</x:Double>
    </Grid.Resources>
    
    <DatePicker Width="200" HorizontalAlignment="Stretch" />
</Grid>
```

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #4862
Fixes #18592
