### PR TITLE
Use `SetCurrentValue` for all `IMenuItem` properties

### DIFF
--- a/src/Avalonia.Controls/IMenuItem.cs
+++ b/src/Avalonia.Controls/IMenuItem.cs
@@ -1,15 +1,11 @@
-﻿using Avalonia.Metadata;
-
-namespace Avalonia.Controls
+﻿namespace Avalonia.Controls
 {
     /// <summary>
     /// Represents a <see cref="MenuItem"/>.
     /// </summary>
     internal interface IMenuItem : IMenuElement
     {
-        /// <summary>
-        /// Gets or sets a value that indicates whether the item has a submenu.
-        /// </summary>
+        /// <inheritdoc cref="MenuItem.HasSubMenu"/>
         bool HasSubMenu { get; }
 
         /// <summary>
@@ -17,21 +13,13 @@ namespace Avalonia.Controls
         /// </summary>
         bool IsPointerOverSubMenu { get; }
 
-        /// <summary>
-        /// Gets or sets a value that indicates whether the submenu of the <see cref="MenuItem"/> is
-        /// open.
-        /// </summary>
+        /// <inheritdoc cref="MenuItem.IsSubMenuOpen"/>
         bool IsSubMenuOpen { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value that indicates the submenu that this <see cref="MenuItem"/> is
-        /// within should not close when this item is clicked.
-        /// </summary>
+        /// <inheritdoc cref="MenuItem.StaysOpenOnClick"/>
         bool StaysOpenOnClick { get; set; }
 
-        /// <summary>
-        /// Gets a value that indicates whether the <see cref="MenuItem"/> is a top-level main menu item.
-        /// </summary>
+        /// <inheritdoc cref="MenuItem.IsTopLevel"/>
         bool IsTopLevel { get; }
 
         /// <summary>
@@ -39,22 +27,15 @@ namespace Avalonia.Controls
         /// </summary>
         IMenuElement? Parent { get; }
 
-        /// <summary>
-        /// Gets toggle type of the menu item.
-        /// </summary>
+        /// <inheritdoc cref="MenuItem.ToggleType"/>
         MenuItemToggleType ToggleType { get; }
-        
-        /// <summary>
-        /// Gets menu item group name when <see cref="ToggleType"/> is <see cref="MenuItemToggleType.Radio"/>.
-        /// </summary>
+
+        /// <inheritdoc cref="MenuItem.GroupName"/>
         string? GroupName { get; }
-        
-        /// <summary>
-        /// Gets or sets if menu item is checked when <see cref="ToggleType"/> is
-        /// <see cref="MenuItemToggleType.CheckBox"/> or <see cref="MenuItemToggleType.Radio"/>.
-        /// </summary>
+
+        /// <inheritdoc cref="MenuItem.IsChecked"/>
         bool IsChecked { get; set; }
-        
+
         /// <summary>
         /// Raises a click event on the menu item.
         /// </summary>

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -288,6 +288,12 @@ namespace Avalonia.Controls
             set => SetValue(IsSubMenuOpenProperty, value);
         }
 
+        bool IMenuItem.IsSubMenuOpen
+        {
+            get => IsSubMenuOpen;
+            set => SetCurrentValue(IsSubMenuOpenProperty, value);
+        }
+
         /// <summary>
         /// Gets or sets a value that indicates the submenu that this <see cref="MenuItem"/> is
         /// within should not close when this item is clicked.
@@ -298,18 +304,35 @@ namespace Avalonia.Controls
             set => SetValue(StaysOpenOnClickProperty, value);
         }
 
-        /// <inheritdoc cref="IMenuItem.ToggleType" />
+        bool IMenuItem.StaysOpenOnClick
+        {
+            get => StaysOpenOnClick; 
+            set => SetCurrentValue(StaysOpenOnClickProperty, value);
+        }
+
+        /// <summary>
+        /// Gets toggle type of the menu item.
+        /// </summary>
         public MenuItemToggleType ToggleType
         {
             get => GetValue(ToggleTypeProperty);
             set => SetValue(ToggleTypeProperty, value);
         }
 
-        /// <inheritdoc cref="IMenuItem.IsChecked"/>
+        /// <summary>
+        /// Gets or sets if menu item is checked when <see cref="ToggleType"/> is
+        /// <see cref="MenuItemToggleType.CheckBox"/> or <see cref="MenuItemToggleType.Radio"/>.
+        /// </summary>
         public bool IsChecked
         {
             get => GetValue(IsCheckedProperty);
             set => SetValue(IsCheckedProperty, value);
+        }
+
+        bool IMenuItem.IsChecked
+        {
+            get => IsChecked;
+            set => SetCurrentValue(IsCheckedProperty, value);
         }
 
         bool IRadioButton.IsChecked
@@ -318,7 +341,9 @@ namespace Avalonia.Controls
             set => SetCurrentValue(IsCheckedProperty, value);
         }
 
-        /// <inheritdoc cref="IMenuItem.GroupName"/>
+        /// <summary>
+        /// Gets menu item group name when <see cref="ToggleType"/> is <see cref="MenuItemToggleType.Radio"/>.
+        /// </summary>
         public string? GroupName
         {
             get => GetValue(GroupNameProperty);


### PR DESCRIPTION
`MenuItem` implements the internal `IMenuItem` interface. Several of its property setters were using `SetValue`, which overwrites the source of the property.

Because these properties are internal functions of the class, they should be using `SetCurrentValue` to preserve the user's assigned bindings, styles, etc. In some cases they were, but in others they were not.

## What is the updated/expected behavior with this PR?

`SetCurrentValue` is now always used when setting a property of `IMenuItem`.

I also added tests to ensure that this doesn't regress.

I also fixed some duplicated XMLDoc comments, and fixed the public `MenuItem` inheriting documentation from the internal `IMenuItem`.

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #16687