### PR TITLE
Fix Win32 clipboard not returning bitmaps in some cases

### DIFF
--- a/src/Windows/Avalonia.Win32/ClipboardFormatRegistry.cs
+++ b/src/Windows/Avalonia.Win32/ClipboardFormatRegistry.cs
@@ -15,11 +15,11 @@ namespace Avalonia.Win32
         private const string AppPrefix = "avn-app-fmt:";
         private static readonly List<(DataFormat Format, ushort Id)> s_formats = [];
 
-        public static DataFormat PngSystemDataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "PNG");
-        public static DataFormat PngMimeDataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "image/png");
-        public static DataFormat HBitmapDataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "CF_BITMAP");
-        public static DataFormat DibDataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "CF_DIB");
-        public static DataFormat DibV5DataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "CF_DIBV5");
+        public static readonly DataFormat PngSystemDataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "PNG");
+        public static readonly DataFormat PngMimeDataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "image/png");
+        public static readonly DataFormat HBitmapDataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "CF_BITMAP");
+        public static readonly DataFormat DibDataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "CF_DIB");
+        public static readonly DataFormat DibV5DataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "CF_DIBV5");
 
         // Ordered from the most preferred to the least preferred
         public static DataFormat[] ImageFormats = [PngMimeDataFormat, PngSystemDataFormat, DibDataFormat, DibV5DataFormat, HBitmapDataFormat];

--- a/src/Windows/Avalonia.Win32/ClipboardFormatRegistry.cs
+++ b/src/Windows/Avalonia.Win32/ClipboardFormatRegistry.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using Avalonia.Input;
 using Avalonia.Media.Imaging;
 using Avalonia.Utilities;
@@ -12,19 +13,15 @@ namespace Avalonia.Win32
     {
         private const int MaxFormatNameLength = 260;
         private const string AppPrefix = "avn-app-fmt:";
-        public const string PngFormatMimeType = "image/png";
-        public const string PngFormatSystemType = "PNG";
-        public const string BitmapFormat = "CF_BITMAP";
-        public const string DibFormat = "CF_DIB";
-        public const string DibV5Format = "CF_DIBV5";
         private static readonly List<(DataFormat Format, ushort Id)> s_formats = [];
 
-        public static DataFormat PngSystemDataFormat = DataFormat.FromSystemName<Bitmap>(PngFormatSystemType, AppPrefix);
-        public static DataFormat PngMimeDataFormat = DataFormat.FromSystemName<Bitmap>(PngFormatMimeType, AppPrefix);
-        public static DataFormat HBitmapDataFormat = DataFormat.FromSystemName<Bitmap>(BitmapFormat, AppPrefix);
-        public static DataFormat DibDataFormat = DataFormat.FromSystemName<Bitmap>(DibFormat, AppPrefix);
-        public static DataFormat DibV5DataFormat = DataFormat.FromSystemName<Bitmap>(DibV5Format, AppPrefix);
+        public static DataFormat PngSystemDataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "PNG");
+        public static DataFormat PngMimeDataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "image/png");
+        public static DataFormat HBitmapDataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "CF_BITMAP");
+        public static DataFormat DibDataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "CF_DIB");
+        public static DataFormat DibV5DataFormat = new DataFormat<Bitmap>(DataFormatKind.Platform, "CF_DIBV5");
 
+        // Ordered from the most preferred to the least preferred
         public static DataFormat[] ImageFormats = [PngMimeDataFormat, PngSystemDataFormat, DibDataFormat, DibV5DataFormat, HBitmapDataFormat];
 
         static ClipboardFormatRegistry()
@@ -44,12 +41,12 @@ namespace Avalonia.Win32
             var buffer = StringBuilderCache.Acquire(MaxFormatNameLength);
             if (UnmanagedMethods.GetClipboardFormatName(id, buffer, buffer.Capacity) > 0)
                 return StringBuilderCache.GetStringAndRelease(buffer);
