### PR TITLE
Move Gesture events to InputElement

### DIFF
--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -105,6 +105,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Avalonia.Input.Gestures</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Avalonia.Input.IDataObject</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
@@ -244,6 +250,12 @@
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Avalonia.Controls.AutoCompleteBox.BindingEvaluator`1</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Avalonia.Controls.ContextRequestedEventArgs</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
   </Suppression>
@@ -501,6 +513,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Avalonia.Input.Gestures</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Avalonia.Input.IDataObject</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
@@ -640,6 +658,12 @@
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Avalonia.Controls.AutoCompleteBox.BindingEvaluator`1</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Avalonia.Controls.ContextRequestedEventArgs</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
   </Suppression>
@@ -867,6 +891,24 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Data.CompiledBindingPathBuilder.StreamObservable</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Data.CompiledBindingPathBuilder.StreamTask</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Data.CompiledBindingPathBuilder.TypeCast(System.Type)</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Data.ReflectionBinding.#ctor(System.String,Avalonia.Data.BindingMode)</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
@@ -910,6 +952,12 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Input.DragEventArgs.get_Data</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Input.HoldingRoutedEventArgs.#ctor(Avalonia.Input.HoldingState,Avalonia.Point,Avalonia.Input.PointerType)</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
   </Suppression>
@@ -1318,6 +1366,12 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:Avalonia.Controls.ContextMenu.PlacementModeProperty</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Avalonia.Controls.Control.ContextRequestedEvent</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
   </Suppression>
@@ -1983,6 +2037,24 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Data.CompiledBindingPathBuilder.StreamObservable</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Data.CompiledBindingPathBuilder.StreamTask</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Data.CompiledBindingPathBuilder.TypeCast(System.Type)</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Data.ReflectionBinding.#ctor(System.String,Avalonia.Data.BindingMode)</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
@@ -2026,6 +2098,12 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Input.DragEventArgs.get_Data</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Input.HoldingRoutedEventArgs.#ctor(Avalonia.Input.HoldingState,Avalonia.Point,Avalonia.Input.PointerType)</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
   </Suppression>
@@ -2434,6 +2512,12 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:Avalonia.Controls.ContextMenu.PlacementModeProperty</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Avalonia.Controls.Control.ContextRequestedEvent</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
   </Suppression>
@@ -3819,6 +3903,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0009</DiagnosticId>
+    <Target>T:Avalonia.Input.HoldingRoutedEventArgs</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0009</DiagnosticId>
     <Target>T:Avalonia.Controls.Primitives.AdornerLayer</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
@@ -3850,6 +3940,12 @@
   <Suppression>
     <DiagnosticId>CP0009</DiagnosticId>
     <Target>T:Avalonia.Input.DataObject</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0009</DiagnosticId>
+    <Target>T:Avalonia.Input.HoldingRoutedEventArgs</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
   </Suppression>

--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -849,6 +849,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Avalonia.Input.HoldingState.Cancelled</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:Avalonia.Media.DrawingImage.ViewboxProperty</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
@@ -1990,6 +1996,12 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:Avalonia.Input.DataFormats.Text</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Avalonia.Input.HoldingState.Cancelled</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
   </Suppression>

--- a/samples/ControlCatalog/Pages/ContextFlyoutPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ContextFlyoutPage.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using ControlCatalog.ViewModels;
 

--- a/samples/ControlCatalog/Pages/ContextMenuPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ContextMenuPage.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using Avalonia.Controls;
+using Avalonia.Input;
 using ControlCatalog.ViewModels;
 
 namespace ControlCatalog.Pages

--- a/samples/ControlCatalog/Pages/GesturePage.cs
+++ b/samples/ControlCatalog/Pages/GesturePage.cs
@@ -52,7 +52,7 @@ namespace ControlCatalog.Pages
                 }
             };
 
-            RotationGesture.AddHandler(Gestures.PinchEvent, (s, e) =>
+            RotationGesture.AddHandler(InputElement.PinchEvent, (s, e) =>
             {
                 AngleSlider.Value = e.Angle;
             });
@@ -94,7 +94,7 @@ namespace ControlCatalog.Pages
                 }
             };
 
-            control.AddHandler(Gestures.PinchEvent, (s, e) =>
+            control.AddHandler(InputElement.PinchEvent, (s, e) =>
             {
                 InitComposition(control!);
 
@@ -114,7 +114,7 @@ namespace ControlCatalog.Pages
                 }
             });
 
-            control.AddHandler(Gestures.PinchEndedEvent, (s, e) =>
+            control.AddHandler(InputElement.PinchEndedEvent, (s, e) =>
             {
                 InitComposition(control!);
 
@@ -124,7 +124,7 @@ namespace ControlCatalog.Pages
                 }
             });
 
