### PR TITLE
Made GetMaxSizeFromConstraint a protected method

### DIFF
--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -363,7 +363,10 @@ namespace Avalonia.Controls
 
         internal bool HasComplexContent => Inlines != null && Inlines.Count > 0;
 
-        private protected Size GetMaxSizeFromConstraint()
+        /// <summary>
+        /// Gets the maximum available size based on the constraint of the control
+        /// </summary>
+        protected Size GetMaxSizeFromConstraint()
         {
             var maxWidth = double.IsNaN(_constraint.Width) ? 0.0 : _constraint.Width;
             var maxHeight = double.IsNaN(_constraint.Height) ? 0.0 : _constraint.Height;


### PR DESCRIPTION
## What does the pull request do?
This changes the protection of `GetMaxSizeFromConstraint` from `private protected` to `protected`.

## What is the current behavior?
Currently, you're unable to use `GetMaxSizeFromConstraint` when inheriting from `TextBlock`, which can be a problem when you want to make a custom `TextBlock` control with shared behavior. (See #20849 for a use-case)

## What is the updated/expected behavior with this PR?
This changes the protection and adds a line of documentation.

## How was the solution implemented (if it's not obvious)?
n/a

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
n/a

## Obsoletions / Deprecations
n/a

## Fixed issues
Fixes #20849