### PR TITLE
Move ConstructorArgumentAttribute and remove BindingMode from ReflectionBinding constructor

### DIFF
--- a/api/Avalonia.Skia.nupkg.xml
+++ b/api/Avalonia.Skia.nupkg.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Skia.ISkiaGpu</Target>
+    <Left>baseline/Avalonia.Skia/lib/net10.0/Avalonia.Skia.dll</Left>
+    <Right>current/Avalonia.Skia/lib/net10.0/Avalonia.Skia.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Skia.ISkiaGpuWithPlatformGraphicsContext</Target>
+    <Left>baseline/Avalonia.Skia/lib/net10.0/Avalonia.Skia.dll</Left>
+    <Right>current/Avalonia.Skia/lib/net10.0/Avalonia.Skia.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Skia.ISkiaGpu</Target>
+    <Left>baseline/Avalonia.Skia/lib/net8.0/Avalonia.Skia.dll</Left>
+    <Right>current/Avalonia.Skia/lib/net8.0/Avalonia.Skia.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Skia.ISkiaGpuWithPlatformGraphicsContext</Target>
+    <Left>baseline/Avalonia.Skia/lib/net8.0/Avalonia.Skia.dll</Left>
+    <Right>current/Avalonia.Skia/lib/net8.0/Avalonia.Skia.dll</Right>
+  </Suppression>
+</Suppressions>

--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -21,7 +21,19 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Avalonia.Platform.IOptionalFeatureProvider</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Avalonia.Platform.IReadableBitmapWithAlphaImpl</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Avalonia.Platform.OptionalFeatureProviderExtensions</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
   </Suppression>
@@ -42,6 +54,12 @@
     <Target>T:Avalonia.Controls.Primitives.IScrollable</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Avalonia.Markup.Xaml.ConstructorArgumentAttribute</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Markup.Xaml.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Markup.Xaml.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
@@ -69,7 +87,19 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Avalonia.Platform.IOptionalFeatureProvider</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Avalonia.Platform.IReadableBitmapWithAlphaImpl</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Avalonia.Platform.OptionalFeatureProviderExtensions</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
   </Suppression>
@@ -90,6 +120,12 @@
     <Target>T:Avalonia.Controls.Primitives.IScrollable</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Avalonia.Markup.Xaml.ConstructorArgumentAttribute</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Markup.Xaml.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Markup.Xaml.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
@@ -118,6 +154,12 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Controls.ResourcesChangedEventArgs.#ctor</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Data.ReflectionBinding.#ctor(System.String,Avalonia.Data.BindingMode)</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
   </Suppression>
@@ -471,6 +513,18 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Data.Binding.#ctor(System.String,Avalonia.Data.BindingMode)</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Markup.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Markup.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Markup.Xaml.MarkupExtensions.ReflectionBindingExtension.#ctor(System.String,Avalonia.Data.BindingMode)</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Markup.Xaml.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Markup.Xaml.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:Avalonia.Media.Fonts.FontCollectionBase._glyphTypefaceCache</Target>
     <Left>baseline/Avalonia/lib/net6.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net6.0/Avalonia.Base.dll</Right>
@@ -520,6 +574,12 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Controls.ResourcesChangedEventArgs.#ctor</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Data.ReflectionBinding.#ctor(System.String,Avalonia.Data.BindingMode)</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
   </Suppression>
@@ -876,6 +936,18 @@
     <Target>M:Avalonia.Dialogs.Internal.ManagedFileChooserFilterViewModel.#ctor(Avalonia.Platform.Storage.FilePickerFileType)</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Dialogs.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Dialogs.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Data.Binding.#ctor(System.String,Avalonia.Data.BindingMode)</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Markup.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Markup.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Markup.Xaml.MarkupExtensions.ReflectionBindingExtension.#ctor(System.String,Avalonia.Data.BindingMode)</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Markup.Xaml.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Markup.Xaml.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
@@ -1239,7 +1311,31 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Media.ImmediateDrawingContext</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
     <Target>T:Avalonia.Media.StreamGeometryContext</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.IPlatformGraphicsContext</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.IPlatformGraphicsWithFeatures</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.IPlatformRenderInterfaceContext</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
   </Suppression>