-            control.AddHandler(Gestures.ScrollGestureEvent, (s, e) =>
+            control.AddHandler(InputElement.ScrollGestureEvent, (s, e) =>
             {
                 InitComposition(control!);
 
@@ -171,7 +171,7 @@ namespace ControlCatalog.Pages
                 }
             };
 
-            control.AddHandler(Gestures.PullGestureEvent, (s, e) =>
+            control.AddHandler(InputElement.PullGestureEvent, (s, e) =>
             {
                 Vector3D center = new((float)control.Bounds.Center.X, (float)control.Bounds.Center.Y, 0);
                 InitComposition(ball!);
@@ -183,7 +183,7 @@ namespace ControlCatalog.Pages
                 }
             });
 
-            control.AddHandler(Gestures.PullGestureEndedEvent, (s, e) =>
+            control.AddHandler(InputElement.PullGestureEndedEvent, (s, e) =>
             {
                 InitComposition(ball!);
                 if (ballCompositionVisual != null)

--- a/samples/IntegrationTestApp/Pages/GesturesPage.axaml
+++ b/samples/IntegrationTestApp/Pages/GesturesPage.axaml
@@ -19,7 +19,7 @@
               AutomationProperties.ControlTypeOverride="Image"
               Tapped="GestureBorder_Tapped"
               DoubleTapped="GestureBorder_DoubleTapped"
-              Gestures.RightTapped="GestureBorder_RightTapped"/>
+              InputElement.RightTapped="GestureBorder_RightTapped"/>
       <Border Name="GestureBorder2" Background="Green" IsVisible="False"
               AutomationProperties.AccessibilityView="Content"
               AutomationProperties.ControlTypeOverride="Image"

--- a/samples/IntegrationTestApp/Pages/GesturesPage.axaml
+++ b/samples/IntegrationTestApp/Pages/GesturesPage.axaml
@@ -19,7 +19,7 @@
               AutomationProperties.ControlTypeOverride="Image"
               Tapped="GestureBorder_Tapped"
               DoubleTapped="GestureBorder_DoubleTapped"
-              InputElement.RightTapped="GestureBorder_RightTapped"/>
+              RightTapped="GestureBorder_RightTapped"/>
       <Border Name="GestureBorder2" Background="Green" IsVisible="False"
               AutomationProperties.AccessibilityView="Content"
               AutomationProperties.ControlTypeOverride="Image"

--- a/src/Avalonia.Base/Input/ContextRequestedEventArgs.cs
+++ b/src/Avalonia.Base/Input/ContextRequestedEventArgs.cs
@@ -1,7 +1,6 @@
-﻿using Avalonia.Input;
-using Avalonia.Interactivity;
+﻿using Avalonia.Interactivity;
 
-namespace Avalonia.Controls
+namespace Avalonia.Input
 {
     /// <summary>
     /// Provides event data for the ContextRequested event.
@@ -14,7 +13,7 @@ namespace Avalonia.Controls
         /// Initializes a new instance of the ContextRequestedEventArgs class.
         /// </summary>
         public ContextRequestedEventArgs()
-            : base(Control.ContextRequestedEvent)
+            : base(InputElement.ContextRequestedEvent)
         {
 
         }
@@ -48,7 +47,7 @@ namespace Avalonia.Controls
         /// <returns>
         /// true if the context request was initiated by a pointer device; otherwise, false.
         /// </returns>
-        public bool TryGetPosition(Control? relativeTo, out Point point)
+        public bool TryGetPosition(InputElement? relativeTo, out Point point)
         {
             if (_pointerEventArgs is null)
             {

--- a/src/Avalonia.Base/Input/ContextRequestedEventArgs.cs
+++ b/src/Avalonia.Base/Input/ContextRequestedEventArgs.cs
@@ -33,10 +33,10 @@ namespace Avalonia.Input
         }
 
         /// <summary>
-        /// Gets the x- and y-coordinates of the pointer position, optionally evaluated against a coordinate origin of a supplied <see cref="Control"/>.
+        /// Gets the x- and y-coordinates of the pointer position, optionally evaluated against a coordinate origin of a supplied <see cref="InputElement"/>.
         /// </summary>
         /// <param name="relativeTo">
-        /// Any <see cref="Control"/>-derived object that is connected to the same object tree.
+        /// Any <see cref="InputElement"/>-derived object that is connected to the same object tree.
         /// To specify the object relative to the overall coordinate system, use a relativeTo  value of null.
         /// </param>
         /// <param name="point">

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -1,15 +1,19 @@
 using System;
 using System.Threading;
 using Avalonia.Interactivity;
-using Avalonia.Platform;
-using Avalonia.Threading;
 using Avalonia.Reactive;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Input
 {
-    public static class Gestures
+    internal static class Gestures
     {
+        public static event EventHandler<HoldingRoutedEventArgs>? Holding;
+        public static event EventHandler<TappedEventArgs>? Tapped;
+        public static event EventHandler<TappedEventArgs>? RightTapped;
+        public static event EventHandler<TappedEventArgs>? DoubleTapped;
+
         private record struct GestureState(GestureStateType Type, IPointer Pointer);
         private enum GestureStateType
         {
@@ -23,200 +27,13 @@ namespace Avalonia.Input
         private static Point s_lastPressPoint;
         private static CancellationTokenSource? s_holdCancellationToken;
 
-        /// <summary>
-        /// Defines the IsHoldingEnabled attached property.
-        /// </summary>
-        public static readonly AttachedProperty<bool> IsHoldingEnabledProperty =
-            AvaloniaProperty.RegisterAttached<StyledElement, bool>("IsHoldingEnabled", typeof(Gestures), true);
-
-        /// <summary>
-        /// Defines the IsHoldWithMouseEnabled attached property.
-        /// </summary>
-        public static readonly AttachedProperty<bool> IsHoldWithMouseEnabledProperty =
-            AvaloniaProperty.RegisterAttached<StyledElement, bool>("IsHoldWithMouseEnabled", typeof(Gestures), false);
-
-        public static readonly RoutedEvent<TappedEventArgs> TappedEvent = RoutedEvent.Register<TappedEventArgs>(
-            "Tapped",
-            RoutingStrategies.Bubble,
-            typeof(Gestures));
-
-        public static readonly RoutedEvent<TappedEventArgs> DoubleTappedEvent = RoutedEvent.Register<TappedEventArgs>(
-            "DoubleTapped",
-            RoutingStrategies.Bubble,
-            typeof(Gestures));
-
-        public static readonly RoutedEvent<TappedEventArgs> RightTappedEvent = RoutedEvent.Register<TappedEventArgs>(
-            "RightTapped",
-            RoutingStrategies.Bubble,
-            typeof(Gestures));
-
-        public static readonly RoutedEvent<ScrollGestureEventArgs> ScrollGestureEvent =
-            RoutedEvent.Register<ScrollGestureEventArgs>(
-                "ScrollGesture", RoutingStrategies.Bubble, typeof(Gestures));
-
-        public static readonly RoutedEvent<ScrollGestureInertiaStartingEventArgs> ScrollGestureInertiaStartingEvent =
-            RoutedEvent.Register<ScrollGestureInertiaStartingEventArgs>(
-                "ScrollGestureInertiaStarting", RoutingStrategies.Bubble, typeof(Gestures));
-
-        public static readonly RoutedEvent<ScrollGestureEndedEventArgs> ScrollGestureEndedEvent =
-            RoutedEvent.Register<ScrollGestureEndedEventArgs>(
-                "ScrollGestureEnded", RoutingStrategies.Bubble, typeof(Gestures));
-        
-        public static readonly RoutedEvent<PointerDeltaEventArgs> PointerTouchPadGestureMagnifyEvent =
-            RoutedEvent.Register<PointerDeltaEventArgs>(
-                "PointerTouchPadGestureMagnify", RoutingStrategies.Bubble, typeof(Gestures));
-        
-        public static readonly RoutedEvent<PointerDeltaEventArgs> PointerTouchPadGestureRotateEvent =
-            RoutedEvent.Register<PointerDeltaEventArgs>(
-                "PointerTouchPadGestureRotate", RoutingStrategies.Bubble, typeof(Gestures));
-        
-        public static readonly RoutedEvent<PointerDeltaEventArgs> PointerTouchPadGestureSwipeEvent =
-            RoutedEvent.Register<PointerDeltaEventArgs>(
-                "PointerTouchPadGestureSwipe", RoutingStrategies.Bubble, typeof(Gestures));
-
-        public static readonly RoutedEvent<PinchEventArgs> PinchEvent =
-            RoutedEvent.Register<PinchEventArgs>(
-                "Pinch", RoutingStrategies.Bubble, typeof(Gestures));
-
-        public static readonly RoutedEvent<PinchEndedEventArgs> PinchEndedEvent =
-            RoutedEvent.Register<PinchEndedEventArgs>(
-                "PinchEnded", RoutingStrategies.Bubble, typeof(Gestures));
-
-        public static readonly RoutedEvent<PullGestureEventArgs> PullGestureEvent =
-            RoutedEvent.Register<PullGestureEventArgs>(
-                "PullGesture", RoutingStrategies.Bubble, typeof(Gestures));
-
-        /// <summary>
-        /// Occurs when a user performs a press and hold gesture (with a single touch, mouse, or pen/stylus contact).
-        /// </summary>
-        public static readonly RoutedEvent<HoldingRoutedEventArgs> HoldingEvent =
-            RoutedEvent.Register<HoldingRoutedEventArgs>(
-                "Holding", RoutingStrategies.Bubble, typeof(Gestures));
-
-        public static readonly RoutedEvent<PullGestureEndedEventArgs> PullGestureEndedEvent =
-            RoutedEvent.Register<PullGestureEndedEventArgs>(
-                "PullGestureEnded", RoutingStrategies.Bubble, typeof(Gestures));
-
-        public static bool GetIsHoldingEnabled(StyledElement element)
-        {
-            return element.GetValue(IsHoldingEnabledProperty);
-        }
-        public static void SetIsHoldingEnabled(StyledElement element, bool value)
-        {
-            element.SetValue(IsHoldingEnabledProperty, value);
-        }
-
-        public static bool GetIsHoldWithMouseEnabled(StyledElement element)
-        {
-            return element.GetValue(IsHoldWithMouseEnabledProperty);
-        }
-        public static void SetIsHoldWithMouseEnabled(StyledElement element, bool value)
-        {
-            element.SetValue(IsHoldWithMouseEnabledProperty, value);
-        }
-
         static Gestures()
         {
             InputElement.PointerPressedEvent.RouteFinished.Subscribe(PointerPressed);
             InputElement.PointerReleasedEvent.RouteFinished.Subscribe(PointerReleased);
             InputElement.PointerMovedEvent.RouteFinished.Subscribe(PointerMoved);
+           //InputElement.PointerCaptureLostEvent.RouteFinished.Subscribe(PointerCaptureLost);
         }
-
-        public static void AddTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
-        {
-            element.AddHandler(TappedEvent, handler);
-        }
-
-        public static void AddDoubleTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
-        {
-            element.AddHandler(DoubleTappedEvent, handler);
-        }
-
-        public static void AddRightTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
-        {
-            element.AddHandler(RightTappedEvent, handler);
-        }
-
-        public static void AddHoldingHandler(Interactive element, EventHandler<HoldingRoutedEventArgs> handler) =>
-            element.AddHandler(HoldingEvent, handler);
-
-        public static void AddPinchHandler(Interactive element, EventHandler<PinchEventArgs> handler) =>
-            element.AddHandler(PinchEvent, handler);
-
-        public static void AddPinchEndedHandler(Interactive element, EventHandler<PinchEndedEventArgs> handler) =>
-            element.AddHandler(PinchEndedEvent, handler);
-
-        public static void AddPullGestureHandler(Interactive element, EventHandler<PullGestureEventArgs> handler) =>
-            element.AddHandler(PullGestureEvent, handler);
-
-        public static void AddPullGestureEndedHandler(Interactive element, EventHandler<PullGestureEndedEventArgs> handler) =>
-            element.AddHandler(PullGestureEndedEvent, handler);
-
-        public static void AddPointerTouchPadGestureMagnifyHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
-            element.AddHandler(PointerTouchPadGestureMagnifyEvent, handler);
-
-        public static void AddPointerTouchPadGestureRotateHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
-            element.AddHandler(PointerTouchPadGestureRotateEvent, handler);
-
-        public static void AddPointerTouchPadGestureSwipeHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
-            element.AddHandler(PointerTouchPadGestureSwipeEvent, handler);
-
-        public static void AddScrollGestureHandler(Interactive element, EventHandler<RoutedEventArgs> handler) =>
-            element.AddHandler(ScrollGestureEvent, handler);
-
-        public static void AddScrollGestureEndedHandler(Interactive element, EventHandler<ScrollGestureEndedEventArgs> handler) =>
-            element.AddHandler(ScrollGestureEndedEvent, handler);
-
-        public static void AddScrollGestureInertiaStartingHandler(Interactive element, EventHandler<ScrollGestureInertiaStartingEventArgs> handler) =>
-            element.AddHandler(ScrollGestureInertiaStartingEvent, handler);
-
-        public static void RemoveTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
-        {
-            element.RemoveHandler(TappedEvent, handler);
-        }
-
-        public static void RemoveDoubleTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
-        {
-            element.RemoveHandler(DoubleTappedEvent, handler);
-        }
-
-        public static void RemoveRightTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
-        {
-            element.RemoveHandler(RightTappedEvent, handler);
-        }
-
-        public static void RemoveHoldingHandler(Interactive element, EventHandler<RoutedEventArgs> handler) =>
-            element.RemoveHandler(HoldingEvent, handler);
-
-        public static void RemovePinchHandler(Interactive element, EventHandler<PinchEventArgs> handler) =>
-            element.RemoveHandler(PinchEvent, handler);
-
-        public static void RemovePinchEndedHandler(Interactive element, EventHandler<PinchEndedEventArgs> handler) =>
-            element.RemoveHandler(PinchEndedEvent, handler);
-
-        public static void RemovePullGestureHandler(Interactive element, EventHandler<PullGestureEventArgs> handler) =>
-            element.RemoveHandler(PullGestureEvent, handler);
-
-        public static void RemovePullGestureEndedHandler(Interactive element, EventHandler<PullGestureEndedEventArgs> handler) =>
-            element.RemoveHandler(PullGestureEndedEvent, handler);
-
-        public static void RemovePointerTouchPadGestureMagnifyHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
-            element.RemoveHandler(PointerTouchPadGestureMagnifyEvent, handler);
-
-        public static void RemovePointerTouchPadGestureRotateHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
-            element.RemoveHandler(PointerTouchPadGestureRotateEvent, handler);
-
-        public static void RemovePointerTouchPadGestureSwipeHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
-            element.RemoveHandler(PointerTouchPadGestureSwipeEvent, handler);
-
-        public static void RemoveScrollGestureHandler(Interactive element, EventHandler<ScrollGestureEventArgs> handler) =>
-            element.RemoveHandler(ScrollGestureEvent,handler);
-
-        public static void RemoveScrollGestureEndedHandler(Interactive element,EventHandler<ScrollGestureEndedEventArgs> handler) =>
-            element.RemoveHandler(ScrollGestureEndedEvent,handler);
-
-        public static void RemoveScrollGestureInertiaStartingHandler(Interactive element, EventHandler<ScrollGestureInertiaStartingEventArgs> handler) =>
-            element.RemoveHandler(ScrollGestureInertiaStartingEvent, handler);
 
         private static object? GetCaptured(RoutedEventArgs? args)
         {
@@ -237,11 +54,11 @@ namespace Avalonia.Input
                 var e = (PointerPressedEventArgs)ev;
                 var visual = (Visual)source;
 
-                if(s_gestureState != null)
+                if (s_gestureState != null)
                 {
-                    if(s_gestureState.Value.Type == GestureStateType.Holding && source is Interactive i)
+                    if (s_gestureState.Value.Type == GestureStateType.Holding && source is Interactive i)
                     {
-                        i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
+                        Holding?.Invoke(i, new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
                     }
                     s_holdCancellationToken?.Cancel();
                     s_holdCancellationToken?.Dispose();
@@ -263,22 +80,23 @@ namespace Avalonia.Input
                     {
                         DispatcherTimer.RunOnce(() =>
                         {
-                            if (s_gestureState != null && !token.IsCancellationRequested && source is InputElement i && GetIsHoldingEnabled(i) && (e.Pointer.Type != PointerType.Mouse || GetIsHoldWithMouseEnabled(i)))
+                            if (s_gestureState != null && !token.IsCancellationRequested && source is InputElement i && InputElement.GetIsHoldingEnabled(i) &&
+                            (e.Pointer.Type != PointerType.Mouse || InputElement.GetIsHoldWithMouseEnabled(i)))
                             {
                                 s_gestureState = new GestureState(GestureStateType.Holding, s_gestureState.Value.Pointer);
-                                i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Started, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
+                                Holding?.Invoke(i, new HoldingRoutedEventArgs(HoldingState.Started, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
                             }
                         }, settings.HoldWaitDuration);
                     }
                 }
                 else if (e.ClickCount % 2 == 0 && e.GetCurrentPoint(visual).Properties.IsLeftButtonPressed)
                 {
-                    if (s_lastPress.TryGetTarget(out var target) && 
-                        target == source && 
+                    if (s_lastPress.TryGetTarget(out var target) &&
+                        target == source &&
                         source is Interactive i)
                     {
                         s_gestureState = new GestureState(GestureStateType.DoubleTapped, e.Pointer);
-                        i.RaiseEvent(new TappedEventArgs(DoubleTappedEvent, e));
+                        DoubleTapped?.Invoke(i, new TappedEventArgs(InputElement.DoubleTappedEvent, e));
                     }
                 }
             }
@@ -307,17 +125,19 @@ namespace Avalonia.Input
                     {
                         if (s_gestureState?.Type == GestureStateType.Holding)
                         {
-                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Completed, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
+                            Holding?.Invoke(i, new HoldingRoutedEventArgs(HoldingState.Completed, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
+
+                            RightTapped?.Invoke(i, new TappedEventArgs(InputElement.RightTappedEvent, e));
                         }
                         else if (e.InitialPressMouseButton == MouseButton.Right)
                         {
-                            i.RaiseEvent(new TappedEventArgs(RightTappedEvent, e));
+                            RightTapped?.Invoke(i, new TappedEventArgs(InputElement.RightTappedEvent, e));
                         }
                         //GestureStateType.DoubleTapped needed here to prevent invoking Tapped event when DoubleTapped is called.
                         //This behaviour matches UWP behaviour.
                         else if (s_gestureState?.Type != GestureStateType.DoubleTapped)
                         {
-                            i.RaiseEvent(new TappedEventArgs(TappedEvent, e));
+                            Tapped?.Invoke(i, new TappedEventArgs(InputElement.TappedEvent, e));
                         }
                     }
                     s_gestureState = null;
@@ -351,16 +171,35 @@ namespace Avalonia.Input
 
                         if (s_gestureState.Value.Type == GestureStateType.Holding)
                         {
-                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
+                            Holding?.Invoke(i, new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
                         }
+
+                        s_holdCancellationToken?.Cancel();
+                        s_holdCancellationToken?.Dispose();
+                        s_holdCancellationToken = null;
+                        s_gestureState = null;
                     }
                 }
-
-                s_holdCancellationToken?.Cancel();
-                s_holdCancellationToken?.Dispose();
-                s_holdCancellationToken = null;
-                s_gestureState = null;
             }
         }
+
+       /* private static void PointerCaptureLost(RoutedEventArgs args)
+        {
+            if (args is PointerCaptureLostEventArgs && s_lastPress.TryGetTarget(out var target))
+            {
+                if (target == args.Source)
+                {
+                    if (s_gestureState?.Type == GestureStateType.Holding)
+                    {
+                        Holding?.Invoke(target, new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_gestureState.Value.Pointer.Type));
+                    }
+
+                    s_holdCancellationToken?.Cancel();
+                    s_holdCancellationToken?.Dispose();
+                    s_holdCancellationToken = null;
+                    s_gestureState = null;
+                }
+            }
+        }*/
     }
 }

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -9,6 +9,10 @@ namespace Avalonia.Input
 {
     internal static class Gestures
     {
+        // These events are only used internally and not propagated through a route.
+        // They have routed event args as their target type because their args generated from
+        // PointerEventArgs. In order to prevent having identical classes with just their base class
+        // being different, these events use routed args.
         public static event EventHandler<HoldingRoutedEventArgs>? Holding;
         public static event EventHandler<TappedEventArgs>? Tapped;
         public static event EventHandler<TappedEventArgs>? RightTapped;
@@ -32,7 +36,6 @@ namespace Avalonia.Input
             InputElement.PointerPressedEvent.RouteFinished.Subscribe(PointerPressed);
             InputElement.PointerReleasedEvent.RouteFinished.Subscribe(PointerReleased);
             InputElement.PointerMovedEvent.RouteFinished.Subscribe(PointerMoved);
-           //InputElement.PointerCaptureLostEvent.RouteFinished.Subscribe(PointerCaptureLost);
         }
 
         private static object? GetCaptured(RoutedEventArgs? args)
@@ -182,24 +185,5 @@ namespace Avalonia.Input
                 }
             }
         }
-
-       /* private static void PointerCaptureLost(RoutedEventArgs args)
-        {
-            if (args is PointerCaptureLostEventArgs && s_lastPress.TryGetTarget(out var target))
-            {
-                if (target == args.Source)
-                {
-                    if (s_gestureState?.Type == GestureStateType.Holding)
-                    {
-                        Holding?.Invoke(target, new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_gestureState.Value.Pointer.Type));
-                    }
-
-                    s_holdCancellationToken?.Cancel();
-                    s_holdCancellationToken?.Dispose();
-                    s_holdCancellationToken = null;
-                    s_gestureState = null;
-                }
-            }
-        }*/
     }
 }

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -61,7 +61,7 @@ namespace Avalonia.Input
                 {
                     if (s_gestureState.Value.Type == GestureStateType.Holding && source is Interactive i)
                     {
-                        Holding?.Invoke(i, new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
+                        Holding?.Invoke(i, new HoldingRoutedEventArgs(HoldingState.Canceled, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
                     }
                     s_holdCancellationToken?.Cancel();
                     s_holdCancellationToken?.Dispose();
@@ -174,7 +174,7 @@ namespace Avalonia.Input
 
                         if (s_gestureState.Value.Type == GestureStateType.Holding)
                         {
-                            Holding?.Invoke(i, new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
+                            Holding?.Invoke(i, new HoldingRoutedEventArgs(HoldingState.Canceled, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
                         }
 
                         s_holdCancellationToken?.Cancel();

--- a/src/Avalonia.Base/Input/HoldingRoutedEventArgs.cs
+++ b/src/Avalonia.Base/Input/HoldingRoutedEventArgs.cs
@@ -6,7 +6,7 @@ namespace Avalonia.Input
     public class HoldingRoutedEventArgs : RoutedEventArgs
     {
         /// <summary>
-        /// Gets the state of the <see cref="Gestures.HoldingEvent"/> event.
+        /// Gets the state of the <see cref="InputElement.HoldingEvent"/> event.
         /// </summary>
         public HoldingState HoldingState { get; }
 
@@ -20,24 +20,17 @@ namespace Avalonia.Input
         /// </summary>
         public PointerType PointerType { get; }
 
-        internal PointerEventArgs? PointerEventArgs { get; }
+        internal PointerEventArgs PointerEventArgs { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HoldingRoutedEventArgs"/> class.
         /// </summary>
-        public HoldingRoutedEventArgs(HoldingState holdingState, Point position, PointerType pointerType) : base(Gestures.HoldingEvent)
+        internal HoldingRoutedEventArgs(HoldingState holdingState, Point position, PointerType pointerType, PointerEventArgs pointerEventArgs) : base(InputElement.HoldingEvent)
         {
+            PointerEventArgs = pointerEventArgs;
             HoldingState = holdingState;
             Position = position;
             PointerType = pointerType;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HoldingRoutedEventArgs"/> class.
-        /// </summary>
-        internal HoldingRoutedEventArgs(HoldingState holdingState, Point position, PointerType pointerType, PointerEventArgs pointerEventArgs) : this(holdingState, position, pointerType)
-        {
-            PointerEventArgs = pointerEventArgs;
         }
     }
 

--- a/src/Avalonia.Base/Input/HoldingRoutedEventArgs.cs
+++ b/src/Avalonia.Base/Input/HoldingRoutedEventArgs.cs
@@ -49,6 +49,6 @@ namespace Avalonia.Input
         /// <summary>
         /// An additional contact is detected or a subsequent gesture (such as a slide) is detected.
         /// </summary>
-        Cancelled,
+        Canceled,
     }
 }

--- a/src/Avalonia.Base/Input/InputElement.Gestures.cs
+++ b/src/Avalonia.Base/Input/InputElement.Gestures.cs
@@ -222,9 +222,9 @@ namespace Avalonia.Input
                         inputElement._isContextMenuOnHolding = true;
                     }
                 }
-                else if (e.HoldingState == HoldingState.Cancelled && inputElement._isContextMenuOnHolding)
+                else if (e.HoldingState == HoldingState.Canceled && inputElement._isContextMenuOnHolding)
                 {
-                    inputElement.RaiseEvent(new RoutedEventArgs(InputElement.ContextCancelledEvent)
+                    inputElement.RaiseEvent(new RoutedEventArgs(InputElement.ContextCanceledEvent)
                     {
                         Source = inputElement
                     });

--- a/src/Avalonia.Base/Input/InputElement.Gestures.cs
+++ b/src/Avalonia.Base/Input/InputElement.Gestures.cs
@@ -72,7 +72,7 @@ namespace Avalonia.Input
         /// </summary>
         public static readonly RoutedEvent<TappedEventArgs> RightTappedEvent =
             RoutedEvent.Register<InputElement, TappedEventArgs>(
-                nameof(Tapped),
+                nameof(RightTapped),
                 RoutingStrategies.Bubble);
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Avalonia.Input
         public static readonly RoutedEvent<TappedEventArgs> DoubleTappedEvent =
             RoutedEvent.Register<InputElement, TappedEventArgs>(
                 nameof(DoubleTapped),
-                RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+                RoutingStrategies.Bubble);
 
         public static bool GetIsHoldingEnabled(StyledElement element)
         {
@@ -142,7 +142,7 @@ namespace Avalonia.Input
         public static void AddPointerTouchPadGestureSwipeHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
             element.AddHandler(PointerTouchPadGestureSwipeEvent, handler);
 
-        public static void AddScrollGestureHandler(Interactive element, EventHandler<RoutedEventArgs> handler) =>
+        public static void AddScrollGestureHandler(Interactive element, EventHandler<ScrollGestureEventArgs> handler) =>
             element.AddHandler(ScrollGestureEvent, handler);
 
         public static void AddScrollGestureEndedHandler(Interactive element, EventHandler<ScrollGestureEndedEventArgs> handler) =>

--- a/src/Avalonia.Base/Input/InputElement.Gestures.cs
+++ b/src/Avalonia.Base/Input/InputElement.Gestures.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Input
+{
+    public partial class InputElement
+    {
+        private bool _isContextMenuOnHolding;
+
+        /// <summary>
+        /// Defines the IsHoldingEnabled attached property.
+        /// </summary>
+        public static readonly AttachedProperty<bool> IsHoldingEnabledProperty =
+            AvaloniaProperty.RegisterAttached<StyledElement, bool>("IsHoldingEnabled", typeof(InputElement), true);
+
+        /// <summary>
+        /// Defines the IsHoldWithMouseEnabled attached property.
+        /// </summary>
+        public static readonly AttachedProperty<bool> IsHoldWithMouseEnabledProperty =
+            AvaloniaProperty.RegisterAttached<StyledElement, bool>("IsHoldWithMouseEnabled", typeof(InputElement), false);
+
+        public static readonly RoutedEvent<PinchEventArgs> PinchEvent =
+            RoutedEvent.Register<PinchEventArgs>(
+                "Pinch", RoutingStrategies.Bubble, typeof(InputElement));
+
+        public static readonly RoutedEvent<PinchEndedEventArgs> PinchEndedEvent =
+            RoutedEvent.Register<PinchEndedEventArgs>(
+                "PinchEnded", RoutingStrategies.Bubble, typeof(InputElement));
+
+        public static readonly RoutedEvent<PullGestureEventArgs> PullGestureEvent =
+            RoutedEvent.Register<PullGestureEventArgs>(
+                "PullGesture", RoutingStrategies.Bubble, typeof(InputElement));
+
+        public static readonly RoutedEvent<PullGestureEndedEventArgs> PullGestureEndedEvent =
+            RoutedEvent.Register<PullGestureEndedEventArgs>(
+                "PullGestureEnded", RoutingStrategies.Bubble, typeof(InputElement));
+
+        public static readonly RoutedEvent<ScrollGestureEventArgs> ScrollGestureEvent =
+            RoutedEvent.Register<ScrollGestureEventArgs>(
+                "ScrollGesture", RoutingStrategies.Bubble, typeof(InputElement));
+
+        public static readonly RoutedEvent<ScrollGestureInertiaStartingEventArgs> ScrollGestureInertiaStartingEvent =
+            RoutedEvent.Register<ScrollGestureInertiaStartingEventArgs>(
+                "ScrollGestureInertiaStarting", RoutingStrategies.Bubble, typeof(InputElement));
+
+        public static readonly RoutedEvent<ScrollGestureEndedEventArgs> ScrollGestureEndedEvent =
+            RoutedEvent.Register<ScrollGestureEndedEventArgs>(
+                "ScrollGestureEnded", RoutingStrategies.Bubble, typeof(InputElement));
+
+        public static readonly RoutedEvent<PointerDeltaEventArgs> PointerTouchPadGestureMagnifyEvent =
+            RoutedEvent.Register<PointerDeltaEventArgs>(
+                "PointerTouchPadGestureMagnify", RoutingStrategies.Bubble, typeof(InputElement));
+
+        public static readonly RoutedEvent<PointerDeltaEventArgs> PointerTouchPadGestureRotateEvent =
+            RoutedEvent.Register<PointerDeltaEventArgs>(
+                "PointerTouchPadGestureRotate", RoutingStrategies.Bubble, typeof(InputElement));
+
+        public static readonly RoutedEvent<PointerDeltaEventArgs> PointerTouchPadGestureSwipeEvent =
+            RoutedEvent.Register<PointerDeltaEventArgs>(
+                "PointerTouchPadGestureSwipe", RoutingStrategies.Bubble, typeof(InputElement));
+
+        /// <summary>
+        /// Defines the <see cref="Tapped"/> event.
+        /// </summary>
+        public static readonly RoutedEvent<TappedEventArgs> TappedEvent =
+            RoutedEvent.Register<InputElement, TappedEventArgs>(
+                nameof(Tapped),
+                RoutingStrategies.Bubble);
+
+        /// <summary>
+        /// Defines the <see cref="RightTapped"/> event.
+        /// </summary>
+        public static readonly RoutedEvent<TappedEventArgs> RightTappedEvent =
+            RoutedEvent.Register<InputElement, TappedEventArgs>(
+                nameof(Tapped),
+                RoutingStrategies.Bubble);
+
+        /// <summary>
+        /// Defines the <see cref="Holding"/> event.
+        /// </summary>
+        public static readonly RoutedEvent<HoldingRoutedEventArgs> HoldingEvent =
+            RoutedEvent.Register<InputElement, HoldingRoutedEventArgs>(
+                nameof(Holding),
+                RoutingStrategies.Bubble);
+
+        /// <summary>
+        /// Defines the <see cref="DoubleTapped"/> event.
+        /// </summary>
+        public static readonly RoutedEvent<TappedEventArgs> DoubleTappedEvent =
+            RoutedEvent.Register<InputElement, TappedEventArgs>(
+                nameof(DoubleTapped),
+                RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+
+        public static bool GetIsHoldingEnabled(StyledElement element)
+        {
+            return element.GetValue(IsHoldingEnabledProperty);
+        }
+        public static void SetIsHoldingEnabled(StyledElement element, bool value)
+        {
+            element.SetValue(IsHoldingEnabledProperty, value);
+        }
+
+        public static bool GetIsHoldWithMouseEnabled(StyledElement element)
+        {
+            return element.GetValue(IsHoldWithMouseEnabledProperty);
+        }
+        public static void SetIsHoldWithMouseEnabled(StyledElement element, bool value)
+        {
+            element.SetValue(IsHoldWithMouseEnabledProperty, value);
+        }
+
+        public static void AddPinchHandler(Interactive element, EventHandler<PinchEventArgs> handler) =>
+            element.AddHandler(PinchEvent, handler);
+
+        public static void AddPinchEndedHandler(Interactive element, EventHandler<PinchEndedEventArgs> handler) =>
+            element.AddHandler(PinchEndedEvent, handler);
+
+        public static void AddPullGestureHandler(Interactive element, EventHandler<PullGestureEventArgs> handler) =>
+            element.AddHandler(PullGestureEvent, handler);
+
+        public static void AddPullGestureEndedHandler(Interactive element, EventHandler<PullGestureEndedEventArgs> handler) =>
+            element.AddHandler(PullGestureEndedEvent, handler);
+
+        public static void RemovePinchHandler(Interactive element, EventHandler<PinchEventArgs> handler) =>
+            element.RemoveHandler(PinchEvent, handler);
+
+        public static void RemovePinchEndedHandler(Interactive element, EventHandler<PinchEndedEventArgs> handler) =>
+            element.RemoveHandler(PinchEndedEvent, handler);
+
+        public static void RemovePullGestureHandler(Interactive element, EventHandler<PullGestureEventArgs> handler) =>
+            element.RemoveHandler(PullGestureEvent, handler);
+
+        public static void RemovePullGestureEndedHandler(Interactive element, EventHandler<PullGestureEndedEventArgs> handler) =>
+            element.RemoveHandler(PullGestureEndedEvent, handler);
+
+        public static void AddPointerTouchPadGestureMagnifyHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
+            element.AddHandler(PointerTouchPadGestureMagnifyEvent, handler);
+
+        public static void AddPointerTouchPadGestureRotateHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
+            element.AddHandler(PointerTouchPadGestureRotateEvent, handler);
+
+        public static void AddPointerTouchPadGestureSwipeHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
+            element.AddHandler(PointerTouchPadGestureSwipeEvent, handler);
+
+        public static void AddScrollGestureHandler(Interactive element, EventHandler<RoutedEventArgs> handler) =>
+            element.AddHandler(ScrollGestureEvent, handler);
+
+        public static void AddScrollGestureEndedHandler(Interactive element, EventHandler<ScrollGestureEndedEventArgs> handler) =>
+            element.AddHandler(ScrollGestureEndedEvent, handler);
+
+        public static void AddScrollGestureInertiaStartingHandler(Interactive element, EventHandler<ScrollGestureInertiaStartingEventArgs> handler) =>
+            element.AddHandler(ScrollGestureInertiaStartingEvent, handler);
+
+        public static void RemovePointerTouchPadGestureMagnifyHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
+            element.RemoveHandler(PointerTouchPadGestureMagnifyEvent, handler);
+
+        public static void RemovePointerTouchPadGestureRotateHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
+            element.RemoveHandler(PointerTouchPadGestureRotateEvent, handler);
+
+        public static void RemovePointerTouchPadGestureSwipeHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
+            element.RemoveHandler(PointerTouchPadGestureSwipeEvent, handler);
+
+        public static void RemoveScrollGestureHandler(Interactive element, EventHandler<ScrollGestureEventArgs> handler) =>
+            element.RemoveHandler(ScrollGestureEvent, handler);
+
+        public static void RemoveScrollGestureEndedHandler(Interactive element, EventHandler<ScrollGestureEndedEventArgs> handler) =>
+            element.RemoveHandler(ScrollGestureEndedEvent, handler);
+
+        public static void RemoveScrollGestureInertiaStartingHandler(Interactive element, EventHandler<ScrollGestureInertiaStartingEventArgs> handler) =>
+            element.RemoveHandler(ScrollGestureInertiaStartingEvent, handler);
+
+        /// <summary>
+        /// Occurs when a tap gesture occurs on the control.
+        /// </summary>
+        public event EventHandler<TappedEventArgs>? Tapped
+        {
+            add { AddHandler(TappedEvent, value); }
+            remove { RemoveHandler(TappedEvent, value); }
+        }
+
+        /// <summary>
+        /// Occurs when a right tap gesture occurs on the control.
+        /// </summary>
+        public event EventHandler<TappedEventArgs>? RightTapped
+        {
+            add { AddHandler(RightTappedEvent, value); }
+            remove { RemoveHandler(RightTappedEvent, value); }
+        }
+
+        /// <summary>
+        /// Occurs when a hold gesture occurs on the control.
+        /// </summary>
+        public event EventHandler<HoldingRoutedEventArgs>? Holding
+        {
+            add { AddHandler(HoldingEvent, value); }
+            remove { RemoveHandler(HoldingEvent, value); }
+        }
+
+        /// <summary>
+        /// Occurs when a double-tap gesture occurs on the control.
+        /// </summary>
+        public event EventHandler<TappedEventArgs>? DoubleTapped
+        {
+            add { AddHandler(DoubleTappedEvent, value); }
+            remove { RemoveHandler(DoubleTappedEvent, value); }
+        }
+
+        private static void OnPreviewHolding(object? sender, HoldingRoutedEventArgs e)
+        {
+            if (sender is InputElement inputElement)
+            {
+                inputElement.RaiseEvent(e);
+
+                if (!e.Handled && e.HoldingState == HoldingState.Started)
+                {
+                    var contextEvent = new ContextRequestedEventArgs(e.PointerEventArgs);
+                    inputElement.RaiseEvent(contextEvent);
+                    e.Handled = contextEvent.Handled;
+
+                    if (contextEvent.Handled)
+                    {
+                        inputElement._isContextMenuOnHolding = true;
+                    }
+                }
+                else if (e.HoldingState == HoldingState.Cancelled && inputElement._isContextMenuOnHolding)
+                {
+                    inputElement.RaiseEvent(new RoutedEventArgs(InputElement.ContextCancelledEvent)
+                    {
+                        Source = inputElement
+                    });
+
+                    inputElement._isContextMenuOnHolding = false;
+                }
+                else if (e.HoldingState == HoldingState.Completed)
+                {
+                    inputElement._isContextMenuOnHolding = false;
+                }
+            }
+        }
+    }
+}

--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -16,7 +16,7 @@ namespace Avalonia.Input
     /// Implements input-related functionality for a control.
     /// </summary>
     [PseudoClasses(":disabled", ":focus", ":focus-visible", ":focus-within", ":pointerover")]
-    public class InputElement : Interactive, IInputElement
+    public partial class InputElement : Interactive, IInputElement
     {
         /// <summary>
         /// Defines the <see cref="Focusable"/> property.
@@ -203,24 +203,20 @@ namespace Avalonia.Input
                 RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
 
         /// <summary>
-        /// Defines the <see cref="Tapped"/> event.
+        /// Provides event data for the <see cref="ContextRequested"/> event.
         /// </summary>
-        public static readonly RoutedEvent<TappedEventArgs> TappedEvent = Gestures.TappedEvent;
+        public static readonly RoutedEvent<ContextRequestedEventArgs> ContextRequestedEvent =
+            RoutedEvent.Register<InputElement, ContextRequestedEventArgs>(
+                nameof(ContextRequested),
+                RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
 
         /// <summary>
-        /// Defines the <see cref="RightTapped"/> event.
+        /// Provides event data for the <see cref="ContextCancelled"/> event.
         /// </summary>
-        public static readonly RoutedEvent<TappedEventArgs> RightTappedEvent = Gestures.RightTappedEvent;
-
-        /// <summary>
-        /// Defines the <see cref="Holding"/> event.
-        /// </summary>
-        public static readonly RoutedEvent<HoldingRoutedEventArgs> HoldingEvent = Gestures.HoldingEvent;
-
-        /// <summary>
-        /// Defines the <see cref="DoubleTapped"/> event.
-        /// </summary>
-        public static readonly RoutedEvent<TappedEventArgs> DoubleTappedEvent = Gestures.DoubleTappedEvent;
+        public static readonly RoutedEvent<RoutedEventArgs> ContextCancelledEvent =
+            RoutedEvent.Register<InputElement, RoutedEventArgs>(
+                nameof(ContextCancelled),
+                RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
 
         private bool _isEffectivelyEnabled = true;
         private bool _isFocused;
@@ -256,6 +252,12 @@ namespace Avalonia.Input
             RightTappedEvent.AddClassHandler<InputElement>((x, e) => x.OnRightTapped(e));
             DoubleTappedEvent.AddClassHandler<InputElement>((x, e) => x.OnDoubleTapped(e));
             HoldingEvent.AddClassHandler<InputElement>((x, e) => x.OnHolding(e));
+
+            Gestures.Tapped += (s, e) => (s as InputElement)?.RaiseEvent(e);
+            Gestures.RightTapped += (s, e) => (s as InputElement)?.RaiseEvent(e);
+            Gestures.DoubleTapped += (s, e) => (s as InputElement)?.RaiseEvent(e);
+
+            Gestures.Holding += OnPreviewHolding;
 
             // Gesture only handlers
             PointerMovedEvent.AddClassHandler<InputElement>((x, e) => x.OnGesturePointerMoved(e), handledEventsToo: true);
@@ -420,42 +422,6 @@ namespace Avalonia.Input
         }
 
         /// <summary>
-        /// Occurs when a tap gesture occurs on the control.
-        /// </summary>
-        public event EventHandler<TappedEventArgs>? Tapped
-        {
-            add { AddHandler(TappedEvent, value); }
-            remove { RemoveHandler(TappedEvent, value); }
-        }
-
-        /// <summary>
-        /// Occurs when a right tap gesture occurs on the control.
-        /// </summary>
-        public event EventHandler<TappedEventArgs>? RightTapped
-        {
-            add { AddHandler(RightTappedEvent, value); }
-            remove { RemoveHandler(RightTappedEvent, value); }
-        }
-
-        /// <summary>
-        /// Occurs when a hold gesture occurs on the control.
-        /// </summary>
-        public event EventHandler<HoldingRoutedEventArgs>? Holding
-        {
-            add { AddHandler(HoldingEvent, value); }
-            remove { RemoveHandler(HoldingEvent, value); }
-        }
-
-        /// <summary>
-        /// Occurs when a double-tap gesture occurs on the control.
-        /// </summary>
-        public event EventHandler<TappedEventArgs>? DoubleTapped
-        {
-            add { AddHandler(DoubleTappedEvent, value); }
-            remove { RemoveHandler(DoubleTappedEvent, value); }
-        }
-
-        /// <summary>
         /// Gets or sets a value indicating whether the control can receive focus.
         /// </summary>
         public bool Focusable
@@ -516,6 +482,24 @@ namespace Avalonia.Input
         {
             get { return _isPointerOver; }
             internal set { SetAndRaise(IsPointerOverProperty, ref _isPointerOver, value); }
+        }
+
+        /// <summary>
+        /// Occurs when the user has completed a context input gesture, such as a right-click.
+        /// </summary>
+        public event EventHandler<ContextRequestedEventArgs>? ContextRequested
+        {
+            add => AddHandler(ContextRequestedEvent, value);
+            remove => RemoveHandler(ContextRequestedEvent, value);
+        }
+
+        /// <summary>
+        /// Occurs when the context input gesture continues into another gesture, to notify the element that the context flyout should not be opened.
+        /// </summary>
+        public event EventHandler<RoutedEventArgs>? ContextCancelled
+        {
+            add => AddHandler(ContextCancelledEvent, value);
+            remove => RemoveHandler(ContextCancelledEvent, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -211,11 +211,11 @@ namespace Avalonia.Input
                 RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
 
         /// <summary>
-        /// Provides event data for the <see cref="ContextCancelled"/> event.
+        /// Provides event data for the <see cref="ContextCanceled"/> event.
         /// </summary>
-        public static readonly RoutedEvent<RoutedEventArgs> ContextCancelledEvent =
+        public static readonly RoutedEvent<RoutedEventArgs> ContextCanceledEvent =
             RoutedEvent.Register<InputElement, RoutedEventArgs>(
-                nameof(ContextCancelled),
+                nameof(ContextCanceled),
                 RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
 
         private bool _isEffectivelyEnabled = true;
@@ -496,10 +496,10 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the context input gesture continues into another gesture, to notify the element that the context flyout should not be opened.
         /// </summary>
-        public event EventHandler<RoutedEventArgs>? ContextCancelled
+        public event EventHandler<RoutedEventArgs>? ContextCanceled
         {
-            add => AddHandler(ContextCancelledEvent, value);
-            remove => RemoveHandler(ContextCancelledEvent, value);
+            add => AddHandler(ContextCanceledEvent, value);
+            remove => RemoveHandler(ContextCanceledEvent, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Input/MouseDevice.cs
+++ b/src/Avalonia.Base/Input/MouseDevice.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Collections.Generic;
-using Avalonia.Reactive;
+using Avalonia.Input.GestureRecognizers;
 using Avalonia.Input.Raw;
 using Avalonia.Interactivity;
 using Avalonia.Metadata;
-using Avalonia.Platform;
-using Avalonia.Utilities;
 using Avalonia.VisualTree;
-using Avalonia.Input.GestureRecognizers;
 #pragma warning disable CS0618
 
 namespace Avalonia.Input
@@ -263,7 +260,7 @@ namespace Avalonia.Input
 
             if (source != null)
             {
-                var e = new PointerDeltaEventArgs(Gestures.PointerTouchPadGestureMagnifyEvent, source,
+                var e = new PointerDeltaEventArgs(InputElement.PointerTouchPadGestureMagnifyEvent, source,
                     _pointer, root.RootElement, p, timestamp, props, inputModifiers, delta);
 
                 source?.RaiseEvent(e);
@@ -283,7 +280,7 @@ namespace Avalonia.Input
 
             if (source != null)
             {
-                var e = new PointerDeltaEventArgs(Gestures.PointerTouchPadGestureRotateEvent, source,
+                var e = new PointerDeltaEventArgs(InputElement.PointerTouchPadGestureRotateEvent, source,
                     _pointer, root.RootElement, p, timestamp, props, inputModifiers, delta);
 
                 source?.RaiseEvent(e);
@@ -303,7 +300,7 @@ namespace Avalonia.Input
 
             if (source != null)
             {
-                var e = new PointerDeltaEventArgs(Gestures.PointerTouchPadGestureSwipeEvent, source, 
+                var e = new PointerDeltaEventArgs(InputElement.PointerTouchPadGestureSwipeEvent, source, 
                     _pointer, root.RootElement, p, timestamp, props, inputModifiers, delta);
 
                 source?.RaiseEvent(e);

--- a/src/Avalonia.Base/Input/PinchEventArgs.cs
+++ b/src/Avalonia.Base/Input/PinchEventArgs.cs
@@ -4,13 +4,13 @@ namespace Avalonia.Input
 {
     public class PinchEventArgs : RoutedEventArgs
     {
-        public PinchEventArgs(double scale, Point scaleOrigin) : base(Gestures.PinchEvent)
+        public PinchEventArgs(double scale, Point scaleOrigin) : base(InputElement.PinchEvent)
         {
             Scale = scale;
             ScaleOrigin = scaleOrigin;
         }
 
-        public PinchEventArgs(double scale, Point scaleOrigin, double angle, double angleDelta) : base(Gestures.PinchEvent)
+        public PinchEventArgs(double scale, Point scaleOrigin, double angle, double angleDelta) : base(InputElement.PinchEvent)
         {
             Scale = scale;
             ScaleOrigin = scaleOrigin;
@@ -41,7 +41,7 @@ namespace Avalonia.Input
 
     public class PinchEndedEventArgs : RoutedEventArgs
     {
-        public PinchEndedEventArgs() : base(Gestures.PinchEndedEvent)
+        public PinchEndedEventArgs() : base(InputElement.PinchEndedEvent)
         {
         }
     }

--- a/src/Avalonia.Base/Input/PullGestureEventArgs.cs
+++ b/src/Avalonia.Base/Input/PullGestureEventArgs.cs
@@ -1,4 +1,3 @@
-using System;
 using Avalonia.Interactivity;
 
 namespace Avalonia.Input
@@ -12,8 +11,8 @@ namespace Avalonia.Input
         private static int _nextId = 1;
 
         internal static int GetNextFreeId() => _nextId++;
-        
-        public PullGestureEventArgs(int id, Vector delta, PullDirection pullDirection) : base(Gestures.PullGestureEvent)
+
+        public PullGestureEventArgs(int id, Vector delta, PullDirection pullDirection) : base(InputElement.PullGestureEvent)
         {
             Id = id;
             Delta = delta;
@@ -26,7 +25,7 @@ namespace Avalonia.Input
         public int Id { get; }
         public PullDirection PullDirection { get; }
 
-        public PullGestureEndedEventArgs(int id, PullDirection pullDirection) : base(Gestures.PullGestureEndedEvent)
+        public PullGestureEndedEventArgs(int id, PullDirection pullDirection) : base(InputElement.PullGestureEndedEvent)
         {
             Id = id;
             PullDirection = pullDirection;

--- a/src/Avalonia.Base/Input/ScrollGestureEventArgs.cs
+++ b/src/Avalonia.Base/Input/ScrollGestureEventArgs.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Input
 
         public static int GetNextFreeId() => _nextId++;
 
-        public ScrollGestureEventArgs(int id, Vector delta) : base(Gestures.ScrollGestureEvent)
+        public ScrollGestureEventArgs(int id, Vector delta) : base(InputElement.ScrollGestureEvent)
         {
             Id = id;
             Delta = delta;
@@ -25,7 +25,7 @@ namespace Avalonia.Input
     {
         public int Id { get; }
 
-        public ScrollGestureEndedEventArgs(int id) : base(Gestures.ScrollGestureEndedEvent)
+        public ScrollGestureEndedEventArgs(int id) : base(InputElement.ScrollGestureEndedEvent)
         {
             Id = id;
         }
@@ -36,7 +36,7 @@ namespace Avalonia.Input
         public int Id { get; }
         public Vector Inertia { get; }
 
-        internal ScrollGestureInertiaStartingEventArgs(int id, Vector inertia) : base(Gestures.ScrollGestureInertiaStartingEvent)
+        internal ScrollGestureInertiaStartingEventArgs(int id, Vector inertia) : base(InputElement.ScrollGestureInertiaStartingEvent)
         {
             Id = id;
             Inertia = inertia;

--- a/src/Avalonia.Base/Input/TappedEventArgs.cs
+++ b/src/Avalonia.Base/Input/TappedEventArgs.cs
@@ -1,6 +1,4 @@
-using System;
 using Avalonia.Interactivity;
-using Avalonia.VisualTree;
 
 namespace Avalonia.Input
 {
@@ -17,7 +15,7 @@ namespace Avalonia.Input
         public IPointer Pointer => lastPointerEventArgs.Pointer;
         public KeyModifiers KeyModifiers => lastPointerEventArgs.KeyModifiers;
         public ulong Timestamp => lastPointerEventArgs.Timestamp;
-        
+
         public Point GetPosition(Visual? relativeTo) => lastPointerEventArgs.GetPosition(relativeTo);
     }
 }

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -1,17 +1,17 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using Avalonia.Automation.Peers;
 using System.Linq;
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
 using Avalonia.Controls.Diagnostics;
 using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Primitives.PopupPositioning;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Styling;
-using Avalonia.Automation;
 using Avalonia.Reactive;
+using Avalonia.Styling;
 
 namespace Avalonia.Controls
 {
@@ -65,7 +65,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="WindowManagerAddShadowHint"/> property.
         /// </summary>
-        public static readonly StyledProperty<bool> WindowManagerAddShadowHintProperty  =
+        public static readonly StyledProperty<bool> WindowManagerAddShadowHintProperty =
             Popup.WindowManagerAddShadowHintProperty.AddOwner<ContextMenu>();
 
         /// <summary>
@@ -205,6 +205,7 @@ namespace Avalonia.Controls
             if (e.OldValue is ContextMenu oldMenu)
             {
                 control.ContextRequested -= ControlContextRequested;
+                control.ContextCancelled -= ControlContextCanceled;
                 control.AttachedToVisualTree -= ControlOnAttachedToVisualTree;
                 control.DetachedFromVisualTree -= ControlDetachedFromVisualTree;
                 oldMenu._attachedControls?.Remove(control);
@@ -214,13 +215,14 @@ namespace Avalonia.Controls
             if (e.NewValue is ContextMenu)
             {
                 control.ContextRequested += ControlContextRequested;
+                control.ContextCancelled += ControlContextCanceled;
                 control.AttachedToVisualTree += ControlOnAttachedToVisualTree;
                 control.DetachedFromVisualTree += ControlDetachedFromVisualTree;
             }
-            
+
             if (control.IsAttachedToVisualTree)
             {
-                AttachControlToContextMenu(control); 
+                AttachControlToContextMenu(control);
             }
         }
 
@@ -292,9 +294,9 @@ namespace Avalonia.Controls
 
         IPopupHost? IPopupHostProvider.PopupHost => _popup?.Host;
 
-        event Action<IPopupHost?>? IPopupHostProvider.PopupHostChanged 
-        { 
-            add => _popupHostChangedHandler += value; 
+        event Action<IPopupHost?>? IPopupHostProvider.PopupHostChanged
+        {
+            add => _popupHostChangedHandler += value;
             remove => _popupHostChangedHandler -= value;
         }
 
@@ -384,7 +386,7 @@ namespace Avalonia.Controls
                 RoutedEvent = ClosedEvent,
                 Source = this,
             });
-            
+
             _popupHostChangedHandler?.Invoke(null);
         }
 
@@ -403,6 +405,17 @@ namespace Avalonia.Controls
             }
         }
 
+        private static void ControlContextCanceled(object? sender, RoutedEventArgs e)
+        {
+            if (!e.Handled
+                && sender is Control control
+                && control.ContextMenu is ContextMenu contextMenu
+                && contextMenu.IsOpen)
+            {
+                contextMenu.Close();
+            }
+        }
+
         private static void ControlContextRequested(object? sender, ContextRequestedEventArgs e)
         {
             if (sender is Control control
@@ -412,14 +425,14 @@ namespace Avalonia.Controls
             {
                 var requestedByPointer = e.TryGetPosition(null, out _);
                 contextMenu.Open(
-                    control, 
-                    e.Source as Control ?? control, 
+                    control,
+                    e.Source as Control ?? control,
                     requestedByPointer ? contextMenu.Placement : PlacementMode.Bottom);
                 e.Handled = true;
             }
         }
-        
-        
+
+
         private static void ControlOnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
         {
             AttachControlToContextMenu(sender);

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -205,7 +205,7 @@ namespace Avalonia.Controls
             if (e.OldValue is ContextMenu oldMenu)
             {
                 control.ContextRequested -= ControlContextRequested;
-                control.ContextCancelled -= ControlContextCanceled;
+                control.ContextCanceled -= ControlContextCanceled;
                 control.AttachedToVisualTree -= ControlOnAttachedToVisualTree;
                 control.DetachedFromVisualTree -= ControlDetachedFromVisualTree;
                 oldMenu._attachedControls?.Remove(control);
@@ -215,7 +215,7 @@ namespace Avalonia.Controls
             if (e.NewValue is ContextMenu)
             {
                 control.ContextRequested += ControlContextRequested;
-                control.ContextCancelled += ControlContextCanceled;
+                control.ContextCanceled += ControlContextCanceled;
                 control.AttachedToVisualTree += ControlOnAttachedToVisualTree;
                 control.DetachedFromVisualTree += ControlDetachedFromVisualTree;
             }

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -58,14 +58,6 @@ namespace Avalonia.Controls
             RoutedEvent.Register<Control, RequestBringIntoViewEventArgs>(
                 "RequestBringIntoView",
                 RoutingStrategies.Bubble);
-
-        /// <summary>
-        /// Provides event data for the <see cref="ContextRequested"/> event.
-        /// </summary>
-        public static readonly RoutedEvent<ContextRequestedEventArgs> ContextRequestedEvent =
-            RoutedEvent.Register<Control, ContextRequestedEventArgs>(
-                nameof(ContextRequested),
-                RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
         
         /// <summary>
         /// Defines the <see cref="Loaded"/> event.
@@ -161,15 +153,6 @@ namespace Avalonia.Controls
         {
             get => GetValue(TagProperty);
             set => SetValue(TagProperty, value);
-        }
-
-        /// <summary>
-        /// Occurs when the user has completed a context input gesture, such as a right-click.
-        /// </summary>
-        public event EventHandler<ContextRequestedEventArgs>? ContextRequested
-        {
-            add => AddHandler(ContextRequestedEvent, value);
-            remove => RemoveHandler(ContextRequestedEvent, value);
         }
 
         /// <summary>
@@ -387,20 +370,6 @@ namespace Avalonia.Controls
             InitializeIfNeeded();
 
             ScheduleOnLoadedCore();
-        }
-
-        protected override void OnHolding(HoldingRoutedEventArgs e)
-        {
-            base.OnHolding(e);
-
-            if (e.Source == this && !e.Handled && e.HoldingState == HoldingState.Started)
-            {
-                // Trigger ContentRequest when hold has started
-                var contextEvent = e.PointerEventArgs is { } ev ? new ContextRequestedEventArgs(ev) : new ContextRequestedEventArgs();
-                RaiseEvent(contextEvent);
-
-                e.Handled = contextEvent.Handled;
-            }
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -23,7 +23,6 @@ namespace Avalonia.Controls
     /// The control class extends <see cref="InputElement"/> and adds the following features:
     ///
     /// - A <see cref="Tag"/> property to allow user-defined data to be attached to the control.
-    /// - <see cref="ContextRequestedEvent"/> and other context menu related members.
     /// </remarks>
     public class Control : InputElement, IDataTemplateHost, IVisualBrushInitialize, ISetterValue
     {

--- a/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
@@ -352,13 +352,13 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnAttachedToVisualTree(e);
             _parentScroller = this.GetVisualParent() as ScrollContentPresenter;
-            _parentScroller?.AddHandler(Gestures.ScrollGestureEndedEvent, OnScrollGestureEnded);
+            _parentScroller?.AddHandler(InputElement.ScrollGestureEndedEvent, OnScrollGestureEnded);
         }
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnDetachedFromVisualTree(e);
-            _parentScroller?.RemoveHandler(Gestures.ScrollGestureEndedEvent, OnScrollGestureEnded);
+            _parentScroller?.RemoveHandler(InputElement.ScrollGestureEndedEvent, OnScrollGestureEnded);
             _parentScroller = null;
         }
 

--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -474,12 +474,12 @@ namespace Avalonia.Controls.Primitives
                 if (args.OldValue is FlyoutBase)
                 {
                     c.ContextRequested -= OnControlContextRequested;
-                    c.ContextCancelled -= OnControlContextCanceled;
+                    c.ContextCanceled -= OnControlContextCanceled;
                 }
                 if (args.NewValue is FlyoutBase)
                 {
                     c.ContextRequested += OnControlContextRequested;
-                    c.ContextCancelled += OnControlContextCanceled;
+                    c.ContextCanceled += OnControlContextCanceled;
                 }
             }
         }

--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -4,12 +4,11 @@ using System.Linq;
 using Avalonia.Controls.Diagnostics;
 using Avalonia.Controls.Primitives.PopupPositioning;
 using Avalonia.Input;
-using Avalonia.Input.Platform;
 using Avalonia.Input.Raw;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Logging;
 using Avalonia.Reactive;
-using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Primitives
 {
@@ -22,11 +21,11 @@ namespace Avalonia.Controls.Primitives
         /// <inheritdoc cref="Popup.HorizontalOffsetProperty"/>
         public static readonly StyledProperty<double> HorizontalOffsetProperty =
             Popup.HorizontalOffsetProperty.AddOwner<PopupFlyoutBase>();
-        
+
         /// <inheritdoc cref="Popup.VerticalOffsetProperty"/>
         public static readonly StyledProperty<double> VerticalOffsetProperty =
             Popup.VerticalOffsetProperty.AddOwner<PopupFlyoutBase>();
-            
+
         /// <inheritdoc cref="Popup.PlacementAnchorProperty"/>
         public static readonly StyledProperty<PopupAnchor> PlacementAnchorProperty =
             Popup.PlacementAnchorProperty.AddOwner<PopupFlyoutBase>();
@@ -50,19 +49,19 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public static readonly StyledProperty<bool> OverlayDismissEventPassThroughProperty =
             Popup.OverlayDismissEventPassThroughProperty.AddOwner<PopupFlyoutBase>();
-        
+
         /// <summary>
         /// Defines the <see cref="OverlayInputPassThroughElement"/> property
         /// </summary>
         public static readonly StyledProperty<IInputElement?> OverlayInputPassThroughElementProperty =
             Popup.OverlayInputPassThroughElementProperty.AddOwner<PopupFlyoutBase>();
-        
+
         /// <summary>
         /// Defines the <see cref="PlacementConstraintAdjustment"/> property
         /// </summary>
         public static readonly StyledProperty<PopupPositionerConstraintAdjustment> PlacementConstraintAdjustmentProperty =
             Popup.PlacementConstraintAdjustmentProperty.AddOwner<PopupFlyoutBase>();
-        
+
         private readonly Lazy<Popup> _popupLazy;
         private Rect? _enlargedPopupRect;
         private PixelRect? _enlargePopupRectScreenPixelRect;
@@ -147,7 +146,7 @@ namespace Avalonia.Controls.Primitives
             get => GetValue(OverlayDismissEventPassThroughProperty);
             set => SetValue(OverlayDismissEventPassThroughProperty, value);
         }
-        
+
         /// <summary>
         /// Gets or sets an element that should receive pointer input events even when underneath
         /// the flyout's overlay.
@@ -164,7 +163,7 @@ namespace Avalonia.Controls.Primitives
             get => GetValue(PlacementConstraintAdjustmentProperty);
             set => SetValue(PlacementConstraintAdjustmentProperty, value);
         }
-        
+
         IPopupHost? IPopupHostProvider.PopupHost => Popup?.Host;
 
         event Action<IPopupHost?>? IPopupHostProvider.PopupHostChanged
@@ -172,7 +171,7 @@ namespace Avalonia.Controls.Primitives
             add => _popupHostChangedHandler += value;
             remove => _popupHostChangedHandler -= value;
         }
-        
+
         public event EventHandler<CancelEventArgs>? Closing;
         public event EventHandler? Opening;
 
@@ -331,7 +330,7 @@ namespace Avalonia.Controls.Primitives
                     if (Popup?.Host is PopupRoot root)
                     {
                         // Get the popup root bounds and convert to screen coordinates
-                        
+
                         var tmp = root.Bounds.Inflate(100);
                         _enlargePopupRectScreenPixelRect = new PixelRect(root.PointToScreen(tmp.TopLeft), root.PointToScreen(tmp.BottomRight));
                     }
@@ -344,7 +343,7 @@ namespace Avalonia.Controls.Primitives
                     return;
                 }
 
-                if (Popup?.Host is PopupRoot && pArgs.Root.RootElement is {} eventRoot)
+                if (Popup?.Host is PopupRoot && pArgs.Root.RootElement is { } eventRoot)
                 {
                     // As long as the pointer stays within the enlargedPopupRect
                     // the flyout stays open. If it leaves, close it
@@ -373,7 +372,7 @@ namespace Avalonia.Controls.Primitives
         {
             Opening?.Invoke(this, args);
         }
-        
+
         protected virtual void OnClosing(CancelEventArgs args)
         {
             Closing?.Invoke(this, args);
@@ -475,11 +474,24 @@ namespace Avalonia.Controls.Primitives
                 if (args.OldValue is FlyoutBase)
                 {
                     c.ContextRequested -= OnControlContextRequested;
+                    c.ContextCancelled -= OnControlContextCanceled;
                 }
                 if (args.NewValue is FlyoutBase)
                 {
                     c.ContextRequested += OnControlContextRequested;
+                    c.ContextCancelled += OnControlContextCanceled;
                 }
+            }
+        }
+
+        private static void OnControlContextCanceled(object? sender, RoutedEventArgs e)
+        {
+            if (!e.Handled
+                && sender is Control control
+                && control.ContextFlyout is { } flyout
+                && flyout.IsOpen)
+            {
+                flyout.Hide();
             }
         }
 
@@ -525,7 +537,7 @@ namespace Avalonia.Controls.Primitives
 
         internal static void SetPresenterClasses(Control? presenter, Classes classes)
         {
-            if(presenter is null)
+            if (presenter is null)
             {
                 return;
             }

--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Collections.Generic;
-using Avalonia.Reactive;
+using System.Linq;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Input.GestureRecognizers;
+using Avalonia.Layout;
+using Avalonia.Reactive;
 using Avalonia.Utilities;
 using Avalonia.VisualTree;
-using System.Linq;
-using Avalonia.Layout;
 
 namespace Avalonia.Controls.Presenters
 {
@@ -118,9 +118,9 @@ namespace Avalonia.Controls.Presenters
         public ScrollContentPresenter()
         {
             AddHandler(RequestBringIntoViewEvent, BringIntoViewRequested);
-            AddHandler(Gestures.ScrollGestureEvent, OnScrollGesture);
-            AddHandler(Gestures.ScrollGestureEndedEvent, OnScrollGestureEnded);
-            AddHandler(Gestures.ScrollGestureInertiaStartingEvent, OnScrollGestureInertiaStartingEnded);
+            AddHandler(InputElement.ScrollGestureEvent, OnScrollGesture);
+            AddHandler(InputElement.ScrollGestureEndedEvent, OnScrollGestureEnded);
+            AddHandler(InputElement.ScrollGestureInertiaStartingEvent, OnScrollGestureInertiaStartingEnded);
 
             this.GetObservable(ChildProperty).Subscribe(UpdateScrollableSubscription);
         }

--- a/src/Avalonia.Controls/Primitives/ItemSelectionEventTriggers.cs
+++ b/src/Avalonia.Controls/Primitives/ItemSelectionEventTriggers.cs
@@ -31,7 +31,7 @@ public static class ItemSelectionEventTriggers
             } => false,
 
             // Select on mouse press, unless the mouse can generate gestures
-            { Pointer.Type: PointerType.Mouse } => eventArgs.RoutedEvent == (Gestures.GetIsHoldWithMouseEnabled(selectable) ?
+            { Pointer.Type: PointerType.Mouse } => eventArgs.RoutedEvent == (InputElement.GetIsHoldWithMouseEnabled(selectable) ?
                 InputElement.PointerReleasedEvent : (RoutedEvent)InputElement.PointerPressedEvent),
 
             // Pen "right clicks" are used for context menus, and gestures are only processed for primary input

--- a/src/Avalonia.Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter.cs
+++ b/src/Avalonia.Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter.cs
@@ -89,8 +89,8 @@ namespace Avalonia.Controls.PullToRefresh
 
             if (_refreshInfoProvider != null && _interactionSource != null)
             {
-                _interactionSource.RemoveHandler(Gestures.PullGestureEvent, _refreshInfoProvider.InteractingStateEntered);
-                _interactionSource.RemoveHandler(Gestures.PullGestureEndedEvent, _refreshInfoProvider.InteractingStateExited);
+                _interactionSource.RemoveHandler(InputElement.PullGestureEvent, _refreshInfoProvider.InteractingStateEntered);
+                _interactionSource.RemoveHandler(InputElement.PullGestureEndedEvent, _refreshInfoProvider.InteractingStateExited);
             }
 
             _refreshInfoProvider = null;
@@ -129,8 +129,8 @@ namespace Avalonia.Controls.PullToRefresh
             if (_interactionSource != null)
             {
                 _interactionSource.GestureRecognizers.Add(_pullGestureRecognizer);
-                _interactionSource.AddHandler(Gestures.PullGestureEvent, _refreshInfoProvider.InteractingStateEntered);
-                _interactionSource.AddHandler(Gestures.PullGestureEndedEvent, _refreshInfoProvider.InteractingStateExited);
+                _interactionSource.AddHandler(InputElement.PullGestureEvent, _refreshInfoProvider.InteractingStateEntered);
+                _interactionSource.AddHandler(InputElement.PullGestureEndedEvent, _refreshInfoProvider.InteractingStateExited);
                 _isVisualizerInteractionSourceAttached = true;
             }
 
@@ -169,11 +169,11 @@ namespace Avalonia.Controls.PullToRefresh
                 visualizerComposition.ImplicitAnimations = animation;
             }
 
-            if(_scrollViewer != null)
+            if (_scrollViewer != null)
             {
                 var scollContentComposition = ElementComposition.GetElementVisual(_scrollViewer);
 
-                if(scollContentComposition != null)
+                if (scollContentComposition != null)
                 {
                     var compositor = scollContentComposition.Compositor;
 
@@ -217,8 +217,8 @@ namespace Avalonia.Controls.PullToRefresh
             if (_pullGestureRecognizer != null && _refreshInfoProvider != null)
             {
                 element?.GestureRecognizers.Add(_pullGestureRecognizer);
-                _interactionSource?.AddHandler(Gestures.PullGestureEvent, _refreshInfoProvider.InteractingStateEntered);
-                _interactionSource?.AddHandler(Gestures.PullGestureEndedEvent, _refreshInfoProvider.InteractingStateExited);
+                _interactionSource?.AddHandler(InputElement.PullGestureEvent, _refreshInfoProvider.InteractingStateEntered);
+                _interactionSource?.AddHandler(InputElement.PullGestureEndedEvent, _refreshInfoProvider.InteractingStateExited);
                 _isVisualizerInteractionSourceAttached = true;
             }
         }

--- a/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Avalonia.Base.UnitTests.Utilities;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Input.GestureRecognizers;
@@ -9,7 +7,6 @@ using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Threading;
 using Avalonia.UnitTests;
-using Avalonia.Utilities;
 using Moq;
 using Xunit;
 // ReSharper disable RedundantArgumentDefaultValue
@@ -19,7 +16,7 @@ namespace Avalonia.Base.UnitTests.Input
     public class GesturesTests
     {
         private readonly MouseTestHelper _mouse = new MouseTestHelper();
-        
+
         [Fact]
         public void Tapped_Should_Follow_Pointer_Pressed_Released()
         {
@@ -64,7 +61,7 @@ namespace Avalonia.Base.UnitTests.Input
             };
             var raised = false;
 
-            root.AddHandler(Gestures.TappedEvent, (_, _) => raised = true);
+            root.AddHandler(InputElement.TappedEvent, (_, _) => raised = true);
 
             _mouse.Click(border, MouseButton.Middle);
 
@@ -81,7 +78,7 @@ namespace Avalonia.Base.UnitTests.Input
             };
             var raised = false;
 
-            root.AddHandler(Gestures.TappedEvent, (_, _) => raised = true);
+            root.AddHandler(InputElement.TappedEvent, (_, _) => raised = true);
 
             _mouse.Click(border, MouseButton.Right);
 
@@ -114,7 +111,7 @@ namespace Avalonia.Base.UnitTests.Input
             };
             _mouse.Click(border, MouseButton.Left);
 
-            root.AddHandler(Gestures.TappedEvent, (_, _) => raised = true);
+            root.AddHandler(InputElement.TappedEvent, (_, _) => raised = true);
 
             _mouse.Click(border, MouseButton.Left);
 
@@ -132,7 +129,7 @@ namespace Avalonia.Base.UnitTests.Input
             };
             var raised = false;
 
-            root.AddHandler(Gestures.RightTappedEvent, (_, _) => raised = true);
+            root.AddHandler(InputElement.RightTappedEvent, (_, _) => raised = true);
 
             _mouse.Click(border, MouseButton.Right);
 
@@ -185,7 +182,7 @@ namespace Avalonia.Base.UnitTests.Input
             };
             var raised = false;
 
-            root.AddHandler(Gestures.DoubleTappedEvent, (_, _) => raised = true);
+            root.AddHandler(InputElement.DoubleTappedEvent, (_, _) => raised = true);
 
             _mouse.Click(border, MouseButton.Middle);
             _mouse.Down(border, MouseButton.Middle, clickCount: 2);
@@ -203,7 +200,7 @@ namespace Avalonia.Base.UnitTests.Input
             };
             var raised = false;
 
-            root.AddHandler(Gestures.DoubleTappedEvent, (_, _) => raised = true);
+            root.AddHandler(InputElement.DoubleTappedEvent, (_, _) => raised = true);
 
             _mouse.Click(border, MouseButton.Right);
             _mouse.Down(border, MouseButton.Right, clickCount: 2);
@@ -220,22 +217,22 @@ namespace Avalonia.Base.UnitTests.Input
             iSettingsMock.Setup(x => x.GetTapSize(It.IsAny<PointerType>())).Returns(new Size(16, 16));
             AvaloniaLocator.CurrentMutable.BindToSelf(this)
                 .Bind<IPlatformSettings>().ToConstant(iSettingsMock.Object);
-            
+
             using var app = UnitTestApplication.Start();
 
             Border border = new Border();
-            Gestures.SetIsHoldWithMouseEnabled(border, true);
+            InputElement.SetIsHoldWithMouseEnabled(border, true);
             var root = new TestRoot
             {
                 Child = border
             };
             HoldingState holding = HoldingState.Cancelled;
 
-            root.AddHandler(Gestures.HoldingEvent, (_, e) => holding = e.HoldingState);
-            
+            root.AddHandler(InputElement.HoldingEvent, (_, e) => holding = e.HoldingState);
+
             _mouse.Down(border);
             Assert.False(holding != HoldingState.Cancelled);
-            
+
             // Verify timer duration, but execute it immediately.
             var timer = Assert.Single(Dispatcher.SnapshotTimersForUnitTests());
             Assert.Equal(iSettingsMock.Object.HoldWaitDuration, timer.Interval);
@@ -247,7 +244,80 @@ namespace Avalonia.Base.UnitTests.Input
 
             Assert.True(holding == HoldingState.Completed);
         }
-       
+
+        [Fact]
+        public void Started_Hold_Gesture_Should_Raise_Context_Requested_Event()
+        {
+            using var scope = AvaloniaLocator.EnterScope();
+            var iSettingsMock = new Mock<IPlatformSettings>();
+            iSettingsMock.Setup(x => x.HoldWaitDuration).Returns(TimeSpan.FromMilliseconds(300));
+            iSettingsMock.Setup(x => x.GetTapSize(It.IsAny<PointerType>())).Returns(new Size(16, 16));
+            AvaloniaLocator.CurrentMutable.BindToSelf(this)
+                .Bind<IPlatformSettings>().ToConstant(iSettingsMock.Object);
+
+            using var app = UnitTestApplication.Start();
+
+            var flyout = new Flyout();
+            Border border = new Border()
+            {
+                ContextFlyout = flyout
+            };
+            InputElement.SetIsHoldWithMouseEnabled(border, true);
+            var root = new TestRoot
+            {
+                Child = border
+            };
+
+            var contextRequested = false;
+
+            flyout.Opened += (s, e) => contextRequested = true;
+
+            _mouse.Down(border);
+            var timer = Assert.Single(Dispatcher.SnapshotTimersForUnitTests());
+            timer.ForceFire();
+            _mouse.Up(border);
+
+            Assert.True(contextRequested);
+        }
+
+        [Fact]
+        public void Cancelled_Hold_Gesture_Should_Cancel_Context_Flyout()
+        {
+            using var scope = AvaloniaLocator.EnterScope();
+            var iSettingsMock = new Mock<IPlatformSettings>();
+            iSettingsMock.Setup(x => x.HoldWaitDuration).Returns(TimeSpan.FromMilliseconds(300));
+            iSettingsMock.Setup(x => x.GetTapSize(It.IsAny<PointerType>())).Returns(new Size(16, 16));
+            AvaloniaLocator.CurrentMutable.BindToSelf(this)
+                .Bind<IPlatformSettings>().ToConstant(iSettingsMock.Object);
+
+            using var app = UnitTestApplication.Start();
+
+            var flyout = new Flyout();
+            Border border = new Border()
+            {
+                ContextFlyout = flyout
+            };
+            InputElement.SetIsHoldWithMouseEnabled(border, true);
+            var root = new TestRoot
+            {
+                Child = border
+            };
+
+            var contextRequested = false;
+            var contextCanceled = false;
+
+            flyout.Opened += (s, e) => contextRequested = true;
+            flyout.Closed += (s, e) => contextCanceled = true;
+
+            _mouse.Down(border);
+            var timer = Assert.Single(Dispatcher.SnapshotTimersForUnitTests());
+            timer.ForceFire();
+            _mouse.Move(border, new Point(100, 100));
+
+            Assert.True(contextRequested);
+            Assert.True(contextCanceled);
+        }
+
         [Fact]
         public void Hold_Should_Not_Raised_When_Pointer_Released_Before_Timer()
         {
@@ -256,25 +326,25 @@ namespace Avalonia.Base.UnitTests.Input
             iSettingsMock.Setup(x => x.HoldWaitDuration).Returns(TimeSpan.FromMilliseconds(300));
             AvaloniaLocator.CurrentMutable.BindToSelf(this)
                 .Bind<IPlatformSettings>().ToConstant(iSettingsMock.Object);
-            
+
             using var app = UnitTestApplication.Start();
 
             Border border = new Border();
-            Gestures.SetIsHoldWithMouseEnabled(border, true);
+            InputElement.SetIsHoldWithMouseEnabled(border, true);
             var root = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            root.AddHandler(Gestures.HoldingEvent, (_, e) => raised = e.HoldingState == HoldingState.Started);
-            
+            root.AddHandler(InputElement.HoldingEvent, (_, e) => raised = e.HoldingState == HoldingState.Started);
+
             _mouse.Down(border);
             Assert.False(raised);
-            
+
             _mouse.Up(border);
             Assert.False(raised);
-            
+
             // Verify timer duration, but execute it immediately.
             var timer = Assert.Single(Dispatcher.SnapshotTimersForUnitTests());
             Assert.Equal(iSettingsMock.Object.HoldWaitDuration, timer.Interval);
@@ -282,7 +352,7 @@ namespace Avalonia.Base.UnitTests.Input
 
             Assert.False(raised);
         }
-        
+
         [Fact]
         public void Hold_Should_Not_Raised_When_Pointer_Is_Moved_Before_Timer()
         {
@@ -291,25 +361,25 @@ namespace Avalonia.Base.UnitTests.Input
             iSettingsMock.Setup(x => x.HoldWaitDuration).Returns(TimeSpan.FromMilliseconds(300));
             AvaloniaLocator.CurrentMutable.BindToSelf(this)
                 .Bind<IPlatformSettings>().ToConstant(iSettingsMock.Object);
-            
+
             using var app = UnitTestApplication.Start();
 
             Border border = new Border();
-            Gestures.SetIsHoldWithMouseEnabled(border, true);
+            InputElement.SetIsHoldWithMouseEnabled(border, true);
             var root = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            root.AddHandler(Gestures.HoldingEvent, (_, e) => raised = e.HoldingState == HoldingState.Completed);
-            
+            root.AddHandler(InputElement.HoldingEvent, (_, e) => raised = e.HoldingState == HoldingState.Completed);
+
             _mouse.Down(border);
             Assert.False(raised);
 
             _mouse.Move(border, position: new Point(20, 20));
             Assert.False(raised);
-            
+
             // Verify timer duration, but execute it immediately.
             var timer = Assert.Single(Dispatcher.SnapshotTimersForUnitTests());
             Assert.Equal(iSettingsMock.Object.HoldWaitDuration, timer.Interval);
@@ -326,19 +396,19 @@ namespace Avalonia.Base.UnitTests.Input
             iSettingsMock.Setup(x => x.HoldWaitDuration).Returns(TimeSpan.FromMilliseconds(300));
             AvaloniaLocator.CurrentMutable.BindToSelf(this)
                 .Bind<IPlatformSettings>().ToConstant(iSettingsMock.Object);
-            
+
             using var app = UnitTestApplication.Start();
 
             Border border = new Border();
-            Gestures.SetIsHoldWithMouseEnabled(border, true);
+            InputElement.SetIsHoldWithMouseEnabled(border, true);
             var root = new TestRoot
             {
                 Child = border
             };
             var cancelled = false;
 
-            root.AddHandler(Gestures.HoldingEvent, (_, e) => cancelled = e.HoldingState == HoldingState.Cancelled);
-            
+            root.AddHandler(InputElement.HoldingEvent, (_, e) => cancelled = e.HoldingState == HoldingState.Cancelled);
+
             _mouse.Down(border);
             Assert.False(cancelled);
 
@@ -366,15 +436,15 @@ namespace Avalonia.Base.UnitTests.Input
             using var app = UnitTestApplication.Start();
 
             Border border = new Border();
-            Gestures.SetIsHoldWithMouseEnabled(border, true);
+            InputElement.SetIsHoldWithMouseEnabled(border, true);
             var root = new TestRoot()
             {
                 Child = border
             };
             var cancelled = false;
 
-            root.AddHandler(Gestures.HoldingEvent, (_, e) => cancelled = e.HoldingState == HoldingState.Cancelled);
-            
+            root.AddHandler(InputElement.HoldingEvent, (_, e) => cancelled = e.HoldingState == HoldingState.Cancelled);
+
             _mouse.Down(border);
 
             var timer = Assert.Single(Dispatcher.SnapshotTimersForUnitTests());
@@ -400,16 +470,16 @@ namespace Avalonia.Base.UnitTests.Input
                 .Bind<IPlatformSettings>().ToConstant(iSettingsMock.Object);
 
             using var app = UnitTestApplication.Start();
-            
+
             Border border = new Border();
-            Gestures.SetIsHoldWithMouseEnabled(border, true);
+            InputElement.SetIsHoldWithMouseEnabled(border, true);
             var testRoot = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            testRoot.AddHandler(Gestures.HoldingEvent, (_, e) => raised = e.HoldingState == HoldingState.Completed);
+            testRoot.AddHandler(InputElement.HoldingEvent, (_, e) => raised = e.HoldingState == HoldingState.Completed);
 
             var secondMouse = new MouseTestHelper();
 
@@ -424,7 +494,7 @@ namespace Avalonia.Base.UnitTests.Input
 
             Assert.False(raised);
         }
-        
+
         private static void AddHandlers(
             TestRoot root,
             Border border,
@@ -454,10 +524,10 @@ namespace Avalonia.Base.UnitTests.Input
             border.AddHandler(InputElement.PointerPressedEvent, (_, _) => result.Add("bp"));
             border.AddHandler(InputElement.PointerReleasedEvent, (_, _) => result.Add("br"));
 
-            root.AddHandler(Gestures.TappedEvent, (_, _) => result.Add("dt"));
-            root.AddHandler(Gestures.DoubleTappedEvent, (_, _) => result.Add("ddt"));
-            border.AddHandler(Gestures.TappedEvent, (_, _) => result.Add("bt"));
-            border.AddHandler(Gestures.DoubleTappedEvent, (_, _) => result.Add("bdt"));
+            root.AddHandler(InputElement.TappedEvent, (_, _) => result.Add("dt"));
+            root.AddHandler(InputElement.DoubleTappedEvent, (_, _) => result.Add("ddt"));
+            border.AddHandler(InputElement.TappedEvent, (_, _) => result.Add("bt"));
+            border.AddHandler(InputElement.DoubleTappedEvent, (_, _) => result.Add("bdt"));
         }
 
         [Fact]
@@ -478,7 +548,7 @@ namespace Avalonia.Base.UnitTests.Input
             };
             var raised = false;
 
-            root.AddHandler(Gestures.PinchEvent, (_, _) => raised = true);
+            root.AddHandler(InputElement.PinchEvent, (_, _) => raised = true);
 
             var firstPoint = new Point(5, 5);
             var secondPoint = new Point(10, 10);
@@ -506,7 +576,7 @@ namespace Avalonia.Base.UnitTests.Input
             };
             var raised = false;
 
-            root.AddHandler(Gestures.PinchEvent, (_, _) => raised = true);
+            root.AddHandler(InputElement.PinchEvent, (_, _) => raised = true);
 
             var firstPoint = new Point(5, 5);
             var secondPoint = new Point(10, 10);
@@ -537,7 +607,7 @@ namespace Avalonia.Base.UnitTests.Input
             };
             var raised = false;
 
-            root.AddHandler(Gestures.PinchEvent, (_, _) => raised = true);
+            root.AddHandler(InputElement.PinchEvent, (_, _) => raised = true);
 
             var firstPoint = new Point(5, 5);
             var secondPoint = new Point(10, 10);
@@ -576,7 +646,7 @@ namespace Avalonia.Base.UnitTests.Input
             };
             var raised = false;
 
-            root.AddHandler(Gestures.ScrollGestureEvent, (_, _) => raised = true);
+            root.AddHandler(InputElement.ScrollGestureEvent, (_, _) => raised = true);
 
             var firstTouch = new TouchTestHelper();
 

--- a/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
@@ -226,12 +226,12 @@ namespace Avalonia.Base.UnitTests.Input
             {
                 Child = border
             };
-            HoldingState holding = HoldingState.Cancelled;
+            HoldingState holding = HoldingState.Canceled;
 
             root.AddHandler(InputElement.HoldingEvent, (_, e) => holding = e.HoldingState);
 
             _mouse.Down(border);
-            Assert.False(holding != HoldingState.Cancelled);
+            Assert.False(holding != HoldingState.Canceled);
 
             // Verify timer duration, but execute it immediately.
             var timer = Assert.Single(Dispatcher.SnapshotTimersForUnitTests());
@@ -407,7 +407,7 @@ namespace Avalonia.Base.UnitTests.Input
             };
             var cancelled = false;
 
-            root.AddHandler(InputElement.HoldingEvent, (_, e) => cancelled = e.HoldingState == HoldingState.Cancelled);
+            root.AddHandler(InputElement.HoldingEvent, (_, e) => cancelled = e.HoldingState == HoldingState.Canceled);
 
             _mouse.Down(border);
             Assert.False(cancelled);
@@ -443,7 +443,7 @@ namespace Avalonia.Base.UnitTests.Input
             };
             var cancelled = false;
 
-            root.AddHandler(InputElement.HoldingEvent, (_, e) => cancelled = e.HoldingState == HoldingState.Cancelled);
+            root.AddHandler(InputElement.HoldingEvent, (_, e) => cancelled = e.HoldingState == HoldingState.Canceled);
 
             _mouse.Down(border);
 

--- a/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
@@ -83,7 +83,7 @@ namespace Avalonia.Controls.UnitTests
                     ContextMenu = sut
                 };
                 var contextRequestedCount = 0;
-                target.AddHandler(Control.ContextRequestedEvent, (s, a) => contextRequestedCount++, Interactivity.RoutingStrategies.Tunnel);
+                target.AddHandler(InputElement.ContextRequestedEvent, (s, a) => contextRequestedCount++, Interactivity.RoutingStrategies.Tunnel);
 
                 var window = PreparedWindow(target);
                 window.Show();

--- a/tests/Avalonia.Controls.UnitTests/FlyoutTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/FlyoutTests.cs
@@ -459,7 +459,7 @@ namespace Avalonia.Controls.UnitTests
                     ContextFlyout = flyout
                 };
                 var contextRequestedCount = 0;
-                target.AddHandler(Control.ContextRequestedEvent, (s, a) => contextRequestedCount++, Interactivity.RoutingStrategies.Tunnel);
+                target.AddHandler(InputElement.ContextRequestedEvent, (s, a) => contextRequestedCount++, Interactivity.RoutingStrategies.Tunnel);
 
                 var window = PreparedWindow(target);
                 window.Show();

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests_Single.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests_Single.cs
@@ -149,7 +149,7 @@ namespace Avalonia.Controls.UnitTests
                 Prepare(target);
 
                 var contextRaised = false;
-                target.AddHandler(Control.ContextRequestedEvent, (sender, args) =>
+                target.AddHandler(InputElement.ContextRequestedEvent, (sender, args) =>
                 {
                     contextRaised = true;
                     args.Handled = true;

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/EventTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/EventTests.cs
@@ -26,14 +26,14 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
         [Fact]
         public void Attached_Event_Is_Assigned()
         {
-            var xaml = @"<Button xmlns='https://github.com/avaloniaui' Gestures.Tapped='OnTapped'/>";
+            var xaml = @"<Button xmlns='https://github.com/avaloniaui' InputElement.Tapped='OnTapped'/>";
             var target = new MyButton();
 
             AvaloniaRuntimeXamlLoader.Load(xaml, rootInstance: target);
 
             target.RaiseEvent(new RoutedEventArgs
             {
-                RoutedEvent = Gestures.TappedEvent,
+                RoutedEvent = InputElement.TappedEvent,
             });
 
             Assert.True(target.WasTapped);
@@ -51,7 +51,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             Assert.NotNull(target);
 
-            target.RaiseEvent(new TappedEventArgs(Gestures.DoubleTappedEvent, null!));
+            target.RaiseEvent(new TappedEventArgs(InputElement.DoubleTappedEvent, null!));
 
             Assert.True(host.WasTapped);
         }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

This PR moves all events from `Gestures` to `InputElement`. The following changes were made;
- All event in `Gestures` have been moved to `InputElement`. 
- `Gestures` class is now `internal`
- `ContextRequestedEventArgs` moved to `Avalonia.Input` namespace.
- `ContextRequested` event moved from `Control` class to `InputElement`.
- `ContextCancelled` event and related event args added. This event is raised when a gesture that raises `ContextRequest` is cancelled, thus closing the context flyout that was opened by the gesture.
- `Gestures` now raise CLR events for `Tapped`, `DoubleTapped`, `RightTapped`, and `Holding` gestures.
- `InputElement` handles the above event and raises their respective routed events.
- `Holding` event with `Started` state now raises `ContextRequested` event.
- `Holding` event with `Cancelled` state will raise `ContextCancelled` event.
- `Holding` event will complete its route before checks are made to trigger context related events.


## What is the current behavior?

Multiple events in `Gesture` have duplicates in `InputElement`. The duplicates point to the same instances. Since there's little relation between `InputElement` and `Gestures` outside of gesture detection, having the same events in multiple places can be confusing to users as to which class is the recommended one. Thus `Gestures` is now an internal class with no public members.
`Holding` events do not complete their event route. This is due to the event being handled by the default `Holding` event handler in `Control`, which raises `ContextRequested` event and sets the `Holding` event as handled. So, if a single control, whether in the a template or logical tree has a context menu or flyout, no ancestor control will receive the `Holding` event. This isn't expected behavior. `Holding` event should complete its route to allow users to trigger custom behaviors and prevent `ContextRequested` event if its determined that the current `Holding` event should not trigger context menus. 


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
- All event in `Gestures` have been moved to `InputElement`. 
- `Gestures` class is now `internal`.
- `ContextRequestedEventArgs` moved to `Avalonia.Input` namespace.
- `ContextRequested` event moved from `Control` class to `InputElement`.
- `Holding.Cancelled` renamed to `Holding.Canceled`.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/17208