### PR TITLE
Fix pixel rounding and visual transforms in NativeControlHost

### DIFF
--- a/src/Avalonia.Controls/NativeControlHost.cs
+++ b/src/Avalonia.Controls/NativeControlHost.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Automation.Peers;
 using Avalonia.Controls.Platform;
+using Avalonia.Layout;
 using Avalonia.Platform;
 using Avalonia.Rendering;
 using Avalonia.Threading;
@@ -152,6 +153,18 @@ namespace Avalonia.Controls
             if (transformToVisual == null)
                 return null;
             var transformedRect = new Rect(default, bounds.Size).TransformToAABB(transformToVisual.Value);
+            // Transformed rect should be pixel-rounded if layout rounding is enabled.
+            // This is important for native controls to align correctly with Avalonia's visual tree.
+            if (UseLayoutRounding)
+            {
+                var scale = LayoutHelper.GetLayoutScale(this);
+                var left = LayoutHelper.RoundLayoutValue(transformedRect.X, scale);
+                var top = LayoutHelper.RoundLayoutValue(transformedRect.Y, scale);
+                var right = LayoutHelper.RoundLayoutValue(transformedRect.Right, scale);
+                var bottom = LayoutHelper.RoundLayoutValue(transformedRect.Bottom, scale);
+                transformedRect = new Rect(new Point(left, top), new Point(right, bottom));
+            }
+
             return transformedRect;
         }
 


### PR DESCRIPTION
## What does the pull request do?
The width and height were computed using (int) truncation which can lose a pixel at the right and bottom edges when the transformed bounds have fractional values. Compute the right/bottom edges using Math.Ceiling before deriving the size to ensure the native window fully covers the visual area.

## What is the current behavior?
<img width="584" height="467" alt="image" src="https://github.com/user-attachments/assets/9b1f514b-9060-4137-acf8-0fdd6131a528" />

## What is the updated/expected behavior with this PR?
No extra offset.

## How was the solution implemented (if it's not obvious)?
Compute the right/bottom edges using Math.Ceiling before deriving the size to ensure the native window fully covers the visual area.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

## Obsoletions / Deprecations


## Fixed issues

Have not checked other platforms, may be affected too.
