### PR TITLE
Capture source change notification

### DIFF
--- a/src/Avalonia.Base/Input/Pointer.cs
+++ b/src/Avalonia.Base/Input/Pointer.cs
@@ -54,7 +54,8 @@ namespace Avalonia.Input
         internal void Capture(IInputElement? control, CaptureSource source)
         {
             var oldCapture = Captured;
-            if (oldCapture == control)
+            var oldSource = CaptureSource;
+            if (oldCapture == control && oldSource == source)
                 return;
 
             var oldVisual = oldCapture as Visual;

--- a/src/Avalonia.Base/Input/Pointer.cs
+++ b/src/Avalonia.Base/Input/Pointer.cs
@@ -55,6 +55,8 @@ namespace Avalonia.Input
         {
             var oldCapture = Captured;
             var oldSource = CaptureSource;
+
+            // If a handler marks Implicit capture as handled, we still want them to have another chance if the element is captured explicitly.
             if (oldCapture == control && oldSource == source)
                 return;
 
@@ -80,7 +82,8 @@ namespace Avalonia.Input
             Captured = control;
             CaptureSource = source;
 
-            if (source != CaptureSource.Platform)
+            // However, we still want to notify the platform only if the captured element actually changed.
+            if (oldCapture != control && source != CaptureSource.Platform)
                 PlatformCapture(control);
 
             if (oldVisual != null)


### PR DESCRIPTION
## What does the pull request do?
Ensures the Pointer's CaptureChanging is fired:
1) when the capture source changes
2) when no element currently has capture; in such case ancestors of the new element are notified
3) on the common parent (or newly captured element) itself

## What is the current behavior?
1) When the element to be captured is already captured, no event is fired.
2) When no element is captured, no event is fired.
3) The event is terminated before the common parent. If there is no parent, no event is fired.

## What is the updated/expected behavior with this PR?
1) The event will be fired if the capture source changes, even if the captured element remains the same. The first event on mouse down is always with `CaptureSource.Implicit`. If the handler relies on seeing `CaptureSource.Explicit`, the explicit capture was missed by the handler if someone captures the already implicitly captured element.
2) Without any previously captured element, the event will be fired on the ancestors of the new element. As a result, handler will have an opportunity to ignore implicit capture even if there is no currently capture element. This introduces slight inconsistency in which line of ancestors will be notified for the same element based on whether there is a currently captured element or not. However, the current situation is not much better, where you either get notified or not.
3) If the element has no parent, it will still receive a notification.

## How was the solution implemented (if it's not obvious)?
1) Shortcut check tightened so that both captured element and capture source must much to skip processing.
2) New element is considered for notification if old element is null.
3) The check for termination of notification was moved after the event is fired.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
