### PR TITLE
Fix menu memory leak

### DIFF
--- a/src/Avalonia.Controls/Menu.cs
+++ b/src/Avalonia.Controls/Menu.cs
@@ -13,6 +13,8 @@ namespace Avalonia.Controls
     /// </summary>
     public class Menu : MenuBase, IMainMenu
     {
+        private IAccessKeyHandler? _accessKeyHandler;
+
         private static readonly FuncTemplate<Panel?> DefaultPanel =
             new (() => new StackPanel { Orientation = Orientation.Horizontal });
 
@@ -88,12 +90,18 @@ namespace Avalonia.Controls
         {
             base.OnAttachedToVisualTree(e);
 
-            var inputRoot = TopLevel.GetTopLevel(this);
+            _accessKeyHandler = TopLevel.GetTopLevel(this)?.AccessKeyHandler;
+            _accessKeyHandler?.MainMenu = this;
+        }
 
-            if (inputRoot?.AccessKeyHandler != null)
-            {
-                inputRoot.AccessKeyHandler.MainMenu = this;
-            }
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (_accessKeyHandler?.MainMenu == this)
+                _accessKeyHandler.MainMenu = null;
+
+            _accessKeyHandler = null;
+
+            base.OnDetachedFromVisualTree(e);
         }
 
         protected internal override void PrepareContainerForItemOverride(Control element, object? item, int index)

--- a/tests/Avalonia.Controls.UnitTests/ButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ButtonTests.cs
@@ -305,11 +305,10 @@ namespace Avalonia.Controls.UnitTests
         public void Raises_Click_When_AccessKey_Raised()
         {
             var raised = 0;
-            var ah = new AccessKeyHandler();
             var kd = new KeyboardDevice();
             using var app = UnitTestApplication.Start(TestServices.StyledWindow
                 .With(
-                    accessKeyHandler: ah, 
+                    accessKeyHandler: () => new AccessKeyHandler(),
                     keyboardDevice: () => kd)
             );
 

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -723,11 +723,10 @@ namespace Avalonia.Controls.UnitTests
         [InlineData(Key.D, "d", 0)]
         public void Should_TabControl_Recognizes_AccessKey(Key accessKey, string accessKeySymbol, int selectedTabIndex)
         {
-            var ah = new AccessKeyHandler();
             var kd = new KeyboardDevice();
             using (UnitTestApplication.Start(TestServices.StyledWindow
                        .With(
-                           accessKeyHandler: ah,
+                           accessKeyHandler: () => new AccessKeyHandler(),
                            keyboardDevice: () => kd)
                    ))
             {

--- a/tests/Avalonia.UnitTests/TestServices.cs
+++ b/tests/Avalonia.UnitTests/TestServices.cs
@@ -87,7 +87,7 @@ namespace Avalonia.UnitTests
             ITextShaperImpl? textShaperImpl = null,
             IWindowImpl? windowImpl = null,
             IWindowingPlatform? windowingPlatform = null,
-            IAccessKeyHandler? accessKeyHandler = null)
+            Func<IAccessKeyHandler?>? accessKeyHandler = null)
         {
             AssetLoader = assetLoader;
             InputManager = inputManager;
@@ -110,7 +110,7 @@ namespace Avalonia.UnitTests
         public IAssetLoader? AssetLoader { get; }
         public IInputManager? InputManager { get; }
         internal IGlobalClock? GlobalClock { get; set; }
-        internal IAccessKeyHandler? AccessKeyHandler { get; }
+        internal Func<IAccessKeyHandler?>? AccessKeyHandler { get; }
         public Func<IKeyboardDevice?>? KeyboardDevice { get; }
         internal Func<IKeyboardNavigationHandler?>? KeyboardNavigation { get; }
         public Func<IMouseDevice?>? MouseDevice { get; }
@@ -128,7 +128,7 @@ namespace Avalonia.UnitTests
             IAssetLoader? assetLoader = null,
             IInputManager? inputManager = null,
             IGlobalClock? globalClock = null,
-            IAccessKeyHandler? accessKeyHandler = null,
+            Func<IAccessKeyHandler?>? accessKeyHandler = null,
             Func<IKeyboardDevice?>? keyboardDevice = null,
             Func<IKeyboardNavigationHandler?>? keyboardNavigation = null,
             Func<IMouseDevice?>? mouseDevice = null,

--- a/tests/Avalonia.UnitTests/UnitTestApplication.cs
+++ b/tests/Avalonia.UnitTests/UnitTestApplication.cs
@@ -89,8 +89,7 @@ namespace Avalonia.UnitTests
                 .Bind<IWindowingPlatform?>().ToConstant(Services.WindowingPlatform)
                 .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>()
                 .Bind<IPlatformSettings>().ToSingleton<DefaultPlatformSettings>()
-                .Bind<IAccessKeyHandler?>().ToConstant(Services.AccessKeyHandler)
-                ;
+                .Bind<IAccessKeyHandler?>().ToFunc(Services.AccessKeyHandler ?? (() => null));
             
             // This is a hack to make tests work, we need to refactor the way font manager is registered
             // See https://github.com/AvaloniaUI/Avalonia/issues/10081


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a `Menu` attached to a window being kept alive by its `AccessKeyHandler` after the menu gets removed from the visual tree.

See #20744 for details.

## Fixed issues
 - Fixes #20744
