### PR TITLE
Add IsAlive property to IRef<T>

### DIFF
--- a/src/Avalonia.Base/Media/Imaging/Bitmap.cs
+++ b/src/Avalonia.Base/Media/Imaging/Bitmap.cs
@@ -291,9 +291,7 @@ namespace Avalonia.Media.Imaging
         {
             get
             {
-                // TODO12: We should probably make PlatformImpl to be nullable or make it possible to check
-                // and fix IRef<T> in general (right now Item is not nullable while it internally is)
-                if (PlatformImpl.Item == null!)
+                if (!PlatformImpl.IsAlive)
                     return null;
                 return PlatformImpl;
             }

--- a/src/Avalonia.Base/Utilities/Ref.cs
+++ b/src/Avalonia.Base/Utilities/Ref.cs
@@ -28,6 +28,10 @@ namespace Avalonia.Utilities
         /// <returns>A reference to the value as the new type but sharing the refcount.</returns>
         IRef<TResult> CloneAs<TResult>() where TResult : class;
 
+        /// <summary>
+        /// Gets whether the reference still tracks a valid item.
+        /// </summary>
+        bool IsAlive { get; }
 
         /// <summary>
         /// The current refcount of the object tracked in this reference. For debugging/unit test use only.
@@ -171,6 +175,8 @@ namespace Avalonia.Utilities
 
                 return new Ref<TResult>(item, counter);
             }
+
+            public bool IsAlive => _item is not null;
 
             public int RefCount => _counter?.RefCount ?? throw new ObjectDisposedException("Ref<" + typeof(T) + ">");
         }


### PR DESCRIPTION
## What does the pull request do?
Since #19476, `Ref<T>.Item` throws an `ObjectDisposedException` if the item is internally null. It means the fix in #13506 no longer works.
Instead, this PR adds an `IsAlive` property to `IRef<T>`.