### PR TITLE
Translation property for CompositionVisual

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual/ServerCompositionVisual.Adorners.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual/ServerCompositionVisual.Adorners.cs
@@ -52,7 +52,7 @@ partial class ServerCompositionVisual
             // We ignore Visual's RenderTransform completely since it's set by AdornerLayer and can be out of sync
             // with compositor-driver animations
             var ownTransform = MatrixUtils.ComputeTransform(Size, AnchorPoint, CenterPoint, Matrix.Identity, Scale,
-                RotationAngle, Orientation, Offset);
+                RotationAngle, Orientation, Offset + Translation);
             if (
                 AdornerLayer_GetExpectedSharedAncestor(this) is {} sharedAncestor
                 && ComputeTransformFromAncestor(AdornedVisual, sharedAncestor, out var adornerLayerToAdornedVisual))
@@ -63,7 +63,7 @@ partial class ServerCompositionVisual
         }
         else
             _ownTransform = MatrixUtils.ComputeTransform(Size, AnchorPoint, CenterPoint, TransformMatrix, Scale,
-                RotationAngle, Orientation, Offset);
+                RotationAngle, Orientation, Offset + Translation);
 
         
         PropagateFlags(true, true);

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual/ServerCompositionVisual.ComputedProperties.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual/ServerCompositionVisual.ComputedProperties.cs
@@ -148,7 +148,7 @@ partial class ServerCompositionVisual
         if (_combinedTransformDirty)
         {
             _ownTransform = MatrixUtils.ComputeTransform(Size, AnchorPoint, CenterPoint, TransformMatrix, Scale,
-                RotationAngle, Orientation, Offset);
+                RotationAngle, Orientation, Offset + Translation);
             
             setDirtyForRender = setDirtyBounds = true;
             

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual/ServerCompositionVisual.DirtyInputs.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual/ServerCompositionVisual.DirtyInputs.cs
@@ -43,7 +43,9 @@ partial class ServerCompositionVisual
         | CompositionVisualChangedFields.Orientation
         | CompositionVisualChangedFields.OrientationAnimated
         | CompositionVisualChangedFields.Offset
-        | CompositionVisualChangedFields.OffsetAnimated;
+        | CompositionVisualChangedFields.OffsetAnimated
+        | CompositionVisualChangedFields.Translation
+        | CompositionVisualChangedFields.TranslationAnimated;
 
     private const CompositionVisualChangedFields ClipSizeDirtyMask =
         CompositionVisualChangedFields.Size
@@ -100,7 +102,8 @@ partial class ServerCompositionVisual
             || property == s_IdOfScaleProperty
             || property == s_IdOfRotationAngleProperty
             || property == s_IdOfOrientationProperty
-            || property == s_IdOfOffsetProperty) 
+            || property == s_IdOfOffsetProperty
+            || property == s_IdOfTranslationProperty) 
             TriggerCombinedTransformDirty();
 
         if (property == s_IdOfClipToBoundsProperty

--- a/src/Avalonia.Base/composition-schema.xml
+++ b/src/Avalonia.Base/composition-schema.xml
@@ -22,6 +22,7 @@
         <Property Name="Clip" Type="Avalonia.Platform.IGeometryImpl?" Internal="true" />
         <Property Name="ClipToBounds" Type="bool" Animated="true" DefaultValue="true"/>
         <Property Name="Offset" Type="Vector3D" Animated="true"/>
+        <Property Name="Translation" Type="Vector3D" Animated="true"/>
         <Property Name="Size" Type="Vector" Animated="true"/>
         <Property Name="AnchorPoint" Type="Vector" Animated="true"/>
         <Property Name="CenterPoint" Type="Vector3D" Animated="true"/>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->


## What does the pull request do?
This pull request introduces support for a new `Translation` property in the composition visual system, ensuring that translation is properly handled alongside existing transform properties. The changes update the transform computation logic, property schema, and dirty flag tracking to account for this new property.

## What is the current behavior?
Currently, we can use `Offset` property to animate a visual's position. 

However, the `Offset` property in `CompositionVisual` is shared with XAML layout framework. 

This means when layout changed(e.g. resize window), any composition animation running on `Offset` will be broken as `SynchronizeCompositionProperties` synchronized the XAML visual's `Offset`.

One solution is wrapping a border around layout properties in Mark-up. While it looks fine, note that the code is less intuitive and requires work in both mark-up and the code-behind. You need to wrap the rectangle in a border and then animate the border not the rect.

## What is the updated/expected behavior with this PR?
Added a new `Translation` property for `CompositionVisual`  as a "relative offset", which only affects the final rendering process. This property won't be synchronized by XAML visual, so it's very suitable for making animations for a visual's position.


https://github.com/user-attachments/assets/dbf2017f-5d02-4b0a-a518-a1df2022111f


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
#9105 (partially)
