### PR TITLE
Fix TopLevelHost mirroring RTL content

### DIFF
--- a/src/Avalonia.Controls/TopLevelHost.cs
+++ b/src/Avalonia.Controls/TopLevelHost.cs
@@ -18,4 +18,6 @@ internal class TopLevelHost : Control
     {
         VisualChildren.Add(tl);
     }
+
+    protected override bool BypassFlowDirectionPolicies => true;
 }

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -3,10 +3,9 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Avalonia.Media;
 using Avalonia.Platform;
-using Avalonia.Rendering;
-using Avalonia.Rendering.Composition;
 using Avalonia.Threading;
 using Avalonia.UnitTests;
+using Avalonia.VisualTree;
 using Moq;
 using Xunit;
 
@@ -687,6 +686,26 @@ namespace Avalonia.Controls.UnitTests
             window.CanResize = false;
 
             Assert.False(window.CanMaximize);
+        }
+
+        [Fact]
+        public void FlowDirection_RTL_Should_Not_Result_In_Mirrored_Host()
+        {
+            var windowImpl = MockWindowingPlatform.CreateWindowMock();
+
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow.With(
+                windowingPlatform: new MockWindowingPlatform(() => windowImpl.Object)));
+
+            var window = new Window
+            {
+                FlowDirection = FlowDirection.RightToLeft
+            };
+
+            var visualRoot = window.GetVisualRoot();
+            Assert.IsType<TopLevelHost>(visualRoot);
+
+            Assert.False(window.HasMirrorTransform);
+            Assert.False(visualRoot.HasMirrorTransform);
         }
 
         public class SizingTests : ScopedTestBase


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the very recently introduced `TopLevelHost` (#20732), which incorrectly mirrors content when its `TopLevel.FlowDirection == RightToLeft`.

## What is the current behavior?
<img width="202" height="232" alt="image" src="https://github.com/user-attachments/assets/b9159f04-445a-448e-9f39-9d0c5f5f9538" />

## What is the updated/expected behavior with this PR?
<img width="202" height="232" alt="image" src="https://github.com/user-attachments/assets/368e7725-e6fb-4b8b-ad63-9ed3409e6ff6" />
