### PR TITLE
Add automation landmarks to HamburgerMenu

### DIFF
--- a/samples/SampleControls/HamburgerMenu/HamburgerMenu.xaml
+++ b/samples/SampleControls/HamburgerMenu/HamburgerMenu.xaml
@@ -73,7 +73,8 @@
                           CornerRadius="{TemplateBinding CornerRadius}"
                           TextElement.FontFamily="{TemplateBinding FontFamily}"
                           TextElement.FontSize="{TemplateBinding FontSize}"
-                          TextElement.FontWeight="{TemplateBinding FontWeight}" />
+                          TextElement.FontWeight="{TemplateBinding FontWeight}"
+                          AutomationProperties.LandmarkType="Main" />
       </ControlTemplate>
     </Setter>
 
@@ -182,7 +183,9 @@
                               HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                               VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
                   <ItemsPresenter Name="PART_ItemsPresenter"
-                                  HorizontalAlignment="Stretch">
+                                  HorizontalAlignment="Stretch"
+                                  AutomationProperties.ControlTypeOverride="List"
+                                  AutomationProperties.LandmarkType="Navigation">
                     <ItemsPresenter.ItemsPanel>
                       <ItemsPanelTemplate>
                         <StackPanel x:Name="HamburgerItemsPanel"
@@ -201,7 +204,9 @@
             </SplitView.Pane>
             <SplitView.Content>
               <DockPanel>
-                <Border Height="{StaticResource HeaderHeight}" DockPanel.Dock="Top">
+                <Border Height="{StaticResource HeaderHeight}"
+                        DockPanel.Dock="Top"
+                        AutomationProperties.LandmarkType="Banner">
                   <TextBlock x:Name="HeaderHolder"
                              VerticalAlignment="Center"
                              Classes="h1"
@@ -246,7 +251,8 @@
                         HorizontalContentAlignment="Center"
                         Theme="{StaticResource NavigationButton}"
                         CornerRadius="4"
-                        IsChecked="{Binding #PART_NavigationPane.IsPaneOpen, Mode=TwoWay}">
+                        IsChecked="{Binding #PART_NavigationPane.IsPaneOpen, Mode=TwoWay}"
+                        AutomationProperties.ControlTypeOverride="ListItem">
             <PathIcon Data="M3 17h18a1 1 0 0 1 .117 1.993L21 19H3a1 1 0 0 1-.117-1.993L3 17h18H3Zm0-6 18-.002a1 1 0 0 1 .117 1.993l-.117.007L3 13a1 1 0 0 1-.117-1.993L3 11l18-.002L3 11Zm0-6h18a1 1 0 0 1 .117 1.993L21 7H3a1 1 0 0 1-.117-1.993L3 5h18H3Z" Foreground="{TemplateBinding Foreground}" />
           </ToggleButton>
         </Panel>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds some standard automation landmark types to HamburgerMenu. Since this control might be reused by other projects, it’s worth making sure this is already implemented for them.

## What is the current behavior?
Screen readers aren’t able to jump between major landmarks, because there aren’t any. They also don’t recognise the menu as being a list.

## What is the updated/expected behavior with this PR?
Screen readers can jump to the major landmarks, announces them to help the user understand where they are, and correctly refers to the menu as a list (this will be more relevant with #20733).

## How was the solution implemented (if it's not obvious)?
* Menu becomes a Navigation landmark, and control type override of List
* Menu items have a control type override of ListItem
* Title area becomes a Banner landmark
* Content area becomes a Main landmark

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML→cumentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
None

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
None

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
None