### PR TITLE
Fix ScrollBar collapsing during active thumb drag

### DIFF
--- a/src/Avalonia.Controls/Primitives/ScrollBar.cs
+++ b/src/Avalonia.Controls/Primitives/ScrollBar.cs
@@ -85,6 +85,7 @@ namespace Avalonia.Controls.Primitives
         private bool _isExpanded;
         private CompositeDisposable? _ownerSubscriptions;
         private ScrollViewer? _owner;
+        private bool _isDragging;
 
         /// <summary>
         /// Initializes static members of the <see cref="ScrollBar"/> class. 
@@ -92,6 +93,7 @@ namespace Avalonia.Controls.Primitives
         static ScrollBar()
         {
             Thumb.DragDeltaEvent.AddClassHandler<ScrollBar>((x, e) => x.OnThumbDragDelta(e), RoutingStrategies.Bubble);
+            Thumb.DragStartedEvent.AddClassHandler<ScrollBar>((x, e) => x.OnThumbDragStart(e), RoutingStrategies.Bubble);
             Thumb.DragCompletedEvent.AddClassHandler<ScrollBar>((x, e) => x.OnThumbDragComplete(e), RoutingStrategies.Bubble);
 
             FocusableProperty.OverrideMetadata<ScrollBar>(new(false));
@@ -325,7 +327,7 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnPointerExited(e);
 
-            if (AllowAutoHide)
+            if (AllowAutoHide && !_isDragging)
             {
                 CollapseAfterDelay();
             }
@@ -491,8 +493,21 @@ namespace Avalonia.Controls.Primitives
         {
             OnScroll(ScrollEventType.ThumbTrack);
         }
+
+        private void OnThumbDragStart(VectorEventArgs e)
+        {
+            _isDragging = true;
+        }
+
         private void OnThumbDragComplete(VectorEventArgs e)
         {
+            _isDragging = false;
+
+            if (AllowAutoHide && !IsPointerOver)
+            {
+                CollapseAfterDelay();
+            }
+
             OnScroll(ScrollEventType.EndScroll);
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR improves the behavior of ScrollBar.IsExpanded to prevent it from collapsing while the user is actively dragging the thumb.

## What is the current behavior?
ScrollBar.IsExpanded was set to false on OnPointerExited, even when the user was in the middle of a thumb drag operation. This could cause the scrollbar to collapse unexpectedly during active scrolling.


## What is the updated/expected behavior with this PR?
ScrollBar.IsExpanded is no longer set to false while a thumb drag is in progress.
The scrollbar now collapses only when:
- `OnThumbDragComplete` is raised (scrolling finished),
- `OnPointerExited` occurs and the user is not currently dragging the thumb.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
