### PR TITLE
[v12] Android - Remove redundant appbuilder methods in android, use AvaloniaActivity in toplevel classes

### DIFF
--- a/api/Avalonia.Android.nupkg.xml
+++ b/api/Avalonia.Android.nupkg.xml
@@ -8,6 +8,18 @@
     <Right>current/Avalonia.Android/lib/net10.0-android36.0/Avalonia.Android.dll</Right>
   </Suppression>
   <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Android.AvaloniaMainActivity.CreateAppBuilder</Target>
+    <Left>baseline/Avalonia.Android/lib/net10.0-android36.0/Avalonia.Android.dll</Left>
+    <Right>current/Avalonia.Android/lib/net10.0-android36.0/Avalonia.Android.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Android.AvaloniaMainActivity.CustomizeAppBuilder(Avalonia.AppBuilder)</Target>
+    <Left>baseline/Avalonia.Android/lib/net10.0-android36.0/Avalonia.Android.dll</Left>
+    <Right>current/Avalonia.Android/lib/net10.0-android36.0/Avalonia.Android.dll</Right>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0008</DiagnosticId>
     <Target>T:Avalonia.Android.AvaloniaActivity</Target>
     <Left>baseline/Avalonia.Android/lib/net10.0-android36.0/Avalonia.Android.dll</Left>

--- a/src/Android/Avalonia.Android/AvaloniaMainActivity.cs
+++ b/src/Android/Avalonia.Android/AvaloniaMainActivity.cs
@@ -44,7 +44,4 @@ public class AvaloniaMainActivity : AvaloniaActivity
             activatableLifetime.CurrentMainActivity = null;
         }
     }
-
-    protected virtual AppBuilder CreateAppBuilder() => AppBuilder.Configure<Application>().UseAndroid();
-    protected virtual AppBuilder CustomizeAppBuilder(AppBuilder builder) => builder;
 }

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -8,7 +8,6 @@ using Android.Runtime;
 using Android.Views;
 using AndroidX.AppCompat.App;
 using Avalonia.Android.Platform.Input;
-using Avalonia.Android.Platform.Specific;
 using Avalonia.Android.Platform.Specific.Helpers;
 using Avalonia.Android.Platform.Storage;
 using Avalonia.Controls;
@@ -254,7 +253,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
         public void SetTransparencyLevelHint(IReadOnlyList<WindowTransparencyLevel> transparencyLevels)
         {
-            if (_view.Context is not AvaloniaMainActivity activity)
+            if (_view.Context is not AvaloniaActivity activity)
                 return;
 
             foreach (var level in transparencyLevels)
@@ -366,7 +365,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
             return false;
         }
 
-        private static void SetBlurBehind(AvaloniaMainActivity activity, int radius)
+        private static void SetBlurBehind(AvaloniaActivity activity, int radius)
         {
             if (radius == 0)
                 activity.Window?.ClearFlags(WindowManagerFlags.BlurBehind);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
AppBuilder methods were made obsolete in the `AvaloniaActivity` classes. They no longer are called by any other class. This pr removes them.
Also, usages of `AvaloniaMainActivity` internally is changed to use `AvaloniaActivity` for better support.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
