### PR TITLE
Do not resolve markup extensions when resolving selector types

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlSelectorTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlSelectorTransformer.cs
@@ -210,7 +210,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             }
 
             var selector = Create(parsed, (p, n) 
-                => TypeReferenceResolver.ResolveType(context, $"{p}:{n}", true, node, true));
+                => TypeReferenceResolver.ResolveType(context, $"{p}:{n}", false, node, true));
             pn.Values[0] = selector;
 
             var templateType = GetLastTemplateTypeFromSelector(selector);

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlSelectorTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlSelectorTransformer.cs
@@ -209,6 +209,8 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                 throw new XamlSelectorsTransformException("Unable to parse selector: " + e.Message, node, e);
             }
 
+            // Selectors should resolve control types only.
+            // isMarkupExtension = false to prevent resolving selector types to XExtension.
             var selector = Create(parsed, (p, n) 
                 => TypeReferenceResolver.ResolveType(context, $"{p}:{n}", false, node, true));
             pn.Values[0] = selector;

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -788,5 +788,25 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             Assert.Equal("Cannot add a Style without selector to a ControlTheme. Line 5, position 14.", exception.Message);
         }
+
+        [Fact]
+        public void Selector_Should_Not_Resolve_To_MarkupExtension_Type()
+        {
+            using var _ = UnitTestApplication.Start(TestServices.StyledWindow);
+
+            var style = (Style)AvaloniaRuntimeXamlLoader.Load(
+                $"""
+                <Style xmlns='https://github.com/avaloniaui'
+                        xmlns:u='using:Avalonia.Markup.Xaml.UnitTests.Xaml'
+                        Selector='u|TestSelectorControl'>
+                </Style>
+                """);
+
+            Assert.NotNull(style.Selector);
+
+            var targetType = style.Selector.TargetType;
+
+            Assert.NotEqual(typeof(TestSelectorControlExtension), targetType);
+        }
     }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/TestSelectorControl.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/TestSelectorControl.cs
@@ -1,0 +1,5 @@
+﻿namespace Avalonia.Markup.Xaml.UnitTests.Xaml;
+
+public class TestSelectorControl;
+
+public class TestSelectorControlExtension;


### PR DESCRIPTION
## What does the pull request do?
This PR changes the `isMarkupExtension` argument passed to `TypeReferenceResolver.ResolveType` in `AvaloniaXamlIlSelectorTransformer` from `true` to `false` when resolving types used in style selectors.
  
Selectors are expected to resolve control types only. Allowing markup extension resolution in this context can lead to incorrect type resolution when a `TypeNameExtension` class exists.
  
  
  ## What is the current behavior?

Currently `ResolveType` is invoked with `isMarkupExtension = true`.
This causes the resolver to also consider `TypeNameExtension` when resolving a selector type.
  
This means that if both `X` and `XExtension` exist, the resolver may resolve the selector to `XExtension` instead of the intended `X` type. Since selectors are expected to reference control types only, allowing markup extension resolution here can lead to incorrect type resolution.
  
## What is the updated/expected behavior with this PR?

Selector type resolution will only consider the exact type name. Markup extension fallback resolution is disabled, ensuring selectors consistently resolve to the intended control type.
  
## How was the solution implemented (if it's not obvious)?

## Checklist
  
  - [ ] Added unit tests (if possible)?
  - [ ] Added XML documentation to any related classes?
  - [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
  
## Breaking changes
None expected. This change only affects incorrect fallback resolution to `*Extension` types during selector compilation.