### PR TITLE
Fix font Weight/Stretch matching

### DIFF
--- a/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
+++ b/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
@@ -731,7 +731,7 @@ namespace Avalonia.Media.Fonts
             {
                 for (var i = 0; stretch + i < 9; i++)
                 {
-                    if (TryGetWithStretch(stretch, out glyphTypeface))
+                    if (TryGetWithStretch(stretch + i, out glyphTypeface))
                     {
                         return true;
                     }
@@ -741,7 +741,7 @@ namespace Avalonia.Media.Fonts
             {
                 for (var i = 0; stretch - i > 1; i++)
                 {
-                    if (TryGetWithStretch(stretch, out glyphTypeface))
+                    if (TryGetWithStretch(stretch - i, out glyphTypeface))
                     {
                         return true;
                     }
@@ -786,7 +786,7 @@ namespace Avalonia.Media.Fonts
                 //Look for available weights between the target and 500, in ascending order.
                 for (var i = 0; weight + i <= 500; i += 50)
                 {
-                    if (TryGetWithWeight(weight, out glyphTypeface))
+                    if (TryGetWithWeight(weight + i, out glyphTypeface))
                     {
                         return true;
                     }
@@ -795,7 +795,7 @@ namespace Avalonia.Media.Fonts
                 //If no match is found, look for available weights less than the target, in descending order.
                 for (var i = 0; weight - i >= 100; i += 50)
                 {
-                    if (TryGetWithWeight(weight, out glyphTypeface))
+                    if (TryGetWithWeight(weight - i, out glyphTypeface))
                     {
                         return true;
                     }
@@ -804,7 +804,7 @@ namespace Avalonia.Media.Fonts
                 //If no match is found, look for available weights greater than 500, in ascending order.
                 for (var i = 0; weight + i <= 900; i += 50)
                 {
-                    if (TryGetWithWeight(weight, out glyphTypeface))
+                    if (TryGetWithWeight(weight + i, out glyphTypeface))
                     {
                         return true;
                     }
@@ -816,7 +816,7 @@ namespace Avalonia.Media.Fonts
             {
                 for (var i = 0; weight - i >= 100; i += 50)
                 {
-                    if (TryGetWithWeight(weight, out glyphTypeface))
+                    if (TryGetWithWeight(weight - i, out glyphTypeface))
                     {
                         return true;
                     }
@@ -825,7 +825,7 @@ namespace Avalonia.Media.Fonts
                 //If no match is found, look for available weights less than the target, in descending order.
                 for (var i = 0; weight + i <= 900; i += 50)
                 {
-                    if (TryGetWithWeight(weight, out glyphTypeface))
+                    if (TryGetWithWeight(weight + i, out glyphTypeface))
                     {
                         return true;
                     }
@@ -837,7 +837,7 @@ namespace Avalonia.Media.Fonts
             {
                 for (var i = 0; weight + i <= 900; i += 50)
                 {
-                    if (TryGetWithWeight(weight, out glyphTypeface))
+                    if (TryGetWithWeight(weight + i, out glyphTypeface))
                     {
                         return true;
                     }
@@ -846,7 +846,7 @@ namespace Avalonia.Media.Fonts
                 //If no match is found, look for available weights less than the target, in descending order.
                 for (var i = 0; weight - i >= 100; i += 50)
                 {
-                    if (TryGetWithWeight(weight, out glyphTypeface))
+                    if (TryGetWithWeight(weight - i, out glyphTypeface))
                     {
                         return true;
                     }

--- a/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
@@ -578,5 +578,46 @@ namespace Avalonia.Skia.UnitTests.Media
                 Assert.Equal("No suitable cmap subtable found.", Assert.IsType<InvalidOperationException>(loggedValues[2]).Message);
             }
         }
+
+        [Theory]
+        [InlineData(FontWeight.Normal, "Inter")]
+        [InlineData(FontWeight.Bold, "Inter")]
+        [InlineData(FontWeight.SemiBold, "Inter SemiBold")]
+        [InlineData(FontWeight.SemiLight, "Inter Light")]
+        public void TryMatchCharacter_Should_Return_Correct_Weight(FontWeight requestedWeight, string expectedFamilyName)
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl()));
+            using var scope = AvaloniaLocator.EnterScope();
+
+            FontManager.Current.AddFontCollection(new InterFontCollection());
+
+            Assert.True(FontManager.Current.TryMatchCharacter(
+                'A', FontStyle.Normal, requestedWeight, FontStretch.Normal, new FontFamily("fonts:Inter#Inter"), null, out var typeface));
+
+            Assert.NotNull(typeface);
+            Assert.Equal(expectedFamilyName, typeface.GlyphTypeface.FamilyName);
+            Assert.Equal(requestedWeight, typeface.Weight);
+        }
+
+        [Theory]
+        [InlineData(FontStretch.Normal)]
+        [InlineData(FontStretch.Condensed)]
+        [InlineData(FontStretch.Expanded)]
+        [InlineData(FontStretch.SemiCondensed)]
+        [InlineData(FontStretch.SemiExpanded)]
+        public void TryMatchCharacter_Should_Return_Correct_Stretch(FontStretch requestedStretch)
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl()));
+            using var scope = AvaloniaLocator.EnterScope();
+
+            FontManager.Current.AddFontCollection(new InterFontCollection());
+
+            Assert.True(FontManager.Current.TryMatchCharacter(
+                'A', FontStyle.Normal, FontWeight.Normal, requestedStretch, new FontFamily("fonts:Inter#Inter"), null, out var typeface));
+
+            Assert.NotNull(typeface);
+            Assert.Equal("Inter", typeface.GlyphTypeface.FamilyName);
+            Assert.Equal(requestedStretch, typeface.Stretch);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes font weight and stretch falling back to the wrong font variants.
The problem was introduced in #20740.
Unit tests have been added.
