### PR TITLE
 Headless NUnit: Handle async SetUp/TearDown 

### DIFF
--- a/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
+++ b/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
@@ -12,14 +12,14 @@ internal class AvaloniaTestMethodCommand : TestCommand
 {
     private readonly HeadlessUnitTestSession _session;
     private readonly TestCommand _innerCommand;
-    private readonly List<Action<TestExecutionContext>> _beforeTest;
-    private readonly List<Action<TestExecutionContext>> _afterTest;
+    private readonly List<Func<TestExecutionContext, Task>> _beforeTest;
+    private readonly List<Func<TestExecutionContext, Task>> _afterTest;
 
     private AvaloniaTestMethodCommand(
         HeadlessUnitTestSession session,
         TestCommand innerCommand,
-        List<Action<TestExecutionContext>> beforeTest,
-        List<Action<TestExecutionContext>> afterTest)
+        List<Func<TestExecutionContext, Task>> beforeTest,
+        List<Func<TestExecutionContext, Task>> afterTest)
         : base(innerCommand.Test)
     {
         _session = session;
@@ -36,8 +36,8 @@ internal class AvaloniaTestMethodCommand : TestCommand
     private static TestCommand ProcessCommand(
         HeadlessUnitTestSession session,
         TestCommand command,
-        List<Action<TestExecutionContext>> before,
-        List<Action<TestExecutionContext>> after)
+        List<Func<TestExecutionContext, Task>> before,
+        List<Func<TestExecutionContext, Task>> after)
     {
         var beforeAndAfterTestCommand = command as BeforeAndAfterTestCommand;
         if (beforeAndAfterTestCommand is not null)
@@ -45,7 +45,7 @@ internal class AvaloniaTestMethodCommand : TestCommand
             ref var beforeTest = ref beforeAndAfterTestCommand.BeforeTest();
             if (beforeTest is not null)
             {
-                before.Add(beforeTest);
+                AddBeforeOrAfterAction(beforeTest, before);
                 beforeTest = _ => { };
             }
         }
@@ -62,7 +62,7 @@ internal class AvaloniaTestMethodCommand : TestCommand
             ref var afterTest = ref beforeAndAfterTestCommand.AfterTest();
             if (afterTest is not null)
             {
-                after.Add(afterTest);
+                AddBeforeOrAfterAction(afterTest, after);
                 afterTest = _ => { };
             }
         }
@@ -81,21 +81,14 @@ internal class AvaloniaTestMethodCommand : TestCommand
     // Unfortunately, NUnit has issues with custom synchronization contexts, which means we need to add some hacks to make it work.
     private async Task<TestResult> ExecuteTestMethod(TestExecutionContext context)
     {
-        _beforeTest.ForEach(a => a(context));
+        foreach (var beforeTest in _beforeTest)
+            await beforeTest(context);
         
         var testMethod = _innerCommand.Test.Method;
         var methodInfo = testMethod!.MethodInfo;
 
         var result = methodInfo.Invoke(context.TestObject, _innerCommand.Test.Arguments);
-        // Only Task, non generic ValueTask are supported in async context. No ValueTask<> nor F# tasks.
-        if (result is Task task)
-        {
-            await task;
-        }
-        else if (result is ValueTask valueTask)
-        {
-            await valueTask;
-        }
+        await ToTask(result);
 
         context.CurrentResult.SetResult(ResultState.Success);
 
@@ -104,10 +97,55 @@ internal class AvaloniaTestMethodCommand : TestCommand
 
         if (context.ExecutionStatus != TestExecutionStatus.AbortRequested)
         {
-            _afterTest.ForEach(a => a(context));
+            foreach (var afterTest in _afterTest)
+                await afterTest(context);
+
             Dispatcher.UIThread.RunJobs();
         }
         
         return context.CurrentResult;
     }