-            if (Enum.IsDefined(typeof(UnmanagedMethods.ClipboardFormat), (int)id))
-                return Enum.GetName(typeof(UnmanagedMethods.ClipboardFormat), (int)id)!;
+            if (Enum.IsDefined(typeof(UnmanagedMethods.ClipboardFormat), id))
+                return Enum.GetName(typeof(UnmanagedMethods.ClipboardFormat), id)!;
             return $"Unknown_Format_{id}";
         }
 
-        public static DataFormat GetFormatById(ushort id)
+        public static DataFormat GetOrAddFormat(ushort id)
         {
             lock (s_formats)
             {
@@ -66,30 +63,12 @@ namespace Avalonia.Win32
             }
         }
 
-        public static ushort GetFormatId(DataFormat format)
+        public static ushort GetOrAddFormat(DataFormat format)
         {
+            Debug.Assert(format != DataFormat.Bitmap); // Callers must pass an effective platform type
+
             lock (s_formats)
             {
-                if (DataFormat.Bitmap.Equals(format))
-                {
-                    (DataFormat, ushort)? pngFormat = null;
-                    (DataFormat, ushort)? dibFormat = null;
-
-                    foreach (var currentFormat in s_formats)
-                    {
-                        if (currentFormat.Id == (ushort)UnmanagedMethods.ClipboardFormat.CF_DIB)
-                            dibFormat = currentFormat;
-                        else if (currentFormat.Format.Identifier == PngFormatMimeType)
-                            pngFormat = currentFormat;
-                    }
-                    var imageFormatId = pngFormat?.Item2 ?? dibFormat?.Item2 ?? 0;
-
-                    if (imageFormatId != 0)
-                    {
-                        return imageFormatId;
-                    }
-                }
-
                 for (var i = 0; i < s_formats.Count; ++i)
                 {
                     if (s_formats[i].Format.Equals(format))

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -2297,7 +2297,7 @@ namespace Avalonia.Win32.Interop
             MDT_DEFAULT = MDT_EFFECTIVE_DPI
         }
 
-        public enum ClipboardFormat
+        public enum ClipboardFormat : ushort
         {
             /// <summary>
             /// A handle to a bitmap

--- a/src/Windows/Avalonia.Win32/OleDataObjectToDataTransferWrapper.cs
+++ b/src/Windows/Avalonia.Win32/OleDataObjectToDataTransferWrapper.cs
@@ -36,11 +36,7 @@ internal sealed class OleDataObjectToDataTransferWrapper(Win32Com.IDataObject ol
 
         foreach (var format in formats)
         {
-            if (format.Identifier is ClipboardFormatRegistry.DibFormat 
-                or ClipboardFormatRegistry.BitmapFormat 
-                or ClipboardFormatRegistry.PngFormatMimeType
-                or ClipboardFormatRegistry.PngFormatSystemType)
-            {
+            if (ClipboardFormatRegistry.ImageFormats.Contains(format)) {
                 hasSupportedImageFormat = true;
                 break;
             }
@@ -65,7 +61,7 @@ internal sealed class OleDataObjectToDataTransferWrapper(Win32Com.IDataObject ol
             if (formatEtc.ptd != IntPtr.Zero)
                 Marshal.FreeCoTaskMem(formatEtc.ptd);
 
-            return ClipboardFormatRegistry.GetFormatById(formatEtc.cfFormat);
+            return ClipboardFormatRegistry.GetOrAddFormat(formatEtc.cfFormat);
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the clipboard not returning a value for `DataFormat.Bitmap` in some specific cases, on Windows.

## What is the current behavior?
As soon as `image/png` is registered (for example, by putting a bitmap onto the clipboard), it's always used even if the clipboard doesn't contain it.

## What is the updated/expected behavior with this PR?
Reading an image from the clipboard when `image/png` is registered works correctly even if the clipboard does not contain such a format.

## How was the solution implemented (if it's not obvious)?
Rather than checking against the format registry, we now check if each image format is contained in the clipboard. The first present one gets used.

As part of this PR, `ImageFormatRegistry.ImageFormats` is used in more places, and the public string constant identifiers are removed to avoid incorrect comparisons (`DataFormat` instances should always be compared using `Equals` or `==`, not by their identifier, otherwise `Platform` and `Application` formats would be considered equal).
