### PR TITLE
[Metal] Dispose GRBackendRenderTarget and @autoreleasepool for metal objects

### DIFF
--- a/native/Avalonia.Native/src/OSX/metal.mm
+++ b/native/Avalonia.Native/src/OSX/metal.mm
@@ -87,32 +87,33 @@ public:
         return (__bridge void*) queue;
     }
     
-    HRESULT ImportIOSurface(void *handle, AvnPixelFormat pixelFormat, IAvnMetalTexture **ppv) override { 
-        auto surf = (IOSurfaceRef)handle;
-        auto width = IOSurfaceGetWidth(surf);
-        auto height = IOSurfaceGetHeight(surf);
-        
-        auto desc = [MTLTextureDescriptor new];
-        if(pixelFormat == kAvnRgba8888)
-            desc.pixelFormat = MTLPixelFormatRGBA8Unorm;
-        else if(pixelFormat == kAvnBgra8888)
-            desc.pixelFormat = MTLPixelFormatBGRA8Unorm;
-        else
-            return E_INVALIDARG;
-        desc.textureType = MTLTextureType2D;
-        desc.width = width;
-        desc.height = height;
-        desc.depth = 1;
-        desc.mipmapLevelCount = 1;
-        desc.sampleCount = 1;
-        desc.usage = MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget;
-        
-        auto texture = [device newTextureWithDescriptor:desc iosurface:surf plane:0];
-        if(texture == nullptr)
-            return E_FAIL;
-        *ppv = new AvnMetalTexture(texture);
-        return S_OK;
-        
+    HRESULT ImportIOSurface(void *handle, AvnPixelFormat pixelFormat, IAvnMetalTexture **ppv) override {
+        @autoreleasepool {
+            auto surf = (IOSurfaceRef)handle;
+            auto width = IOSurfaceGetWidth(surf);
+            auto height = IOSurfaceGetHeight(surf);
+
+            auto desc = [MTLTextureDescriptor new];
+            if(pixelFormat == kAvnRgba8888)
+                desc.pixelFormat = MTLPixelFormatRGBA8Unorm;
+            else if(pixelFormat == kAvnBgra8888)
+                desc.pixelFormat = MTLPixelFormatBGRA8Unorm;
+            else
+                return E_INVALIDARG;
+            desc.textureType = MTLTextureType2D;
+            desc.width = width;
+            desc.height = height;
+            desc.depth = 1;
+            desc.mipmapLevelCount = 1;
+            desc.sampleCount = 1;
+            desc.usage = MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget;
+
+            auto texture = [device newTextureWithDescriptor:desc iosurface:surf plane:0];
+            if(texture == nullptr)
+                return E_FAIL;
+            *ppv = new AvnMetalTexture(texture);
+            return S_OK;
+        }
     }
     
     HRESULT ImportSharedEvent(void *mtlSharedEventInstance, IAvnMTLSharedEvent**ppv) override {
@@ -134,16 +135,18 @@ public:
     {
         if (@available(macOS 12.0, *))
         {
-            auto e = dynamic_cast<AvnMTLSharedEvent*>(ev);
-            if(e == nullptr)
-                return E_FAIL;;
-            auto buf = [queue commandBuffer];
-            if(wait)
-                [buf encodeWaitForEvent:e->GetEvent() value:value];
-            else
-                [buf encodeSignalEvent:e->GetEvent() value:value];
-            [buf commit];
-            return S_OK;
+            @autoreleasepool {
+                auto e = dynamic_cast<AvnMTLSharedEvent*>(ev);
+                if(e == nullptr)
+                    return E_FAIL;
+                auto buf = [queue commandBuffer];
+                if(wait)
+                    [buf encodeWaitForEvent:e->GetEvent() value:value];
+                else
+                    [buf encodeSignalEvent:e->GetEvent() value:value];
+                [buf commit];
+                return S_OK;
+            }
         }
         else
             return E_FAIL;
@@ -204,9 +207,11 @@ public:
 
     ~AvnMetalRenderSession()
     {
-        auto buffer = [_queue commandBuffer];
-        [buffer presentDrawable: _drawable];
-        [buffer commit];
+        @autoreleasepool {
+            auto buffer = [_queue commandBuffer];
+            [buffer presentDrawable: _drawable];
+            [buffer commit];
+        }
     }
 };
 
@@ -227,26 +232,28 @@ public:
     }
 
     HRESULT BeginDrawing(IAvnMetalRenderingSession **ret) override {
-        if([NSThread isMainThread])
-        {
-            // Flush all existing rendering
-            auto buffer = [_device->queue commandBuffer];
-            [buffer commit];
-            [buffer waitUntilCompleted];
-            _size = PendingSize;
-            _scaling= PendingScaling;
-            CGSize layerSize = {(CGFloat)_size.Width, (CGFloat)_size.Height};
+        @autoreleasepool {
+            if([NSThread isMainThread])
+            {
+                // Flush all existing rendering
+                auto buffer = [_device->queue commandBuffer];
+                [buffer commit];
+                [buffer waitUntilCompleted];
+                _size = PendingSize;
+                _scaling= PendingScaling;
+                CGSize layerSize = {(CGFloat)_size.Width, (CGFloat)_size.Height};
 
-            [_layer setDrawableSize: layerSize];
+                [_layer setDrawableSize: layerSize];
+            }
+            auto drawable = [_layer nextDrawable];
+            if(drawable == nil)
+            {
+                ret = nil;
+                return E_FAIL;
+            }
+            *ret = new AvnMetalRenderSession(_device, _layer, drawable, _size, _scaling);
+            return 0;
         }
-        auto drawable = [_layer nextDrawable];
-        if(drawable == nil)
-        {
-            ret = nil;
-            return E_FAIL;
-        }
-        *ret = new AvnMetalRenderSession(_device, _layer, drawable, _size, _scaling);
-        return 0;
     }
 };
 
@@ -289,15 +296,16 @@ class AvnMetalDisplay : public ComSingleObject<IAvnMetalDisplay, &IID_IAvnMetalD
 public:
     FORWARD_IUNKNOWN()
     HRESULT CreateDevice(IAvnMetalDevice **ret) override {
-
-        auto device = MTLCreateSystemDefaultDevice();
-        if(device == nil) {
-            ret = nil;
-            return E_FAIL;
+        @autoreleasepool {
+            auto device = MTLCreateSystemDefaultDevice();
+            if(device == nil) {
+                ret = nil;
+                return E_FAIL;
+            }
+            auto queue = [device newCommandQueue];
+            *ret = new AvnMetalDevice(device, queue);
+            return S_OK;
         }
-        auto queue = [device newCommandQueue];
-        *ret = new AvnMetalDevice(device, queue);
-        return S_OK;
     }
 };
 

--- a/native/Avalonia.Native/src/OSX/metal.mm
+++ b/native/Avalonia.Native/src/OSX/metal.mm
@@ -88,32 +88,31 @@ public:
     }
     
     HRESULT ImportIOSurface(void *handle, AvnPixelFormat pixelFormat, IAvnMetalTexture **ppv) override {
-        @autoreleasepool {
-            auto surf = (IOSurfaceRef)handle;
-            auto width = IOSurfaceGetWidth(surf);
-            auto height = IOSurfaceGetHeight(surf);
+        START_COM_ARP_CALL;
+        auto surf = (IOSurfaceRef)handle;
+        auto width = IOSurfaceGetWidth(surf);
+        auto height = IOSurfaceGetHeight(surf);
 
-            auto desc = [MTLTextureDescriptor new];
-            if(pixelFormat == kAvnRgba8888)
-                desc.pixelFormat = MTLPixelFormatRGBA8Unorm;
-            else if(pixelFormat == kAvnBgra8888)
-                desc.pixelFormat = MTLPixelFormatBGRA8Unorm;
-            else
-                return E_INVALIDARG;
-            desc.textureType = MTLTextureType2D;
-            desc.width = width;
-            desc.height = height;
-            desc.depth = 1;
-            desc.mipmapLevelCount = 1;
-            desc.sampleCount = 1;
-            desc.usage = MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget;
+        auto desc = [MTLTextureDescriptor new];
+        if(pixelFormat == kAvnRgba8888)
+            desc.pixelFormat = MTLPixelFormatRGBA8Unorm;
+        else if(pixelFormat == kAvnBgra8888)
+            desc.pixelFormat = MTLPixelFormatBGRA8Unorm;
+        else
+            return E_INVALIDARG;
+        desc.textureType = MTLTextureType2D;
+        desc.width = width;
+        desc.height = height;
+        desc.depth = 1;
+        desc.mipmapLevelCount = 1;
+        desc.sampleCount = 1;
+        desc.usage = MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget;
 
-            auto texture = [device newTextureWithDescriptor:desc iosurface:surf plane:0];
-            if(texture == nullptr)
-                return E_FAIL;
-            *ppv = new AvnMetalTexture(texture);
-            return S_OK;
-        }
+        auto texture = [device newTextureWithDescriptor:desc iosurface:surf plane:0];
+        if(texture == nullptr)
+            return E_FAIL;
+        *ppv = new AvnMetalTexture(texture);
+        return S_OK;
     }
     
     HRESULT ImportSharedEvent(void *mtlSharedEventInstance, IAvnMTLSharedEvent**ppv) override {
@@ -133,20 +132,19 @@ public:
     
     HRESULT SignalOrWait(IAvnMTLSharedEvent *ev, uint64_t value, bool wait)
     {
+        START_ARP_CALL;
         if (@available(macOS 12.0, *))
         {
-            @autoreleasepool {
-                auto e = dynamic_cast<AvnMTLSharedEvent*>(ev);
-                if(e == nullptr)
-                    return E_FAIL;
-                auto buf = [queue commandBuffer];
-                if(wait)
-                    [buf encodeWaitForEvent:e->GetEvent() value:value];
-                else
-                    [buf encodeSignalEvent:e->GetEvent() value:value];
-                [buf commit];
-                return S_OK;
-            }
+            auto e = dynamic_cast<AvnMTLSharedEvent*>(ev);
+            if(e == nullptr)
+                return E_FAIL;
+            auto buf = [queue commandBuffer];
+            if(wait)
+                [buf encodeWaitForEvent:e->GetEvent() value:value];
+            else
+                [buf encodeSignalEvent:e->GetEvent() value:value];
+            [buf commit];
+            return S_OK;
         }
         else
             return E_FAIL;
@@ -207,11 +205,10 @@ public:
 
     ~AvnMetalRenderSession()
     {
-        @autoreleasepool {
-            auto buffer = [_queue commandBuffer];
-            [buffer presentDrawable: _drawable];
-            [buffer commit];
-        }
+        START_ARP_CALL;
+        auto buffer = [_queue commandBuffer];
+        [buffer presentDrawable: _drawable];
+        [buffer commit];
     }
 };
 
@@ -232,28 +229,27 @@ public:
     }
 
     HRESULT BeginDrawing(IAvnMetalRenderingSession **ret) override {
-        @autoreleasepool {
-            if([NSThread isMainThread])
-            {
-                // Flush all existing rendering
-                auto buffer = [_device->queue commandBuffer];
-                [buffer commit];
-                [buffer waitUntilCompleted];
-                _size = PendingSize;
-                _scaling= PendingScaling;
-                CGSize layerSize = {(CGFloat)_size.Width, (CGFloat)_size.Height};
+        START_COM_ARP_CALL;
+        if([NSThread isMainThread])
+        {
+            // Flush all existing rendering
+            auto buffer = [_device->queue commandBuffer];
+            [buffer commit];
+            [buffer waitUntilCompleted];
+            _size = PendingSize;
+            _scaling= PendingScaling;
+            CGSize layerSize = {(CGFloat)_size.Width, (CGFloat)_size.Height};
 
-                [_layer setDrawableSize: layerSize];
-            }
-            auto drawable = [_layer nextDrawable];
-            if(drawable == nil)
-            {
-                ret = nil;
-                return E_FAIL;
-            }
-            *ret = new AvnMetalRenderSession(_device, _layer, drawable, _size, _scaling);
-            return 0;
+            [_layer setDrawableSize: layerSize];
         }
+        auto drawable = [_layer nextDrawable];
+        if(drawable == nil)
+        {
+            ret = nil;
+            return E_FAIL;
+        }
+        *ret = new AvnMetalRenderSession(_device, _layer, drawable, _size, _scaling);
+        return 0;
     }
 };
 
