### PR TITLE
Fix Android surface recreation

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaView.cs
+++ b/src/Android/Avalonia.Android/AvaloniaView.cs
@@ -39,6 +39,7 @@ namespace Avalonia.Android
             OnConfigurationChanged();
 
             _view.InternalView.SurfaceWindowCreated += InternalView_SurfaceWindowCreated;
+            _view.InternalView.SurfaceWindowDestroyed += InternalView_SurfaceWindowDestroyed;
 
             _accessHelper = new AvaloniaAccessHelper(this);
             ViewCompat.SetAccessibilityDelegate(this, _accessHelper);
@@ -51,7 +52,16 @@ namespace Avalonia.Android
             if (Visibility == ViewStates.Visible)
             {
                 OnVisibilityChanged(true);
+
+                _root?.InvalidateMeasure();
+                Invalidate();
             }
+        }
+
+        private void InternalView_SurfaceWindowDestroyed(object? sender, EventArgs e)
+        {
+            OnVisibilityChanged(false);
+            _surfaceCreated = false;
         }
 
         internal TopLevelImpl TopLevelImpl => _view;

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
@@ -18,6 +18,8 @@ namespace Avalonia.Android
         private double _scaling = 1;
 
         public event EventHandler? SurfaceWindowCreated;
+        public event EventHandler? SurfaceWindowDestroyed;
+
         public PixelSize Size => _size;
         public double Scaling => _scaling;
 
@@ -61,6 +63,7 @@ namespace Avalonia.Android
                 .Log(this, "InvalidationAwareSurfaceView Destroyed");
             ReleaseNativeWindowHandle();
             _size = new PixelSize(1, 1);
+            SurfaceWindowDestroyed?.Invoke(this, EventArgs.Empty);
         }
 
         public virtual void SurfaceRedrawNeeded(ISurfaceHolder holder)


### PR DESCRIPTION
## What does the pull request do?

Fixes black screens and broken layout when moving an application in the foreground on Android. I believe this started happening after https://github.com/AvaloniaUI/Avalonia/pull/18756 and https://github.com/AvaloniaUI/Avalonia/pull/18893, but I could be wrong. It's certainly been like this for several months.

## What is the current behavior?

When an Android application is put in the background, the system will destroy its surface after a couple of seconds. Then when it is opened again with a new surface, state is not properly reset.

I have not been able to reproduce these problems in SafeAreaDemo.Android (not sure why, maybe there's a race condition or view complexity matters), however, in my project I see the following:

- Android 15 x86 emulator - the layout is broken in a way that is hard to describe, but it's always the same controls. Most buttons lose text labels, some icons are gone, elements in a row flex are for some reason aligned in a column instead, ...
- Android 10, physical device - the screen is just completely blank

Crucially, the minimizing needs to happen using the home button, not back. On both of these devices, when the "corruption" happens, you can press the back button to minimize (this destroys the _activity_), reopen the application, and the issue disappears.

## What is the updated/expected behavior with this PR?

Smooth transition from background to foreground, application continues to work without issues.

## How was the solution implemented (if it's not obvious)?

```cs
_root?.InvalidateMeasure();
Invalidate();
```

These invalidation calls on surface creation fix the Android 15 scenario for me.

```cs
private void InternalView_SurfaceWindowDestroyed(object? sender, EventArgs e)
{
    OnVisibilityChanged(false);
    _surfaceCreated = false;
}
```

This addresses the Android 10 black screen.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

No