### PR TITLE
Fix TimePicker to respect custom Width property

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/DatePicker.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/DatePicker.xaml
@@ -93,6 +93,7 @@
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="{TemplateBinding CornerRadius}"
                     IsEnabled="{TemplateBinding IsEnabled}"
+                    MinWidth="{TemplateBinding MinWidth}"
                     MaxWidth="{TemplateBinding MaxWidth}"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"

--- a/src/Avalonia.Themes.Fluent/Controls/TimePicker.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/TimePicker.xaml
@@ -78,6 +78,8 @@
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="HorizontalAlignment" Value="Left" />
     <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="MinWidth" Value="{DynamicResource TimePickerThemeMinWidth}" />
+    <Setter Property="MaxWidth" Value="{DynamicResource TimePickerThemeMaxWidth}" />
     <Setter Property="Template">
       <ControlTemplate>
         <DataValidationErrors>
@@ -90,8 +92,8 @@
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="{TemplateBinding CornerRadius}"
                     IsEnabled="{TemplateBinding IsEnabled}"
-                    MinWidth="{DynamicResource TimePickerThemeMinWidth}"
-                    MaxWidth="{DynamicResource TimePickerThemeMaxWidth}"
+                    MinWidth="{TemplateBinding MinWidth}"
+                    MaxWidth="{TemplateBinding MaxWidth}"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch">
 


### PR DESCRIPTION
## What does the pull request do?

Allows developers to set a custom `Width` on `TimePicker` without the content overflowing. Currently, the internal `Button` has a hardcoded `MinWidth` from `TimePickerThemeMinWidth` (242px) that cannot be overridden, preventing compact TimePickers in narrower layouts.

I made a PR to fix the `DatePicker` [here](https://github.com/AvaloniaUI/Avalonia/pull/20487), but I forgot to also update `TimePicker`. This PR is identical, except it addresses TimePicker instead. 

## What is the current behavior?

When setting `Width="200"` on a TimePicker, the content overflows because the internal Button enforces `MinWidth=242` regardless of the control's Width setting.

```xml
<TimePicker Width="200" />  <!-- Content overflows -->
```

<img width="222" height="60" alt="Before" src="https://github.com/user-attachments/assets/be046ef6-8df7-4d24-9001-cd7e9c5d93dd" />

## What is the updated/expected behavior with this PR?

Developers can now create compact TimePickers by setting `MinWidth="0"`:

```xml
<TimePicker Width="200" MinWidth="0" />  <!-- Content fits -->
```

<img width="222" height="61" alt="After" src="https://github.com/user-attachments/assets/a2d2de50-4050-4149-ab9c-bd08112d15cb" />

Default behavior is unchanged - TimePickers without explicit MinWidth still use the theme default (242px).

## How was the solution implemented?

1. Added MinWidth and MaxWidth setters to the ControlTheme (preserves default appearance).
2. Removed MinWidth from internal Button, changed MaxWidth to use TemplateBinding.

This allows the Button to shrink when the TimePicker's MinWidth is overridden, while maintaining backward compatibility.

## How to test this new behavior:
Add to `samples/ControlCatalog/Pages/DateTimePickerPage.xaml`:

```xml
<TextBlock FontSize="18">A TimePicker with custom Width.</TextBlock>
<StackPanel Orientation="Vertical">
    <Border BorderBrush="Red" BorderThickness="2" Width="200" HorizontalAlignment="Left">
        <TimePicker Width="200" MinWidth="0" />
    </Border>
</StackPanel>
```

## Workaround (for developers waiting for this fix)

Until this PR is merged, you can override the theme resources locally:

```xml
<Grid>
    <Grid.Resources>
        <x:Double x:Key="TimePickerThemeMinWidth">0</x:Double>
        <x:Double x:Key="TimePickerThemeMaxWidth">1000</x:Double>
    </Grid.Resources>
    
    <TimePicker Width="200" HorizontalAlignment="Stretch" />
</Grid>
```

## Breaking changes
None

## Obsoletions / Deprecations
None