@@ -1251,7 +1347,103 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Application</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Controls.Embedding.Offscreen.OffscreenTopLevelImplBase</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Controls.Platform.IWin32OptionsTopLevelImpl</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.IPopupImpl</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.ITopLevelImpl</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.IWindowBaseImpl</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.IWindowImpl</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Metal.IMetalDevice</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Metal.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Metal.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.OpenGL.Egl.EglContext</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.OpenGL.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.OpenGL.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.OpenGL.IGlContext</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.OpenGL.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.OpenGL.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Vulkan.IVulkanDevice</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Vulkan.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Vulkan.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Vulkan.IVulkanPlatformGraphicsContext</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Vulkan.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Vulkan.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Media.ImmediateDrawingContext</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
     <Target>T:Avalonia.Media.StreamGeometryContext</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.IPlatformGraphicsContext</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.IPlatformGraphicsWithFeatures</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.IPlatformRenderInterfaceContext</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
   </Suppression>
@@ -1260,6 +1452,78 @@
     <Target>T:Avalonia.Platform.IWriteableBitmapImpl</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Application</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Controls.Embedding.Offscreen.OffscreenTopLevelImplBase</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Controls.Platform.IWin32OptionsTopLevelImpl</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.IPopupImpl</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.ITopLevelImpl</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.IWindowBaseImpl</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Platform.IWindowImpl</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Metal.IMetalDevice</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Metal.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Metal.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.OpenGL.Egl.EglContext</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.OpenGL.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.OpenGL.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.OpenGL.IGlContext</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.OpenGL.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.OpenGL.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Vulkan.IVulkanDevice</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Vulkan.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Vulkan.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Avalonia.Vulkan.IVulkanPlatformGraphicsContext</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Vulkan.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Vulkan.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0009</DiagnosticId>

--- a/src/Avalonia.Base/Data/CompiledBinding.cs
+++ b/src/Avalonia.Base/Data/CompiledBinding.cs
@@ -7,6 +7,7 @@ using Avalonia.Data.Converters;
 using Avalonia.Data.Core;
 using Avalonia.Data.Core.ExpressionNodes;
 using Avalonia.Data.Core.Parsers;
+using Avalonia.Metadata;
 
 namespace Avalonia.Data;
 
@@ -70,6 +71,7 @@ public class CompiledBinding : BindingBase
     /// <summary>
     /// Gets or sets the binding path.
     /// </summary>
+    [ConstructorArgument("path")]
     public CompiledBindingPath? Path { get; set; }
 
     /// <summary>

--- a/src/Avalonia.Base/Data/ReflectionBinding.cs
+++ b/src/Avalonia.Base/Data/ReflectionBinding.cs
@@ -35,17 +35,6 @@ namespace Avalonia.Data
         {
             Path = path;
         }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ReflectionBinding"/> class.
-        /// </summary>
-        /// <param name="path">The binding path.</param>
-        /// <param name="mode">The binding mode.</param>
-        public ReflectionBinding(string path, BindingMode mode)
-        {
-            Path = path;
-            Mode = mode;
-        }
         
         /// <summary>
         /// Gets or sets the amount of time, in milliseconds, to wait before updating the binding 
@@ -91,7 +80,6 @@ namespace Avalonia.Data
         /// <summary>
         /// Gets or sets the binding mode.
         /// </summary>
-        [ConstructorArgument("mode")]
         public BindingMode Mode { get; set; }
 
         /// <summary>

--- a/src/Avalonia.Base/Data/ReflectionBinding.cs
+++ b/src/Avalonia.Base/Data/ReflectionBinding.cs
@@ -8,6 +8,7 @@ using Avalonia.Data.Converters;
 using Avalonia.Data.Core;
 using Avalonia.Data.Core.ExpressionNodes;
 using Avalonia.Data.Core.Parsers;
+using Avalonia.Metadata;
 using Avalonia.Utilities;
 
 namespace Avalonia.Data
@@ -90,11 +91,13 @@ namespace Avalonia.Data
         /// <summary>
         /// Gets or sets the binding mode.
         /// </summary>
+        [ConstructorArgument("mode")]
         public BindingMode Mode { get; set; }
 
         /// <summary>
         /// Gets or sets the binding path.
         /// </summary>
+        [ConstructorArgument("path")]
         public string Path { get; set; } = "";
 
         /// <summary>

