### PR TITLE
Remove NativeMenuItemToggleType and NativeMenuBar.EnableMenuItemClickForwarding

### DIFF
--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -27,6 +27,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Avalonia.Controls.NativeMenuItemToggleType</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Avalonia.Controls.Primitives.IScrollable</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
@@ -60,6 +66,12 @@
     <Target>T:Avalonia.Utilities.StringTokenizer</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Avalonia.Controls.NativeMenuItemToggleType</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
@@ -219,6 +231,18 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Avalonia.Controls.NativeMenuBar.EnableMenuItemClickForwardingProperty</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Avalonia.Controls.NativeMenuItem.ToggleTypeProperty</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:Avalonia.Controls.TextBlock.LetterSpacingProperty</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
@@ -298,6 +322,18 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Controls.Design.SetPreviewWith(Avalonia.Styling.IStyle,Avalonia.Controls.ITemplate{Avalonia.Controls.Control})</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Controls.NativeMenuBar.SetEnableMenuItemClickForwarding(Avalonia.Controls.MenuItem,System.Boolean)</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Controls.NativeMenuItem.get_ToggleType</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
   </Suppression>
@@ -531,6 +567,18 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Avalonia.Controls.NativeMenuBar.EnableMenuItemClickForwardingProperty</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Avalonia.Controls.NativeMenuItem.ToggleTypeProperty</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:Avalonia.Controls.TextBlock.LetterSpacingProperty</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
@@ -610,6 +658,18 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Controls.Design.SetPreviewWith(Avalonia.Styling.IStyle,Avalonia.Controls.ITemplate{Avalonia.Controls.Control})</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Controls.NativeMenuBar.SetEnableMenuItemClickForwarding(Avalonia.Controls.MenuItem,System.Boolean)</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Controls.NativeMenuItem.get_ToggleType</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
   </Suppression>

--- a/samples/IntegrationTestApp/MainWindow.axaml.cs
+++ b/samples/IntegrationTestApp/MainWindow.axaml.cs
@@ -37,7 +37,7 @@ namespace IntegrationTestApp
                 {
                     Header = (string?)page.Name,
                     ToolTip = $"Tip:{(string?)page.Name}",
-                    ToggleType = NativeMenuItemToggleType.Radio,
+                    ToggleType = MenuItemToggleType.Radio
                 };
 
                 menuItem.Click += (_, _) =>

--- a/src/Avalonia.Controls/NativeMenuBar.cs
+++ b/src/Avalonia.Controls/NativeMenuBar.cs
@@ -3,8 +3,6 @@ using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
-using Avalonia.Interactivity;
-using Avalonia.Metadata;
 using Avalonia.Reactive;
 using Avalonia.VisualTree;
 
