### PR TITLE
Add NumericUpDown.ValueIfTextIsNullOrEmpty property

### DIFF
--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -109,6 +109,12 @@ namespace Avalonia.Controls
                 defaultBindingMode: BindingMode.TwoWay, enableDataValidation: true);
 
         /// <summary>
+        /// Defines the <see cref="ValueIfTextIsNullOrEmpty"/> property.
+        /// </summary>
+        public static readonly StyledProperty<decimal?> ValueIfTextIsNullOrEmptyProperty =
+            AvaloniaProperty.Register<NumericUpDown, decimal?>(nameof(ValueIfTextIsNullOrEmpty));
+        
+        /// <summary>
         /// Defines the <see cref="PlaceholderText"/> property.
         /// </summary>
         public static readonly StyledProperty<string?> PlaceholderTextProperty =
@@ -313,6 +319,15 @@ namespace Avalonia.Controls
         {
             get => GetValue(ValueProperty);
             set => SetValue(ValueProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the fallback value if the text is null or empty.
+        /// </summary>
+        public decimal? ValueIfTextIsNullOrEmpty
+        {
+            get => GetValue(ValueIfTextIsNullOrEmptyProperty);
+            set => SetValue(ValueIfTextIsNullOrEmptyProperty, value);
         }
 
         /// <summary>
@@ -703,7 +718,7 @@ namespace Avalonia.Controls
 
             if (string.IsNullOrEmpty(text))
             {
-                return result;
+                return ValueIfTextIsNullOrEmpty;
             }
 
             // Since the conversion from Value to text using a FormatString may not be parsable,

--- a/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
@@ -100,6 +100,31 @@ namespace Avalonia.Controls.UnitTests
             });
         }
 
+        [Theory]
+        [InlineData(10.0, 0.0)]
+        [InlineData(0.5, 0.5)]
+        [InlineData(-0.5, -0.5)]
+        [InlineData(null, null)]
+        public void FallbackValueIsApplied(double? value, double? fallbackValue)
+        {
+            RunTest((control, textbox) =>
+            {
+                // prepare the control
+                control.Value = (decimal?)value;
+                control.ValueIfTextIsNullOrEmpty = (decimal?)fallbackValue;
+                Assert.Equal(control.Value, (decimal?)value);
+                Assert.Equal(control.Text, textbox.Text);
+                
+                // clear textBox
+                textbox.Text = string.Empty;
+                Dispatcher.UIThread.RunJobs();
+                
+                // Assert that the fallback was set and the textBox displays it.
+                Assert.Equal(control.Value, (decimal?)fallbackValue);
+                Assert.Equal(control.Text, textbox.Text);
+            });
+        }
+        
         public static IEnumerable<object?[]> Increment_Decrement_TestData()
         {
             // if min and max are not defined and value was null, 0 should be ne new value after spin


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Adds a new styled property `decimal? ValueIfTextIsNullOrEmpty` to `NumericUpDown`. this way the developers can configure what should happen in the user clears the TextBox of the NUD control. The default value is `null`, which is the current behavior.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
If the control is bound to a property that is not nullable and the user clears the input field, a validation message is shown instead of a default value. This can be confusing for some users.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The developer can set a fallback to any value. Some may want to set it to `0`, other to `Minimum` or `Maximum`. 

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation (should be done after we decide the API shape)

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #19471

