### PR TITLE
Add boundary check to HarfBuzzTextShaper

### DIFF
--- a/src/HarfBuzz/Avalonia.HarfBuzz/HarfBuzzTextShaper.cs
+++ b/src/HarfBuzz/Avalonia.HarfBuzz/HarfBuzzTextShaper.cs
@@ -121,6 +121,8 @@ namespace Avalonia.Harfbuzz
         {
             var length = buffer.Length;
 
+            if (length == 0) return;
+
             var glyphInfos = buffer.GetGlyphInfoSpan();
 
             var second = glyphInfos[length - 1];

--- a/src/HarfBuzz/Avalonia.HarfBuzz/HarfBuzzTextShaper.cs
+++ b/src/HarfBuzz/Avalonia.HarfBuzz/HarfBuzzTextShaper.cs
@@ -24,6 +24,9 @@ namespace Avalonia.Harfbuzz
         {
             var textSpan = text.Span;
 
+            if (text.Length == 0)
+                return new ShapedBuffer(text, 0, options.GlyphTypeface, options.FontRenderingEmSize, options.BidiLevel);
+
             var glyphTypeface = options.GlyphTypeface;
 
             if (glyphTypeface.TextShaperTypeface is not HarfBuzzTypeface harfBuzzTypeface)

--- a/tests/Avalonia.Base.UnitTests/Media/Fonts/Tables/HeadTableTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/Fonts/Tables/HeadTableTests.cs
@@ -191,66 +191,66 @@ namespace Avalonia.Base.UnitTests.Media.Fonts.Tables
             Assert.True(HeadTable.TryLoad(typeface, out var headTable));
             Assert.Equal(FontDirectionHint.LeftToRightWithNeutrals, headTable.FontDirectionHint);
         }
+    }
+    
+    internal class CustomPlatformTypeface : IPlatformTypeface
+    {
+        private readonly UnmanagedFontMemory _fontMemory;
 
-        private class CustomPlatformTypeface : IPlatformTypeface
+        public CustomPlatformTypeface(Stream stream, string fontFamily = "Custom")
         {
-            private readonly UnmanagedFontMemory _fontMemory;
-
-            public CustomPlatformTypeface(Stream stream, string fontFamily = "Custom")
-            {
-                _fontMemory = UnmanagedFontMemory.LoadFromStream(stream);
-                FamilyName = fontFamily;
-            }
-
-            public FontWeight Weight => FontWeight.Normal;
-
-            public FontStyle Style => FontStyle.Normal;
-
-            public FontStretch Stretch => FontStretch.Normal;
-
-            public string FamilyName { get; }
-
-            public FontSimulations FontSimulations => FontSimulations.None;
-
-            public void Dispose()
-            {
-                ((IDisposable)_fontMemory).Dispose();
-            }
-
-            public unsafe bool TryGetStream([NotNullWhen(true)] out Stream stream)
-            {
-                var memory = _fontMemory.Memory;
-
-                var handle = memory.Pin();
-                stream = new PinnedUnmanagedMemoryStream(handle, memory.Length);
-
-                return true;
-            }
-
-            private sealed class PinnedUnmanagedMemoryStream : UnmanagedMemoryStream
-            {
-                private MemoryHandle _handle;
-
-                public unsafe PinnedUnmanagedMemoryStream(MemoryHandle handle, long length)
-                    : base((byte*)handle.Pointer, length)
-                {
-                    _handle = handle;
-                }
-
-                protected override void Dispose(bool disposing)
-                {
-                    try
-                    {
-                        base.Dispose(disposing);
-                    }
-                    finally
-                    {
-                        _handle.Dispose();
-                    }
-                }
-            }
-
-            public bool TryGetTable(OpenTypeTag tag, out ReadOnlyMemory<byte> table) => _fontMemory.TryGetTable(tag, out table);
+            _fontMemory = UnmanagedFontMemory.LoadFromStream(stream);
+            FamilyName = fontFamily;
         }
+
+        public FontWeight Weight => FontWeight.Normal;
+
+        public FontStyle Style => FontStyle.Normal;
+
+        public FontStretch Stretch => FontStretch.Normal;
+
+        public string FamilyName { get; }
+
+        public FontSimulations FontSimulations => FontSimulations.None;
+
+        public void Dispose()
+        {
+            ((IDisposable)_fontMemory).Dispose();
+        }
+
+        public unsafe bool TryGetStream([NotNullWhen(true)] out Stream stream)
+        {
+            var memory = _fontMemory.Memory;
+
+            var handle = memory.Pin();
+            stream = new PinnedUnmanagedMemoryStream(handle, memory.Length);
+
+            return true;
+        }
+
+        private sealed class PinnedUnmanagedMemoryStream : UnmanagedMemoryStream
+        {
+            private MemoryHandle _handle;
+
+            public unsafe PinnedUnmanagedMemoryStream(MemoryHandle handle, long length)
+                : base((byte*)handle.Pointer, length)
+            {
+                _handle = handle;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                try
+                {
+                    base.Dispose(disposing);
+                }
+                finally
+                {
+                    _handle.Dispose();
+                }
+            }
+        }
+
+        public bool TryGetTable(OpenTypeTag tag, out ReadOnlyMemory<byte> table) => _fontMemory.TryGetTable(tag, out table);
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Media/TextFormatting/HarfbuzzTextShaperTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/TextFormatting/HarfbuzzTextShaperTests.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Linq;
+using Avalonia.Base.UnitTests.Media.Fonts.Tables;
+using Avalonia.Harfbuzz;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+using Avalonia.Platform;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Media.TextFormatting;
+
+public class HarfBuzzTextShaperTests
+{
+    private static readonly string s_InterFontUri =
+        "resm:Avalonia.Base.UnitTests.Assets.Inter-Regular.ttf?assembly=Avalonia.Base.UnitTests";
+
+    private readonly HarfBuzzTextShaper _shaper;
+    
+    private TestServices Services => TestServices.MockThreadingInterface.With(
+        textShaperImpl: _shaper);
+
+    public HarfBuzzTextShaperTests()
+    {
+        _shaper = new HarfBuzzTextShaper();
+    }
+
+    [Fact]
+    public void ShapeText_WithValidInput_ReturnsShapedBuffer()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var text = "Hello World".AsMemory();
+            var options = CreateTextShaperOptions();
+            
+            var result = _shaper.ShapeText(text, options);
+            
+            Assert.NotNull(result);
+            Assert.Equal(text.Length, result.Length);
+        }
+    }
+
+    [Fact]
+    public void ShapeText_WithEmptyString_ReturnsEmptyShapedBuffer()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var text = "".AsMemory();
+            var options = CreateTextShaperOptions();
+            
+            var result = _shaper.ShapeText(text, options);
+            
+            Assert.NotNull(result);
+            Assert.Equal(0, result.Length);
+        }
+    }
+
+    [Fact]
+    public void ShapeText_WithTabCharacter_ReplacesWithSpace()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var text = "Hello\tWorld".AsMemory();
+            var options = CreateTextShaperOptions();
+            
+            var result = _shaper.ShapeText(text, options);
+            
+            Assert.NotNull(result);
+            Assert.True(result.Length == 11);
+        }
+    }
+
+    [Fact]
+    public void ShapeText_WithCRLF_MergesBreakPair()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var text = "Line1\r\nLine2".AsMemory();
+            var options = CreateTextShaperOptions();
+            
+            var result = _shaper.ShapeText(text, options);
+            
+            Assert.NotNull(result);
+            Assert.NotEqual(0.0, result[5].GlyphAdvance);
+        }
+    }
+    
+    [Fact]
+    public void ShapeText_EndWithCRLF_MergesBreakPair()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var text = "Line1\r\n".AsMemory();
+            var options = CreateTextShaperOptions();
+            
+            var result = _shaper.ShapeText(text, options);
+            
+            Assert.NotNull(result);
+            Assert.Equal(0.0, result[5].GlyphAdvance);
+        }
+    }
+
+    private TextShaperOptions CreateTextShaperOptions(
+        sbyte bidiLevel = 0,
+        double letterSpacing = 0,
+        double fontSize = 16)
+    {
+        var assetLoader = new StandardAssetLoader();
+
+        using var stream = assetLoader.Open(new Uri(s_InterFontUri));
+
+        var typeface = new GlyphTypeface(new CustomPlatformTypeface(stream));
+
+        return new TextShaperOptions(
+            typeface,
+            fontSize,
+            bidiLevel,
+            letterSpacing: letterSpacing);
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Add a basic boundary check, so empty string won't trigger index out of boundary exception. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Shaping an empty text will throw execption

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Currently there seems no unit test associated with text shapers. please let me know if you need any. 