### PR TITLE
Update SkiaSharp to 3.119.3-preview.1.1

### DIFF
--- a/Avalonia.sln
+++ b/Avalonia.sln
@@ -207,6 +207,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		NOTICE.md = NOTICE.md
 		NuGet.Config = NuGet.Config
 		readme.md = readme.md
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Generators", "src\tools\Avalonia.Generators\Avalonia.Generators.csproj", "{DDA28789-C21A-4654-86CE-D01E81F095C5}"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,9 +12,9 @@
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="Dotnet.Bundle" Version="0.9.13" />
     <PackageVersion Include="GtkSharp" Version="3.24.24.95" />
-    <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.2" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.2" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="8.3.1.2" />
+    <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.3" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.3" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="8.3.1.3" />
     <PackageVersion Include="MicroCom.CodeGenerator" Version="0.11.0" />
     <PackageVersion Include="MicroCom.CodeGenerator.MSBuild" Version="0.11.0" />
     <PackageVersion Include="MicroCom.Runtime" Version="0.11.0" />
@@ -46,9 +46,9 @@
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.22.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.22.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="2.1.12" />
-    <PackageVersion Include="SkiaSharp" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.1" />
+    <PackageVersion Include="SkiaSharp" Version="3.119.3-preview.1.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.3-preview.1.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.3-preview.1.1" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="4.5.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.10" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />


### PR DESCRIPTION
## What does the pull request do?
This PR updates:
- `SkiaSharp` from `3.119.1` to `3.119.3-preview.1.1`
- `HarfBuzzSharp` from `8.3.1.2` to `8.3.1.3`

Updating to a preview version of SkiaSharp is necessary to fix startup crashes on Linux ARM64. See https://github.com/mono/SkiaSharp/pull/3494
