### PR TITLE
Win32 - Add support for mouse wheel zoom

### DIFF
--- a/samples/ControlCatalog/Pages/GesturePage.cs
+++ b/samples/ControlCatalog/Pages/GesturePage.cs
@@ -114,6 +114,29 @@ namespace ControlCatalog.Pages
                 }
             });
 
+            control.AddHandler(Gestures.PointerTouchPadGestureMagnifyEvent, (s, e) =>
+            {
+                const double scalingStep = 0.05;
+
+                InitComposition(control!);
+                if (compositionVisual != null)
+                {
+                    var scale = _currentScale + ((float)e.Delta.Y * scalingStep);
+
+                    if (scale <= 1)
+                    {
+                        scale = 1;
+                        compositionVisual.Offset = default;
+                    }
+
+                    compositionVisual.Scale = new(scale, scale, 1);
+
+                    _currentScale = scale;
+
+                    e.Handled = true;
+                }
+            });
+
             control.AddHandler(Gestures.PinchEndedEvent, (s, e) =>
             {
                 InitComposition(control!);

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -224,7 +224,7 @@ namespace Avalonia.Win32
                     }
 
                     var requestIcon = (Icons)wParam;
-                    var requestDpi = (uint) lParam;
+                    var requestDpi = (uint)lParam;
 
                     if (requestDpi == 0)
                     {
@@ -411,13 +411,22 @@ namespace Avalonia.Win32
                         {
                             break;
                         }
-                        e = new RawMouseWheelEventArgs(
-                            _mouseDevice,
-                            timestamp,
-                            Owner,
-                            PointToClient(PointFromLParam(lParam)),
-                            new Vector(0, (ToInt32(wParam) >> 16) / wheelDelta),
-                            GetMouseModifiers(wParam));
+                        var modifiers = GetMouseModifiers(wParam);
+                        e = modifiers == RawInputModifiers.Control ?
+                            new RawPointerGestureEventArgs(_mouseDevice,
+                                timestamp,
+                                Owner,
+                                RawPointerEventType.Magnify,
+                                PointToClient(PointFromLParam(lParam)),
+                                new Vector(0, (ToInt32(wParam) >> 16) / wheelDelta),
+                                modifiers) :
+                            new RawMouseWheelEventArgs(
+                                _mouseDevice,
+                                timestamp,
+                                Owner,
+                                PointToClient(PointFromLParam(lParam)),
+                                new Vector(0, (ToInt32(wParam) >> 16) / wheelDelta),
+                                modifiers);
                         break;
                     }
 
@@ -453,7 +462,6 @@ namespace Avalonia.Win32
                             WindowsKeyboardDevice.Instance.Modifiers);
                         break;
                     }
-
                 // covers WM_CANCELMODE which sends WM_CAPTURECHANGED in DefWindowProc
                 case WindowsMessage.WM_CAPTURECHANGED:
                     {
@@ -946,7 +954,7 @@ namespace Avalonia.Win32
                     break;
                 case WindowsMessage.WM_WINDOWPOSCHANGED:
                     var winPos = Marshal.PtrToStructure<WINDOWPOS>(lParam);
-                    if((winPos.flags & (uint)SetWindowPosFlags.SWP_SHOWWINDOW) != 0)
+                    if ((winPos.flags & (uint)SetWindowPosFlags.SWP_SHOWWINDOW) != 0)
                     {
                         OnShowHideMessage(true);
                     }
@@ -973,7 +981,7 @@ namespace Avalonia.Win32
 
                 if (message == WindowsMessage.WM_KEYDOWN)
                 {
-                    if(e is RawKeyEventArgs args && args.Key == Key.ImeProcessed)
+                    if (e is RawKeyEventArgs args && args.Key == Key.ImeProcessed)
                     {
                         _ignoreWmChar = true;
                     }
@@ -1118,7 +1126,7 @@ namespace Avalonia.Win32
                     var x = mp.x > 32767 ? mp.x - 65536 : mp.x;
                     var y = mp.y > 32767 ? mp.y - 65536 : mp.y;
 
-                    if(mp.time <= prevMovePoint.time || mp.time >= movePoint.time)
+                    if (mp.time <= prevMovePoint.time || mp.time >= movePoint.time)
                         continue;
 
                     s_sortedPoints.Add(new InternalPoint

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1005,7 +1005,7 @@ namespace Avalonia.Win32
 
             Handle = new WindowImplPlatformHandle(this);
 
-                RegisterTouchWindow(_hwnd, 0);
+            RegisterTouchWindow(_hwnd, 0);
 
             if (ShCoreAvailable && Win32Platform.WindowsVersion >= PlatformConstants.Windows8_1)
             {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds support for mouse wheel zoom for Win32. This is triggered by pressing the Control key while scrolling, or pinching on a touch pad. The action sends a `PointerTouchPadGestureMagnifyEvent` with a value of -1 or 1 as `Delta.Y`. 


## What is the current behavior?
Mouse wheel will always scroll the content, even if the Control key is held.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
