### PR TITLE
Fixed wrong Mac accessibility roles for List, ListItem, and StatusBar

### DIFF
--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -95,8 +95,8 @@
         case AutomationEdit: return NSAccessibilityTextFieldRole;
         case AutomationHyperlink: return NSAccessibilityLinkRole;
         case AutomationImage: return NSAccessibilityImageRole;
-        case AutomationListItem: return NSAccessibilityRowRole;
-        case AutomationList: return NSAccessibilityTableRole;
+        case AutomationListItem: return NSAccessibilityGroupRole;
+        case AutomationList: return NSAccessibilityListRole;
         case AutomationMenu: return NSAccessibilityMenuBarRole;
         case AutomationMenuBar: return NSAccessibilityMenuBarRole;
         case AutomationMenuItem: return NSAccessibilityMenuItemRole;
@@ -105,7 +105,7 @@
         case AutomationScrollBar: return NSAccessibilityScrollBarRole;
         case AutomationSlider: return NSAccessibilitySliderRole;
         case AutomationSpinner: return NSAccessibilityIncrementorRole;
-        case AutomationStatusBar: return NSAccessibilityTableRole;
+        case AutomationStatusBar: return NSAccessibilityGroupRole;
         case AutomationTab: return NSAccessibilityTabGroupRole;
         case AutomationTabItem: return NSAccessibilityRadioButtonRole;
         case AutomationText: return NSAccessibilityStaticTextRole;
@@ -136,6 +136,11 @@
 
 - (NSAccessibilitySubrole)accessibilitySubrole
 {
+    auto controlType = _peer->GetAutomationControlType();
+    switch (controlType) {
+        case AutomationList: return @"AXContentList";
+    }
+
     auto landmarkType = _peer->GetLandmarkType();
     switch (landmarkType) {
         case LandmarkBanner: return @"AXLandmarkBanner";
@@ -146,8 +151,9 @@
         case LandmarkMain: return @"AXLandmarkMain";
         case LandmarkNavigation: return @"AXLandmarkNavigation";
         case LandmarkSearch: return @"AXLandmarkSearch";
-        default: return NSAccessibilityUnknownSubrole;
     }
+
+    return NSAccessibilityUnknownSubrole;
 }
 
 - (NSString *)accessibilityRoleDescription


### PR DESCRIPTION
## What does the pull request do?
This fixes the wrong roles being used on Mac for List and StatusBar controls. They are currently both set to `AXTable`, but [as per W3C's accessibility mapping](https://www.w3.org/TR/core-aam-1.2/#role-map-list), we should be using `AXList` here, as well as `AXListItem` for list items.

`StatusBar` was also wrong, as it should be `AXGroup`.

## What is the current behavior?
Currently, lists and status bars are reported to be tables, which confuses screen readers; can't enter and navigate lists through VoiceOver input.

## What is the updated/expected behavior with this PR?
Screen readers should now report the elements correctly, and you can now navigate lists properly through VoiceOver.

## How was the solution implemented (if it's not obvious)?
This follows [W3C's accessibility mapping](https://www.w3.org/TR/core-aam-1.2/#role-map-list).

## Checklist
- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
n/a

## Obsoletions / Deprecations
n/a

## Fixed issues
n/a