### PR TITLE
macOS: Ensure render target is at least 1x1

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -42,7 +42,8 @@
 - (void) updateRenderTarget
 {
     if(_currentRenderTarget) {
-        [_currentRenderTarget resize:_lastPixelSize withScale:static_cast<float>([[self window] backingScaleFactor])];
+        AvnPixelSize size { MAX(_lastPixelSize.Width, 1), MAX(_lastPixelSize.Height, 1) };
+        [_currentRenderTarget resize:size withScale:static_cast<float>([[self window] backingScaleFactor])];
         [self setNeedsDisplayInRect:[self frame]];
     }
 }

--- a/src/Avalonia.Native/TopLevelImpl.cs
+++ b/src/Avalonia.Native/TopLevelImpl.cs
@@ -566,8 +566,8 @@ internal class TopLevelImpl : ITopLevelImpl, IFramebufferPlatformSurface
         {
             ObjectDisposedException.ThrowIf(_target is null, this);
 
-            var w = _parent._savedLogicalSize.Width * _parent._savedScaling;
-            var h = _parent._savedLogicalSize.Height * _parent._savedScaling;
+            var w = Math.Max(_parent._savedLogicalSize.Width * _parent._savedScaling, 1);
+            var h = Math.Max(_parent._savedLogicalSize.Height * _parent._savedScaling, 1);
             var dpi = _parent._savedScaling * 96;
             return new DeferredFramebuffer(_target, cb =>
             {


### PR DESCRIPTION
## What does the pull request do?
This PR makes sure that render targets in Metal and Software modes are always created with a size of at least 1x1.
This matches the OpenGL implementation.

## What is the current behavior?
Having a view with a width or height of 0 results in an exception in Metal and Software rendering modes, but not in OpenGL.

## What is the updated/expected behavior with this PR?
The render target surface is valid, and no exception is thrown.