--- a/src/Avalonia.Base/Data/TemplateBinding.cs
+++ b/src/Avalonia.Base/Data/TemplateBinding.cs
@@ -48,6 +48,7 @@ namespace Avalonia.Data
         /// <summary>
         /// Gets or sets the name of the source property on the templated parent.
         /// </summary>
+        [ConstructorArgument("property")]
         [InheritDataTypeFrom(InheritDataTypeFromScopeKind.ControlTemplate)]
         public AvaloniaProperty? Property { get; set; }
 

--- a/src/Avalonia.Base/IOptionalFeatureProvider.cs
+++ b/src/Avalonia.Base/IOptionalFeatureProvider.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-// TODO12: move to Avalonia namespace. 
-namespace Avalonia.Platform;
+namespace Avalonia;
 
 public interface IOptionalFeatureProvider
 {

--- a/src/Avalonia.Base/Metadata/ConstructorArgumentAttribute.cs
+++ b/src/Avalonia.Base/Metadata/ConstructorArgumentAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Avalonia.Metadata;
+
+/// <summary>
+/// Indicates that a property corresponds to a named parameter in the constructor.
+/// </summary>
+/// <param name="name">The name of the parameter in the constructor.</param>
+/// <remarks>This attribute is used for XAML.</remarks>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class ConstructorArgumentAttribute(string name) : Attribute
+{
+    /// <summary>
+    /// Gets the name of the parameter in the constructor.
+    /// </summary>
+    public string Name { get; } = name;
+}

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/DynamicResourceExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/DynamicResourceExtension.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Data.Core;
 using Avalonia.Markup.Xaml.XamlIl.Runtime;
+using Avalonia.Metadata;
 using Avalonia.Styling;
 
 namespace Avalonia.Markup.Xaml.MarkupExtensions
@@ -22,6 +23,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
             ResourceKey = resourceKey;
         }
 
+        [ConstructorArgument("resourceKey")]
         public object? ResourceKey { get; set; }
 
         public BindingBase ProvideValue(IServiceProvider serviceProvider)

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ReflectionBindingExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ReflectionBindingExtension.cs
@@ -22,13 +22,6 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
         /// <param name="path">The binding path.</param>
         public ReflectionBindingExtension(string path) : base(path) { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ReflectionBinding"/> class.
-        /// </summary>
-        /// <param name="path">The binding path.</param>
-        /// <param name="mode">The binding mode.</param>
-        public ReflectionBindingExtension(string path, BindingMode mode) : base(path, mode) { }
-
         public ReflectionBinding ProvideValue(IServiceProvider serviceProvider)
         {
             return new ReflectionBinding

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/RelativeSourceExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/RelativeSourceExtension.cs
@@ -1,5 +1,6 @@
 using System;
 using Avalonia.Data;
+using Avalonia.Metadata;
 
 namespace Avalonia.Markup.Xaml.MarkupExtensions
 {

--- a/src/Markup/Avalonia.Markup.Xaml/XamlTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlTypes.cs
@@ -32,14 +32,4 @@ namespace Avalonia.Markup.Xaml
         [RequiresUnreferencedCode(TrimmingMessages.XamlTypeResolvedRequiresUnreferenceCodeMessage)]
         Type Resolve (string qualifiedTypeName);
     }
-
-    // TODO12: Move to Avalonia.Base
-    [AttributeUsage(AttributeTargets.Property)]
-    public sealed class ConstructorArgumentAttribute : Attribute
-    {
-        public ConstructorArgumentAttribute(string name)
-        {
-            
-        }
-    }
 }

--- a/src/Markup/Avalonia.Markup/Data/Binding.cs
+++ b/src/Markup/Avalonia.Markup/Data/Binding.cs
@@ -16,6 +16,4 @@ public class Binding : ReflectionBinding
     public Binding() { }
 
     public Binding(string path) : base(path) { }
-
-    public Binding(string path, BindingMode mode) : base(path, mode) { }
 }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Binding.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Binding.cs
@@ -1091,7 +1091,11 @@ namespace Avalonia.Base.UnitTests
             var target = new Class1();
             var source = new TestTwoWayBindingViewModel();
 
-            target.Bind(Class1.DoubleValueProperty, new Binding(nameof(source.Value), BindingMode.TwoWay) { Source = source });
+            target.Bind(Class1.DoubleValueProperty, new Binding(nameof(source.Value))
+            {
+                Mode = BindingMode.TwoWay,
+                Source = source
+            });
 
             target.DoubleValue = 123.4;
 