+
+    private static void AddBeforeOrAfterAction(Action<TestExecutionContext> action, List<Func<TestExecutionContext, Task>> targets)
+    {
+        // We need to extract the SetUp and TearDown methods to run them asynchronously on Avalonia's synchronization context.
+        if (action.Target is SetUpTearDownItem setUpTearDownItem)
+        {
+            var methods = action.Method.Name switch
+            {
+                nameof(SetUpTearDownItem.RunSetUp) => setUpTearDownItem.SetUpMethods(),
+                nameof(SetUpTearDownItem.RunTearDown) => setUpTearDownItem.TearDownMethods(),
+                _ => null
+            };
+
+            if (methods is not null)
+            {
+                foreach (var method in methods)
+                {
+                    targets.Add(context =>
+                    {
+                        var result = method.Invoke(method.IsStatic ? null : context.TestObject, null);
+                        return ToTask(result);
+                    });
+                }
+
+                return;
+            }
+        }
+
+        targets.Add(context =>
+        {
+            action(context);
+            return Task.CompletedTask;
+        });
+    }
+
+    private static Task ToTask(object? result)
+        // Only Task, non generic ValueTask are supported in async context. No ValueTask<> nor F# tasks.
+        => result switch
+        {
+            Task task => task,
+            ValueTask valueTask => valueTask.AsTask(),
+            _ => Task.CompletedTask
+        };
 }

--- a/src/Headless/Avalonia.Headless.NUnit/NUnitReflection.cs
+++ b/src/Headless/Avalonia.Headless.NUnit/NUnitReflection.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Commands;
+
+namespace Avalonia.Headless.NUnit;
+
+/// <summary>
+/// 2023-05-10, original comment from Max about NUnit 3:
+/// There are multiple problems with NUnit integration at the moment when we wrote this integration.
+/// NUnit doesn't have extensibility API for running on custom dispatcher/sync-context.
+/// See https://github.com/nunit/nunit/issues/2917 https://github.com/nunit/nunit/issues/2774
+/// To workaround that we had to replace inner TestMethodCommand with our own implementation while keeping original hierarchy of commands.
+/// Which will respect proper async/await awaiting code that works with our session and can be block-awaited to fit in NUnit.
+/// Also, we need to push BeforeTest/AfterTest callbacks to the very same session call.
+/// I hope there will be a better solution without reflection, but for now that's it.
+///
+/// 2026-02-04: the situation hasn't changed at all with NUnit 4.
+/// </summary>
+internal static class NUnitReflection
+{
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = ReflectionDelegatingTestCommand.InnerCommandFieldName)]
+    private static extern ref TestCommand DelegatingTestCommand_InnerCommand(DelegatingTestCommand instance);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = ReflectionBeforeAndAfterTestCommand.BeforeTestFieldName)]
+    private static extern ref Action<TestExecutionContext>? BeforeAndAfterTestCommand_BeforeTest(BeforeAndAfterTestCommand instance);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = ReflectionBeforeAndAfterTestCommand.AfterTestFieldName)]
+    private static extern ref Action<TestExecutionContext>? BeforeAndAfterTestCommand_AfterTest(BeforeAndAfterTestCommand instance);
+
+    extension(DelegatingTestCommand instance)
+    {
+        public ref TestCommand InnerCommand()
+            => ref DelegatingTestCommand_InnerCommand(instance);
+    }
+
+    extension(BeforeAndAfterTestCommand instance)
+    {
+        public ref Action<TestExecutionContext>? BeforeTest()
+            => ref BeforeAndAfterTestCommand_BeforeTest(instance);
+
+        public ref Action<TestExecutionContext>? AfterTest()
+            => ref BeforeAndAfterTestCommand_AfterTest(instance);
+    }
+
+    private sealed class ReflectionDelegatingTestCommand : DelegatingTestCommand
+    {
+        public ReflectionDelegatingTestCommand(TestCommand innerCommand)
+            : base(innerCommand)
+        {
+        }
+
+        public const string InnerCommandFieldName = nameof(innerCommand);
+
+        public override TestResult Execute(TestExecutionContext context)
+            => throw new NotSupportedException("Reflection-only type, this method should never be called");
+    }
+
+    private sealed class ReflectionBeforeAndAfterTestCommand : BeforeAndAfterTestCommand
+    {
+        public ReflectionBeforeAndAfterTestCommand(TestCommand innerCommand)
+            : base(innerCommand)
+        {
+        }
+
+        public const string BeforeTestFieldName = nameof(BeforeTest);
+        public const string AfterTestFieldName = nameof(AfterTest);
+    }
+}

--- a/src/Headless/Avalonia.Headless.NUnit/NUnitReflectionHelper.cs
+++ b/src/Headless/Avalonia.Headless.NUnit/NUnitReflectionHelper.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Commands;
 
