### PR TITLE
[Navigation] Fire Page lifecycle events after transitions complete, not before

### DIFF
--- a/src/Avalonia.Controls/Page/NavigationPage.cs
+++ b/src/Avalonia.Controls/Page/NavigationPage.cs
@@ -43,6 +43,7 @@ namespace Avalonia.Controls
         private ContentPresenter? _pagePresenter;
         private ContentPresenter? _pageBackPresenter;
         private CancellationTokenSource? _currentTransition;
+        private Task? _lastPageTransitionTask;
         private CancellationTokenSource? _currentModalTransition;
         private Border? _navBar;
         private Border? _navBarShadow;
@@ -776,8 +777,10 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Performs the stack mutation and lifecycle events for a pop. The visual transition runs
-        /// subsequently via <see cref="UpdateActivePage"/>.
+        /// Performs the stack mutation for a pop. The visual transition runs
+        /// subsequently via <see cref="UpdateActivePage"/>. Callers are responsible
+        /// for firing lifecycle events (SendNavigatedFrom, SendNavigatedTo, Popped)
+        /// after awaiting the page transition.
         /// </summary>
         private Page? ExecutePopCore()
         {
@@ -810,11 +813,6 @@ namespace Avalonia.Controls
             {
                 old.Navigation = null;
                 old.SetInNavigationPage(false);
-
-                var newCurrentPage = CurrentPage;
-                old.SendNavigatedFrom(new NavigatedFromEventArgs(newCurrentPage, NavigationType.Pop));
-                newCurrentPage?.SendNavigatedTo(new NavigatedToEventArgs(old, NavigationType.Pop));
-                Popped?.Invoke(this, new NavigationEventArgs(old, NavigationType.Pop));
             }
 
             return old;
@@ -886,7 +884,19 @@ namespace Avalonia.Controls
                         return null;
                 }
 
-                return ExecutePopCore();
+                var old = ExecutePopCore();
+
+                await AwaitPageTransitionAsync();
+
+                if (old != null)
+                {
+                    var newCurrentPage = CurrentPage;
+                    old.SendNavigatedFrom(new NavigatedFromEventArgs(newCurrentPage, NavigationType.Pop));
+                    newCurrentPage?.SendNavigatedTo(new NavigatedToEventArgs(old, NavigationType.Pop));
+                    Popped?.Invoke(this, new NavigationEventArgs(old, NavigationType.Pop));
+                }
+
+                return old;
             }
             finally
             {
@@ -931,6 +941,7 @@ namespace Avalonia.Controls
                 }
 
                 bool isIncc = Pages is INotifyCollectionChanged;
+                var poppedPages = new List<Page>();
 
                 void TearDownPopped(Page popped)
                 {
@@ -939,8 +950,7 @@ namespace Avalonia.Controls
                         LogicalChildren.Remove(poppedLogical);
                     popped.Navigation = null;
                     popped.SetInNavigationPage(false);
-                    popped.SendNavigatedFrom(new NavigatedFromEventArgs(rootPage, NavigationType.PopToRoot));
-                    Popped?.Invoke(this, new NavigationEventArgs(popped, NavigationType.PopToRoot));
+                    poppedPages.Add(popped);
                 }
 
                 if (Pages is Stack<Page> stack)
@@ -961,6 +971,14 @@ namespace Avalonia.Controls
                 InvalidateNavigationStackCache();
                 _isPop = true;
                 UpdateActivePage();
+
+                await AwaitPageTransitionAsync();
+
+                foreach (var popped in poppedPages)
+                {
+                    popped.SendNavigatedFrom(new NavigatedFromEventArgs(rootPage, NavigationType.PopToRoot));
+                    Popped?.Invoke(this, new NavigationEventArgs(popped, NavigationType.PopToRoot));
+                }
 
                 var newCurrentPage = CurrentPage;
 
@@ -1013,6 +1031,7 @@ namespace Avalonia.Controls
                 }
 
                 bool isIncc = Pages is INotifyCollectionChanged;
