### PR TITLE
[WIP]Fix compositor dirty rect gap when ServerList children are replaced

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual/ServerCompositionVisual.DirtyInputs.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual/ServerCompositionVisual.DirtyInputs.cs
@@ -150,6 +150,12 @@ partial class ServerCompositionVisual
             Parent.AddExtraDirtyRect(_transformedSubTreeBounds.Value);
         AttHelper_ParentChanging();
     }
+
+    internal void AddTransformedSubTreeBoundsToParentDirtyRect()
+    {
+        if (Parent != null && _transformedSubTreeBounds.HasValue)
+            Parent.AddExtraDirtyRect(_transformedSubTreeBounds.Value);
+    }
     
     partial void OnParentChanged()
     {

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual/ServerCompositionVisual.DirtyInputs.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual/ServerCompositionVisual.DirtyInputs.cs
@@ -146,8 +146,7 @@ partial class ServerCompositionVisual
     
     partial void OnParentChanging()
     {
-        if (Parent != null && _transformedSubTreeBounds.HasValue)
-            Parent.AddExtraDirtyRect(_transformedSubTreeBounds.Value);
+        AddTransformedSubTreeBoundsToParentDirtyRect();
         AttHelper_ParentChanging();
     }
 

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisualCollection.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisualCollection.cs
@@ -1,0 +1,11 @@
+namespace Avalonia.Rendering.Composition.Server
+{
+    partial class ServerCompositionVisualCollection
+    {
+        protected override void OnBeforeListClear()
+        {
+            foreach (var child in List)
+                child.AddTransformedSubTreeBoundsToParentDirtyRect();
+        }
+    }
+}

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerList.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerList.cs
@@ -16,12 +16,17 @@ namespace Avalonia.Rendering.Composition.Server
         {
             if (reader.Read<byte>() == 1)
             {
+                OnBeforeListClear();
                 List.Clear();
                 var count = reader.Read<int>();
                 for (var c = 0; c < count; c++) 
                     List.Add(reader.ReadObject<T>());
             }
             base.DeserializeChangesCore(reader, committedAt);
+        }
+
+        protected virtual void OnBeforeListClear()
+        {
         }
 
         public List<T>.Enumerator GetEnumerator() => List.GetEnumerator();

--- a/tests/Avalonia.Base.UnitTests/Rendering/CompositorInvalidationTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/CompositorInvalidationTests.cs
@@ -145,7 +145,7 @@ public class CompositorInvalidationTests : CompositorTestsBase
 
             // The old child's rect (10,20 100x50) must appear in the dirty rects.
             s.RunJobs();
-            Assert.Contains(new Rect(10, 20, 100, 50).ToString(), s.Events.Rects.Select(r => r.ToString()));
+            Assert.Contains(new Rect(10, 20, 100, 50), s.Events.Rects);
         }
     }
 

--- a/tests/Avalonia.Base.UnitTests/Rendering/CompositorInvalidationTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/CompositorInvalidationTests.cs
@@ -1,4 +1,7 @@
+using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Xunit;
 
@@ -104,6 +107,96 @@ public class CompositorInvalidationTests : CompositorTestsBase
             s.Events.Rects.Clear();
             control.IsVisible = false;
             s.AssertRects(new Rect(40, 60, 20, 10));
+        }
+    }
+
+    [Fact]
+    public void Old_Child_Rect_Should_Be_Dirty_When_Children_Replaced_Via_VisualChildren()
+    {
+        using (var s = new CompositorCanvas())
+        {
+            var host = new LightweightHost
+            {
+                Width = 200, Height = 200,
+                [Canvas.LeftProperty] = 10, [Canvas.TopProperty] = 20
+            };
+            s.Canvas.Children.Add(host);
+
+            var oldChild = new Border
+            {
+                Background = Brushes.Red,
+                Width = 100, Height = 50
+            };
+            host.AddChild(oldChild);
+            s.RunJobs();
+            s.Events.Rects.Clear();
+
+            // Remove old child and add a new child at the same position.
+            // The host manages children via VisualChildren directly (no Panel.Children),
+            // has no Background, and no Render override — so the compositor must
+            // dirty-track the old child's area via ServerList.OnBeforeListClear.
+            host.RemoveChild(oldChild);
+            var newChild = new Border
+            {
+                Background = Brushes.Blue,
+                Width = 100, Height = 50
+            };
+            host.AddChild(newChild);
+
+            // The old child's rect (10,20 100x50) must appear in the dirty rects.
+            s.RunJobs();
+            Assert.Contains(new Rect(10, 20, 100, 50).ToString(), s.Events.Rects.Select(r => r.ToString()));
+        }
+    }
+
+    /// <summary>
+    /// A lightweight container that manages children directly via
+    /// <see cref="Visual.VisualChildren"/> and <see cref="StyledElement.LogicalChildren"/>,
+    /// bypassing <see cref="Panel.Children"/>. It has no Background
+    /// and no <see cref="Visual.Render"/> override, so the compositor visual never has its
+    /// own draw commands.
+    /// </summary>
+    private class LightweightHost : Control
+    {
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            foreach (var child in VisualChildren)
+            {
+                if (child is Layoutable l)
+                    l.Measure(availableSize);
+            }
+
+            return availableSize;
+        }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            double y = 0;
+            foreach (var child in VisualChildren)
+            {
+                if (child is Layoutable l)
+                {
+                    var ds = l.DesiredSize;
+                    l.Arrange(new Rect(0, y, ds.Width, ds.Height));
+                    y += ds.Height;
+                }
+            }
+
+            return finalSize;
+        }
+
+        public void AddChild(Control child)
+        {
+            VisualChildren.Add(child);
+            LogicalChildren.Add(child);
+            InvalidateMeasure();
+        }
+
+        public void RemoveChild(Control child)
+        {
+            VisualChildren.Remove(child);
+            LogicalChildren.Remove(child);
+            InvalidateMeasure();
         }
     }
 }


### PR DESCRIPTION
This pull request introduces an important fix to the compositor's dirty tracking logic when visual children are replaced, ensuring that the area occupied by removed children is properly marked as dirty. The changes add a hook for pre-clear actions in visual collections and provide a unit test to verify the fix.

**Compositor dirty tracking improvements:**

* Added the `OnBeforeListClear` virtual method in `ServerList` and implemented it in `ServerCompositionVisualCollection` to clear parent references for children before the list is cleared, enabling correct dirty rect tracking for removed visuals. [[1]](diffhunk://#diff-69a65ecae5f160728258cdc04dafccfde27333f816b1b1609bab209b74fb2e02R28-R31) [[2]](diffhunk://#diff-03239fd3dbbabdfe720dbd91e404974efbfc903bd171f8524e9923b598d54ff2R1-R11)
* Invoked `OnBeforeListClear` in `DeserializeChangesCore` before clearing the list, ensuring that state changes are handled before removal.

**Testing and validation:**

* Introduced a new unit test `Old_Child_Rect_Should_Be_Dirty_When_Children_Replaced_Via_VisualChildren` in `CompositorInvalidationTests` to verify that the compositor marks the old child's area as dirty when children are replaced directly via `VisualChildren`.
* Added a helper class `LightweightHost` for testing scenarios where children are managed directly via `VisualChildren` and `LogicalChildren`, bypassing `Panel.Children`.
* Added necessary using statements for layout and logical tree operations in the test file.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation