### PR TITLE
Fix values of known atoms

### DIFF
--- a/src/Avalonia.X11/ActivityTrackingHelper.cs
+++ b/src/Avalonia.X11/ActivityTrackingHelper.cs
@@ -38,7 +38,7 @@ internal class WindowActivationTrackingHelper : IDisposable
         
         if (Mode == X11Globals.WindowActivationTrackingMode._NET_WM_STATE_FOCUSED)
             OnNetWmStateChanged(XLib.XGetWindowPropertyAsIntPtrArray(_platform.Display, _window.Handle.Handle,
-                _platform.Info.Atoms._NET_WM_STATE, _platform.Info.Atoms.XA_ATOM) ?? []);
+                _platform.Info.Atoms._NET_WM_STATE, _platform.Info.Atoms.ATOM) ?? []);
     }
 
     private void OnWindowActivationTrackingModeChanged() =>
@@ -70,7 +70,7 @@ internal class WindowActivationTrackingHelper : IDisposable
         {
             var value = XLib.XGetWindowPropertyAsIntPtrArray(_platform.Display, _platform.Info.RootWindow,
                 _platform.Info.Atoms._NET_ACTIVE_WINDOW,
-                (IntPtr)_platform.Info.Atoms.XA_WINDOW);
+                (IntPtr)_platform.Info.Atoms.WINDOW);
             if (value == null || value.Length == 0)
                 SetActive(false);
             else

