### PR TITLE
Remove unnecessary style for fullscreen button

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
@@ -190,12 +190,7 @@
     <Style Selector="^:maximized /template/ Path#RestoreButtonPath">
       <Setter Property="Data" Value="M2048 410h-410v-410h-1638v1638h410v410h1638v-1638zM1434 1434h-1229v-1229h1229v1229zM1843 1843h-1229v-205h1024v-1024h205v1229z" />
     </Style>
-
-    <!-- Fullscreen: update fullscreen button icon to "exit fullscreen" -->
-    <Style Selector="^:fullscreen /template/ Path#FullScreenButtonPath">
-      <Setter Property="Data" Value="M205 1024h819v-819h-205v469l-674 -674l-145 145l674 674h-469v205zM1374 1229h469v-205h-819v819h205v-469l674 674l145 -145z" />
-    </Style>
-
+    
     <!-- Disabled buttons -->
     <Style Selector="^ /template/ Button:disabled">
       <Setter Property="Opacity" Value="0.2"/>

--- a/src/Avalonia.Themes.Simple/Controls/WindowDrawnDecorations.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/WindowDrawnDecorations.xaml
@@ -197,11 +197,6 @@
       <Setter Property="Data" Value="M2048 410h-410v-410h-1638v1638h410v410h1638v-1638zM1434 1434h-1229v-1229h1229v1229zM1843 1843h-1229v-205h1024v-1024h205v1229z" />
     </Style>
 
-    <!-- Fullscreen: update fullscreen button icon to "exit fullscreen" -->
-    <Style Selector="^:fullscreen /template/ Path#FullScreenButtonPath">
-      <Setter Property="Data" Value="M205 1024h819v-819h-205v469l-674 -674l-145 145l674 674h-469v205zM1374 1229h469v-205h-819v819h205v-469l674 674l145 -145z" />
-    </Style>
-
     <!-- Disabled buttons -->
     <Style Selector="^ /template/ Button:disabled">
       <Setter Property="Opacity" Value="0.2"/>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
We now have a dedicated fullscreen button for fullscreen popover, no longer necessary to switch original button's path. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Note: I also notice the `AutomationProperties.Name` is removed from buttons. should I add it back?