### PR TITLE
[debug] Throw useful exception when handler is null

### DIFF
--- a/src/Avalonia.X11/Dispatching/X11EventDispatcher.cs
+++ b/src/Avalonia.X11/Dispatching/X11EventDispatcher.cs
@@ -47,7 +47,12 @@ internal class X11EventDispatcher
                     }
                 }
                 else if (_eventHandlers.TryGetValue(xev.AnyEvent.window, out var handler))
+                {
+                    if (handler is null)
+                        throw new NullReferenceException($"Event handler for event '{xev.AnyEvent}' and window '{xev.AnyEvent.window}' is null");
+
                     handler(ref xev);
+                }
             }
             finally
             {


### PR DESCRIPTION
Related to #20293

The PR is a simple way to get more information for the NullReferenceException issue.