### PR TITLE
Disable scroll chaining for ScrollVIewers in popup.

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/AutoCompleteBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/AutoCompleteBox.xaml
@@ -66,7 +66,8 @@
                          BorderThickness="0"
                          Background="Transparent"
                          ItemTemplate="{TemplateBinding ItemTemplate}"
-                         Margin="{DynamicResource AutoCompleteListPadding}" />
+                         Margin="{DynamicResource AutoCompleteListPadding}"
+                         ScrollViewer.IsScrollChainingEnabled="False" />
               </Border>
             </Popup>
           </Grid>

--- a/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
@@ -172,6 +172,7 @@
                       HorizontalAlignment="Stretch"
                       CornerRadius="{DynamicResource OverlayCornerRadius}">
                 <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                              IsScrollChainingEnabled="False"
                               VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
                               IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}">
                   <ItemsPresenter Name="PART_ItemsPresenter"

--- a/src/Avalonia.Themes.Fluent/Controls/MenuScrollViewer.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/MenuScrollViewer.xaml
@@ -21,6 +21,7 @@
 
   <ControlTheme x:Key="FluentMenuScrollViewer" TargetType="ScrollViewer">
     <Setter Property="Background" Value="Transparent" />
+    <Setter Property="IsScrollChainingEnabled" Value="False" />
     <Setter Property="Template">
       <ControlTemplate>
         <DockPanel>

--- a/src/Avalonia.Themes.Simple/Controls/AutoCompleteBox.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/AutoCompleteBox.xaml
@@ -38,6 +38,7 @@
                        BorderThickness="0"
                        Foreground="{TemplateBinding Foreground}"
                        ItemTemplate="{TemplateBinding ItemTemplate}"
+                       ScrollViewer.IsScrollChainingEnabled="False"
                        ScrollViewer.HorizontalScrollBarVisibility="Auto"
                        ScrollViewer.VerticalScrollBarVisibility="Auto" />
             </Border>

--- a/src/Avalonia.Themes.Simple/Controls/ComboBox.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ComboBox.xaml
@@ -87,7 +87,8 @@
                       BorderThickness="1">
                 <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                               VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                              IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}">
+                              IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}"
+                              ScrollViewer.IsScrollChainingEnabled="False">
                   <ItemsPresenter Name="PART_ItemsPresenter"
                                   ItemsPanel="{TemplateBinding ItemsPanel}" />
                 </ScrollViewer>

--- a/src/Avalonia.Themes.Simple/Controls/MenuFlyoutPresenter.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/MenuFlyoutPresenter.xaml
@@ -17,7 +17,6 @@
                 CornerRadius="{TemplateBinding CornerRadius}">
           <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                         Theme="{StaticResource SimpleMenuScrollViewer}"
-                        ScrollViewer.IsScrollChainingEnabled="False"
                         VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
             <ItemsPresenter Name="PART_ItemsPresenter"
                             Margin="{TemplateBinding Padding}"

--- a/src/Avalonia.Themes.Simple/Controls/MenuFlyoutPresenter.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/MenuFlyoutPresenter.xaml
@@ -17,6 +17,7 @@
                 CornerRadius="{TemplateBinding CornerRadius}">
           <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                         Theme="{StaticResource SimpleMenuScrollViewer}"
+                        ScrollViewer.IsScrollChainingEnabled="False"
                         VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
             <ItemsPresenter Name="PART_ItemsPresenter"
                             Margin="{TemplateBinding Padding}"

--- a/src/Avalonia.Themes.Simple/Controls/ScrollViewer.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ScrollViewer.xaml
@@ -40,6 +40,7 @@
   <ControlTheme x:Key="SimpleMenuScrollViewer"
                 TargetType="ScrollViewer">
     <Setter Property="Background" Value="Transparent" />
+    <Setter Property="IsScrollChainingEnabled" Value="False" />
     <Setter Property="Template">
       <ControlTemplate>
         <DockPanel>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When a scrollable control goes to end and continue to scroll, it will chain to the scrollviewer in underlying view. which doesn't make sense at all. It should be disabled. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When scrolling a scrollViewer to the end of a list, it should not trigger an offset change of background view. 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Scrollviewer or List works as proposal

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Set `ScrollViewer.IsScrollChainingEnabled="False"` to false. 

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
