### PR TITLE
Fix TextBox validation error persisting when reverting to same valid value

### DIFF
--- a/src/Avalonia.Base/Data/Core/BindingExpression.cs
+++ b/src/Avalonia.Base/Data/Core/BindingExpression.cs
@@ -463,7 +463,7 @@ internal class BindingExpression : UntypedBindingExpressionBase, IDescription, I
             TargetProperty is not null &&
             target.GetValue(TargetProperty) is var value &&
             LeafNode is { } leafNode &&
-            !TypeUtilities.IdentityEquals(value, leafNode.Value, TargetType))
+            (!TypeUtilities.IdentityEquals(value, leafNode.Value, TargetType) || ErrorType != BindingErrorType.None))
         {
             WriteValueToSource(value);
         }

--- a/src/Avalonia.Base/Data/Core/BindingExpression.cs
+++ b/src/Avalonia.Base/Data/Core/BindingExpression.cs
@@ -460,12 +460,9 @@ internal class BindingExpression : UntypedBindingExpressionBase, IDescription, I
         StopDelayTimer();
 
         if (TryGetTarget(out var target) &&
-            TargetProperty is not null &&
-            target.GetValue(TargetProperty) is var value &&
-            LeafNode is { } leafNode &&
-            (!TypeUtilities.IdentityEquals(value, leafNode.Value, TargetType) || ErrorType != BindingErrorType.None))
+            TargetProperty is not null)
         {
-            WriteValueToSource(value);
+            WriteValueToSource(target.GetValue(TargetProperty));
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?

Fixes a bug where a `TextBox` validation error persists after the user reverts to the same valid value that was previously set.

## What is the current behavior?

When a `TextBox` is bound (TwoWay) to a property whose setter throws on invalid values:

1. Type a valid value (e.g. "Hello") — no error
2. Clear the text (e.g. Ctrl+A, Ctrl+X) — setter throws, error appears correctly
3. Paste back the same valid value ("Hello") — **bug: the error stays visible**

The root cause is in `WriteTargetValueToSource()`. It compares the current target value against `LeafNode.Value` (the last successfully-written value) and skips the write if they match. When the user pastes back the same valid value, the comparison short-circuits and `WriteValueToSource()` is never called, so the validation error is never cleared.

## What is the updated/expected behavior with this PR?

Pasting back the same valid value clears the validation error as expected.

## How was the solution implemented?

Added `|| ErrorType != BindingErrorType.None` to the condition in `WriteTargetValueToSource()` so that the setter is still invoked when there is a pending validation error, even if the value hasn't changed. This matches the pattern already used inside `WriteValueToSource()`.

## Fixed issues

Fixes #20534
