### PR TITLE
Fix unexpected crashes during accessibility actions on Android

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
+++ b/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
@@ -135,8 +135,28 @@ namespace Avalonia.Android
         protected override bool OnPerformActionForVirtualView(int virtualViewId, int action, Bundle? arguments)
         {
             return (GetNodeInfoProvidersFromVirtualViewId(virtualViewId) ?? [])
-                .Select(x => x.PerformNodeAction(action, arguments))
+                .Select(x => TryPerformNodeAction(x, action, arguments))
                 .Aggregate(false, (a, b) => a | b);
+        }
+
+        private static bool TryPerformNodeAction(INodeInfoProvider nodeInfoProvider, int action, Bundle? arguments)
+        {
+            try
+            {
+                return nodeInfoProvider.PerformNodeAction(action, arguments);
+            }
+            catch (ElementNotEnabledException)
+            {
+                return false;
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+            catch (NotSupportedException)
+            {
+                return false;
+            }
         }
 
         protected override void OnPopulateNodeForVirtualView(int virtualViewId, AccessibilityNodeInfoCompat? nodeInfo)


### PR DESCRIPTION
## What does the pull request do?
Fixes unexpected crashes when operating disabled controls or performing unsupported/invalid operations in accessibility actions.

## What is the current behavior?
When a disabled control is invoked via TalkBack, `ElementNotEnabledException` is thrown. This exception is not caught in the Android bridge, leading to an application crash.

This issue exists in both the master version and 11.3.x, and needs to be backported to 11.3.x.

## What is the updated/expected behavior with this PR?
The exception is caught within `AvaloniaAccessHelper`, and the action returns `false` to the Android system instead of crashing.

`ElementNotEnabledException`, `InvalidOperationException`, and `NotSupportedException` will be caught, as these represent expected unavailability semantics. They should return false according to Android platform characteristics rather than crashing. However, other exceptions will still be released to avoid masking real bugs in future paths.

I conducted tests on a real device using the ControlCatalog.Android sample project, and this fix has resolved the issue.

## Checklist
- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #20680