### PR TITLE
Add thread name in DxgiConnection

### DIFF
--- a/src/Windows/Avalonia.Win32/DirectX/DxgiConnection.cs
+++ b/src/Windows/Avalonia.Win32/DirectX/DxgiConnection.cs
@@ -168,6 +168,7 @@ namespace Avalonia.Win32.DirectX
             });
             thread.IsBackground = true;
             thread.SetApartmentState(System.Threading.ApartmentState.STA);
+            thread.Name = "DxgiRenderTimerLoop";
             thread.Start();
             // block until 
             return tcs.Task.Result;


### PR DESCRIPTION


<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Add thread name in DxgiConnection to help debug.

The thread name in WinUiCompositorConnection is DwmRenderTimerLoop:

https://github.com/AvaloniaUI/Avalonia/blob/ac37bd6353dfffb5c48c4011f433a8a421c046d0/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositorConnection.cs#L73

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

The thread without name.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

The loop thread with name

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