@@ -1105,7 +1109,11 @@ namespace Avalonia.Base.UnitTests
             var target = new Class1();
             var source = new TestTwoWayBindingViewModel();
 
-            target.Bind(Class1.DoubleValueProperty, new Binding(nameof(source.Value), BindingMode.TwoWay) { Source = source });
+            target.Bind(Class1.DoubleValueProperty, new Binding(nameof(source.Value))
+            {
+                Mode = BindingMode.TwoWay,
+                Source = source
+            });
 
             Assert.False(source.SetterCalled);
         }
@@ -1116,7 +1124,11 @@ namespace Avalonia.Base.UnitTests
             var target = new Class1();
             var source = new TestTwoWayBindingViewModel();
 
-            target.Bind(Class1.DoubleValueProperty, new Binding("[0]", BindingMode.TwoWay) { Source = source });
+            target.Bind(Class1.DoubleValueProperty, new Binding("[0]")
+            {
+                Mode = BindingMode.TwoWay,
+                Source = source
+            });
 
             Assert.False(source.SetterCalled);
         }
@@ -1127,7 +1139,7 @@ namespace Avalonia.Base.UnitTests
             var target = new TextBlock();
             target.DataContext = null;
 
-            target.Bind(TextBlock.TextProperty, new Binding("Missing", BindingMode.TwoWay));
+            target.Bind(TextBlock.TextProperty, new Binding("Missing") { Mode = BindingMode.TwoWay });
         }
 
         [Fact]
@@ -1136,7 +1148,7 @@ namespace Avalonia.Base.UnitTests
             var target = new TextBlock();
             target.DataContext = null;
 
-            target.Bind(TextBlock.TextProperty, new Binding("[0]", BindingMode.TwoWay));
+            target.Bind(TextBlock.TextProperty, new Binding("[0]") { Mode = BindingMode.TwoWay });
         }
 
         [Theory(Skip = "Will need changes to binding internals in order to pass")]
