### PR TITLE
Defer default icon loading until Window is shown

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -248,7 +248,7 @@ namespace Avalonia.Controls
             this.GetObservable(ClientSizeProperty).Skip(1).Subscribe(x => PlatformImpl?.Resize(x, WindowResizeReason.Application));
 
             CreatePlatformImplBinding(TitleProperty, title => PlatformImpl!.SetTitle(title));
-            CreatePlatformImplBinding(IconProperty, icon => PlatformImpl!.SetIcon((icon ?? s_defaultIcon.Value)?.PlatformImpl));
+            CreatePlatformImplBinding(IconProperty, SetEffectiveIcon);
             CreatePlatformImplBinding(CanResizeProperty, canResize => PlatformImpl!.CanResize(canResize));
             CreatePlatformImplBinding(CanMinimizeProperty, canMinimize => PlatformImpl!.SetCanMinimize(canMinimize));
             CreatePlatformImplBinding(CanMaximizeProperty, canMaximize => PlatformImpl!.SetCanMaximize(canMaximize));
@@ -892,6 +892,8 @@ namespace Avalonia.Controls
                 _shown = true;
                 IsVisible = true;
 
+                SetEffectiveIcon(Icon);
+
                 // If window position was not set before then platform may provide incorrect scaling at this time,
                 // but we need it for proper calculation of position and in some cases size (size to content)
                 SetExpectedScaling(owner);
@@ -1378,7 +1380,7 @@ namespace Avalonia.Controls
 
         private static WindowIcon? LoadDefaultIcon()
         {
-            // Use AvaloniaLocator instead of static AssetLoader, so it won't fail on Unit Tests without any asset loader. 
+            // Use AvaloniaLocator instead of static AssetLoader, so it won't fail on Unit Tests without any asset loader.
             if (AvaloniaLocator.Current.GetService<IAssetLoader>() is { } assetLoader
                 && Assembly.GetEntryAssembly()?.GetName()?.Name is { } assemblyName
                 && Uri.TryCreate($"avares://{assemblyName}/!__AvaloniaDefaultWindowIcon", UriKind.Absolute, out var path)
@@ -1388,6 +1390,12 @@ namespace Avalonia.Controls
                 return new WindowIcon(stream);
             }
             return null;
+        }
+
+        private void SetEffectiveIcon(WindowIcon? icon)
+        {
+            icon ??= _shown ? s_defaultIcon.Value : null;
+            PlatformImpl?.SetIcon(icon?.PlatformImpl);
         }
 
         private static bool CoerceCanMaximize(AvaloniaObject target, bool value)

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -71,6 +71,7 @@ namespace Avalonia.X11
         private bool _useCompositorDrivenRenderWindowResize = false;
         private bool _usePositioningFlags = false;
         private X11WindowMode _mode;
+        private IWindowIconImpl? _iconImpl;
 
         private enum XSyncState
         {
@@ -1530,6 +1531,11 @@ namespace Avalonia.X11
 
         public void SetIcon(IWindowIconImpl? icon)
         {
+            if (ReferenceEquals(_iconImpl, icon))
+                return;
+
+            _iconImpl = icon;
+
             if (icon != null)
             {
                 var data = ((X11IconData)icon).Data;

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -809,6 +809,9 @@ namespace Avalonia.Win32
 
         public void SetIcon(IWindowIconImpl? icon)
         {
+            if (ReferenceEquals(_iconImpl, icon))
+                return;
+
             _iconImpl = (IconImpl?)icon;
             ClearIconCache();
             RefreshIcon();

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -1188,6 +1188,26 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        [Fact]
+        public void Show_Should_Apply_Default_Icon_When_No_Custom_Icon_Is_Set()
+        {
+            var windowImpl = MockWindowingPlatform.CreateWindowMock();
+            var windowingPlatform = new MockWindowingPlatform(() => windowImpl.Object);
+
+            using (UnitTestApplication.Start(TestServices.StyledWindow.With(windowingPlatform: windowingPlatform)))
+            {
+                var target = new Window();
+
+                // Clear any SetIcon calls from construction.
+                windowImpl.Invocations.Clear();
+
+                target.Show();
+
+                // ShowCore should apply the default icon when no custom icon was set.
+                windowImpl.Verify(x => x.SetIcon(It.IsAny<IWindowIconImpl?>()), Times.AtLeastOnce());
+            }
+        }
+
         private class TopmostWindow : Window
         {
             static TopmostWindow()


### PR DESCRIPTION
## What does the PR do?

Defers loading of the default window icon from the `Window` constructor to `ShowCore`. Previously, `CreatePlatformImplBinding` for `IconProperty` would immediately evaluate `s_defaultIcon.Value`, forcing `LoadDefaultIcon()` to run during construction, even when a custom icon was going to be set or when no icon was needed at all.

This caused unnecessary I/O (reading assembly embedded resources) on every first `Window` instantiation.

### Changes

- Extracted icon resolution into `SetEffectiveIcon`, which both the binding and `ShowCore` call
- The method only falls back to `s_defaultIcon.Value` when `_shown` is true, avoiding the eager load during construction
- Setting `Icon = null` after the window is shown still correctly falls back to the default icon (no behavioral change)

Fixes #20478

## What is the current behavior?

`LoadDefaultIcon()` is called during `Window` construction via the `Lazy<WindowIcon?>`, regardless of whether a custom icon will be set.

## What is the expected behavior?

`LoadDefaultIcon()` should only be called when the window is shown and no custom icon has been set.

## How was the fix tested?

Unit test `Show_Should_Apply_Default_Icon_When_No_Custom_Icon_Is_Set` verifies that `ShowCore` calls `SetIcon` on the platform impl when no custom icon has been set. The test follows the repo convention: first commit introduces the failing test, second commit applies the fix.

All 35 existing `WindowTests` continue to pass.