@@ -296,16 +292,15 @@ class AvnMetalDisplay : public ComSingleObject<IAvnMetalDisplay, &IID_IAvnMetalD
 public:
     FORWARD_IUNKNOWN()
     HRESULT CreateDevice(IAvnMetalDevice **ret) override {
-        @autoreleasepool {
-            auto device = MTLCreateSystemDefaultDevice();
-            if(device == nil) {
-                ret = nil;
-                return E_FAIL;
-            }
-            auto queue = [device newCommandQueue];
-            *ret = new AvnMetalDevice(device, queue);
-            return S_OK;
+        START_COM_ARP_CALL;
+        auto device = MTLCreateSystemDefaultDevice();
+        if(device == nil) {
+            ret = nil;
+            return E_FAIL;
         }
+        auto queue = [device newCommandQueue];
+        *ret = new AvnMetalDevice(device, queue);
+        return S_OK;
     }
 };
 

--- a/src/Skia/Avalonia.Skia/Gpu/Metal/SkiaMetalGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/Metal/SkiaMetalGpu.cs
@@ -105,7 +105,7 @@ internal class SkiaMetalGpu : ISkiaGpu
                 session.IsYFlipped ? GRSurfaceOrigin.BottomLeft : GRSurfaceOrigin.TopLeft,
                 SKColorType.Bgra8888);
 