--- a/src/Avalonia.X11/Clipboard/ClipboardDataFormatHelper.cs
+++ b/src/Avalonia.X11/Clipboard/ClipboardDataFormatHelper.cs
@@ -19,7 +19,7 @@ internal static class ClipboardDataFormatHelper
 
         if (formatAtom == atoms.UTF16_STRING ||
             formatAtom == atoms.UTF8_STRING ||
-            formatAtom == atoms.XA_STRING ||
+            formatAtom == atoms.STRING ||
             formatAtom == atoms.OEMTEXT)
         {
             return DataFormat.Text;
@@ -92,7 +92,7 @@ internal static class ClipboardDataFormatHelper
 
     private static IntPtr GetPreferredStringFormatAtom(IntPtr[] textFormatAtoms, X11Atoms atoms)
     {
-        ReadOnlySpan<IntPtr> preferredFormats = [atoms.UTF16_STRING, atoms.UTF8_STRING, atoms.XA_STRING];
+        ReadOnlySpan<IntPtr> preferredFormats = [atoms.UTF16_STRING, atoms.UTF8_STRING, atoms.STRING];
 
         foreach (var preferredFormat in preferredFormats)
         {
@@ -111,7 +111,7 @@ internal static class ClipboardDataFormatHelper
         if (formatAtom == atoms.UTF8_STRING)
             return Encoding.UTF8;
 
-        if (formatAtom == atoms.XA_STRING || formatAtom == atoms.OEMTEXT)
+        if (formatAtom == atoms.STRING || formatAtom == atoms.OEMTEXT)
             return Encoding.ASCII;
 
         return null;

--- a/src/Avalonia.X11/Clipboard/X11Clipboard.cs
+++ b/src/Avalonia.X11/Clipboard/X11Clipboard.cs
@@ -32,7 +32,7 @@ namespace Avalonia.X11.Clipboard
             _avaloniaSaveTargetsAtom = XInternAtom(_x11.Display, "AVALONIA_SAVE_TARGETS_PROPERTY_ATOM", false);
             _textAtoms = new[]
             {
-                _x11.Atoms.XA_STRING,
+                _x11.Atoms.STRING,
                 _x11.Atoms.OEMTEXT,
                 _x11.Atoms.UTF8_STRING,
                 _x11.Atoms.UTF16_STRING
@@ -99,7 +99,7 @@ namespace Avalonia.X11.Clipboard
                 {
                     var atoms = ConvertDataTransfer(_storedDataTransfer);
                     XChangeProperty(_x11.Display, window, property,
-                        _x11.Atoms.XA_ATOM, 32, PropertyMode.Replace, atoms, atoms.Length);
+                        _x11.Atoms.ATOM, 32, PropertyMode.Replace, atoms, atoms.Length);
                     return property;
                 }
                 else if (target == _x11.Atoms.SAVE_TARGETS && _x11.Atoms.SAVE_TARGETS != IntPtr.Zero)
@@ -287,7 +287,7 @@ namespace Avalonia.X11.Clipboard
                     _storeAtomTcs = new TaskCompletionSource<bool>();
 
                 var atoms = ConvertDataTransfer(dataTransfer);
-                XChangeProperty(_x11.Display, _handle, _avaloniaSaveTargetsAtom, _x11.Atoms.XA_ATOM, 32,
+                XChangeProperty(_x11.Display, _handle, _avaloniaSaveTargetsAtom, _x11.Atoms.ATOM, 32,
                     PropertyMode.Replace, atoms, atoms.Length);
                 XConvertSelection(_x11.Display, _x11.Atoms.CLIPBOARD_MANAGER, _x11.Atoms.SAVE_TARGETS,
                     _avaloniaSaveTargetsAtom, _handle, IntPtr.Zero);

--- a/src/Avalonia.X11/Screens/X11Screen.Providers.cs
+++ b/src/Avalonia.X11/Screens/X11Screen.Providers.cs
@@ -56,7 +56,7 @@ internal partial class X11Screens
             if (!hasEDID)
                 return null;
             XRRGetOutputProperty(x11.Display, rrOutput, x11.Atoms.EDID, 0, EDIDStructureLength, false, false,
-                x11.Atoms.AnyPropertyType, out IntPtr actualType, out int actualFormat, out int bytesAfter, out _,
+                AnyPropertyType, out IntPtr actualType, out int actualFormat, out int bytesAfter, out _,
                 out IntPtr prop);
             if (actualType != x11.Atoms.INTEGER)
                 return null;
@@ -89,7 +89,7 @@ internal partial class X11Screens
                 IntPtr.Zero,
                 new IntPtr(128),
                 false,
-                x11.Atoms.AnyPropertyType,
+                AnyPropertyType,
                 out var type,
                 out var format,
                 out var count,

--- a/src/Avalonia.X11/Screens/X11Screen.Providers.cs
+++ b/src/Avalonia.X11/Screens/X11Screen.Providers.cs
@@ -58,7 +58,7 @@ internal partial class X11Screens
             XRRGetOutputProperty(x11.Display, rrOutput, x11.Atoms.EDID, 0, EDIDStructureLength, false, false,
                 x11.Atoms.AnyPropertyType, out IntPtr actualType, out int actualFormat, out int bytesAfter, out _,
                 out IntPtr prop);
-            if (actualType != x11.Atoms.XA_INTEGER)
+            if (actualType != x11.Atoms.INTEGER)
                 return null;
             if (actualFormat != 8) // Expecting an byte array
                 return null;

--- a/src/Avalonia.X11/TransparencyHelper.cs
+++ b/src/Avalonia.X11/TransparencyHelper.cs
@@ -89,7 +89,7 @@ namespace Avalonia.X11
                 {
                     IntPtr value = IntPtr.Zero;
                     XLib.XChangeProperty(_x11.Display, _window, _x11.Atoms._KDE_NET_WM_BLUR_BEHIND_REGION,
-                        _x11.Atoms.XA_CARDINAL, 32, PropertyMode.Replace, ref value, 1);
+                        _x11.Atoms.CARDINAL, 32, PropertyMode.Replace, ref value, 1);
                     _blurAtomsAreSet = true;
                 }
             }

--- a/src/Avalonia.X11/X11Atoms.cs
+++ b/src/Avalonia.X11/X11Atoms.cs
@@ -44,7 +44,6 @@ namespace Avalonia.X11
         private readonly IntPtr _display;
 
         // Our atoms
-        public readonly IntPtr AnyPropertyType = 0;
         public readonly IntPtr PRIMARY = 1;
         public readonly IntPtr SECONDARY = 2;
         public readonly IntPtr ARC = 3;

--- a/src/Avalonia.X11/X11Atoms.cs
+++ b/src/Avalonia.X11/X11Atoms.cs
@@ -44,75 +44,75 @@ namespace Avalonia.X11
         private readonly IntPtr _display;
 
         // Our atoms
-        public IntPtr AnyPropertyType = (IntPtr)0;
-        public IntPtr XA_PRIMARY = (IntPtr)1;
-        public IntPtr XA_SECONDARY = (IntPtr)2;
-        public IntPtr XA_ARC = (IntPtr)3;
-        public IntPtr XA_ATOM = (IntPtr)4;
-        public IntPtr XA_BITMAP = (IntPtr)5;
-        public IntPtr XA_CARDINAL = (IntPtr)6;
-        public IntPtr XA_COLORMAP = (IntPtr)7;
-        public IntPtr XA_CURSOR = (IntPtr)8;
-        public IntPtr XA_CUT_BUFFER0 = (IntPtr)9;
-        public IntPtr XA_CUT_BUFFER1 = (IntPtr)10;
-        public IntPtr XA_CUT_BUFFER2 = (IntPtr)11;
-        public IntPtr XA_CUT_BUFFER3 = (IntPtr)12;
-        public IntPtr XA_CUT_BUFFER4 = (IntPtr)13;
-        public IntPtr XA_CUT_BUFFER5 = (IntPtr)14;
-        public IntPtr XA_CUT_BUFFER6 = (IntPtr)15;
-        public IntPtr XA_CUT_BUFFER7 = (IntPtr)16;
-        public IntPtr XA_DRAWABLE = (IntPtr)17;
-        public IntPtr XA_FONT = (IntPtr)18;
-        public IntPtr XA_INTEGER = (IntPtr)19;
-        public IntPtr XA_PIXMAP = (IntPtr)20;
-        public IntPtr XA_POINT = (IntPtr)21;
-        public IntPtr XA_RECTANGLE = (IntPtr)22;
-        public IntPtr XA_RESOURCE_MANAGER = (IntPtr)23;
-        public IntPtr XA_RGB_COLOR_MAP = (IntPtr)24;
-        public IntPtr XA_RGB_BEST_MAP = (IntPtr)25;
-        public IntPtr XA_RGB_BLUE_MAP = (IntPtr)26;
-        public IntPtr XA_RGB_DEFAULT_MAP = (IntPtr)27;
-        public IntPtr XA_RGB_GRAY_MAP = (IntPtr)28;
-        public IntPtr XA_RGB_GREEN_MAP = (IntPtr)29;
-        public IntPtr XA_RGB_RED_MAP = (IntPtr)30;
-        public IntPtr XA_STRING = (IntPtr)31;
-        public IntPtr XA_VISUALID = (IntPtr)32;
-        public IntPtr XA_WINDOW = (IntPtr)33;
-        public IntPtr XA_WM_COMMAND = (IntPtr)34;
-        public IntPtr XA_WM_HINTS = (IntPtr)35;
-        public IntPtr XA_WM_CLIENT_MACHINE = (IntPtr)36;
-        public IntPtr XA_WM_ICON_NAME = (IntPtr)37;
-        public IntPtr XA_WM_ICON_SIZE = (IntPtr)38;
-        public IntPtr XA_WM_NAME = (IntPtr)39;
-        public IntPtr XA_WM_NORMAL_HINTS = (IntPtr)40;
-        public IntPtr XA_WM_SIZE_HINTS = (IntPtr)41;
-        public IntPtr XA_WM_ZOOM_HINTS = (IntPtr)42;
-        public IntPtr XA_MIN_SPACE = (IntPtr)43;
-        public IntPtr XA_NORM_SPACE = (IntPtr)44;
-        public IntPtr XA_MAX_SPACE = (IntPtr)45;
-        public IntPtr XA_END_SPACE = (IntPtr)46;
-        public IntPtr XA_SUPERSCRIPT_X = (IntPtr)47;
-        public IntPtr XA_SUPERSCRIPT_Y = (IntPtr)48;
-        public IntPtr XA_SUBSCRIPT_X = (IntPtr)49;
-        public IntPtr XA_SUBSCRIPT_Y = (IntPtr)50;
-        public IntPtr XA_UNDERLINE_POSITION = (IntPtr)51;
-        public IntPtr XA_UNDERLINE_THICKNESS = (IntPtr)52;
-        public IntPtr XA_STRIKEOUT_ASCENT = (IntPtr)53;
-        public IntPtr XA_STRIKEOUT_DESCENT = (IntPtr)54;
-        public IntPtr XA_ITALIC_ANGLE = (IntPtr)55;
-        public IntPtr XA_X_HEIGHT = (IntPtr)56;
-        public IntPtr XA_QUAD_WIDTH = (IntPtr)57;
-        public IntPtr XA_WEIGHT = (IntPtr)58;
-        public IntPtr XA_POINT_SIZE = (IntPtr)59;
-        public IntPtr XA_RESOLUTION = (IntPtr)60;
-        public IntPtr XA_COPYRIGHT = (IntPtr)61;
-        public IntPtr XA_NOTICE = (IntPtr)62;
-        public IntPtr XA_FONT_NAME = (IntPtr)63;
-        public IntPtr XA_FAMILY_NAME = (IntPtr)64;
-        public IntPtr XA_FULL_NAME = (IntPtr)65;
-        public IntPtr XA_CAP_HEIGHT = (IntPtr)66;
-        public IntPtr XA_WM_CLASS = (IntPtr)67;
-        public IntPtr XA_WM_TRANSIENT_FOR = (IntPtr)68;
+        public readonly IntPtr AnyPropertyType = 0;
+        public readonly IntPtr PRIMARY = 1;
+        public readonly IntPtr SECONDARY = 2;
+        public readonly IntPtr ARC = 3;
+        public readonly IntPtr ATOM = 4;
+        public readonly IntPtr BITMAP = 5;
+        public readonly IntPtr CARDINAL = 6;
+        public readonly IntPtr COLORMAP = 7;
+        public readonly IntPtr CURSOR = 8;
+        public readonly IntPtr CUT_BUFFER0 = 9;
+        public readonly IntPtr CUT_BUFFER1 = 10;
+        public readonly IntPtr CUT_BUFFER2 = 11;
+        public readonly IntPtr CUT_BUFFER3 = 12;
+        public readonly IntPtr CUT_BUFFER4 = 13;
+        public readonly IntPtr CUT_BUFFER5 = 14;
+        public readonly IntPtr CUT_BUFFER6 = 15;
+        public readonly IntPtr CUT_BUFFER7 = 16;
+        public readonly IntPtr DRAWABLE = 17;
+        public readonly IntPtr FONT = 18;
+        public readonly IntPtr INTEGER = 19;
+        public readonly IntPtr PIXMAP = 20;
+        public readonly IntPtr POINT = 21;
+        public readonly IntPtr RECTANGLE = 22;
+        public readonly IntPtr RESOURCE_MANAGER = 23;
+        public readonly IntPtr RGB_COLOR_MAP = 24;
+        public readonly IntPtr RGB_BEST_MAP = 25;
+        public readonly IntPtr RGB_BLUE_MAP = 26;
+        public readonly IntPtr RGB_DEFAULT_MAP = 27;
+        public readonly IntPtr RGB_GRAY_MAP = 28;
+        public readonly IntPtr RGB_GREEN_MAP = 29;
+        public readonly IntPtr RGB_RED_MAP = 30;
+        public readonly IntPtr STRING = 31;
+        public readonly IntPtr VISUALID = 32;
+        public readonly IntPtr WINDOW = 33;
+        public readonly IntPtr WM_COMMAND = 34;
+        public readonly IntPtr WM_HINTS = 35;
+        public readonly IntPtr WM_CLIENT_MACHINE = 36;
+        public readonly IntPtr WM_ICON_NAME = 37;
+        public readonly IntPtr WM_ICON_SIZE = 38;
+        public readonly IntPtr WM_NAME = 39;
+        public readonly IntPtr WM_NORMAL_HINTS = 40;
+        public readonly IntPtr WM_SIZE_HINTS = 41;
+        public readonly IntPtr WM_ZOOM_HINTS = 42;
+        public readonly IntPtr MIN_SPACE = 43;
+        public readonly IntPtr NORM_SPACE = 44;
+        public readonly IntPtr MAX_SPACE = 45;
+        public readonly IntPtr END_SPACE = 46;
+        public readonly IntPtr SUPERSCRIPT_X = 47;
+        public readonly IntPtr SUPERSCRIPT_Y = 48;
+        public readonly IntPtr SUBSCRIPT_X = 49;
+        public readonly IntPtr SUBSCRIPT_Y = 50;
+        public readonly IntPtr UNDERLINE_POSITION = 51;
+        public readonly IntPtr UNDERLINE_THICKNESS = 52;
+        public readonly IntPtr STRIKEOUT_ASCENT = 53;
+        public readonly IntPtr STRIKEOUT_DESCENT = 54;
+        public readonly IntPtr ITALIC_ANGLE = 55;
+        public readonly IntPtr X_HEIGHT = 56;
+        public readonly IntPtr QUAD_WIDTH = 57;
+        public readonly IntPtr WEIGHT = 58;
+        public readonly IntPtr POINT_SIZE = 59;
+        public readonly IntPtr RESOLUTION = 60;
+        public readonly IntPtr COPYRIGHT = 61;
+        public readonly IntPtr NOTICE = 62;
+        public readonly IntPtr FONT_NAME = 63;
+        public readonly IntPtr FAMILY_NAME = 64;
+        public readonly IntPtr FULL_NAME = 65;
+        public readonly IntPtr CAP_HEIGHT = 66;
+        public readonly IntPtr WM_CLASS = 67;
+        public readonly IntPtr WM_TRANSIENT_FOR = 68;
 
         public IntPtr EDID;
 
@@ -183,7 +183,6 @@ namespace Avalonia.X11
         public IntPtr CLIPBOARD_MANAGER;
         public IntPtr SAVE_TARGETS;
         public IntPtr MULTIPLE;
-        public IntPtr PRIMARY;
         public IntPtr OEMTEXT;
         public IntPtr UNICODETEXT;
         public IntPtr TARGETS;
@@ -208,9 +207,14 @@ namespace Avalonia.X11
             if (value != IntPtr.Zero)
             {
                 field = value;
-                _namesToAtoms[name] = value;
-                _atomsToNames[value] = name;
+                SetName(name, value);
             }
+        }
+
+        private void SetName(string name, IntPtr value)
+        {
+            _namesToAtoms[name] = value;
+            _atomsToNames[value] = name;
         }
 
         public IntPtr GetAtom(string name)

--- a/src/Avalonia.X11/X11Globals.cs
+++ b/src/Avalonia.X11/X11Globals.cs
@@ -109,13 +109,13 @@ namespace Avalonia.X11
         {
             XGetWindowProperty(_x11.Display, _rootWindow, _x11.Atoms._NET_SUPPORTING_WM_CHECK,
                 IntPtr.Zero, new IntPtr(IntPtr.Size), false,
-                _x11.Atoms.XA_WINDOW, out IntPtr actualType, out int actualFormat, out IntPtr nitems,
+                _x11.Atoms.WINDOW, out IntPtr actualType, out int actualFormat, out IntPtr nitems,
                 out IntPtr bytesAfter, out IntPtr prop);
             if (nitems.ToInt32() != 1)
                 return IntPtr.Zero;
             try
             {
-                if (actualType != _x11.Atoms.XA_WINDOW)
+                if (actualType != _x11.Atoms.WINDOW)
                     return IntPtr.Zero;
                 return *(IntPtr*)prop.ToPointer();
             }
@@ -197,7 +197,7 @@ namespace Avalonia.X11
             if (wm == IntPtr.Zero)
                 return WindowActivationTrackingMode.FocusEvents;
             var supportedFeatures = XGetWindowPropertyAsIntPtrArray(_x11.Display, _x11.RootWindow,
-                _x11.Atoms._NET_SUPPORTED, _x11.Atoms.XA_ATOM) ?? [];
+                _x11.Atoms._NET_SUPPORTED, _x11.Atoms.ATOM) ?? [];
 
             if (supportedFeatures.Contains(_x11.Atoms._NET_WM_STATE_FOCUSED))
                 return WindowActivationTrackingMode._NET_WM_STATE_FOCUSED;

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -252,14 +252,14 @@ namespace Avalonia.X11
 
             _mode.AppendWmProtocols(data);
 
-            XChangeProperty(_x11.Display, _handle, _x11.Atoms.WM_PROTOCOLS, _x11.Atoms.XA_ATOM, 32,
+            XChangeProperty(_x11.Display, _handle, _x11.Atoms.WM_PROTOCOLS, _x11.Atoms.ATOM, 32,
                     PropertyMode.Replace, data.ToArray(), data.Count);
 
             if (_x11.HasXSync)
             {
                 _xSyncCounter = XSyncCreateCounter(_x11.Display, _xSyncValue);
                 XChangeProperty(_x11.Display, _handle, _x11.Atoms._NET_WM_SYNC_REQUEST_COUNTER,
-                    _x11.Atoms.XA_CARDINAL, 32, PropertyMode.Replace, ref _xSyncCounter, 1);
+                    _x11.Atoms.CARDINAL, 32, PropertyMode.Replace, ref _xSyncCounter, 1);
             }
 
             _storageProvider = new FallbackStorageProvider(new[]
@@ -365,7 +365,7 @@ namespace Avalonia.X11
             var pid = (uint)s_pid;
             // The type of `_NET_WM_PID` is `CARDINAL` which is 32-bit unsigned integer, see https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html
             XChangeProperty(_x11.Display, windowXId,
-                _x11.Atoms._NET_WM_PID, _x11.Atoms.XA_CARDINAL, 32,
+                _x11.Atoms._NET_WM_PID, _x11.Atoms.CARDINAL, 32,
                 PropertyMode.Replace, ref pid, 1);
 
             const int maxLength = 1024;
@@ -384,7 +384,7 @@ namespace Avalonia.X11
             }
 
             XChangeProperty(_x11.Display, windowXId,
-                _x11.Atoms.XA_WM_CLIENT_MACHINE, _x11.Atoms.XA_STRING, 8,
+                _x11.Atoms.WM_CLIENT_MACHINE, _x11.Atoms.STRING, 8,
                 PropertyMode.Replace, name, length);
         }
 
