### PR TITLE
Fix TargetException in ToggleNodeInfoProvider on Android

### DIFF
--- a/src/Android/Avalonia.Android/Automation/ToggleNodeInfoProvider.cs
+++ b/src/Android/Avalonia.Android/Automation/ToggleNodeInfoProvider.cs
@@ -45,7 +45,7 @@ namespace Avalonia.Android.Automation
             if (s_checkedProperty?.PropertyType == typeof(int))
             {
                 // Needed for Xamarin.AndroidX.Core 1.17+
-                s_checkedProperty.SetValue(this, 
+                s_checkedProperty.SetValue(nodeInfo, 
                     provider.ToggleState switch
                     {
                         ToggleState.On => 1,
@@ -56,7 +56,7 @@ namespace Avalonia.Android.Automation
             else if (s_checkedProperty?.PropertyType == typeof(bool))
             {
                 // Needed for Xamarin.AndroidX.Core < 1.17
-                s_checkedProperty.SetValue(this, provider.ToggleState == ToggleState.On);
+                s_checkedProperty.SetValue(nodeInfo, provider.ToggleState == ToggleState.On);
             }
 
             nodeInfo.Checkable = true;


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a `System.Reflection.TargetException` that occurs on Android devices when accessibility services are active. The fix ensures that the reflection `SetValue` call uses the correct target object (`nodeInfo`) instead of the provider instance (`this`).

This fix is specifically targeted at 11.3.x. The master version has been refactored or updated, and this issue no longer exists.

## What is the current behavior?
On Android devices with accessibility services enabled, interacting with or focusing on a `CheckBox` or `ToggleSwitch` causes a crash:
`System.Reflection.TargetException: Object does not match target type.`

## What is the updated/expected behavior with this PR?
The property is correctly set on the `nodeInfo` instance. The application no longer crashes when accessibility services (like TalkBack ) scan the UI tree.

I conducted tests on a real device using the ControlCatalog.Android sample project, and this fix has resolved the issue.

## How was the solution implemented (if it's not obvious)?
Obvious.

## Checklist
- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #20354
Fixes #20453