### PR TITLE
Make NumericUpDown.ClipValueToMinMax true by default

### DIFF
--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -721,8 +721,6 @@ namespace Avalonia.Controls
                 return MathUtilities.Clamp(result.Value, Minimum, Maximum);
             }
 
-            ValidateMinMax(result);
-
             return result;
         }
 
@@ -1201,22 +1199,6 @@ namespace Avalonia.Controls
                 result = outputValue;
             }
             return result;
-        }
-
-        private void ValidateMinMax(decimal? value)
-        {
-            if (!value.HasValue)
-            {
-                return;
-            }
-            if (value < Minimum)
-            {
-                throw new ArgumentOutOfRangeException(nameof(value), $"Value must be greater than Minimum value of {Minimum}");
-            }
-            else if (value > Maximum)
-            {
-                throw new ArgumentOutOfRangeException(nameof(value), $"Value must be less than Maximum value of {Maximum}");
-            }
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -44,7 +44,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="ClipValueToMinMax"/> property.
         /// </summary>
         public static readonly StyledProperty<bool> ClipValueToMinMaxProperty =
-            AvaloniaProperty.Register<NumericUpDown, bool>(nameof(ClipValueToMinMax));
+            AvaloniaProperty.Register<NumericUpDown, bool>(nameof(ClipValueToMinMax), true);
 
         /// <summary>
         /// Defines the <see cref="NumberFormat"/> property.

--- a/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
@@ -100,6 +100,33 @@ namespace Avalonia.Controls.UnitTests
             });
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(50)]
+        [InlineData(100)]
+        [InlineData(-180)]
+        [InlineData(180)]
+        public void No_Clip_To_Min_Max_Can_Accept_Any_Value(double value)
+        {
+            RunTest((control, textbox) =>
+            {
+                // Set the allowed range of the control and disable clipping to the min/max.
+                control.ClipValueToMinMax = false;
+                control.Minimum = 0;
+                control.Maximum = 100;
+                
+                // type text
+                textbox.Text = value.ToString(CultureInfo.InvariantCulture);
+                
+                Dispatcher.UIThread.RunJobs();
+                
+                // Assert that the control's text is the same as the value.
+                Assert.Equal(value.ToString(CultureInfo.InvariantCulture), control.Text);
+                // Assert that the control's value is the same as the value.
+                Assert.Equal((decimal)value, control.Value);
+            });
+        }
+        
         public static IEnumerable<object?[]> Increment_Decrement_TestData()
         {
             // if min and max are not defined and value was null, 0 should be ne new value after spin


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Make `ClipValueToMinMax` true by default

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
this is a behavior breaking change, so better not backport it. However I think most users want to clip to MinMax actually

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #18898
