### PR TITLE
Fix X11IconLoader exception for icons < 128px

### DIFF
--- a/src/Avalonia.X11/X11IconLoader.cs
+++ b/src/Avalonia.X11/X11IconLoader.cs
@@ -40,14 +40,15 @@ namespace Avalonia.X11
             _width = Math.Min(bitmap.PixelSize.Width, 128);
             _height = Math.Min(bitmap.PixelSize.Height, 128);
             var pixels = new uint[_width * _height];
+            var size = new PixelSize(_width, _height);
 
-            using (var rtb = new RenderTargetBitmap(new PixelSize(128, 128)))
+            using (var rtb = new RenderTargetBitmap(size))
             {
                 using (var ctx = rtb.CreateDrawingContext(true)) 
                     ctx.DrawImage(bitmap, new Rect(rtb.Size));
                 
                 fixed (void* pPixels = pixels)
-                    rtb.CopyPixels(new LockedFramebuffer((IntPtr)pPixels, new PixelSize(_width, _height), _width * 4,
+                    rtb.CopyPixels(new LockedFramebuffer((IntPtr)pPixels, size, _width * 4,
                         new Vector(96, 96), PixelFormat.Bgra8888, AlphaFormat.Premul, null));
             }
             


### PR DESCRIPTION
## What does the pull request do?
This PR fixes an `ArgumentOutOfRangeException` thrown on X11 when an icon with a width or height less than 128 pixels is loaded.

## Fixed issues
 - Fixes #20913