@@ -1147,7 +1159,11 @@ namespace Avalonia.Base.UnitTests
         {
             var target = new Class1();
             var source = new TestTwoWayBindingViewModel();
-            var binding = new Binding(nameof(source.Value), BindingMode.TwoWay) { Source = source };
+            var binding = new Binding(nameof(source.Value))
+            {
+                Mode = BindingMode.TwoWay,
+                Source = source
+            };
 
             target.Bind(Class1.DoubleValueProperty, binding, priority);
             target.SetValue(Class1.DoubleValueProperty, 123.4, priority - 1);
@@ -1165,7 +1181,11 @@ namespace Avalonia.Base.UnitTests
         {
             var target = new Class1();
             var source = new TestTwoWayBindingViewModel();
-            var binding1 = new Binding(nameof(source.Value), BindingMode.TwoWay) { Source = source };
+            var binding1 = new Binding(nameof(source.Value))
+            {
+                Mode = BindingMode.TwoWay,
+                Source = source
+            };
             var binding2 = new BehaviorSubject<double>(123.4);
             
             target.Bind(Class1.DoubleValueProperty, binding1, priority);
@@ -1182,7 +1202,11 @@ namespace Avalonia.Base.UnitTests
             var target = new Class1();
             var source = new TestTwoWayBindingViewModel();
 
-            target.Bind(Class1.DoubleValueProperty, new Binding(nameof(source.Value), BindingMode.TwoWay) { Source = source });
+            target.Bind(Class1.DoubleValueProperty, new Binding(nameof(source.Value))
+            {
+                Mode = BindingMode.TwoWay,
+                Source = source
+            });
             target.SetValue(Class1.DoubleValueProperty, 123.4, BindingPriority.Animation);
 
             // Setter should not be called because the TwoWay binding with Style priority
@@ -1197,7 +1221,11 @@ namespace Avalonia.Base.UnitTests
             var source1 = new TestTwoWayBindingViewModel();
             var source2 = new BehaviorSubject<double>(123.4);
 
-            target.Bind(Class1.DoubleValueProperty, new Binding(nameof(source1.Value), BindingMode.TwoWay) { Source = source1 });
+            target.Bind(Class1.DoubleValueProperty, new Binding(nameof(source1.Value))
+            {
+                Mode = BindingMode.TwoWay,
+                Source = source1
+            });
             target.Bind(Class1.DoubleValueProperty, source2, BindingPriority.Animation);
 
             // Setter should not be called because the TwoWay binding with Style priority

--- a/tests/Avalonia.Base.UnitTests/Styling/SetterTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/SetterTests.cs
@@ -143,8 +143,9 @@ namespace Avalonia.Base.UnitTests.Styling
                 Classes = { "foo" },
             };
 
-            var binding = new Binding("Name", BindingMode.OneWay)
+            var binding = new Binding("Name")
             {
+                Mode = BindingMode.OneWay,
                 Converter = new TestConverter(),
                 RelativeSource = new RelativeSource(RelativeSourceMode.Self),
             };

--- a/tests/Avalonia.Benchmarks/Data/Binding_Setup.cs
+++ b/tests/Avalonia.Benchmarks/Data/Binding_Setup.cs
@@ -31,7 +31,7 @@ public class Binding_Setup
     public void Setup_DataContext_Property_Binding_TwoWay()
     {
         var target = _target;
-        var binding = new Binding(nameof(_data.IntValue), mode: BindingMode.TwoWay);
+        var binding = new Binding(nameof(_data.IntValue)) { Mode = BindingMode.TwoWay };
 
         for (var i = 0; i < 100; ++i)
         {

--- a/tests/Avalonia.Benchmarks/Data/Binding_Values.cs
+++ b/tests/Avalonia.Benchmarks/Data/Binding_Values.cs
@@ -36,7 +36,7 @@ public class Binding_Values
         _data.IntValue = -1;
 
         var target = _target;
-        var binding = new Binding(nameof(_data.IntValue), mode: BindingMode.TwoWay);
+        var binding = new Binding(nameof(_data.IntValue)) { Mode = BindingMode.TwoWay };
         using var d = target.Bind(TestControl.IntValueProperty, binding);
 
         for (var i = 0; i < 100; ++i)

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests_DataValidation.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests_DataValidation.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Controls.UnitTests
                 var target = new TextBox
                 {
                     DataContext = new ExceptionTest(),
-                    [!TextBox.TextProperty] = new Binding(nameof(ExceptionTest.LessThan10), BindingMode.TwoWay),
+                    [!TextBox.TextProperty] = new Binding(nameof(ExceptionTest.LessThan10)) { Mode = BindingMode.TwoWay },
                     Template = CreateTemplate(),
                 };
 
@@ -51,7 +51,7 @@ namespace Avalonia.Controls.UnitTests
                 var target = new TextBox
                 {
                     DataContext = new ExceptionTest(),
-                    [!TextBox.TextProperty] = new Binding(nameof(ExceptionTest.LessThan10), BindingMode.TwoWay),
+                    [!TextBox.TextProperty] = new Binding(nameof(ExceptionTest.LessThan10)) { Mode = BindingMode.TwoWay },
                     Template = CreateTemplate(),
                 };
 
@@ -77,7 +77,7 @@ namespace Avalonia.Controls.UnitTests
                 var target = new TextBox
                 {
                     DataContext = new ExceptionTest(),
-                    [!TextBox.TextProperty] = new Binding(nameof(ExceptionTest.LessThan10), BindingMode.TwoWay),
+                    [!TextBox.TextProperty] = new Binding(nameof(ExceptionTest.LessThan10)) { Mode = BindingMode.TwoWay },
                     Template = CreateTemplate()  
                 };
                 DataValidationErrors.SetErrorConverter(target, err => "Error: " + err);
@@ -101,7 +101,7 @@ namespace Avalonia.Controls.UnitTests
                 var target = new TextBox
                 {
                     DataContext = new ExceptionTest(),
-                    [!TextBox.TextProperty] = new Binding(nameof(ExceptionTest.LessThan10), BindingMode.TwoWay),
+                    [!TextBox.TextProperty] = new Binding(nameof(ExceptionTest.LessThan10)) { Mode = BindingMode.TwoWay },
                     Template = CreateTemplate(),
                 };
 

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
@@ -544,8 +544,8 @@ namespace Avalonia.Markup.UnitTests.Data
             var root = new Panel { Children = { target1, target2 } };
             var source = new Source { Foo = "foo" };
 
-            using (target1.Bind(TextBlock.TextProperty, new Binding("Foo", BindingMode.OneTime)))
-            using (target2.Bind(TextBlock.TextProperty, new Binding("Foo", BindingMode.OneWayToSource)))
+            using (target1.Bind(TextBlock.TextProperty, new Binding("Foo") { Mode = BindingMode.OneTime }))
+            using (target2.Bind(TextBlock.TextProperty, new Binding("Foo") { Mode = BindingMode.OneWayToSource }))
             {
                 root.DataContext = source;
             }
@@ -643,8 +643,8 @@ namespace Avalonia.Markup.UnitTests.Data
                 Children = { target1, target2 }
             };
 
-            target1.Bind(TextBlock.TextProperty, new Binding("Foo", BindingMode.TwoWay));
-            target2.Bind(TextBlock.TextProperty, new Binding("Foo", BindingMode.OneWayToSource));
+            target1.Bind(TextBlock.TextProperty, new Binding("Foo") { Mode = BindingMode.TwoWay });
+            target2.Bind(TextBlock.TextProperty, new Binding("Foo") { Mode = BindingMode.OneWayToSource });
 
             Assert.Equal("OneWayToSource", source.Foo);
 

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Delay.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Delay.cs
@@ -29,7 +29,11 @@ public class BindingTests_Delay : ScopedTestBase, IDisposable
 
         _source = new BindingTests.Source { Foo = InitialFooValue };
         _target = new TextBox { DataContext = _source };
-        _binding = new Binding(nameof(_source.Foo), BindingMode.TwoWay) { Delay = DelayMilliseconds };
+        _binding = new Binding(nameof(_source.Foo))
+        {
+            Mode = BindingMode.TwoWay,
+            Delay = DelayMilliseconds
+        };
 
         _bindingExpr = _target.Bind(TextBox.TextProperty, _binding);
 
@@ -120,7 +124,12 @@ public class BindingTests_Delay : ScopedTestBase, IDisposable
 
         new TestRoot() { Child = new Panel() { Children = { _target, secondBox } } };
 
-        _target.Bind(TextBox.TextProperty, new Binding(nameof(_source.Foo), BindingMode.TwoWay) { Delay = DelayMilliseconds, UpdateSourceTrigger = UpdateSourceTrigger.LostFocus });
+        _target.Bind(TextBox.TextProperty, new Binding(nameof(_source.Foo))
+        {
+            Mode = BindingMode.TwoWay,
+            Delay = DelayMilliseconds,
+            UpdateSourceTrigger = UpdateSourceTrigger.LostFocus
+        });
 
         Assert.True(_target.Focus());
         _target.Text = "bar";
@@ -134,7 +143,11 @@ public class BindingTests_Delay : ScopedTestBase, IDisposable
     [Fact]
     public void Delayed_Binding_OneWayToSource_DataContext_Change_Should_Update_Source_Immediately()
     {
-        _target.Bind(TextBlock.TextProperty, new Binding(nameof(_source.Foo), BindingMode.OneWayToSource) { Delay = DelayMilliseconds });
+        _target.Bind(TextBlock.TextProperty, new Binding(nameof(_source.Foo))
+        {
+            Mode = BindingMode.OneWayToSource,
+            Delay = DelayMilliseconds
+        });
 
         _target.Text = "bar";
 

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Self.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Self.cs
@@ -34,8 +34,9 @@ namespace Avalonia.Markup.UnitTests.Data
             var target = new TextBlock
             {
                 Tag = "Hello World!",
-                [!TextBlock.TextProperty] = new Binding("Tag", BindingMode.TwoWay)
+                [!TextBlock.TextProperty] = new Binding("Tag")
                 {
+                    Mode = BindingMode.TwoWay,
                     RelativeSource = new RelativeSource(RelativeSourceMode.Self)
                 },
             };


### PR DESCRIPTION
## What does the pull request do?
This PR moves the `ConstructorArgumentAttribute` from the `Avalonia.Markup.Xaml` assembly to `Avalonia.Base`, according to the TODO12 comment.

This attribute is also applied to several binding-related classes.

While working on this PR, an inconsistency was found: `ReflectionBinding`'s constructor has a `BindingMode` argument, but other bindings don't (`CompiledBinding`, `TemplatedBinding`, `MultiBinding`). It was decided to remove the `BindingMode` from `ReflectionBinding`. We don't expect this to affect many people: `CompiledBinding` should always be preferred, and has been the default for a few years now.