-            return new SkiaMetalRenderSession(_gpu, surface, session);
+            return new SkiaMetalRenderSession(_gpu, surface, session, backendTarget);
         }
 
         public bool IsCorrupted => false;
@@ -118,14 +118,17 @@ internal class SkiaMetalGpu : ISkiaGpu
         private readonly SkiaMetalGpu _gpu;
         private SKSurface? _surface;
         private IMetalPlatformSurfaceRenderingSession? _session;
+        private GRBackendRenderTarget? _backendTarget;
 
-        public SkiaMetalRenderSession(SkiaMetalGpu gpu, 
+        public SkiaMetalRenderSession(SkiaMetalGpu gpu,
             SKSurface surface,
-            IMetalPlatformSurfaceRenderingSession session)
+            IMetalPlatformSurfaceRenderingSession session,
+            GRBackendRenderTarget backendTarget)
         {
             _gpu = gpu;
             _surface = surface;
             _session = session;
+            _backendTarget = backendTarget;
         }
 
         public void Dispose()
@@ -133,11 +136,13 @@ internal class SkiaMetalGpu : ISkiaGpu
             _surface?.Canvas.Flush();
             _surface?.Flush();
             _gpu._context?.Flush();
-            
+
             _surface?.Dispose();
             _surface = null;
             _session?.Dispose();
             _session = null;