@@ -1149,7 +1149,7 @@ namespace Avalonia.X11
         public void SetParent(IWindowImpl? parent)
         {
             if (parent == null || parent.Handle == null || parent.Handle.Handle == IntPtr.Zero)
-                XDeleteProperty(_x11.Display, _handle, _x11.Atoms.XA_WM_TRANSIENT_FOR);
+                XDeleteProperty(_x11.Display, _handle, _x11.Atoms.WM_TRANSIENT_FOR);
             else
                 XSetTransientForHint(_x11.Display, _handle, parent.Handle.Handle);
         }
@@ -1393,7 +1393,7 @@ namespace Avalonia.X11
             if (string.IsNullOrEmpty(title))
             {
                 XDeleteProperty(_x11.Display, _handle, _x11.Atoms._NET_WM_NAME);
-                XDeleteProperty(_x11.Display, _handle, _x11.Atoms.XA_WM_NAME);
+                XDeleteProperty(_x11.Display, _handle, _x11.Atoms.WM_NAME);
             }
             else
             {
@@ -1642,7 +1642,7 @@ namespace Avalonia.X11
                 _ => _x11.Atoms._NET_WM_WINDOW_TYPE_NORMAL
             };
 
-            XChangeProperty(_x11.Display, _handle, _x11.Atoms._NET_WM_WINDOW_TYPE, _x11.Atoms.XA_ATOM,
+            XChangeProperty(_x11.Display, _handle, _x11.Atoms._NET_WM_WINDOW_TYPE, _x11.Atoms.ATOM,
                 32, PropertyMode.Replace, new[] { atom }, 1);
 
         }

