### PR TITLE
Validate layoutable Thickness properties to block NaN or infinite values

### DIFF
--- a/src/Avalonia.Base/Layout/Layoutable.cs
+++ b/src/Avalonia.Base/Layout/Layoutable.cs
@@ -161,10 +161,7 @@ namespace Avalonia.Layout
         private static bool ValidateMinimumDimension(double value) => !double.IsPositiveInfinity(value) && ValidateMaximumDimension(value);
         private static bool ValidateMaximumDimension(double value) => value >= 0;
 
-        private static bool ValidateThicknessDimension(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
-        private static bool ValidateThickness(Thickness value) => 
-            ValidateThicknessDimension(value.Left) && ValidateThicknessDimension(value.Top) && 
-            ValidateThicknessDimension(value.Right) && ValidateThicknessDimension(value.Bottom);
+        private static bool ValidateThickness(Thickness value) => double.IsFinite(value.Left) && double.IsFinite(value.Top) && double.IsFinite(value.Right) && double.IsFinite(value.Bottom);
 
         /// <summary>
         /// Occurs when the element's effective viewport changes.

--- a/src/Avalonia.Base/Layout/Layoutable.cs
+++ b/src/Avalonia.Base/Layout/Layoutable.cs
@@ -113,7 +113,7 @@ namespace Avalonia.Layout
         /// Defines the <see cref="Margin"/> property.
         /// </summary>
         public static readonly StyledProperty<Thickness> MarginProperty =
-            AvaloniaProperty.Register<Layoutable, Thickness>(nameof(Margin));
+            AvaloniaProperty.Register<Layoutable, Thickness>(nameof(Margin), validate: ValidateThickness);
 
         /// <summary>
         /// Defines the <see cref="HorizontalAlignment"/> property.
@@ -160,6 +160,11 @@ namespace Avalonia.Layout
         private static bool ValidateDimension(double value) => double.IsNaN(value) || ValidateMinimumDimension(value);
         private static bool ValidateMinimumDimension(double value) => !double.IsPositiveInfinity(value) && ValidateMaximumDimension(value);
         private static bool ValidateMaximumDimension(double value) => value >= 0;
+
+        private static bool ValidateThicknessDimension(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+        private static bool ValidateThickness(Thickness value) => 
+            ValidateThicknessDimension(value.Left) && ValidateThicknessDimension(value.Top) && 
+            ValidateThicknessDimension(value.Right) && ValidateThicknessDimension(value.Bottom);
 
         /// <summary>
         /// Occurs when the element's effective viewport changes.

--- a/src/Avalonia.Controls/Border.cs
+++ b/src/Avalonia.Controls/Border.cs
@@ -38,7 +38,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="BorderThickness"/> property.
         /// </summary>
         public static readonly StyledProperty<Thickness> BorderThicknessProperty =
-            AvaloniaProperty.Register<Border, Thickness>(nameof(BorderThickness));
+            AvaloniaProperty.Register<Border, Thickness>(nameof(BorderThickness), validate: MarginProperty.ValidateValue);
 
         /// <summary>
         /// Defines the <see cref="CornerRadius"/> property.

--- a/src/Avalonia.Controls/Chrome/WindowDrawnDecorations.cs
+++ b/src/Avalonia.Controls/Chrome/WindowDrawnDecorations.cs
@@ -58,13 +58,13 @@ public class WindowDrawnDecorations : StyledElement
     /// Defines the <see cref="DefaultFrameThickness"/> property.
     /// </summary>
     public static readonly StyledProperty<Thickness> DefaultFrameThicknessProperty =
-        AvaloniaProperty.Register<WindowDrawnDecorations, Thickness>(nameof(DefaultFrameThickness));
+        AvaloniaProperty.Register<WindowDrawnDecorations, Thickness>(nameof(DefaultFrameThickness), validate: Border.BorderThicknessProperty.ValidateValue);
 
     /// <summary>
     /// Defines the <see cref="DefaultShadowThickness"/> property.
     /// </summary>
     public static readonly StyledProperty<Thickness> DefaultShadowThicknessProperty =
-        AvaloniaProperty.Register<WindowDrawnDecorations, Thickness>(nameof(DefaultShadowThickness));
+        AvaloniaProperty.Register<WindowDrawnDecorations, Thickness>(nameof(DefaultShadowThickness), validate: Border.BorderThicknessProperty.ValidateValue);
 
     /// <summary>
     /// Defines the <see cref="TitleBarHeight"/> property.

--- a/src/Avalonia.Controls/Decorator.cs
+++ b/src/Avalonia.Controls/Decorator.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="Padding"/> property.
         /// </summary>
         public static readonly StyledProperty<Thickness> PaddingProperty =
-            AvaloniaProperty.Register<Decorator, Thickness>(nameof(Padding));
+            AvaloniaProperty.Register<Decorator, Thickness>(nameof(Padding), validate: MarginProperty.ValidateValue);
 
         /// <summary>
         /// Initializes static members of the <see cref="Decorator"/> class.

--- a/src/Avalonia.Controls/Page/Page.cs
+++ b/src/Avalonia.Controls/Page/Page.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="SafeAreaPadding"/> property.
         /// </summary>
         public static readonly StyledProperty<Thickness> SafeAreaPaddingProperty =
-            AvaloniaProperty.Register<Page, Thickness>(nameof(SafeAreaPadding));
+            AvaloniaProperty.Register<Page, Thickness>(nameof(SafeAreaPadding), validate: PaddingProperty.ValidateValue);
 
         /// <summary>
         /// Defines the <see cref="Header"/> property.

--- a/tests/Avalonia.Controls.UnitTests/BorderTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/BorderTests.cs
@@ -1,9 +1,6 @@
+using System;
 using Avalonia.Layout;
-using Avalonia.Media;
-using Avalonia.Rendering;
 using Avalonia.UnitTests;
-using Avalonia.VisualTree;
-using Moq;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
@@ -45,14 +42,31 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.Equal(new Rect(6, 6, 0, 0), content.Bounds);
         }
-        
+
+        [Fact]
+        public void Should_Reject_NaN_Or_Infinite_Thicknesses()
+        {
+            var target = new Border();
+
+            SetValues(target, Layoutable.MarginProperty);
+            SetValues(target, Decorator.PaddingProperty);
+            SetValues(target, Border.BorderThicknessProperty);
+
+            static void SetValues(Border target, AvaloniaProperty<Thickness> property)
+            {
+                Assert.Throws<ArgumentException>(() => target.SetValue(property, new Thickness(0, 0, 0, double.NaN)));
+                Assert.Throws<ArgumentException>(() => target.SetValue(property, new Thickness(0, 0, 0, double.PositiveInfinity)));
+                Assert.Throws<ArgumentException>(() => target.SetValue(property, new Thickness(0, 0, 0, double.NegativeInfinity)));
+            }
+        }
+
         public class UseLayoutRounding : ScopedTestBase
         {
             [Fact]
             public void Measure_Rounds_Padding()
             {
-                var target = new Border 
-                { 
+                var target = new Border
+                {
                     Padding = new Thickness(1),
                     Child = new Canvas
                     {


### PR DESCRIPTION
This PR is an extension of #15753 which adds validation to `Thickness` properties.

## What is the current behavior?
It is currently possible to set `Margin`, `Padding`, `BorderThickness` etc. of various types to values which result in a `InvalidOperationException` when `Measure` is called.

If the control is visible, then changing the properties will immediately trigger a new measure and the exception above will be thrown. But if the control is not visible, then the exception will not be thrown until later on, and the point at which the invalid value was set will not be known.

This behaviour makes validation and debugging harder. Users of Avalonia must validate the values they set manually, which means duplicating logic from inside Avalonia's private methods.

## What is the updated/expected behavior with this PR?
The relevant properties now have validation methods which immediately block invalid values, no matter what state the control is in.

An exception will be thrown when an invalid value is set. This allows immediate error handling with a try/catch block.

The exception message will be something like `0,0,0,NaN is not a valid value for 'Margin'`, which is considerably more useful than `Invalid size returned for Measure`, which is the message of the exception that would otherwise be thrown by `Measure`.

## How was the solution implemented (if it's not obvious)?
Instead of changing the public API by making the validation method in `Avalonia.Base` public or protected, properties in `Avalonia.Control` which need validation read the value of `StyledProperty.ValidateValue` from a suitable base property, with `Layoutable.MarginProperty` providing the original delegate.

## Breaking changes
It's possible that a custom control somewhere supports values that the validation methods in this PR reject. This can happen if its overridden MeasureOverride method continues to return a valid size.

This weird situation could be worked around by providing new properties on the custom control which don't block NaN or infinite values.

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #20835
