### PR TITLE
Fix TabItem's Content inheriting TabControl's DataContext instead of TabItem's

### DIFF
--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -170,15 +170,10 @@ namespace Avalonia.Controls
             {
                 tabItem.TabStripPlacement = TabStripPlacement;
             }
-        }
-
-        protected internal override void ContainerForItemPreparedOverride(Control container, object? item, int index)
-        {
-            base.ContainerForItemPreparedOverride(container, item, index);
             
             if (index == SelectedIndex)
             {
-                UpdateSelectedContent(container);
+                UpdateSelectedContent(element);
             }
         }
 
@@ -241,16 +236,17 @@ namespace Avalonia.Controls
                             var contentDataContext = contentElement?.DataContext;
                             SelectedContent = content;
 
-                            // Reset the TabItem Content's DataContext since it gets set to TabControl's DataContext
-                            // when SelectedContent is set to TabItem's Content. Happens when the content's parent
-                            // is set to ContentPart (ContentPresenter) and the DataContext property is inherited.
+                            // When the ContentPresenter (ContentPart) displays content that is a Control, it doesn't
+                            // set its DataContext to that of the Control's. If the content doesn't set a DataContext,
+                            // then it gets inherited from the TabControl. Work around this issue by setting the
+                            // DataContext of the ContentPart to the content's original DataContext (inherited from
+                            // container).
                             if (contentElement is not null &&
-                                contentElement.DataContext != contentDataContext)
+                                contentElement.DataContext != contentDataContext &&
+                                ContentPart is not null)
                             {
-                                // Unfortunately this forces the property to go from inherited to set with local
-                                // priority
                                 Debug.Assert(!contentElement.IsSet(DataContextProperty));
-                                contentElement.DataContext = contentDataContext;
+                                ContentPart.DataContext = contentDataContext;
                             }
                         }),
                         container.GetObservable(ContentControl.ContentTemplateProperty).Subscribe(v => SelectedContentTemplate = SelectContentTemplate(v)));

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -9,6 +9,8 @@ using Avalonia.Controls.Selection;
 using Avalonia.Controls.Templates;
 using Avalonia.Controls.Utils;
 using Avalonia.Data;
+using Avalonia.Harfbuzz;
+using Avalonia.Headless;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.LogicalTree;
@@ -259,51 +261,48 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void DataContexts_Should_Be_Correctly_Set()
         {
+            using var app = Start();
             var items = new object[]
             {
                 "Foo",
                 new Item("Bar"),
                 new TextBlock { Text = "Baz" },
                 new TabItem { Content = "Qux" },
-                new TabItem { Content = new TextBlock { Text = "Bob" } }
+                new TabItem { Content = new TextBlock { Text = "Bob" } },
+                new TabItem { DataContext = "Rob", Content = new TextBlock { Text = "Bob" } },
             };
 
             var target = new TabControl
             {
-                Template = TabControlTemplate(),
                 DataContext = "Base",
-                DataTemplates =
-                {
-                    new FuncDataTemplate<Item>((x, __) => new Button { Content = x })
-                },
                 ItemsSource = items,
             };
 
-            ApplyTemplate(target);
+            var root = CreateRoot(target);
+            root.LayoutManager.ExecuteInitialLayoutPass();
 
-            target.ContentPart!.UpdateChild();
             var dataContext = ((TextBlock)target.ContentPart.Child!).DataContext;
             Assert.Equal(items[0], dataContext);
-
+            
             target.SelectedIndex = 1;
-            target.ContentPart.UpdateChild();
             dataContext = ((Button)target.ContentPart.Child).DataContext;
             Assert.Equal(items[1], dataContext);
-
+            
             target.SelectedIndex = 2;
-            target.ContentPart.UpdateChild();
             dataContext = ((TextBlock)target.ContentPart.Child).DataContext;
             Assert.Equal("Base", dataContext);
-
+            
             target.SelectedIndex = 3;
-            target.ContentPart.UpdateChild();
             dataContext = ((TextBlock)target.ContentPart.Child).DataContext;
             Assert.Equal("Qux", dataContext);
-
+            
             target.SelectedIndex = 4;
-            target.ContentPart.UpdateChild();
             dataContext = target.ContentPart.DataContext;
             Assert.Equal("Base", dataContext);
+
+            target.SelectedIndex = 5;
+            dataContext = target.ContentPart.Child.DataContext;
+            Assert.Equal("Rob", dataContext);
         }
 
         /// <summary>
@@ -843,6 +842,45 @@ namespace Avalonia.Controls.UnitTests
                 }.RegisterInNameScope(scope));
         }
 
