### PR TITLE
Headless: use HarfBuzz by default

### DIFF
--- a/src/Headless/Avalonia.Headless/Avalonia.Headless.csproj
+++ b/src/Headless/Avalonia.Headless/Avalonia.Headless.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />
     <ProjectReference Include="..\..\Avalonia.Fonts.Inter\Avalonia.Fonts.Inter.csproj" />
+    <ProjectReference Include="..\..\HarfBuzz\Avalonia.HarfBuzz\Avalonia.HarfBuzz.csproj" />
   </ItemGroup>
 
   <Import Project="..\..\..\build\DevAnalyzers.props" />

--- a/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
@@ -236,7 +236,9 @@ public sealed class HeadlessUnitTestSession : IDisposable, IAsyncDisposable
                 // If windowing subsystem wasn't initialized by user, force headless with default parameters.
                 if (appBuilder.WindowingSubsystemName != "Headless")
                 {
-                    appBuilder = appBuilder.UseHeadless(new AvaloniaHeadlessPlatformOptions());
+                    appBuilder = appBuilder
+                        .UseHeadless(new AvaloniaHeadlessPlatformOptions())
+                        .UseHarfBuzz();
                 }
 
                 // ReSharper disable once AccessToModifiedClosure


### PR DESCRIPTION
## What does the pull request do?
After #19852, the headless platform fails to initialize if no `AvaloniaTestApplicationAttribute` is specified because there's no `ITextShaperImpl` available.
This PR fixes that issue.

## What is the current behavior?
An exception is thrown because no `ITextShaperImpl` is found.

## What is the updated/expected behavior with this PR?
The headless tests work.