### PR TITLE
Switch all time values in X11 to UIntPtr

### DIFF
--- a/src/Avalonia.X11/X11Info.cs
+++ b/src/Avalonia.X11/X11Info.cs
@@ -27,7 +27,7 @@ namespace Avalonia.X11
         
         public Version? XInputVersion { get; }
 
-        public IntPtr LastActivityTimestamp { get; set; }
+        public UIntPtr LastActivityTimestamp { get; set; }
         public XVisualInfo? TransparentVisualInfo { get; }
         public bool HasXim { get; }
         public bool HasXSync { get; }

--- a/src/Avalonia.X11/X11Structs.cs
+++ b/src/Avalonia.X11/X11Structs.cs
@@ -69,7 +69,7 @@ namespace Avalonia.X11 {
 		internal IntPtr		window;
 		internal IntPtr		root;
 		internal IntPtr		subwindow;
-		internal IntPtr		time;
+		internal UIntPtr	time;
 		internal int		x;
 		internal int		y;
 		internal int		x_root;
@@ -88,7 +88,7 @@ namespace Avalonia.X11 {
 		internal IntPtr		window;
 		internal IntPtr		root;
 		internal IntPtr		subwindow;
-		internal IntPtr		time;
+		internal UIntPtr	time;
 		internal int		x;
 		internal int		y;
 		internal int		x_root;
@@ -107,7 +107,7 @@ namespace Avalonia.X11 {
 		internal IntPtr		window;
 		internal IntPtr		root;
 		internal IntPtr		subwindow;
-		internal IntPtr		time;
+		internal UIntPtr	time;
 		internal int		x;
 		internal int		y;
 		internal int		x_root;
@@ -126,7 +126,7 @@ namespace Avalonia.X11 {
 		internal IntPtr		window;
 		internal IntPtr		root;
 		internal IntPtr		subwindow;
-		internal IntPtr		time;
+		internal UIntPtr	time;
 		internal int		x;
 		internal int		y;
 		internal int		x_root;
@@ -401,7 +401,7 @@ namespace Avalonia.X11 {
 		internal IntPtr		display;
 		internal IntPtr		window;
 		internal IntPtr		atom;
-		internal IntPtr		time;
+		internal UIntPtr	time;
 		internal int		state;
 	}
 
@@ -413,7 +413,7 @@ namespace Avalonia.X11 {
 		internal IntPtr		display;
 		internal IntPtr		window;
 		internal IntPtr		selection;
-		internal IntPtr		time;
+		internal UIntPtr	time;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
@@ -427,7 +427,7 @@ namespace Avalonia.X11 {
 		internal IntPtr		selection;
 		internal IntPtr		target;
 		internal IntPtr		property;
-		internal IntPtr		time;
+		internal UIntPtr	time;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
@@ -440,7 +440,7 @@ namespace Avalonia.X11 {
 		internal IntPtr		selection;
 		internal IntPtr		target;
 		internal IntPtr		property;
-		internal IntPtr		time;
+		internal UIntPtr	time;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]

--- a/src/Avalonia.X11/X11Window.Ime.cs
+++ b/src/Avalonia.X11/X11Window.Ime.cs
@@ -77,7 +77,7 @@ namespace Avalonia.X11
             {
                 (_ime, _imeControl) = ime.Value;
                 _imeControl.Commit += s =>
-                    ScheduleInput(new RawTextInputEventArgs(_keyboard, (ulong)_x11.LastActivityTimestamp.ToInt64(),
+                    ScheduleInput(new RawTextInputEventArgs(_keyboard, _x11.LastActivityTimestamp.ToUInt64(),
                         InputRoot, s));
                 _imeControl.ForwardKey += OnImeControlForwardKey;
             }
@@ -91,7 +91,7 @@ namespace Avalonia.X11
             ScheduleInput(forwardedKey.WithText ?
                 new RawKeyEventArgsWithText(
                     _keyboard,
-                    (ulong)_x11.LastActivityTimestamp.ToInt64(),
+                    _x11.LastActivityTimestamp.ToUInt64(),
                     InputRoot,
                     forwardedKey.Type,
                     X11KeyTransform.KeyFromX11Key(x11Key),
@@ -101,7 +101,7 @@ namespace Avalonia.X11
                     keySymbol) :
                 new RawKeyEventArgs(
                     _keyboard,
-                    (ulong)_x11.LastActivityTimestamp.ToInt64(),
+                    _x11.LastActivityTimestamp.ToUInt64(),
                     InputRoot,
                     forwardedKey.Type,
                     X11KeyTransform.KeyFromX11Key(x11Key),
@@ -117,7 +117,7 @@ namespace Avalonia.X11
             var physicalKey = X11KeyTransform.PhysicalKeyFromScanCode(ev.KeyEvent.keycode);
             var (x11Key, key, symbol) = LookupKey(ref ev.KeyEvent, physicalKey);
             var modifiers = TranslateModifiers(ev.KeyEvent.state);
-            var timestamp = (ulong)ev.KeyEvent.time.ToInt64();
+            var timestamp = ev.KeyEvent.time.ToUInt64();
 
             var args = ev.type == XEventName.KeyPress ?
                 new RawKeyEventArgsWithText(

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -574,7 +574,7 @@ namespace Avalonia.X11
                             : ev.ButtonEvent.button == 6
                                 ? new Vector(1, 0)
                                 : new Vector(-1, 0);
-                    ScheduleInput(new RawMouseWheelEventArgs(_mouse, (ulong)ev.ButtonEvent.time.ToInt64(),
+                    ScheduleInput(new RawMouseWheelEventArgs(_mouse, ev.ButtonEvent.time.ToUInt64(),
                         _inputRoot, new Point(ev.ButtonEvent.x, ev.ButtonEvent.y), delta,
                         TranslateModifiers(ev.ButtonEvent.state)), ref ev);
                 }
@@ -781,7 +781,7 @@ namespace Avalonia.X11
                     ChangeWMAtoms(false, _x11.Atoms._NET_WM_STATE_FULLSCREEN);
                     ChangeWMAtoms(false, _x11.Atoms._NET_WM_STATE_MAXIMIZED_VERT,
                         _x11.Atoms._NET_WM_STATE_MAXIMIZED_HORZ);
-                    SendNetWMMessage(_x11.Atoms._NET_ACTIVE_WINDOW, (IntPtr)1, _x11.LastActivityTimestamp,
+                    SendNetWMMessage(_x11.Atoms._NET_ACTIVE_WINDOW, (IntPtr)1, (IntPtr)_x11.LastActivityTimestamp,
                         IntPtr.Zero);
                 }
                 WindowStateChanged?.Invoke(value);
@@ -972,7 +972,7 @@ namespace Avalonia.X11
             if (_inputRoot is null)
                 return;
             var mev = new RawPointerEventArgs(
-                _mouse, (ulong)ev.ButtonEvent.time.ToInt64(), _inputRoot,
+                _mouse, ev.ButtonEvent.time.ToUInt64(), _inputRoot,
                 type, new Point(ev.ButtonEvent.x, ev.ButtonEvent.y), TranslateModifiers(mods));
             ScheduleInput(mev, ref ev);
         }

--- a/src/Avalonia.X11/XI2Manager.cs
+++ b/src/Avalonia.X11/XI2Manager.cs
@@ -307,7 +307,7 @@ namespace Avalonia.X11
                         _pointerDevice.Valuators[scroller.Number].Value = 0;
                     }
 
-                    client.ScheduleXI2Input(new RawPointerEventArgs(client.MouseDevice, (ulong)ev.time.ToInt64(),
+                    client.ScheduleXI2Input(new RawPointerEventArgs(client.MouseDevice, ev.time.ToUInt64(),
                         client.InputRoot,
                         RawPointerEventType.LeaveWindow, new Point(ev.event_x, ev.event_y), buttons));
                 }
@@ -557,7 +557,7 @@ namespace Avalonia.X11
             public ParsedDeviceEvent(XIDeviceEvent* ev)
             {
                 Type = ev->evtype;
-                Timestamp = (ulong)ev->time.ToInt64();
+                Timestamp = ev->time.ToUInt64();
                 var state = (XModifierMask)ev->mods.Effective;
                 if (state.HasAllFlags(XModifierMask.ShiftMask))
                     Modifiers |= RawInputModifiers.Shift;

--- a/src/Avalonia.X11/XIStructs.cs
+++ b/src/Avalonia.X11/XIStructs.cs
@@ -219,7 +219,7 @@ namespace Avalonia.X11
         public IntPtr display; /* Display the event was read from */
         public int extension; /* XI extension offset */
         public XiEventType evtype;
-        public IntPtr time;
+        public UIntPtr time;
         public int deviceid;
         public int sourceid;
         public int detail;
@@ -246,7 +246,7 @@ namespace Avalonia.X11
         public IntPtr display; /* Display the event was read from */
         public int extension; /* XI extension offset */
         public XiEventType evtype;
-        public IntPtr time;
+        public UIntPtr time;
         public int deviceid;
         public int sourceid;
         public XiEnterLeaveDetail detail;
@@ -287,7 +287,7 @@ namespace Avalonia.X11
         public IntPtr display; /* Display the event was read from */
         public int extension; /* XI extension offset */
         public XiEventType evtype;
-        public IntPtr time;
+        public UIntPtr time;
     }
 
     internal enum XiEventType


### PR DESCRIPTION
They're all unsigned at the native layer. This means we should always be treated them as unsigned in the FFI layer

## What does the pull request do?
#20858 reported a bug where on 32 bit linux, the signed IntPtr would overflow after 25 days. This meant when converting to long and then to ulong, the negative value would overflow to a massively large positive value, causing a crash when converting that value to a TimeSpan.

The PR switches all instances of time in X11 from IntPtr to UIntPtr. This means theres no signed expansion, which means the cast on 32 bit platforms from UIntPtr to ulong will just rollover back to 0, instead of a huge negative number.

On 64 bit platforms, this change is unobservable, as getting to 63 bits of milliseconds is well beyond any feasable timespan.

## What is the current behavior?
An event occuring after 25 days on 32 bit platforms rolls over to a very large value and crashes.


## What is the updated/expected behavior with this PR?
The event timestamps last for 50 days, but then rollover to 0, instead of a large positive number.

## Breaking changes
None, all internal structures.

## Fixed issues
Fixes the crash of ##20858, but doesn't check what the behavior of other parts of the system is after rollover.
-->
