### PR TITLE
Create DiagnosticTextRenderer lazily

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Appium.WebDriver" Version="5.2.0" />
     <PackageVersion Include="Avalonia.Angle.Windows.Natives" Version="2.1.25547.20250602" />
     <PackageVersion Include="Avalonia.BuildServices" Version="11.3.2" />
-    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.1.1" />
+    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0-beta2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.6" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="Dotnet.Bundle" Version="0.9.13" />

--- a/src/Avalonia.Base/Rendering/Composition/Compositor.Factories.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Compositor.Factories.cs
@@ -14,7 +14,7 @@ public partial class Compositor
     /// <returns></returns>
     internal CompositionTarget CreateCompositionTarget(Func<IEnumerable<object>> surfaces)
     {
-        return new CompositionTarget(this, new ServerCompositionTarget(_server, surfaces, DiagnosticTextRenderer));
+        return new CompositionTarget(this, new ServerCompositionTarget(_server, surfaces));
     }
     
     public CompositionContainerVisual CreateContainerVisual() => new(this, new ServerCompositionContainerVisual(_server));

--- a/src/Avalonia.Base/Rendering/Composition/Compositor.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Compositor.cs
@@ -37,28 +37,11 @@ namespace Avalonia.Rendering.Composition
         private readonly object _pendingBatchLock = new();
         private readonly List<Action> _pendingServerCompositorJobs = new();
         private readonly List<Action> _pendingServerCompositorPostTargetJobs = new();
-        private DiagnosticTextRenderer? _diagnosticTextRenderer;
         private readonly Action _triggerCommitRequested;
 
         internal IEasing DefaultEasing { get; }
 
         internal Dispatcher Dispatcher { get; }
-
-        private DiagnosticTextRenderer? DiagnosticTextRenderer
-        {
-            get
-            {
-                if (_diagnosticTextRenderer == null)
-                {
-                    // We are running in some unit test context
-                    if (AvaloniaLocator.Current.GetService<IFontManagerImpl>() == null)
-                        return null;
-                    _diagnosticTextRenderer = new(Typeface.Default.GlyphTypeface, 12.0);
-                }
-
-                return _diagnosticTextRenderer;
-            }
-        }
 
         internal event Action? AfterCommit;
 

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -39,13 +39,12 @@ namespace Avalonia.Rendering.Composition.Server
         public int RenderedVisuals { get; set; }
         public int VisitedVisuals { get; set; }
 
-        public ServerCompositionTarget(ServerCompositor compositor, Func<IEnumerable<object>> surfaces,
-            DiagnosticTextRenderer? diagnosticTextRenderer)
+        public ServerCompositionTarget(ServerCompositor compositor, Func<IEnumerable<object>> surfaces)
             : base(compositor)
         {
             _compositor = compositor;
             _surfaces = surfaces;
-            _overlays = new CompositionTargetOverlays(this, diagnosticTextRenderer);
+            _overlays = new CompositionTargetOverlays(this);
             var platformRender = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
 
             if (platformRender?.SupportsRegions == true && compositor.Options.UseRegionDirtyRectClipping != false)


### PR DESCRIPTION
## What does the pull request do?
This PR changes the `DiagnosticTextRenderer`, used to render text for diagnostic graphs, to be created lazily.

At the time it was introduced, there were threading concerns, and instances were created solely on the UI thread.
Now, it should be safe to create the underlying `GlyphRun` instances on the render thread on demand.

This avoids allocating unnecessary `GlyphRun` instances on startup and loading the default font, which might otherwise go unused.

Plus, with the removal of the legacy dev tools, it's unlikely those graphs will even be displayed in most apps (they require `RendererDiagnostics` to be explicitly configured).