### PR TITLE
Explicitly truncate when opening a stream for writing

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageItem.cs
+++ b/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageItem.cs
@@ -410,7 +410,7 @@ internal sealed class AndroidStorageFile : AndroidStorageItem, IStorageBookmarkF
         }
 
         return isOutput
-            ? context.ContentResolver?.OpenOutputStream(uri)
+            ? context.ContentResolver?.OpenOutputStream(uri, "wt")
             : context.ContentResolver?.OpenInputStream(uri);
     }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Prior to this change, calling `IStorageFile.OpenWriteAsync()` on the Android platform [actually](https://learn.microsoft.com/en-us/dotnet/api/android.content.contentresolver.openoutputstream) called `Android.Context.ContentResolver?.OpenOutputStream(uri)`, which is equivalent to `Android.Context.ContentResolver?.OpenOutputStream(uri, "w")`. This resulted in the file [not being truncated before writing](https://developer.android.com/reference/android/content/ContentResolver#openOutputStream(android.net.Uri,%20java.lang.String)), causing platform differences (files were truncated on Windows and [Android versions prior to 9](https://issuetracker.google.com/issues/180526528); I haven't verified the behavior on other operating systems).

This could lead to users mistakenly leaving unnecessary data behind when attempting to overwrite files, or even security vulnerabilities (even Google made this mistake: CVE-2023-21036 aka.[aCropalypse](https://en.wikipedia.org/wiki/ACropalypse)).

Another problematic aspect was that even attempts to truncate the file using `Stream.SetLength(0)` [failed](https://github.com/dotnet/android/blob/ffa5d830d1d456fa0f981fe9ddf622053d540367/src/Mono.Android/Android.Runtime/OutputStreamInvoker.cs#L89-L92).

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When attempting to overwrite a larger file with a smaller file using `OpenWrite` and `OpenWriteAsync`, the excess portion will remain in the target file in Android.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The `OpenWrite` and `OpenWriteAsync` methods in Android will attempt to truncate the file.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Calling `OpenOutputStream(uri, "wt")` instead of `OpenOutputStream(uri)`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
I'm not sure if anyone is deliberately exploiting this bug(or feature?), but the file won't be truncated before that.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