+                var poppedPages = new List<Page>();
 
                 void TearDownPopped(Page popped)
                 {
@@ -1021,8 +1040,7 @@ namespace Avalonia.Controls
                         LogicalChildren.Remove(poppedLogical);
                     popped.Navigation = null;
                     popped.SetInNavigationPage(false);
-                    popped.SendNavigatedFrom(new NavigatedFromEventArgs(page, NavigationType.Pop));
-                    Popped?.Invoke(this, new NavigationEventArgs(popped, NavigationType.Pop));
+                    poppedPages.Add(popped);
                 }
 
                 if (Pages is Stack<Page> stack)
@@ -1043,6 +1061,14 @@ namespace Avalonia.Controls
                 InvalidateNavigationStackCache();
                 _isPop = true;
                 UpdateActivePage();
+
+                await AwaitPageTransitionAsync();
+
+                foreach (var popped in poppedPages)
+                {
+                    popped.SendNavigatedFrom(new NavigatedFromEventArgs(page, NavigationType.Pop));
+                    Popped?.Invoke(this, new NavigationEventArgs(popped, NavigationType.Pop));
+                }
 
                 var newCurrentPage = CurrentPage;
                 if (newCurrentPage != null)
@@ -1356,7 +1382,14 @@ namespace Avalonia.Controls
             {
                 if (stack.Count > 0 && ReferenceEquals(stack.Peek(), page))
                 {
-                    ExecutePopCore();
+                    var old = ExecutePopCore();
+                    if (old != null)
+                    {
+                        var newCurrentPage = CurrentPage;
+                        old.SendNavigatedFrom(new NavigatedFromEventArgs(newCurrentPage, NavigationType.Pop));
+                        newCurrentPage?.SendNavigatedTo(new NavigatedToEventArgs(old, NavigationType.Pop));
+                        Popped?.Invoke(this, new NavigationEventArgs(old, NavigationType.Pop));
+                    }
                     PageRemoved?.Invoke(this, new PageRemovedEventArgs(page));
                     return;
                 }
@@ -1387,7 +1420,14 @@ namespace Avalonia.Controls
 
                 if (idx == list.Count - 1)
                 {
-                    ExecutePopCore();
+                    var old = ExecutePopCore();
+                    if (old != null)
+                    {
+                        var newCurrentPage = CurrentPage;
+                        old.SendNavigatedFrom(new NavigatedFromEventArgs(newCurrentPage, NavigationType.Pop));
+                        newCurrentPage?.SendNavigatedTo(new NavigatedToEventArgs(old, NavigationType.Pop));
+                        Popped?.Invoke(this, new NavigationEventArgs(old, NavigationType.Pop));
+                    }
                     PageRemoved?.Invoke(this, new PageRemovedEventArgs(page));
                     return;
                 }
@@ -1595,12 +1635,14 @@ namespace Avalonia.Controls
                         oldPresenter.ZIndex = 0;
                     }
 
-                    _ = RunPageTransitionAsync(resolvedTransition, oldPresenter, newPresenter, !isPop, cancel.Token);
+                    _lastPageTransitionTask = RunPageTransitionAsync(resolvedTransition, oldPresenter, newPresenter, !isPop, cancel.Token);
 
                     (_pagePresenter, _pageBackPresenter) = (newPresenter, oldPresenter);
                 }
                 else
                 {
+                    _lastPageTransitionTask = null;
+
                     _pagePresenter.Content = page;
                     _pagePresenter.IsVisible = page != null;
                     _pagePresenter.ZIndex = 0;
@@ -1684,6 +1726,16 @@ namespace Avalonia.Controls
             from.Content = null;
             from.RenderTransform = null;
             from.Opacity = 1;
+        }
+
+        private async Task AwaitPageTransitionAsync()
+        {
+            var task = _lastPageTransitionTask;
+            if (task != null)
+            {
+                _lastPageTransitionTask = null;
+                await task;
+            }
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Page/NavigationPage.cs
+++ b/src/Avalonia.Controls/Page/NavigationPage.cs
@@ -770,10 +770,6 @@ namespace Avalonia.Controls
             page.SetInNavigationPage(true);
 
             UpdateActivePage();
-
-            previousPage?.SendNavigatedFrom(new NavigatedFromEventArgs(page, NavigationType.Push));
-            page.SendNavigatedTo(new NavigatedToEventArgs(previousPage, NavigationType.Push));
-            Pushed?.Invoke(this, new NavigationEventArgs(page, NavigationType.Push));
         }
 
         /// <summary>
