### PR TITLE
iOS: fix universal link activation with scenes

### DIFF
--- a/src/iOS/Avalonia.iOS/AvaloniaSceneDelegate.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaSceneDelegate.cs
@@ -24,6 +24,13 @@ internal sealed class AvaloniaSceneDelegate : UIResponder, IUIWindowSceneDelegat
         Window.MakeKeyAndVisible();
     }
 
+    [Export("scene:continueUserActivity:")]
+    public void ContinueUserActivity(UIScene scene, NSUserActivity userActivity)
+    {
+        var appDelegate = UIApplication.SharedApplication.Delegate as IAvaloniaAppInternalDelegate;
+        appDelegate?.ContinueUserActivity(userActivity);
+    }
+
     internal static void InitWindow(UIWindow window, SingleViewLifetime lifetime)
     {
         var view = new AvaloniaView();


### PR DESCRIPTION
## What does the pull request do?
This PR fixes an issue where universal link activation doesn't work on iOS 13+.
It was introduced in #20454: iOS calls a different method when scenes are enabled.

## Fixed issues
 - Fixes #20703