+            _backendTarget?.Dispose();
+            _backendTarget = null;
         }
 
         public GRContext GrContext => _gpu._context!;


### PR DESCRIPTION
## What does the pull request do?
The 12.x branch uses Metal as default for macOS. In testing other features, I saw that memory usage increased whenever I resized the window. @maxkatz6 pointed me to https://github.com/AvaloniaUI/Avalonia/issues/17025, and it's this issue. For 11.2+, the default was changed to OpenGL, and for 12.x/master, it was set to Metal, but the underlying issue is still here, it was masked by the fact it was only in master.

This PR addresses that by:

- Adding `@autoreleasepool` to several `metal.mm` methods to free up their objects.
- Disposing GRBackendRenderTarget. This is created within SkiaMetalGpu, and is rendered with every new frame redraw. But GRBackendRenderTarget was not tracked and left hanging. 

This should keep memory use consistent when using the Metal backend. I needed both of these changes for it to work right: If I just disposed GRBackendRenderTarget then other objects would still leak from the Metal methods, and if I just used autoreleasepool, the memory use due to GRBackendRenderTarget would still explode.

This is before:

https://github.com/user-attachments/assets/8af1be62-b6ed-4b9e-a305-4feb25b6bd76

This is after:

https://github.com/user-attachments/assets/ce88dd9b-133c-4482-bb3a-5694a8fd554d


## Fixed issues
Fixes #17025