@@ -842,6 +838,12 @@ namespace Avalonia.Controls
                 }
 
                 ExecutePushCore(page, previousPage);
+
+                await AwaitPageTransitionAsync();
+
+                previousPage?.SendNavigatedFrom(new NavigatedFromEventArgs(page, NavigationType.Push));
+                page.SendNavigatedTo(new NavigatedToEventArgs(previousPage, NavigationType.Push));
+                Pushed?.Invoke(this, new NavigationEventArgs(page, NavigationType.Push));
             }
             finally
             {

--- a/src/Avalonia.Controls/Page/NavigationPage.cs
+++ b/src/Avalonia.Controls/Page/NavigationPage.cs
@@ -43,7 +43,7 @@ namespace Avalonia.Controls
         private ContentPresenter? _pagePresenter;
         private ContentPresenter? _pageBackPresenter;
         private CancellationTokenSource? _currentTransition;
-        private Task? _lastPageTransitionTask;
+        private Task _lastPageTransitionTask = Task.CompletedTask;
         private CancellationTokenSource? _currentModalTransition;
         private Border? _navBar;
         private Border? _navBarShadow;
@@ -779,8 +779,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Performs the stack mutation for a pop. The visual transition runs
         /// subsequently via <see cref="UpdateActivePage"/>. Callers are responsible
-        /// for firing lifecycle events (SendNavigatedFrom, SendNavigatedTo, Popped)
-        /// after awaiting the page transition.
+        /// for firing lifecycle events via <see cref="SendPopLifecycleEvents"/>
+        /// after awaiting the page transition where possible.
         /// </summary>
         private Page? ExecutePopCore()
         {
@@ -889,12 +889,7 @@ namespace Avalonia.Controls
                 await AwaitPageTransitionAsync();
 
                 if (old != null)
-                {
-                    var newCurrentPage = CurrentPage;
-                    old.SendNavigatedFrom(new NavigatedFromEventArgs(newCurrentPage, NavigationType.Pop));
-                    newCurrentPage?.SendNavigatedTo(new NavigatedToEventArgs(old, NavigationType.Pop));
-                    Popped?.Invoke(this, new NavigationEventArgs(old, NavigationType.Pop));
-                }
+                    SendPopLifecycleEvents(old, NavigationType.Pop);
 
                 return old;
             }
@@ -1384,12 +1379,7 @@ namespace Avalonia.Controls
                 {
                     var old = ExecutePopCore();
                     if (old != null)
-                    {
-                        var newCurrentPage = CurrentPage;
-                        old.SendNavigatedFrom(new NavigatedFromEventArgs(newCurrentPage, NavigationType.Pop));
-                        newCurrentPage?.SendNavigatedTo(new NavigatedToEventArgs(old, NavigationType.Pop));
-                        Popped?.Invoke(this, new NavigationEventArgs(old, NavigationType.Pop));
-                    }
+                        SendPopLifecycleEvents(old, NavigationType.Pop);
                     PageRemoved?.Invoke(this, new PageRemovedEventArgs(page));
                     return;
                 }
@@ -1422,12 +1412,7 @@ namespace Avalonia.Controls
                 {
                     var old = ExecutePopCore();
                     if (old != null)
-                    {
-                        var newCurrentPage = CurrentPage;
-                        old.SendNavigatedFrom(new NavigatedFromEventArgs(newCurrentPage, NavigationType.Pop));
-                        newCurrentPage?.SendNavigatedTo(new NavigatedToEventArgs(old, NavigationType.Pop));
-                        Popped?.Invoke(this, new NavigationEventArgs(old, NavigationType.Pop));
-                    }
+                        SendPopLifecycleEvents(old, NavigationType.Pop);
                     PageRemoved?.Invoke(this, new PageRemovedEventArgs(page));
                     return;
                 }
@@ -1641,7 +1626,7 @@ namespace Avalonia.Controls
                 }
                 else
                 {
-                    _lastPageTransitionTask = null;
+                    _lastPageTransitionTask = Task.CompletedTask;
 
                     _pagePresenter.Content = page;
                     _pagePresenter.IsVisible = page != null;
@@ -1728,14 +1713,23 @@ namespace Avalonia.Controls
             from.Opacity = 1;
         }
 