@@ -13,25 +11,11 @@ namespace Avalonia.Controls
     [TemplatePart("PART_NativeMenuPresenter", typeof(MenuBase))]
     public class NativeMenuBar : TemplatedControl
     {
-        [Unstable("To be removed in 12.0, NativeMenuBar now has a default template")] // TODO12
-        public static readonly AttachedProperty<bool> EnableMenuItemClickForwardingProperty =
-            AvaloniaProperty.RegisterAttached<NativeMenuBar, MenuItem, bool>(
-                "EnableMenuItemClickForwarding");
-
         private MenuBase? _menu;
         private IDisposable? _subscriptions;
 
         static NativeMenuBar()
         {
-            EnableMenuItemClickForwardingProperty.Changed.Subscribe(args =>
-            {
-                var item = (MenuItem)args.Sender;
-                if (args.NewValue.GetValueOrDefault<bool>())
-                    item.Click += OnMenuItemClick;
-                else
-                    item.Click -= OnMenuItemClick;
-            });
-
             // TODO12 Ideally we should make NativeMenuBar inherit MenuBase directly, but it would be a breaking change for 11.x.
             // Changing default template while keeping old StyleKeyOverride => Menu isn't a breaking change.
             TemplateProperty.OverrideDefaultValue<NativeMenuBar>(new FuncControlTemplate((_, ns) => new NativeMenuBarPresenter
@@ -75,17 +59,6 @@ namespace Avalonia.Controls
 
             _subscriptions?.Dispose();
             _subscriptions = null;
-        }
-
-        [Unstable("To be removed in 12.0, NativeMenuBar now has a default template.")] // TODO12
-        public static void SetEnableMenuItemClickForwarding(MenuItem menuItem, bool enable)
-        {
-            menuItem.SetValue(EnableMenuItemClickForwardingProperty, enable);
-        }
-
-        private static void OnMenuItemClick(object? sender, RoutedEventArgs e)
-        {
-            (((MenuItem)sender!).DataContext as INativeMenuItemExporterEventsImplBridge)?.RaiseClicked();
         }
 
         private void SubscribeToToplevel(TopLevel topLevel, MenuBase menu)

--- a/src/Avalonia.Controls/NativeMenuBarPresenter.cs
+++ b/src/Avalonia.Controls/NativeMenuBarPresenter.cs
@@ -32,9 +32,7 @@ internal class NativeMenuBarPresenter : Menu
                 [!MenuItem.CommandParameterProperty] =
                     nativeItem.GetObservable(NativeMenuItem.CommandParameterProperty).ToBinding(),
                 [!MenuItem.InputGestureProperty] = nativeItem.GetObservable(NativeMenuItem.GestureProperty).ToBinding(),
-                [!MenuItem.ToggleTypeProperty] = nativeItem.GetObservable(NativeMenuItem.ToggleTypeProperty)
-                    // TODO12 remove NativeMenuItemToggleType
-                    .Select(v => (MenuItemToggleType)v).ToBinding(),
+                [!MenuItem.ToggleTypeProperty] = nativeItem.GetObservable(NativeMenuItem.ToggleTypeProperty).ToBinding(),
                 [!ToolTip.TipProperty] =
                     nativeItem.GetObservable(NativeMenuItem.ToolTipProperty).ToBinding(),
             };

--- a/src/Avalonia.Controls/NativeMenuItem.cs
+++ b/src/Avalonia.Controls/NativeMenuItem.cs
@@ -119,11 +119,11 @@ namespace Avalonia.Controls
         }
         
         /// <inheritdoc cref="MenuItem.ToggleTypeProperty"/>
-        public static readonly StyledProperty<NativeMenuItemToggleType> ToggleTypeProperty =
-            AvaloniaProperty.Register<NativeMenuItem, NativeMenuItemToggleType>(nameof(ToggleType));
+        public static readonly StyledProperty<MenuItemToggleType> ToggleTypeProperty =
+            AvaloniaProperty.Register<NativeMenuItem, MenuItemToggleType>(nameof(ToggleType));
 
         /// <inheritdoc cref="MenuItem.ToggleType"/>
-        public NativeMenuItemToggleType ToggleType
+        public MenuItemToggleType ToggleType
         {
             get => GetValue(ToggleTypeProperty);
             set => SetValue(ToggleTypeProperty, value);
@@ -231,13 +231,5 @@ namespace Avalonia.Controls
                 DebugDisplayHelper.AppendOptionalValue(builder, nameof(Header), Header, true);
             }
         }
-    }
-
-    // TODO12: remove this enum and use MenuItemToggleType only 
-    public enum NativeMenuItemToggleType
-    {
-        None = MenuItemToggleType.None,
-        CheckBox = MenuItemToggleType.CheckBox,
-        Radio = MenuItemToggleType.Radio
     }
 }

--- a/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
+++ b/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
@@ -260,13 +260,13 @@ namespace Avalonia.FreeDesktop
 
                     if (name == "toggle-type")
                     {
-                        if (item.ToggleType == NativeMenuItemToggleType.CheckBox)
+                        if (item.ToggleType == MenuItemToggleType.CheckBox)
                             return VariantValue.String("checkmark");
-                        if (item.ToggleType == NativeMenuItemToggleType.Radio)
+                        if (item.ToggleType == MenuItemToggleType.Radio)
                             return VariantValue.String("radio");
                     }
 
-                    if (name == "toggle-state" && item.ToggleType != NativeMenuItemToggleType.None)
+                    if (name == "toggle-state" && item.ToggleType != MenuItemToggleType.None)
                         return VariantValue.Int32(item.IsChecked ? 1 : 0);
 
                     if (name == "icon-data")

--- a/src/Avalonia.Native/IAvnMenuItem.cs
+++ b/src/Avalonia.Native/IAvnMenuItem.cs
@@ -43,7 +43,7 @@ namespace Avalonia.Native.Interop.Impl
         private void UpdateIsVisible(bool isVisible) => SetIsVisible(isVisible.AsComBool());
         private void UpdateIsChecked(bool isChecked) => SetIsChecked(isChecked.AsComBool());
 
-        private void UpdateToggleType(NativeMenuItemToggleType toggleType)
+        private void UpdateToggleType(MenuItemToggleType toggleType)
         {
             SetToggleType((AvnMenuItemToggleType)toggleType);
         }


### PR DESCRIPTION
## What does the pull request do?
This PR removes `NativeMenuItemToggleType` (`MenuItemToggleType` is used instead) and `NativeMenuBar.EnableMenuItemClickForwarding` (obsolete) according to the TODO12 comments.