+        private static ControlTheme CreateTabControlControlTheme()
+        {
+            return new ControlTheme(typeof(TabControl))
+            {
+                Setters =
+                {
+                    new Setter(TabControl.TemplateProperty, TabControlTemplate()),
+                },
+            };
+        }
+
+        private static ControlTheme CreateTabItemControlTheme()
+        {
+            return new ControlTheme(typeof(TabItem))
+            {
+                Setters =
+                {
+                    new Setter(TabItem.TemplateProperty, TabItemTemplate()),
+                },
+            };
+        }
+        
+        private static TestRoot CreateRoot(Control child)
+        {
+            return new TestRoot
+            {
+                Resources =
+                {
+                    { typeof(TabControl), CreateTabControlControlTheme() },
+                    { typeof(TabItem), CreateTabItemControlTheme() },
+                },
+                DataTemplates =
+                {
+                    new FuncDataTemplate<Item>((x, _) => new Button { Content = x.Value })
+                },
+                Child = child,
+            };
+        }
+
         private class TestTopLevel : TopLevel
         {
             private readonly ILayoutManager _layoutManager;
@@ -890,6 +928,19 @@ namespace Avalonia.Controls.UnitTests
             }
 
             target.ContentPart!.ApplyTemplate();
+        }
+
+        private IDisposable Start()
+        {
+            return UnitTestApplication.Start(
+                TestServices.MockThreadingInterface.With(
+                    fontManagerImpl: new HeadlessFontManagerStub(),
+                    keyboardDevice: () => new KeyboardDevice(),
+                    keyboardNavigation: () => new KeyboardNavigationHandler(),
+                    inputManager: new InputManager(),
+                    renderInterface: new HeadlessPlatformRenderInterface(),
+                    textShaperImpl: new HarfBuzzTextShaper(),
+                    assetLoader: new StandardAssetLoader()));
         }
 
         private class Item

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -283,19 +283,19 @@ namespace Avalonia.Controls.UnitTests
 
             var dataContext = ((TextBlock)target.ContentPart.Child!).DataContext;
             Assert.Equal(items[0], dataContext);
-            
+
             target.SelectedIndex = 1;
             dataContext = ((Button)target.ContentPart.Child).DataContext;
             Assert.Equal(items[1], dataContext);
-            
+
             target.SelectedIndex = 2;
             dataContext = ((TextBlock)target.ContentPart.Child).DataContext;
             Assert.Equal("Base", dataContext);
-            
+
             target.SelectedIndex = 3;
             dataContext = ((TextBlock)target.ContentPart.Child).DataContext;
             Assert.Equal("Qux", dataContext);
-            
+
             target.SelectedIndex = 4;
             dataContext = target.ContentPart.DataContext;
             Assert.Equal("Base", dataContext);

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -281,7 +281,7 @@ namespace Avalonia.Controls.UnitTests
             var root = CreateRoot(target);
             root.LayoutManager.ExecuteInitialLayoutPass();
 
-            var dataContext = ((TextBlock)target.ContentPart.Child!).DataContext;
+            var dataContext = ((TextBlock)target.ContentPart!.Child!).DataContext;
             Assert.Equal(items[0], dataContext);
 
             target.SelectedIndex = 1;


### PR DESCRIPTION
## What does the pull request do?
Fixes the TabItem's Content inheriting TabControl's DataContext instead of TabItem's.


## What is the current behavior?
When the `TabItem` content's `DataContext` is not explicitly set, it inherits the `DataContext` from `TabControl` after `UpdateSelectedContent`.

1. `TabItem`'s Content inherits `DataContext` from `TabItem` after getting added to logical tree (`TabControl`'s Items)
2. `TabItem`'s Content has its `InheritanceParent` set to `TabControl.ContentPart` (`ContentPresenter`) when `TabItem` is selected.
3. This makes the `TabItem`'s Content `DataContext` effectively inherit `TabControl`'s `DataContext`


## What is the updated/expected behavior with this PR?
The `TabItem`'s Content keeps its `DataContext` inherited from `TabItem`.


## How was the solution implemented (if it's not obvious)?
~First, the initial `UpdateSelectedContent` call is changed to happen in `ContainerForItemPreparedOverride` rather than `PrepareContainerForItemOverride` so that the `TabItem` Content's `DataContext` can be inherited from `TabItem` after getting added to the logical tree.~

Then, when `UpdateSelectedContent` is called the original Content's `DataContext` is saved to a variable before changing its `InheritanceParent` to `ContentPart`. The saved `DataContext` is reapplied after. See code comments for further details.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
~Perhaps changing the expectation of `UpdateSelectedContent` being called from `ContainerForItemPreparedOverride` instead?~

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #10958