@@ -17,7 +19,7 @@ namespace Avalonia.Headless.NUnit;
 ///
 /// 2026-02-04: the situation hasn't changed at all with NUnit 4.
 /// </summary>
-internal static class NUnitReflection
+internal static class NUnitReflectionHelper
 {
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = ReflectionDelegatingTestCommand.InnerCommandFieldName)]
     private static extern ref TestCommand DelegatingTestCommand_InnerCommand(DelegatingTestCommand instance);
@@ -27,6 +29,12 @@ internal static class NUnitReflection
 
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = ReflectionBeforeAndAfterTestCommand.AfterTestFieldName)]
     private static extern ref Action<TestExecutionContext>? BeforeAndAfterTestCommand_AfterTest(BeforeAndAfterTestCommand instance);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_setUpMethods")]
+    private static extern ref IList<IMethodInfo> SetUpTearDownItem_SetUpMethods(SetUpTearDownItem instance);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_tearDownMethods")]
+    private static extern ref IList<IMethodInfo> SetUpTearDownItem_TearDownMethods(SetUpTearDownItem instance);
 
     extension(DelegatingTestCommand instance)
     {
@@ -41,6 +49,15 @@ internal static class NUnitReflection
 
         public ref Action<TestExecutionContext>? AfterTest()
             => ref BeforeAndAfterTestCommand_AfterTest(instance);
+    }
+
+    extension(SetUpTearDownItem instance)
+    {
+        public ref IList<IMethodInfo> SetUpMethods()
+            => ref SetUpTearDownItem_SetUpMethods(instance);
+
+        public ref IList<IMethodInfo> TearDownMethods()
+            => ref SetUpTearDownItem_TearDownMethods(instance);
     }
 
     private sealed class ReflectionDelegatingTestCommand : DelegatingTestCommand

--- a/tests/Avalonia.Headless.UnitTests/AsyncSetupTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/AsyncSetupTests.cs
@@ -1,0 +1,32 @@
+﻿#if NUNIT
+
+using System.Threading.Tasks;
+
+namespace Avalonia.Headless.UnitTests;
+
+public class AsyncSetupTests
+{
+    private static int s_instanceCount;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await Task.Delay(100);
+        ++s_instanceCount;
+    }
+
+    [AvaloniaTest, TestCase(1), TestCase(2)]
+    public void Async_Setup_TearDown_Should_Work(int index)
+    {
+        AssertHelper.Equal(1, s_instanceCount);
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await Task.Delay(100);
+        --s_instanceCount;
+    }
+}
+
+#endif

--- a/tests/Avalonia.Headless.UnitTests/SetupTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/SetupTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace Avalonia.Headless.UnitTests;
+
+public class SetupTests
+#if XUNIT
+    : IDisposable
+#endif
+{
+    private static int s_instanceCount;
+
+#if NUNIT
+    [SetUp]
+    public void SetUp()
+#elif XUNIT
+    public SetupTests()
+#endif
+    {
+        ++s_instanceCount;
+    }
+
+#if NUNIT
+    [AvaloniaTest, TestCase(1), TestCase(2)]
+#elif XUNIT
+    [AvaloniaTheory, InlineData(1), InlineData(2)]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
+        "Usage",
+        "xUnit1026:Theory methods should use all of their parameters",
+        Justification = "Used to run the test several times")]
+#endif
+    public void Setup_TearDown_Should_Work(int index)
+    {
+        AssertHelper.Equal(1, s_instanceCount);
+    }
+
+#if NUNIT
+    [TearDown]
+    public void TearDown()
+#elif XUNIT
+    public void Dispose()
+#endif
+    {
+        --s_instanceCount;
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
This PR makes NUnit asynchronous `[SetUp]` and `[TearDown]` methods work with Avalonia's headless infrastructure.
It's basically a rewrite of #18306 (which was abandoned and targeted NUnit 3) for NUnit 4.
Reflection is heavily used because NUnit doesn't provide the needed extensibility points.

## What is the current behavior?
Async `SetUp` and `TearDown` cause a deadlock.

## What is the updated/expected behavior with this PR?
Async `SetUp` and `TearDown` work.

## Fixed issues
 - Fixes #18304 
