### PR TITLE
Reduce the number of WrapDirect3D11Texture calls

### DIFF
--- a/src/Windows/Avalonia.Win32/DirectX/DxgiRenderTarget.cs
+++ b/src/Windows/Avalonia.Win32/DirectX/DxgiRenderTarget.cs
@@ -135,8 +135,6 @@ namespace Avalonia.Win32.DirectX
                 var res = base.BeginDraw(_surface, _window.Size, _window.Scaling, () =>
                 {
                     _swapChain.Present((ushort)0U, (ushort)0U);
-                    // No need to Dispose here. The _surface only Dispose when _renderTexture Disposed.
-                    //_surface.Dispose();
                     transaction?.Dispose();
                     contextLock?.Dispose();
                 }, true);

--- a/src/Windows/Avalonia.Win32/DirectX/DxgiRenderTarget.cs
+++ b/src/Windows/Avalonia.Win32/DirectX/DxgiRenderTarget.cs
@@ -23,7 +23,8 @@ namespace Avalonia.Win32.DirectX
 
         private IUnknown? _renderTexture;
         private RECT _clientRect;
-        
+        private EglSurface? _surface;
+
         public DxgiRenderTarget(EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo window, EglContext context, DxgiConnection connection) : base(context)
         {
             _window = window;
@@ -83,7 +84,6 @@ namespace Avalonia.Win32.DirectX
             }
 
             var contextLock = Context.EnsureCurrent();
-            EglSurface? surface = null;
             IDisposable? transaction = null;
             var success = false;
             try
@@ -96,6 +96,9 @@ namespace Avalonia.Win32.DirectX
 
                     if (_renderTexture is not null)
                     {
+                        _surface?.Dispose();
+                        _surface = null;
+
                         _renderTexture.Dispose();
                         _renderTexture = null;
                     }
@@ -114,19 +117,26 @@ namespace Avalonia.Win32.DirectX
                 var texture = _renderTexture;
                 if (texture is null)
                 {
+                    _surface?.Dispose();
+                    _surface = null;
+
                     Guid textureGuid = ID3D11Texture2DGuid;
                     texture = MicroComRuntime.CreateProxyFor<IUnknown>(_swapChain.GetBuffer(0, &textureGuid), true);
                 }
                 _renderTexture = texture;
 
-                // I also have to get the pointer to this texture directly 
-                surface = ((AngleWin32EglDisplay)Context.Display).WrapDirect3D11Texture(MicroComRuntime.GetNativeIntPtr(_renderTexture),
-                    0, 0, size.Width, size.Height);
+                if (_surface is null)
+                {
+                    // I also have to get the pointer to this texture directly 
+                    _surface = ((AngleWin32EglDisplay)Context.Display).WrapDirect3D11Texture(MicroComRuntime.GetNativeIntPtr(_renderTexture),
+                        0, 0, size.Width, size.Height);
+                }
 
-                var res = base.BeginDraw(surface, _window.Size, _window.Scaling, () =>
+                var res = base.BeginDraw(_surface, _window.Size, _window.Scaling, () =>
                 {
                     _swapChain.Present((ushort)0U, (ushort)0U);
-                    surface.Dispose();
+                    // No need to Dispose here. The _surface only Dispose when _renderTexture Disposed.
+                    //_surface.Dispose();
                     transaction?.Dispose();
                     contextLock?.Dispose();
                 }, true);
@@ -137,7 +147,8 @@ namespace Avalonia.Win32.DirectX
             {
                 if (!success)
                 {
-                    surface?.Dispose();
+                    _surface?.Dispose();
+                    _surface = null;
                     if (_renderTexture is not null)
                     {
                         _renderTexture.Dispose();
@@ -155,6 +166,7 @@ namespace Avalonia.Win32.DirectX
             _dxgiDevice?.Dispose();
             _dxgiFactory?.Dispose();
             _swapChain?.Dispose();
+            _surface?.Dispose();
             _renderTexture?.Dispose();
         }
 


### PR DESCRIPTION


<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Reduce the number of WrapDirect3D11Texture calls by tying the EglSurface lifetime to _renderTexture. When testing on a 4K display, I observed that eglCreatePbufferFromClientBuffer, which is invoked by WrapDirect3D11Texture, can take around 5 ms per frame. By reducing the number of eglCreatePbufferFromClientBuffer calls, I was able to improve rendering performance by about 30%. However, I’m not sure why the previous implementation needed to call WrapDirect3D11Texture on every frame.

I'm only familiar with DirectX but not Angle.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Call WrapDirect3D11Texture on every frame. And running in my device with 4K screen will only 30 frames of frequency left.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Only call the WrapDirect3D11Texture when the size changed. It improve rendering performance by about 30%

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
