### PR TITLE
Make TextBox.PlaceholderText accessible

### DIFF
--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -220,6 +220,11 @@
     return GetNSStringAndRelease(_peer->GetHelpText()); 
 }
 
+- (NSString *)accessibilityPlaceholderValue
+{
+    return GetNSStringAndRelease(_peer->GetPlaceholderText());
+}
+
 - (id)accessibilityValue
 {
     if (_peer->IsRangeValueProvider())

--- a/samples/IntegrationTestApp/Pages/AutomationPage.axaml
+++ b/samples/IntegrationTestApp/Pages/AutomationPage.axaml
@@ -10,7 +10,7 @@
       TextBlockWithNameAndAutomationId
     </TextBlock>
     <TextBlock Name="TextBlockAsLabel">Label for TextBox</TextBlock>
-    <TextBox Name="LabeledByTextBox" AutomationProperties.LabeledBy="{Binding #TextBlockAsLabel}">
+    <TextBox Name="LabeledByTextBox" AutomationProperties.LabeledBy="{Binding #TextBlockAsLabel}" PlaceholderText="Placeholder for TextBox">
       Foo
     </TextBox>
     <TextBlock Name="TextBlockWithHeader1" AutomationProperties.ControlTypeOverride="Header" AutomationProperties.HeadingLevel="1">

--- a/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
@@ -284,11 +284,28 @@ namespace Avalonia.Automation.Peers
         public string GetHelpText() => GetHelpTextCore() ?? string.Empty;
 
         /// <summary>
+        /// Gets text that provides a placeholder for the element that is associated with this automation peer.
+        /// </summary>
+        /// <remarks>
+        /// <list type="table">
+        ///   <item>
+        ///     <term>Windows</term>
+        ///     <description>No mapping.</description>
+        ///   </item>
+        ///   <item>
+        ///     <term>macOS</term>
+        ///     <description><c>NSAccessibilityProtocol.accessibilityPlaceholderValue</c></description>
+        ///   </item>
+        /// </list>
+        /// </remarks>
+        public string GetPlaceholderText() => GetPlaceholderTextCore() ?? string.Empty;
+
+        /// <summary>
         /// Gets the control type for the element that is associated with the UI Automation peer.
         /// </summary>
         /// <remarks>
         /// Gets the type of the element.
-        /// 
+        ///
         /// <list type="table">
         ///   <item>
         ///     <term>Windows</term>
@@ -595,6 +612,7 @@ namespace Avalonia.Automation.Peers
         protected abstract AutomationPeer? GetLabeledByCore();
         protected abstract string? GetNameCore();
         protected virtual string? GetHelpTextCore() => null;
+        protected virtual string? GetPlaceholderTextCore() => null;
         protected virtual AutomationLandmarkType? GetLandmarkTypeCore() => null;
         protected virtual int GetHeadingLevelCore() => 0;
         protected virtual string? GetItemTypeCore() => null;

--- a/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
@@ -132,6 +132,12 @@ namespace Avalonia.Automation.Peers
                 result = ToolTip.GetTip(Owner) as string;
             }
 
+            // Windows uses HelpText for placeholder text; macOS uses a separate property.
+            if (string.IsNullOrWhiteSpace(result))
+            {
+                result = GetPlaceholderTextCore();
+            }
+
             return result;
         }
         protected override AutomationLandmarkType? GetLandmarkTypeCore() => AutomationProperties.GetLandmarkType(Owner);

--- a/src/Avalonia.Controls/Automation/Peers/InteropAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/InteropAutomationPeer.cs
@@ -29,6 +29,7 @@ internal class InteropAutomationPeer : AutomationPeer
     protected override AutomationPeer? GetLabeledByCore() => throw new NotImplementedException();
     protected override string? GetNameCore() => throw new NotImplementedException();
     protected override string? GetHelpTextCore() => throw new NotImplementedException();
+    protected override string? GetPlaceholderTextCore() => throw new NotImplementedException();
     protected override IReadOnlyList<AutomationPeer> GetOrCreateChildrenCore() => throw new NotImplementedException();
     protected override AutomationPeer? GetParentCore() => _parent;
     protected override bool HasKeyboardFocusCore() => throw new NotImplementedException();

--- a/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.cs
@@ -21,6 +21,8 @@ namespace Avalonia.Automation.Peers
             return AutomationControlType.Edit;
         }
 
+        protected override string? GetPlaceholderTextCore() => Owner.PlaceholderText;
+
         protected virtual void OwnerPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
         {
             if(e.Property == TextBox.TextProperty)

--- a/src/Avalonia.Native/AvnAutomationPeer.cs
+++ b/src/Avalonia.Native/AvnAutomationPeer.cs
@@ -46,6 +46,7 @@ namespace Avalonia.Native
         public IAvnAutomationPeer? LabeledBy => Wrap(_inner.GetLabeledBy());
         public IAvnString? Name => _inner.GetName().ToAvnString();
         public IAvnString? HelpText => _inner.GetHelpText().ToAvnString();
+        public IAvnString? PlaceholderText => _inner.GetPlaceholderText().ToAvnString();
         public AvnLandmarkType LandmarkType => (AvnLandmarkType?)_inner.GetLandmarkType() ?? AvnLandmarkType.LandmarkNone;
         public int HeadingLevel => _inner.GetHeadingLevel();
         public IAvnAutomationPeer? Parent => Wrap(_inner.GetParent());

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -1328,6 +1328,7 @@ interface IAvnAutomationPeer : IUnknown
      void ValueProvider_SetValue([const] char* value);
 
      IAvnString* GetHelpText();
+     IAvnString* GetPlaceholderText();
 
      AvnLandmarkType GetLandmarkType();
      int GetHeadingLevel();


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
macOS uses a unique `-accessibilityPlaceholderValue` property for the placeholder of a text field; `-accessibilityHelp` has different meaning from `HelpText` on Windows, and is only spoken when the user specifically presses the shortcut to hear help. Map `TextBox.PlaceholderText` to be returned by `-accessibilityPlaceholderValue`.

It also makes `HelpText` fall back to using the placeholder if not otherwise set, making Windows match the macOS behavior.

## What is the current behavior?
The placeholder is never spoken. `AutomationProperties.HelpText` can be set to the same as the placeholder to fix this, but only on Windows.

## What is the updated/expected behavior with this PR?
The placeholder is now spoken when VoiceOver or UIA deems it appropriate, e.g. when the field is empty.

## How was the solution implemented (if it's not obvious)?
A new method is added to `AutomationPeer`, named `GetPlaceholderTextCore()`. This is overridden by `TextBoxAutomationPeer` to return the `PlaceholderText`.

`ControlAutomationPeer.GetHelpTextCore()` is also updated to add a final case where if no other value is found, it will use the placeholder, if any.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
None

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
None

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
None