### PR TITLE
Improve the error message for invalid surface size

### DIFF
--- a/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
@@ -125,6 +125,14 @@ namespace Avalonia.Skia
             
             _currentFramebufferAddress = framebuffer.Address;
 
+            // A surface with a width/height of 0 is invalid and can't be created
+            if (desiredImageInfo.Width <= 0 || desiredImageInfo.Height <= 0)
+            {
+                throw new ArgumentException(
+                    $"Unable to create a surface with size {desiredImageInfo.Width}x{desiredImageInfo.Height}",
+                    nameof(desiredImageInfo));
+            }
+
             var surface = SKSurface.Create(desiredImageInfo, _currentFramebufferAddress, 
                 framebuffer.RowBytes, new SKSurfaceProperties(SKPixelGeometry.RgbHorizontal));
 


### PR DESCRIPTION
## What does the pull request do?
This PR improves the error message when trying to create a `SKSurface` in `FramebufferRenderTarget` with an invalid size (e.g. 0x0).

## What is the current behavior?
If one of the surface dimensions is 0, the creation fails. Avalonia then tries to create a compatible surface, which also fails. This results in an exception with a message similar to _Unable to create pixel format shim surface for conversion from Rgba8888 to Bgra8888_, which isn't the real problem at all.

## What is the updated/expected behavior with this PR?
The exception message is something like _Unable to create a surface with size 0x0_, making the problem clearer.
