### PR TITLE
Add PopupOverlayLayer

### DIFF
--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Controls.Primitives
             IsClipEnabledProperty.Changed.Subscribe(AdornerIsClipEnabledChanged);
         }
 
-        internal AdornerLayer()
+        public AdornerLayer()
         {
             Children.CollectionChanged += ChildrenCollectionChanged;
             _trackingHelper.SetVisual(this);

--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -11,8 +11,6 @@ namespace Avalonia.Controls.Primitives
     /// Represents a surface for showing adorners.
     /// Adorners are always on top of the adorned element and are positioned to stay relative to the adorned element.
     /// </summary>
-    /// <remarks>
-    /// </remarks>
     public class AdornerLayer : Canvas
     {
         /// <summary>
@@ -54,7 +52,7 @@ namespace Avalonia.Controls.Primitives
             IsClipEnabledProperty.Changed.Subscribe(AdornerIsClipEnabledChanged);
         }
 
-        public AdornerLayer()
+        internal AdornerLayer()
         {
             Children.CollectionChanged += ChildrenCollectionChanged;
             _trackingHelper.SetVisual(this);

--- a/src/Avalonia.Controls/Primitives/IPopupHost.cs
+++ b/src/Avalonia.Controls/Primitives/IPopupHost.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Controls.Primitives
     /// <remarks>
     /// A popup host can be either be a popup window created by the operating system
     /// (<see cref="PopupRoot"/>) or an <see cref="OverlayPopupHost"/> which is created
-    /// on an <see cref="OverlayLayer"/>.
+    /// on an <see cref="PopupOverlayLayer"/>.
     /// </remarks>
     internal interface IPopupHost : IDisposable, IFocusScope
     {

--- a/src/Avalonia.Controls/Primitives/OverlayLayer.cs
+++ b/src/Avalonia.Controls/Primitives/OverlayLayer.cs
@@ -3,12 +3,25 @@ using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Primitives
 {
+    /// <summary>
+    /// Represents a surface for showing overlays.
+    /// Overlays are displayed on top of other elements, but behind popups.
+    /// </summary>
     public class OverlayLayer : Canvas
     {
         protected override bool BypassFlowDirectionPolicies => true;
 
         public Size AvailableSize { get; private set; }
 
+        internal OverlayLayer()
+        {
+        }
+
+        /// <summary>
+        /// Retrieves the overlay layer associated with the specified visual, if any.
+        /// </summary>
+        /// <param name="visual">The visual for which to retrieve the associated overlay layer.</param>
+        /// <returns>The <see cref="OverlayLayer"/> associated with the visual, or null if no overlay layer exists.</returns>
         public static OverlayLayer? GetOverlayLayer(Visual visual)
         {
             foreach (var v in visual.GetVisualAncestors())
@@ -24,6 +37,7 @@ namespace Avalonia.Controls.Primitives
             return null;
         }
 
+        /// <inheritdoc />
         protected override Size MeasureOverride(Size availableSize)
         {
             foreach (var child in Children)
@@ -31,6 +45,7 @@ namespace Avalonia.Controls.Primitives
             return availableSize;
         }
 
+        /// <inheritdoc />
         protected override Size ArrangeOverride(Size finalSize)
         {
             // We are saving it here since child controls might need to know the entire size of the overlay

--- a/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
+++ b/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Controls.Primitives
         public static readonly StyledProperty<Transform?> TransformProperty =
             PopupRoot.TransformProperty.AddOwner<OverlayPopupHost>();
 
-        private readonly OverlayLayer _overlayLayer;
+        private readonly PopupOverlayLayer _overlayLayer;
         private readonly ManagedPopupPositioner _positioner;
         private readonly IKeyboardNavigationHandler? _keyboardNavigationHandler;
         internal IKeyboardNavigationHandler Tests_KeyboardNavigationHandler => _keyboardNavigationHandler!;
@@ -31,7 +31,7 @@ namespace Avalonia.Controls.Primitives
         static OverlayPopupHost()
             => KeyboardNavigation.TabNavigationProperty.OverrideDefaultValue<OverlayPopupHost>(KeyboardNavigationMode.Cycle);
 
-        internal OverlayPopupHost(OverlayLayer overlayLayer)
+        internal OverlayPopupHost(PopupOverlayLayer overlayLayer)
         {
             _overlayLayer = overlayLayer;
             _positioner = new ManagedPopupPositioner(this);
@@ -161,7 +161,7 @@ namespace Avalonia.Controls.Primitives
                 }
             }
 
-            if (OverlayLayer.GetOverlayLayer(target) is { } overlayLayer)
+            if (PopupOverlayLayer.GetPopupOverlayLayer(target) is { } overlayLayer)
             {
                 return new OverlayPopupHost(overlayLayer);
             }

--- a/src/Avalonia.Controls/Primitives/PopupOverlayLayer.cs
+++ b/src/Avalonia.Controls/Primitives/PopupOverlayLayer.cs
@@ -3,22 +3,22 @@ using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Primitives
 {
-    public class OverlayLayer : Canvas
+    internal sealed class PopupOverlayLayer : Canvas
     {
         protected override bool BypassFlowDirectionPolicies => true;
 
         public Size AvailableSize { get; private set; }
 
-        public static OverlayLayer? GetOverlayLayer(Visual visual)
+        public static PopupOverlayLayer? GetPopupOverlayLayer(Visual visual)
         {
             foreach (var v in visual.GetVisualAncestors())
-                if (v is VisualLayerManager { OverlayLayer: { } layer })
+                if (v is VisualLayerManager { PopupOverlayLayer: { } layer })
                     return layer;
 
             if (TopLevel.GetTopLevel(visual) is { } tl)
             {
                 var layers = tl.GetVisualDescendants().OfType<VisualLayerManager>().FirstOrDefault();
-                return layers?.OverlayLayer;
+                return layers?.PopupOverlayLayer;
             }
 
             return null;

--- a/src/Avalonia.Controls/Primitives/TextSelectorLayer.cs
+++ b/src/Avalonia.Controls/Primitives/TextSelectorLayer.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Avalonia.Rendering;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Primitives
@@ -7,14 +6,16 @@ namespace Avalonia.Controls.Primitives
     public class TextSelectorLayer : Canvas
     {
         protected override bool BypassFlowDirectionPolicies => true;
+
         public Size AvailableSize { get; private set; }
+
         public static TextSelectorLayer? GetTextSelectorLayer(Visual visual)
         {
             foreach (var v in visual.GetVisualAncestors())
-                if (v is VisualLayerManager vlm)
-                    if (vlm.TextSelectorLayer != null)
-                        return vlm.TextSelectorLayer;
-            if (visual is TopLevel tl)
+                if (v is VisualLayerManager { TextSelectorLayer: { } textSelectorLayer })
+                    return textSelectorLayer;
+
+            if (TopLevel.GetTopLevel(visual) is { } tl)
             {
                 var layers = tl.GetVisualDescendants().OfType<VisualLayerManager>().FirstOrDefault();
                 return layers?.TextSelectorLayer;
@@ -25,7 +26,7 @@ namespace Avalonia.Controls.Primitives
 
         protected override Size MeasureOverride(Size availableSize)
         {
-            foreach (Control child in Children)
+            foreach (var child in Children)
                 child.Measure(availableSize);
             return default;
         }

--- a/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
+++ b/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
@@ -6,8 +6,8 @@ namespace Avalonia.Controls.Primitives
     public sealed class VisualLayerManager : Decorator
     {
         private const int AdornerZIndex = int.MaxValue - 100;
-        private const int LightDismissOverlayZIndex = int.MaxValue - 98;
-        private const int OverlayZIndex = int.MaxValue - 97;
+        private const int OverlayZIndex = int.MaxValue - 98;
+        private const int LightDismissOverlayZIndex = int.MaxValue - 97;
         private const int PopupOverlayZIndex = int.MaxValue - 96;
         private const int TextSelectorLayerZIndex = int.MaxValue - 95;
 

--- a/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
+++ b/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
@@ -8,7 +8,8 @@ namespace Avalonia.Controls.Primitives
         private const int AdornerZIndex = int.MaxValue - 100;
         private const int LightDismissOverlayZIndex = int.MaxValue - 98;
         private const int OverlayZIndex = int.MaxValue - 97;
-        private const int TextSelectorLayerZIndex = int.MaxValue - 96;
+        private const int PopupOverlayZIndex = int.MaxValue - 96;
+        private const int TextSelectorLayerZIndex = int.MaxValue - 95;
 
         private ILogicalRoot? _logicalRoot;
         private readonly List<Control> _layers = new();
@@ -26,6 +27,19 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
+        internal PopupOverlayLayer? PopupOverlayLayer
+        {
+            get
+            {
+                if (IsPopup)
+                    return null;
+                var rv = FindLayer<PopupOverlayLayer>();
+                if (rv == null)
+                    AddLayer(rv = new PopupOverlayLayer(), PopupOverlayZIndex);
+                return rv;
+            }
+        }
+        
         internal OverlayLayer? OverlayLayer
         {
             get

--- a/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
@@ -39,7 +39,7 @@ namespace Avalonia.Controls.UnitTests
             _toolTipOpenSubscription = ToolTip.IsOpenProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<bool>>(e =>
             {
                 if (e.Sender is Visual visual && TopLevel.GetTopLevel(visual) is {} root)
-                    OverlayLayer.GetOverlayLayer(visual)?.Measure(root.ClientSize);
+                    PopupOverlayLayer.GetPopupOverlayLayer(visual)?.Measure(root.ClientSize);
             }));
         }
 


### PR DESCRIPTION
## What does the pull request do?
This PR adds a `PopupOverlayLayer` that's in front of `OverlayLayer`. Avalonia popups are now in `PopupOverlayLayer` and users are free to add controls to the `OverlayLayer`.