### PR TITLE
Fix warnings and index bugs in ControlCatalog sample

### DIFF
--- a/samples/ControlCatalog.Desktop/Program.cs
+++ b/samples/ControlCatalog.Desktop/Program.cs
@@ -45,7 +45,7 @@ namespace ControlCatalog.Desktop
             double GetScaling()
             {
                 var idx = Array.IndexOf(args, "--scaling");
-                if (idx != 0 && args.Length > idx + 1 &&
+                if (idx >= 0 && args.Length > idx + 1 &&
                     double.TryParse(args[idx + 1], NumberStyles.Any, CultureInfo.InvariantCulture, out var scaling))
                     return scaling;
                 return 1;
@@ -114,7 +114,7 @@ namespace ControlCatalog.Desktop
             {
                 builder.With(new Win32PlatformOptions()
                 {
-                    CompositionMode = new [] { Win32CompositionMode.LowLatencyDxgiSwapChain }
+                    CompositionMode = [Win32CompositionMode.LowLatencyDxgiSwapChain]
                 });
                 return builder.StartWithClassicDesktopLifetime(args);
             }
@@ -151,14 +151,14 @@ namespace ControlCatalog.Desktop
                 .WithDeveloperTools()
                 .AfterSetup(builder =>
                 {
-                    EmbedSample.Implementation = OperatingSystem.IsWindows() ? (INativeDemoControl)new EmbedSampleWin()
+                    EmbedSample.Implementation = OperatingSystem.IsWindows() ? new EmbedSampleWin()
                         : OperatingSystem.IsMacOS() ? new EmbedSampleMac()
                         : OperatingSystem.IsLinux() ? new EmbedSampleGtk()
                         : null;
                 })
                 .LogToTrace();
 
-        static void SilenceConsole()
+        private static void SilenceConsole()
         {
             new Thread(() =>
             {


### PR DESCRIPTION
## What does the pull request do?
Fixes a bug in the ControlCatalog sample found in #20154

Also while fixing, saw some other warnings in my IDE that figured should be fixed too.

## What is the current behavior?
--scaling won't work if it's the first parameter


## What is the updated/expected behavior with this PR?
--scaling now works as the first parameter


## How was the solution implemented (if it's not obvious)?
`>= instead of !=`
