### PR TITLE
Release implicit mouse capture on focus lost

### DIFF
--- a/samples/IntegrationTestApp/Pages/EmbeddingPage.axaml
+++ b/samples/IntegrationTestApp/Pages/EmbeddingPage.axaml
@@ -16,5 +16,7 @@
       </Popup>
     </StackPanel>
     <Button Name="Reset" Click="Reset_Click">Reset</Button>
+    <Button Name="RunNativeModalSession" Click="RunNativeModalSession_OnClick">Open Native Modal</Button>
+    <TextBox Name="ModalResultTextBox" />
   </StackPanel>
 </UserControl>

--- a/samples/IntegrationTestApp/Pages/EmbeddingPage.axaml.cs
+++ b/samples/IntegrationTestApp/Pages/EmbeddingPage.axaml.cs
@@ -1,10 +1,19 @@
+using System;
+using Avalonia.Automation;
 using Avalonia.Controls;
+using Avalonia.Controls.Embedding;
 using Avalonia.Interactivity;
+using IntegrationTestApp.Embedding;
+using MonoMac.AppKit;
+using MonoMac.CoreGraphics;
+using MonoMac.ObjCRuntime;
 
 namespace IntegrationTestApp;
 
 public partial class EmbeddingPage : UserControl
 {
+    private const long NSModalResponseContinue = -1002;
+
     public EmbeddingPage()
     {
         InitializeComponent();
@@ -19,5 +28,65 @@ public partial class EmbeddingPage : UserControl
     private void Reset_Click(object? sender, RoutedEventArgs e)
     {
         ResetText();
+        ModalResultTextBox.Text = "";
+    }
+
+    private void RunNativeModalSession_OnClick(object? sender, RoutedEventArgs e)
+    {
+        MacHelper.EnsureInitialized();
+
+        var app = NSApplication.SharedApplication;
+        var modalWindow = CreateNativeWindow();
+        var session = app.BeginModalSession(modalWindow);
+
+        while (true)
+        {
+            if (app.RunModalSession(session) != NSModalResponseContinue)
+                break;
+        }
+
+        app.EndModalSession(session);
+    }
+
+    private NSWindow CreateNativeWindow()
+    {
+        var button = new Button
+        {
+            Name = "ButtonInModal",
+            Content = "Button"
+        };
+
+        AutomationProperties.SetAutomationId(button, "ButtonInModal");
+
+        var root = new EmbeddableControlRoot
+        {
+            Width = 200,
+            Height = 200,
+            Content = button
+        };
+        root.Prepare();
+
+        var window = new NSWindow(
+            new CGRect(0, 0, root.Width, root.Height),
+            NSWindowStyle.Titled | NSWindowStyle.Closable,
+            NSBackingStore.Buffered,
+            false);
+
+        window.Identifier = "ModalNativeWindow";
+        window.WillClose += (_, _) => NSApplication.SharedApplication.StopModal();
+
+        button.Click += (_, _) =>
+        {
+            ModalResultTextBox.Text = "Clicked";
+            window.Close();
+        };
+
+        if (root.TryGetPlatformHandle() is not { } handle)
+            throw new InvalidOperationException("Could not get platform handle");
+
+        window.ContentView = (NSView)Runtime.GetNSObject(handle.Handle)!;
+        root.StartRendering();
+
+        return window;
     }
 }

--- a/src/Avalonia.Base/Input/MouseDevice.cs
+++ b/src/Avalonia.Base/Input/MouseDevice.cs
@@ -34,6 +34,8 @@ namespace Avalonia.Input
             _pointer = pointer ?? new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, true);
         }
 
+        internal Pointer Pointer => _pointer;
+
         internal static TMouseDevice GetOrCreatePrimary<TMouseDevice>() where TMouseDevice : MouseDevice, new()
         {
             if (_primary is TMouseDevice device)

--- a/src/Avalonia.Base/Input/Pointer.cs
+++ b/src/Avalonia.Base/Input/Pointer.cs
@@ -77,6 +77,7 @@ namespace Avalonia.Input
             if (oldVisual != null)
                 oldVisual.DetachedFromVisualTree -= OnCaptureDetached;
             Captured = control;
+            CaptureSource = source;
 
             if (source != CaptureSource.Platform)
                 PlatformCapture(control);
@@ -115,6 +116,7 @@ namespace Avalonia.Input
         public IInputElement? Captured { get; private set; }
 
         public PointerType Type { get; }
+
         public bool IsPrimary { get; }
 
         /// <summary>
@@ -123,6 +125,8 @@ namespace Avalonia.Input
         internal GestureRecognizer? CapturedGestureRecognizer { get; private set; }
 
         public bool IsGestureRecognitionSkipped { get; set; }
+
+        internal CaptureSource CaptureSource { get; private set; } = CaptureSource.Platform;
 
         public void Dispose()
         {

--- a/src/Avalonia.Native/TopLevelImpl.cs
+++ b/src/Avalonia.Native/TopLevelImpl.cs
@@ -65,8 +65,8 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
     private NativeControlHostImpl? _nativeControlHost;
     private PlatformBehaviorInhibition? _platformBehaviorInhibition;
 
-    private readonly MouseDevice? _mouse;
-    private readonly PenDevice? _pen;
+    private readonly MouseDevice _mouse;
+    private readonly PenDevice _pen;
 
     private readonly IKeyboardDevice? _keyboard;
     private readonly ICursorFactory? _cursorFactory;
@@ -480,6 +480,18 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
         void IAvnTopLevelEvents.LostFocus()
         {
             _parent.LostFocus?.Invoke();
+
+            // macOS doesn't have the concept of mouse capture. If we're losing the focus during an implicit capture
+            // (standard mouse down), we should release it to avoid mouse events going to an old window.
+            var mouse = _parent._mouse;
+            var captured = mouse.Pointer.Captured;
+
+            if (captured is not null &&
+                mouse.Pointer.CaptureSource == CaptureSource.Implicit &&
+                TopLevel.GetTopLevel(captured as Visual)?.PlatformImpl == _parent)
+            {
+                mouse.PlatformCaptureLost();
+            }
         }
 
         AvnDragDropEffects IAvnTopLevelEvents.DragEvent(AvnDragEventType type, AvnPoint position,


### PR DESCRIPTION
## What does the pull request do?
This PR fixes an issue where the mouse capture is incorrectly kept on the wrong window on macOS when interacting with native windows.

Note that the issue is fairly recent: before #19898, each window had its own mouse device, so the problem wasn't visible.

## What is the current behavior?
In certain cases, when opening a new native window during a mouse event, Avalonia might incorrectly keep the capture on the old window. This causes issues such as needing an additional click to interact with the window, or even the mouse being "stuck" on `MenuItem`.

## What is the updated/expected behavior with this PR?
Opening a native `NSWindow` containing an Avalonia view on mouse down correctly resets the mouse capture in all cases.

## How was the solution implemented (if it's not obvious)?
When the focus is lost on macOS, we're now releasing the capture if it was implicit (i.e., taken on mouse down).

## Notes
I added the scenario that reproduces the issue to the `IntegrationTestApp`, expecting to add an integration test for it.
I spent too much time trying to make the test work, but that would need some large infrastructure change: the current accessibility implementation on macOS only works with an `AvnWindow`.