--- a/src/Avalonia.X11/XLib.cs
+++ b/src/Avalonia.X11/XLib.cs
@@ -22,6 +22,8 @@ namespace Avalonia.X11
         private const string libXInput = "libXi.so.6";
         private const string libXCursor = "libXcursor.so.1";
 
+        public const IntPtr AnyPropertyType = 0;
+
         [DllImport(libX11)]
         public static extern IntPtr XOpenDisplay(IntPtr display);
 

--- a/src/Avalonia.X11/XResources.cs
+++ b/src/Avalonia.X11/XResources.cs
@@ -51,9 +51,9 @@ internal class XResources
     
     string? ReadResourcesString()
     {
-        XGetWindowProperty(_x11.Display, _x11.RootWindow, _x11.Atoms.XA_RESOURCE_MANAGER,
+        XGetWindowProperty(_x11.Display, _x11.RootWindow, _x11.Atoms.RESOURCE_MANAGER,
             IntPtr.Zero, new IntPtr(0x7fffffff),
-            false, _x11.Atoms.XA_STRING, out _, out var actualFormat,
+            false, _x11.Atoms.STRING, out _, out var actualFormat,
             out var nitems, out _, out var prop);
         try
         {
@@ -69,7 +69,7 @@ internal class XResources
     
     private void OnRootPropertyChanged(IntPtr atom)
     {
-        if (atom == _x11.Atoms.XA_RESOURCE_MANAGER)
+        if (atom == _x11.Atoms.RESOURCE_MANAGER)
             UpdateResources();
     }
 }

--- a/src/tools/DevGenerators/X11AtomsGenerator.cs
+++ b/src/tools/DevGenerators/X11AtomsGenerator.cs
@@ -1,9 +1,8 @@
-using System.IO;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Generator;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace DevGenerators;
@@ -40,24 +39,44 @@ public class X11AtomsGenerator : IIncrementalGenerator
                     .AppendLine(cl.Name)
                     .AppendLine("{");
 
-                var fields = cl.GetMembers().OfType<IFieldSymbol>()
+                var allFields = cl.GetMembers().OfType<IFieldSymbol>()
                     .Where(f => f.Type.Name == "IntPtr"
-                                && f.DeclaredAccessibility == Accessibility.Public).ToList();
-                
+                                && f.DeclaredAccessibility == Accessibility.Public);
+
+                var writeableFields = new List<IFieldSymbol>(128);
+                var readonlyFields = new List<IFieldSymbol>(128);
+
+                foreach (var field in allFields)
+                {
+                    var fields = field.IsReadOnly ? readonlyFields : writeableFields;
+                    fields.Add(field);
+                }
+
                 classBuilder.Pad(1).AppendLine("private void PopulateAtoms(IntPtr display)").Pad(1).AppendLine("{");
-                classBuilder.Pad(2).Append("var atoms = new IntPtr[").Append(fields.Count).AppendLine("];");
-                classBuilder.Pad(2).Append("var atomNames = new string[").Append(fields.Count).AppendLine("] {");
 
+                for (int c = 0; c < readonlyFields.Count; c++)
+                {
+                    var field = readonlyFields[c];
+                    var initializer =
+                        (field.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(context.CancellationToken) as VariableDeclaratorSyntax)
+                        ?.Initializer?.Value;
 
-                for (int c = 0; c < fields.Count; c++)
-                    classBuilder.Pad(3).Append("\"").Append(fields[c].Name).AppendLine("\",");
+                    classBuilder.Pad(2).Append("SetName(").Append('\"')
+                        .Append(field.Name).Append("\", ").Append(initializer).AppendLine(");");
+                }
+
+                classBuilder.Pad(2).Append("var atoms = new IntPtr[").Append(writeableFields.Count).AppendLine("];");
+                classBuilder.Pad(2).Append("var atomNames = new string[").Append(writeableFields.Count).AppendLine("] {");
+
+                for (int c = 0; c < writeableFields.Count; c++)
+                    classBuilder.Pad(3).Append("\"").Append(writeableFields[c].Name).AppendLine("\",");
                 classBuilder.Pad(2).AppendLine("};");
                 
                 classBuilder.Pad(2).AppendLine("XInternAtoms(display, atomNames, atomNames.Length, true, atoms);");
 
-                for (int c = 0; c < fields.Count; c++)
-                    classBuilder.Pad(2).Append("InitAtom(ref ").Append(fields[c].Name).Append(", \"")
-                        .Append(fields[c].Name).Append("\", atoms[").Append(c).AppendLine("]);");
+                for (int c = 0; c < writeableFields.Count; c++)
+                    classBuilder.Pad(2).Append("InitAtom(ref ").Append(writeableFields[c].Name).Append(", \"")
+                        .Append(writeableFields[c].Name).Append("\", atoms[").Append(c).AppendLine("]);");
 
 
                 classBuilder.Pad(1).AppendLine("}");


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the values of known X11 atoms (`XA_*`, from 0 to 68) being incorrect.
The values for these atoms were overridden with values for atoms named with the `"XA_"` prefix.
For example, the actual name of the `XA_STRING` atom is `"STRING"`, not `"XA_STRING"`.

## How was the solution implemented (if it's not obvious)?
Known atoms are now read-only. The source generator does not intern them anymore.

Plus, to avoid confusion, the  `XA_` prefix has been completely removed: the name of the field now always matches the name of the atom.
