### PR TITLE
Make sure that adorners are actually correctly positioned in visual tree for TransformToVisual and friends

### DIFF
--- a/samples/ControlCatalog/Pages/AdornerLayerPage.xaml
+++ b/samples/ControlCatalog/Pages/AdornerLayerPage.xaml
@@ -44,21 +44,31 @@
                 VerticalContentAlignment="Center" VerticalAlignment="Stretch" 
                 Width="200" Height="42">
           <AdornerLayer.Adorner>
-            <Canvas x:Name="AdornerCanvas"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    Background="Cyan"
-                    IsHitTestVisible="False"
-                    Opacity="0.3"
-                    IsVisible="True"
-                    AdornerLayer.IsClipEnabled="False">
-              <Line StartPoint="-10000,0" EndPoint="10000,0" Stroke="Cyan" StrokeThickness="1" />
-              <Line StartPoint="-10000,42" EndPoint="10000,42" Stroke="Cyan" StrokeThickness="1" />
-              <Line StartPoint="0,-10000" EndPoint="0,10000" Stroke="Cyan" StrokeThickness="1" />
-              <Line StartPoint="200,-10000" EndPoint="200,10000" Stroke="Cyan" StrokeThickness="1" />
-            </Canvas>
+            <Border AdornerLayer.IsClipEnabled="False" ClipToBounds="False" Background="Red" Opacity="0.3" Margin="-5" Padding="5"
+                    IsHitTestVisible="False">
+              <Canvas
+                x:Name="AdornerCanvas"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                Background="Cyan"
+                IsHitTestVisible="False"
+                IsVisible="True"
+                AdornerLayer.IsClipEnabled="False">
+                <Line StartPoint="-10000,0" EndPoint="10000,0" Stroke="Cyan" StrokeThickness="1" />
+                <Line StartPoint="-10000,42" EndPoint="10000,42" Stroke="Cyan" StrokeThickness="1" />
+                <Line StartPoint="0,-10000" EndPoint="0,10000" Stroke="Cyan" StrokeThickness="1" />
+                <Line StartPoint="200,-10000" EndPoint="200,10000" Stroke="Cyan" StrokeThickness="1" />
+              </Canvas>
+            </Border>
           </AdornerLayer.Adorner>
+          <Button.ContextMenu>
+            <ContextMenu PlacementTarget="{ResolveByName AdornerCanvas}" Placement="TopEdgeAlignedLeft">
+              <MenuItem Header="Menu 1"/>
+              <MenuItem Header="Menu 2"/>
+            </ContextMenu>
+          </Button.ContextMenu>
         </Button>
+        
 
       </LayoutTransformControl>
     </Grid>

--- a/src/Avalonia.Base/Input/TextInput/InputMethodManager.cs
+++ b/src/Avalonia.Base/Input/TextInput/InputMethodManager.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Input.TextInput
         private IInputElement? _focusedElement;
         private Interactive? _visualRoot;
         private TextInputMethodClient? _client;