-        private async Task AwaitPageTransitionAsync()
+        private Task AwaitPageTransitionAsync()
         {
             var task = _lastPageTransitionTask;
-            if (task != null)
-            {
-                _lastPageTransitionTask = null;
-                await task;
-            }
+            _lastPageTransitionTask = Task.CompletedTask;
+            return task;
+        }
+
+        /// <summary>
+        /// Fires lifecycle events after a pop: SendNavigatedFrom on the old page,
+        /// SendNavigatedTo on the new current page, and raises the Popped event.
+        /// </summary>
+        private void SendPopLifecycleEvents(Page oldPage, NavigationType navigationType)
+        {
+            var newCurrentPage = CurrentPage;
+            oldPage.SendNavigatedFrom(new NavigatedFromEventArgs(newCurrentPage, navigationType));
+            newCurrentPage?.SendNavigatedTo(new NavigatedToEventArgs(oldPage, navigationType));
+            Popped?.Invoke(this, new NavigationEventArgs(oldPage, navigationType));
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/NavigationPageTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NavigationPageTests.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Animation;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.UnitTests;
@@ -1571,6 +1575,166 @@ public class NavigationPageTests
             Assert.True(m1PoppedFired);
             Assert.True(m2PoppedFired);
             Assert.True(rootNavigatedToFired);
+        }
+    }
+
+    public class LifecycleAfterTransitionTests : ScopedTestBase
+    {
+        [Fact]
+        public async Task PushAsync_LifecycleEvents_FireAfterTransition()
+        {
+            var tcs = new TaskCompletionSource();
+            var transition = new ControllableTransition(tcs.Task);
+            var nav = CreateNavigationPage(transition);
+
+            var root = new ContentPage { Header = "Root" };
+            await nav.PushAsync(root);
+
+            bool navigatedFromDuringTransition = false;
+            bool navigatedToDuringTransition = false;
+            bool pushedDuringTransition = false;
+
+            var second = new ContentPage { Header = "Second" };
+            root.NavigatedFrom += (_, _) => navigatedFromDuringTransition = !tcs.Task.IsCompleted;
+            second.NavigatedTo += (_, _) => navigatedToDuringTransition = !tcs.Task.IsCompleted;
+            nav.Pushed += (_, _) => pushedDuringTransition = !tcs.Task.IsCompleted;
+
+            var pushTask = nav.PushAsync(second);
+
+            tcs.SetResult();
+            await pushTask;
+
+            Assert.False(navigatedFromDuringTransition);
+            Assert.False(navigatedToDuringTransition);
+            Assert.False(pushedDuringTransition);
+        }
+
+        [Fact]
+        public async Task PopAsync_LifecycleEvents_FireAfterTransition()
+        {
+            var tcs = new TaskCompletionSource();
+            var nav = CreateNavigationPage(null);
+
+            var root = new ContentPage { Header = "Root" };
+            var top = new ContentPage { Header = "Top" };
+            await nav.PushAsync(root);
+            await nav.PushAsync(top);
+
+            nav.PageTransition = new ControllableTransition(tcs.Task);
+
+            bool navigatedFromDuringTransition = false;
+            bool navigatedToDuringTransition = false;
+            bool poppedDuringTransition = false;
+
+            top.NavigatedFrom += (_, _) => navigatedFromDuringTransition = !tcs.Task.IsCompleted;
+            root.NavigatedTo += (_, _) => navigatedToDuringTransition = !tcs.Task.IsCompleted;
+            nav.Popped += (_, _) => poppedDuringTransition = !tcs.Task.IsCompleted;
+
+            var popTask = nav.PopAsync();
+
+            tcs.SetResult();
+            await popTask;
+
+            Assert.False(navigatedFromDuringTransition);
+            Assert.False(navigatedToDuringTransition);
+            Assert.False(poppedDuringTransition);
+        }
+
+        [Fact]
+        public async Task PopToRootAsync_LifecycleEvents_FireAfterTransition()
+        {
+            var tcs = new TaskCompletionSource();
+            var nav = CreateNavigationPage(null);
+
+            var root = new ContentPage { Header = "Root" };
+            var second = new ContentPage { Header = "Second" };
+            var third = new ContentPage { Header = "Third" };
+            await nav.PushAsync(root);
+            await nav.PushAsync(second);
+            await nav.PushAsync(third);
+
+            nav.PageTransition = new ControllableTransition(tcs.Task);
+
+            bool navigatedFromDuringTransition = false;
+            bool navigatedToDuringTransition = false;
+            bool poppedToRootDuringTransition = false;
+
+            second.NavigatedFrom += (_, _) => navigatedFromDuringTransition = !tcs.Task.IsCompleted;
+            third.NavigatedFrom += (_, _) => navigatedFromDuringTransition = !tcs.Task.IsCompleted;
+            root.NavigatedTo += (_, _) => navigatedToDuringTransition = !tcs.Task.IsCompleted;
+            nav.PoppedToRoot += (_, _) => poppedToRootDuringTransition = !tcs.Task.IsCompleted;
+
+            var popTask = nav.PopToRootAsync();
+
+            tcs.SetResult();
+            await popTask;
+
+            Assert.False(navigatedFromDuringTransition);
+            Assert.False(navigatedToDuringTransition);
+            Assert.False(poppedToRootDuringTransition);
+        }
+
+        private static NavigationPage CreateNavigationPage(IPageTransition? transition)
+        {
+            var nav = new NavigationPage
+            {
+                PageTransition = transition,
+                Template = NavigationPageTemplate()
+            };
+            var root = new TestRoot { Child = nav };
+            root.LayoutManager.ExecuteInitialLayoutPass();
+            return nav;
+        }
+
+        private static IControlTemplate NavigationPageTemplate()
+        {
+            return new FuncControlTemplate<NavigationPage>((parent, ns) =>
+            {
+                var contentHost = new Panel
+                {
+                    Name = "PART_ContentHost",
+                    Children =
+                    {
+                        new ContentPresenter { Name = "PART_PageBackPresenter" }.RegisterInNameScope(ns),
+                        new ContentPresenter { Name = "PART_PagePresenter" }.RegisterInNameScope(ns),
+                    }
+                }.RegisterInNameScope(ns);
+
+                return new Panel
+                {
+                    Children =
+                    {
+                        new Border
+                        {
+                            Name = "PART_NavigationBar",
+                            Child = new Button { Name = "PART_BackButton" }.RegisterInNameScope(ns)
+                        }.RegisterInNameScope(ns),
+                        contentHost,
+                        new ContentPresenter { Name = "PART_TopCommandBar" }.RegisterInNameScope(ns),
+                        new ContentPresenter { Name = "PART_ModalBackPresenter" }.RegisterInNameScope(ns),
+                        new ContentPresenter { Name = "PART_ModalPresenter" }.RegisterInNameScope(ns),
+                    }
+                };
+            });
+        }
+
+        private class ControllableTransition : IPageTransition
+        {
+            private readonly Task _gate;
+
+            public ControllableTransition(Task gate)
+            {
+                _gate = gate;
+            }
+
+            public async Task Start(Visual? from, Visual? to, bool forward, CancellationToken cancellationToken)
+            {
+                if (to != null)
+                    to.IsVisible = true;
+                await _gate;
+                if (from != null)
+                    from.IsVisible = false;
+            }
         }
     }
 


### PR DESCRIPTION
I got bit by this while working on the .NET MAUI/Avalonia Handlers, and porting the existing code we were writing to use the new Navigation controls.

## What does the pull request do?
Moves the lifecycle events out to happen after the animation events have been returned.

## What is the current behavior?
NavigationPage was firing lifecycle events (SendNavigatedFrom, SendNavigatedTo, Popped) synchronously inside ExecutePopCore before the page transition animation had finished. This meant event consumers (ex. Handlers disposing resources) would run while the old page was still visually animating out. For me, this caused all MAUI Cross Platform Layout to be nulled out and either crash, or glitch.

## What is the updated/expected behavior with this PR?
Fires the lifecycle events _after_ the animation events have been returned. This way, we can rely on those events to know that the new page is visible so we can handle what we need to for previous pages. 

## How was the solution implemented (if it's not obvious)?

- Moves ExecutePopCore to only handle stack mutation and teardown, deferring lifecycle events to callers
- In async pop paths (PopAsync, PopToRootAsync, PopToPageAsync), awaits the page transition via AwaitPageTransitionAsync()
  before firing lifecycle events
- Extracts SendPopLifecycleEvents to consolidate the repeated event-firing pattern
