### PR TITLE
[iOS] Truncate file in IOSStorageFile.OpenWrite

### DIFF
--- a/src/iOS/Avalonia.iOS/Storage/IOSStorageItem.cs
+++ b/src/iOS/Avalonia.iOS/Storage/IOSStorageItem.cs
@@ -184,15 +184,25 @@ internal sealed class IOSStorageFile : IOSStorageItem, IStorageBookmarkFile
 
     private Stream CreateStream(FileMode fileMode, FileAccess fileAccess)
     {
-        var document = new UIDocument(Url);
+        using var document = new UIDocument(Url);
         var path = document.FileUrl.Path!;
         var scopeCreated = SecurityScopedAncestorUrl.StartAccessingSecurityScopedResource();
-        var stream = new FileStream(path, fileMode, fileAccess);
+
+        FileStream stream;
+        try
+        {
+            stream = new FileStream(path, fileMode, fileAccess);
+        }
+        catch
+        {
+            if (scopeCreated)
+                SecurityScopedAncestorUrl.StopAccessingSecurityScopedResource();
+            throw;
+        }
 
         return scopeCreated ?
             new SecurityScopedStream(stream, Disposable.Create(() =>
             {
-                document.Dispose();
                 SecurityScopedAncestorUrl.StopAccessingSecurityScopedResource();
             })) :
             stream;

--- a/src/iOS/Avalonia.iOS/Storage/IOSStorageItem.cs
+++ b/src/iOS/Avalonia.iOS/Storage/IOSStorageItem.cs
@@ -174,20 +174,20 @@ internal sealed class IOSStorageFile : IOSStorageItem, IStorageBookmarkFile
 
     public Task<Stream> OpenReadAsync()
     {
-        return Task.FromResult(CreateStream(FileAccess.Read));
+        return Task.FromResult(CreateStream(FileMode.Open, FileAccess.Read));
     }
 
     public Task<Stream> OpenWriteAsync()
     {
-        return Task.FromResult(CreateStream(FileAccess.Write));
+        return Task.FromResult(CreateStream(FileMode.Create, FileAccess.Write));
     }
 
-    private Stream CreateStream(FileAccess fileAccess)
+    private Stream CreateStream(FileMode fileMode, FileAccess fileAccess)
     {
         var document = new UIDocument(Url);
         var path = document.FileUrl.Path!;
         var scopeCreated = SecurityScopedAncestorUrl.StartAccessingSecurityScopedResource();
-        var stream = File.Open(path, FileMode.Open, fileAccess);
+        var stream = new FileStream(path, fileMode, fileAccess);
 
         return scopeCreated ?
             new SecurityScopedStream(stream, Disposable.Create(() =>


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that calling `IStorageFile.OpenWriteAsync` on iOS truncates the file.
The matches the behavior observed on Windows, Linux, macOS, and Android (with #20804).