-        private readonly TransformTrackingHelper _transformTracker = new TransformTrackingHelper();
+        private readonly TransformTrackingHelper _transformTracker = new TransformTrackingHelper(true);
 
         public TextInputMethodManager()
         {

--- a/src/Avalonia.Base/Input/TextInput/TransformTrackingHelper.cs
+++ b/src/Avalonia.Base/Input/TextInput/TransformTrackingHelper.cs
@@ -74,6 +74,7 @@ namespace Avalonia.Input.TextInput
 
         void UpdateMatrix()
         {
+            _queuedForUpdate = false;
             Matrix? matrix = null;
             if (_visual != null && _visual.VisualRoot != null)
                 matrix = _visual.TransformToVisual((Visual)_visual.VisualRoot);

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual/ServerCompositionVisual.Adorners.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual/ServerCompositionVisual.Adorners.cs
@@ -46,20 +46,25 @@ partial class ServerCompositionVisual
     public void UpdateAdorner()
     {
         GetAttHelper().EnqueuedForAdornerUpdate = false;
-        var ownTransform = MatrixUtils.ComputeTransform(Size, AnchorPoint, CenterPoint, TransformMatrix, Scale,
-            RotationAngle, Orientation, Offset);
-
+        
         if (AdornedVisual != null && Parent != null)
         {
+            // We ignore Visual's RenderTransform completely since it's set by AdornerLayer and can be out of sync
+            // with compositor-driver animations
+            var ownTransform = MatrixUtils.ComputeTransform(Size, AnchorPoint, CenterPoint, Matrix.Identity, Scale,
+                RotationAngle, Orientation, Offset);
             if (
                 AdornerLayer_GetExpectedSharedAncestor(this) is {} sharedAncestor
                 && ComputeTransformFromAncestor(AdornedVisual, sharedAncestor, out var adornerLayerToAdornedVisual))
-                ownTransform = (ownTransform ?? Matrix.Identity) * adornerLayerToAdornedVisual;
+                _ownTransform = (ownTransform ?? Matrix.Identity) * adornerLayerToAdornedVisual;
             else
-                ownTransform = default(Matrix); // Don't render, something is broken
+                _ownTransform = default(Matrix); // Don't render, something is broken
 
         }
-        _ownTransform = ownTransform;
+        else
+            _ownTransform = MatrixUtils.ComputeTransform(Size, AnchorPoint, CenterPoint, TransformMatrix, Scale,
+                RotationAngle, Orientation, Offset);
+
         
         PropagateFlags(true, true);
     }

--- a/src/Avalonia.Controls/Primitives/AdornerHelper.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerHelper.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+
+namespace Avalonia.Controls.Primitives;
+
+class AdornerHelper
+{
+
+    public static IDisposable SubscribeToAncestorPropertyChanges(Visual visual, 
+        bool includeClip, Action changed)
+    {
+        return new AncestorPropertyChangesSubscription(visual, includeClip, changed);
+    }
+
+    private class AncestorPropertyChangesSubscription : IDisposable
+    {
+        private readonly Visual _visual;
+        private readonly bool _includeClip;
+        private readonly Action _changed;
+        private readonly EventHandler<AvaloniaPropertyChangedEventArgs> _propertyChangedHandler;
+        private readonly List<Visual> _subscriptions = new List<Visual>();
+        private bool _isDisposed;
+
+        public AncestorPropertyChangesSubscription(Visual visual, bool includeClip, Action changed)
+        {
+            _visual = visual;
+            _includeClip = includeClip;
+            _changed = changed;
+            _propertyChangedHandler = OnPropertyChanged;
+
+            _visual.AttachedToVisualTree += OnAttachedToVisualTree;
+            _visual.DetachedFromVisualTree += OnDetachedFromVisualTree;
+
+            if (_visual.IsAttachedToVisualTree)
+            {
+                SubscribeToAncestors();
+            }
+        }
+
+        private void SubscribeToAncestors()
+        {
+            UnsubscribeFromAncestors();
+
+            // Subscribe to the visual's own Bounds property
+            _visual.PropertyChanged += _propertyChangedHandler;
+            _subscriptions.Add(_visual);
+
+            // Walk up the ancestor chain
+            var ancestor = _visual.VisualParent;
+            while (ancestor != null)
+            {
+                if (ancestor is Visual visualAncestor)
+                {
+                    visualAncestor.PropertyChanged += _propertyChangedHandler;
+                    _subscriptions.Add(visualAncestor);
+                }
+                ancestor = ancestor.VisualParent;
+            }
+        }
+
+        private void UnsubscribeFromAncestors()
+        {
+            foreach (var subscription in _subscriptions)
+            {
+                subscription.PropertyChanged -= _propertyChangedHandler;
+            }
+            _subscriptions.Clear();
+        }
+
+        private void OnPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (!e.IsEffectiveValueChange)
+                return;
+
+            bool shouldNotify = false;
+
+            if (e.Property == Visual.RenderTransformProperty || e.Property == Visual.BoundsProperty)
+            {
+                shouldNotify = true;
+            }
+            else if (_includeClip)
+            {
+                if (e.Property == Visual.ClipToBoundsProperty ||
+                    e.Property == Visual.ClipProperty) shouldNotify = true;
+            }
+            
+            if (shouldNotify)
+            {
+                _changed();
+            }
+        }
+
+        private void OnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+        {
+            SubscribeToAncestors();
+            _changed();
+        }
+
+        private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+        {
+            UnsubscribeFromAncestors();
+            _changed();
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+                return;
+
+            _isDisposed = true;
+            UnsubscribeFromAncestors();
+            _visual.AttachedToVisualTree -= OnAttachedToVisualTree;
+            _visual.DetachedFromVisualTree -= OnDetachedFromVisualTree;
+        }
+    }
+
+    public static Geometry? CalculateAdornerClip(Visual adornedElement)
+    {
+        // Walk ancestor stack and calculate clip geometry relative to the current visual.
+        // If ClipToBounds = true, add extra RectangleGeometry for Bounds.Size
+        
+        Geometry? result = null;
+        var ancestor = adornedElement.VisualParent;
+
+        while (ancestor != null)
+        {
+            if (ancestor is Visual visualAncestor)
+            {
+                Geometry? ancestorClip = null;
+
+                // Check if ancestor has ClipToBounds enabled
+                if (visualAncestor.ClipToBounds)
+                {
+                    ancestorClip = new RectangleGeometry(new Rect(visualAncestor.Bounds.Size));
+                }
+
+                // Check if ancestor has explicit Clip geometry
+                if (visualAncestor.Clip != null)
+                {
+                    if (ancestorClip != null)
+                    {
+                        ancestorClip = new CombinedGeometry(GeometryCombineMode.Intersect, ancestorClip, visualAncestor.Clip);
+                    }
+                    else
+                    {
+                        ancestorClip = visualAncestor.Clip;
+                    }
+                }
+
+                // Transform the clip geometry to adorned element's coordinate space
+                if (ancestorClip != null)
+                {
+                    var transform = visualAncestor.TransformToVisual(adornedElement);
+                    if (transform.HasValue && !transform.Value.IsIdentity)
+                    {
+                        ancestorClip = ancestorClip.Clone();
+                        ancestorClip.Transform = new MatrixTransform(transform.Value);
+                    }
+
+                    // Combine with existing result
+                    if (result != null)
+                    {
+                        result = new CombinedGeometry(GeometryCombineMode.Intersect, result, ancestorClip);
+                    }
+                    else
+                    {
+                        result = ancestorClip;
+                    }
+                }
+            }
+
+            ancestor = ancestor.VisualParent;
+        }
+
+        return result;
+    }
+    
+}

--- a/src/Avalonia.Controls/Primitives/AdornerHelper.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerHelper.cs
@@ -122,7 +122,7 @@ class AdornerHelper
         // If ClipToBounds = true, add extra RectangleGeometry for Bounds.Size
         
         Geometry? result = null;
-        var ancestor = adornedElement.VisualParent;
+        var ancestor = adornedElement;
 
         while (ancestor != null)
         {
@@ -156,7 +156,10 @@ class AdornerHelper
                     if (transform.HasValue && !transform.Value.IsIdentity)
                     {
                         ancestorClip = ancestorClip.Clone();
-                        ancestorClip.Transform = new MatrixTransform(transform.Value);
+                        var matrix = ancestorClip.Transform is { Value.IsIdentity: false }
+                            ? transform.Value * ancestorClip.Transform.Value
+                            : transform.Value;
+                        ancestorClip.Transform = new MatrixTransform(matrix);
                     }
 
                     // Combine with existing result

--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Specialized;
+using Avalonia.Input.TextInput;
 using Avalonia.Media;
 using Avalonia.Reactive;
 using Avalonia.VisualTree;
@@ -45,15 +46,20 @@ namespace Avalonia.Controls.Primitives
         private static readonly AttachedProperty<AdornerLayer?> s_savedAdornerLayerProperty =
             AvaloniaProperty.RegisterAttached<Visual, Visual, AdornerLayer?>("SavedAdornerLayer");
 
+        private TransformTrackingHelper _trackingHelper = new TransformTrackingHelper(false);
+
         static AdornerLayer()
         {
             AdornedElementProperty.Changed.Subscribe(AdornedElementChanged);
             AdornerProperty.Changed.Subscribe(AdornerChanged);
+            IsClipEnabledProperty.Changed.Subscribe(AdornerIsClipEnabledChanged);
         }
 
         public AdornerLayer()
         {
             Children.CollectionChanged += ChildrenCollectionChanged;
+            _trackingHelper.SetVisual(this);
+            _trackingHelper.MatrixChanged += delegate { InvalidateMeasure(); };
         }
 
         public static Visual? GetAdornedElement(Visual adorner)
@@ -199,9 +205,9 @@ namespace Avalonia.Controls.Primitives
                 {
                     var info = ao.GetValue(s_adornedElementInfoProperty);
 
-                    if (info != null && info.Bounds.HasValue)
+                    if (info is { AdornedElement: not null })
                     {
-                        child.Measure(info.Bounds.Value.Bounds.Size);
+                        child.Measure(info.AdornedElement.Bounds.Size);
                     }
                     else
                     {
@@ -223,12 +229,22 @@ namespace Avalonia.Controls.Primitives
                     var info = ao.GetValue(s_adornedElementInfoProperty);
                     var isClipEnabled = ao.GetValue(IsClipEnabledProperty);
 
-                    if (info != null && info.Bounds.HasValue)
+                    var adorned = info?.AdornedElement;
+                    
+                    if (adorned != null)
                     {
-                        child.RenderTransform = new MatrixTransform(info.Bounds.Value.Transform);
+                        child.Arrange(new(adorned.Bounds.Size));
+                        var transform = adorned.TransformToVisual(this);
+                        // If somebody decides that having Margin on an adorner is a good idea,
+                        // we need to compensate for element being positioned at non-(0,0) coords.
+                        if (transform != null && child.Bounds.Position != default)
+                        {
+                            transform = Matrix.CreateTranslation(child.Bounds.Position) * transform.Value *
+                                        Matrix.CreateTranslation(-child.Bounds.Position);
+                        }
+                        child.RenderTransform = new MatrixTransform(transform ?? default);
                         child.RenderTransformOrigin = new RelativePoint(new Point(0, 0), RelativeUnit.Absolute);
-                        UpdateClip(child, info.Bounds.Value, isClipEnabled);
-                        child.Arrange(info.Bounds.Value.Bounds);
+                        UpdateClip(child, adorned, isClipEnabled);
                     }
                     else
                     {
@@ -248,29 +264,22 @@ namespace Avalonia.Controls.Primitives
             layer?.UpdateAdornedElement(adorner, adorned);
         }
 
-        private void UpdateClip(Control control, TransformedBounds bounds, bool isEnabled)
+        private static void AdornerIsClipEnabledChanged(AvaloniaPropertyChangedEventArgs<bool> e)
+        {
+            var info = ((Visual)e.Sender).GetValue(s_adornedElementInfoProperty);
+            info?.UpdateSubscription();
+            info?.Layer?.InvalidateMeasure();
+        }
+
+        private void UpdateClip(Control control, Visual adorned, bool isEnabled)
         {
             if (!isEnabled)
             {
                 control.Clip = null;
-
                 return;
             }
 
-            if (!(control.Clip is RectangleGeometry clip))
-            {
-                clip = new RectangleGeometry();
-                control.Clip = clip;
-            }
-
-            var clipBounds = bounds.Bounds;
-
-            if (bounds.Transform.HasInverse)
-            {
-                clipBounds = bounds.Clip.TransformToAABB(bounds.Transform.Invert());
-            }
-
-            clip.Rect = clipBounds;
+            control.Clip = AdornerHelper.CalculateAdornerClip(adorned);
         }
 
         private void ChildrenCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -313,24 +322,35 @@ namespace Avalonia.Controls.Primitives
             {
                 if (info == null)
                 {
-                    info = new AdornedElementInfo();
+                    info = new AdornedElementInfo(adorner);
                     adorner.SetValue(s_adornedElementInfoProperty, info);
                 }
 
-                if (adorner.CompositionVisual != null)
-                    info.Subscription = adorned.GetObservable(BoundsProperty).Subscribe(x =>
-                    {
-                        info.Bounds = new TransformedBounds(new Rect(adorned.Bounds.Size), new Rect(adorned.Bounds.Size), Matrix.Identity);
-                        InvalidateMeasure();
-                    });
+                info.Layer = this;
+                info.AdornedElement = adorned;
+                info.UpdateSubscription();
             }
         }
 
-        private class AdornedElementInfo
+        private class AdornedElementInfo(Visual adorner)
         {
+            public AdornerLayer? Layer { get; set; }
             public IDisposable? Subscription { get; set; }
+            public Visual? AdornedElement { get; set; }
 
-            public TransformedBounds? Bounds { get; set; }
+            public void UpdateSubscription()
+            {
+                Subscription?.Dispose();
+                Subscription = null;
+                if (AdornedElement != null)
+                {
+                    Subscription = AdornerHelper.SubscribeToAncestorPropertyChanges(AdornedElement,
+                        GetIsClipEnabled(adorner), () =>
+                        {
+                            Layer?.InvalidateMeasure();
+                        });
+                }
+            }
         }
     }
 }

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -456,7 +456,7 @@ namespace Avalonia.Controls.Primitives
 
             if (InheritsTransform)
             {
-                TransformTrackingHelper.Track(placementTarget, PlacementTargetTransformChanged)
+                TransformTrackingHelper.Track(placementTarget, true, PlacementTargetTransformChanged)
                     .DisposeWith(handlerCleanup);
             }
             else

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
@@ -570,16 +570,8 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             var target = positionRequest.Target;
             if (target == null)
                 throw new InvalidOperationException("Placement mode is not Pointer and PlacementTarget is null");
-            Matrix? matrix;
-            if (TryGetAdorner(target, out var adorned, out var adornerLayer))
-            {
-                matrix = adorned!.TransformToVisual(topLevel) * target.TransformToVisual(adornerLayer!);
-            }
-            else
-            {
-                matrix = target.TransformToVisual(topLevel);
-            }
-
+            Matrix? matrix = target.TransformToVisual(topLevel);
+            
             if (matrix == null)
             {
                 if (target.GetVisualRoot() == null)
@@ -590,25 +582,6 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             var bounds = new Rect(default, target.Bounds.Size);
             var anchorRect = positionRequest.AnchorRect ?? bounds;
             return anchorRect.Intersect(bounds).TransformToAABB(matrix.Value);
-        }
-
-        private static bool TryGetAdorner(Visual target, out Visual? adorned, out Visual? adornerLayer)
-        {
-            var element = target;
-            while (element != null)
-            {
-                if (AdornerLayer.GetAdornedElement(element) is { } adornedElement)
-                {
-                    adorned = adornedElement;
-                    adornerLayer = AdornerLayer.GetAdornerLayer(adorned);
-                    return true;
-                }
-                element = element.VisualParent;
-            }
-
-            adorned = null;
-            adornerLayer = null;
-            return false;
         }
     }
 


### PR DESCRIPTION
During migration from DeferredRenderer to the current composition engine, we've also fixed a bug with adorners being out of sync with adorned elements (off by one frame).

The fix was implemented by hardcoding adorners into the compositor and having a separate pass for them which made them sort of guaranteed to be in sync. 

This caused adorners to be incorrectly positioned in UI thread's view of the visual tree and introduced various hacks to account for that.

This PR makes sure that adorner has the same RenderTransform as one that would have been used by the compositor if no compositor animations are running.

Supercedes #20315
