### PR TITLE
Fix the DxgiRenderTimerLoop thread get the screens from UI thread

### DIFF
--- a/src/Windows/Avalonia.Win32/DirectX/DxgiConnection.cs
+++ b/src/Windows/Avalonia.Win32/DirectX/DxgiConnection.cs
@@ -1,12 +1,19 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia.Logging;
 using Avalonia.OpenGL.Egl;
 using Avalonia.Rendering;
-using static Avalonia.Win32.Interop.UnmanagedMethods;
-using static Avalonia.Win32.DirectX.DirectXUnmanagedMethods;
+
 using MicroCom.Runtime;
+
+using Windows.Win32;
+using Windows.Win32.Graphics.Gdi;
+
+using static Avalonia.Win32.DirectX.DirectXUnmanagedMethods;
+using static Avalonia.Win32.Interop.UnmanagedMethods;
 
 namespace Avalonia.Win32.DirectX
 {
@@ -111,6 +118,8 @@ namespace Avalonia.Win32.DirectX
 
             ushort adapterIndex = 0;
 
+            Dictionary<HMONITOR /*MonitorHandler*/, uint /*Frequency*/> monitorFrequencies = GetAllMonitorFrequencies();
+
             // this looks odd, but that's just how one enumerates adapters in DXGI 
             while (fact.EnumAdapters(adapterIndex, &adapterPointer) == 0)
             {
@@ -122,8 +131,12 @@ namespace Avalonia.Win32.DirectX
                     using var output = MicroComRuntime.CreateProxyFor<IDXGIOutput>(outputPointer, true);
                     DXGI_OUTPUT_DESC outputDesc = output.Desc;
 
-                    var screen = Win32Platform.Instance.Screen.ScreenFromHMonitor((IntPtr)outputDesc.Monitor.Value);
-                    var frequency = screen?.Frequency ?? highestRefreshRate;
+                    var hMonitor = new HMONITOR(outputDesc.Monitor.Value);
+
+                    var frequency =
+                        monitorFrequencies.TryGetValue(hMonitor, out uint frequencyValue) ?
+                            frequencyValue :
+                            highestRefreshRate;
 
                     if (highestRefreshRate < frequency)
                     {
@@ -143,6 +156,33 @@ namespace Avalonia.Win32.DirectX
                 adapterIndex++;
             }
 
+        }
+
+        private unsafe Dictionary<HMONITOR /*MonitorHandler*/, uint /*Frequency*/> GetAllMonitorFrequencies()
+        {
+            var monitorHandlers = ScreenImpl.GetAllDisplayMonitorHandlers();
+            var dictionary = new Dictionary<HMONITOR /*MonitorHandler*/, uint /*Frequency*/>(monitorHandlers.Count);
+
+            foreach (var monitorHandler in monitorHandlers)
+            {
+                var info = MONITORINFOEX.Create();
+                var hMonitor = new HMONITOR(monitorHandler);
+                PInvoke.GetMonitorInfo(hMonitor, (MONITORINFO*)&info);
+
+                var deviceMode = new DEVMODEW
+                {
+                    dmFields = DEVMODE_FIELD_FLAGS.DM_DISPLAYORIENTATION | DEVMODE_FIELD_FLAGS.DM_DISPLAYFREQUENCY,
+                    dmSize = (ushort)Marshal.SizeOf<DEVMODEW>()
+                };
+                PInvoke.EnumDisplaySettings(info.szDevice.ToString(), ENUM_DISPLAY_SETTINGS_MODE.ENUM_CURRENT_SETTINGS,
+                    ref deviceMode);
+
+                var frequency = deviceMode.dmDisplayFrequency;
+
+                dictionary[hMonitor] = frequency;
+            }
+
+            return dictionary;
         }
 
         // Used the windows composition as a blueprint for this startup/creation 

--- a/src/Windows/Avalonia.Win32/ScreenImpl.cs
+++ b/src/Windows/Avalonia.Win32/ScreenImpl.cs
@@ -16,6 +16,11 @@ internal unsafe class ScreenImpl : ScreensBase<nint, WinScreen>
 
     protected override IReadOnlyList<nint> GetAllScreenKeys()
     {
+        return GetAllDisplayMonitorHandlers();
+    }
+
+    public static List<nint> GetAllDisplayMonitorHandlers()
+    {
         var screens = new List<nint>();
         var gcHandle = GCHandle.Alloc(screens);
         try


### PR DESCRIPTION

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Fixes https://github.com/AvaloniaUI/Avalonia/issues/20508

Call the direct pinvoke to get the monitor DisplayFrequency in the DxgiRenderTimerLoop thread.

Why not call the WinScreen to get the Frequency property? Because the WinScreen will do too many things.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Throw the exception.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Now direct pinvoke from the DxgiRenderTimerLoop thread. And it can get the correct DisplayFrequency.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

https://github.com/AvaloniaUI/Avalonia/issues/20508