### PR TITLE
Add AppBuilder.UseTextShapingSubsystem

### DIFF
--- a/src/Avalonia.Controls/AppBuilder.cs
+++ b/src/Avalonia.Controls/AppBuilder.cs
@@ -61,6 +61,16 @@ namespace Avalonia
         public string? RenderingSubsystemName { get; private set; }
 
         /// <summary>
+        /// Gets or sets a method to call the initialize the text shaping subsystem.
+        /// </summary>
+        public Action? TextShapingSubsystemInitializer { get; private set; }
+
+        /// <summary>
+        /// Gets the name of the currently selected text shaping subsystem.
+        /// </summary>
+        public string? TextShapingSubsystemName { get; private set; }
+
+        /// <summary>
         /// Gets a method to call after the <see cref="Application"/> is setup.
         /// </summary>
         public Action<AppBuilder> AfterSetupCallback { get; private set; } = builder => { };
@@ -224,6 +234,19 @@ namespace Avalonia
             RenderingSubsystemName = name;
             return Self;
         }
+
+        /// <summary>
+        /// Specifies a text shaping subsystem to use.
+        /// </summary>
+        /// <param name="initializer">The method to call to initialize the text shaping subsystem.</param>
+        /// <param name="name">The name of the text shaping subsystem.</param>
+        /// <returns>An <see cref="AppBuilder"/> instance.</returns>
+        public AppBuilder UseTextShapingSubsystem(Action initializer, string name = "")
+        {
+            TextShapingSubsystemInitializer = initializer;
+            TextShapingSubsystemName = name;
+            return Self;
+        }
         
         /// <summary>
         /// Specifies a runtime platform subsystem to use.
@@ -311,6 +334,11 @@ namespace Avalonia
                 throw new InvalidOperationException("No rendering system configured.");
             }
 
+            if (TextShapingSubsystemInitializer == null)
+            {
+                throw new InvalidOperationException("No text shaping system configured.");
+            }
+
             if (_appFactory == null)
             {
                 throw new InvalidOperationException("No Application factory configured.");
@@ -333,6 +361,7 @@ namespace Avalonia
         {
             _optionsInitializers?.Invoke();
             RuntimePlatformServicesInitializer?.Invoke();
+            TextShapingSubsystemInitializer?.Invoke();
             RenderingSubsystemInitializer?.Invoke();
             WindowingSubsystemInitializer?.Invoke();
             AfterPlatformServicesSetupCallback?.Invoke(Self);

--- a/src/Avalonia.Controls/AppBuilder.cs
+++ b/src/Avalonia.Controls/AppBuilder.cs
@@ -331,12 +331,12 @@ namespace Avalonia
 
             if (RenderingSubsystemInitializer == null)
             {
-                throw new InvalidOperationException("No rendering system configured.");
+                throw new InvalidOperationException("No rendering system configured. Consider calling UseSkia().");
             }
 
             if (TextShapingSubsystemInitializer == null)
             {
-                throw new InvalidOperationException("No text shaping system configured.");
+                throw new InvalidOperationException("No text shaping system configured. Consider calling UseHarfBuzz().");
             }
 
             if (_appFactory == null)

--- a/src/HarfBuzz/Avalonia.HarfBuzz/HarfBuzzApplicationExtensions.cs
+++ b/src/HarfBuzz/Avalonia.HarfBuzz/HarfBuzzApplicationExtensions.cs
@@ -20,7 +20,9 @@ namespace Avalonia
         /// <returns>The configured <see cref="AppBuilder"/> instance.</returns>
         public static AppBuilder UseHarfBuzz(this AppBuilder builder)
         {
-            return builder.With<ITextShaperImpl>(new HarfBuzzTextShaper());
+            return builder.UseTextShapingSubsystem(
+                () => AvaloniaLocator.CurrentMutable.Bind<ITextShaperImpl>().ToConstant(new HarfBuzzTextShaper()),
+                "HarfBuzz");
         }
     }
 

--- a/src/Headless/Avalonia.Headless/AvaloniaHeadlessPlatform.cs
+++ b/src/Headless/Avalonia.Headless/AvaloniaHeadlessPlatform.cs
@@ -121,7 +121,8 @@ namespace Avalonia.Headless
                 builder = builder.UseRenderingSubsystem(HeadlessPlatformRenderInterface.Initialize, "Headless");
             return builder
                 .UseStandardRuntimePlatformSubsystem()
-                .UseWindowingSubsystem(() => AvaloniaHeadlessPlatform.Initialize(opts), "Headless");
+                .UseWindowingSubsystem(() => AvaloniaHeadlessPlatform.Initialize(opts), "Headless")
+                .UseHarfBuzz();
         }
     }
 }

--- a/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
@@ -236,9 +236,12 @@ public sealed class HeadlessUnitTestSession : IDisposable, IAsyncDisposable
                 // If windowing subsystem wasn't initialized by user, force headless with default parameters.
                 if (appBuilder.WindowingSubsystemName != "Headless")
                 {
-                    appBuilder = appBuilder
-                        .UseHeadless(new AvaloniaHeadlessPlatformOptions())
-                        .UseHarfBuzz();
+                    appBuilder = appBuilder.UseHeadless(new AvaloniaHeadlessPlatformOptions());
+                }
+
+                if (appBuilder.TextShapingSubsystemInitializer is null)
+                {
+                    appBuilder = appBuilder.UseHarfBuzz();
                 }
 
                 // ReSharper disable once AccessToModifiedClosure

--- a/tests/Avalonia.IntegrationTests.Win32/Avalonia.IntegrationTests.Win32.csproj
+++ b/tests/Avalonia.IntegrationTests.Win32/Avalonia.IntegrationTests.Win32.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/Skia/Avalonia.Skia/Avalonia.Skia.csproj" />
+    <ProjectReference Include="../../src/HarfBuzz/Avalonia.HarfBuzz/Avalonia.HarfBuzz.csproj" />
     <ProjectReference Include="../../src/Windows/Avalonia.Win32/Avalonia.Win32.csproj" />
     <ProjectReference Include="../../src/Avalonia.Themes.Fluent/Avalonia.Themes.Fluent.csproj" />
   </ItemGroup>

--- a/tests/Avalonia.IntegrationTests.Win32/Infrastructure/AppManager.cs
+++ b/tests/Avalonia.IntegrationTests.Win32/Infrastructure/AppManager.cs
@@ -24,6 +24,7 @@ internal static class AppManager
                 .Configure<Application>()
                 .UseWin32()
                 .UseSkia()
+                .UseHarfBuzz()
                 .SetupWithoutStarting();
 
             appBuilder.Instance!.Styles.Add(new FluentTheme());


### PR DESCRIPTION
## What does the pull request do?
This PR adds an `AppBuilder.UseTextShapingSubsystem` method to configure the text shaper.
`UseHarfBuzz()` uses that.
In case of a missing text shaper, a clear exception is now thrown.

## What is the current behavior?
When a text shaper is not configured, an exception *InvalidOperationException: Could not locate ITextShaperImpl* is thrown when text shaping is first used, usually deep in a call stack.

## What is the updated/expected behavior with this PR?
When a text shaper is not configured, an exception *InvalidOperationException: No text shaping system configured. Consider calling UseHarfBuzz()* is thrown on startup.
