### PR TITLE
X11: Fix clipboard bitmap transferred with INCR

### DIFF
--- a/src/Avalonia.X11/Clipboard/ClipboardReadSession.cs
+++ b/src/Avalonia.X11/Clipboard/ClipboardReadSession.cs
@@ -127,6 +127,7 @@ class ClipboardReadSession : IDisposable
             Append(part);
         }
 
+        ms.Position = 0L;
         return new(null, ms, actualTypeAtom);
     }
     


### PR DESCRIPTION
## What does the pull request do?
On X11, if a bitmap is retrieved using the INCR protocol (because it's large), an exception is thrown. This happens because the memory stream used for the INCR transfer is already at its end.

This PR fixes that issue by resetting the stream's position to the beginning.
