### PR TITLE
Fix Windows Snap in BorderOnly mode

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1472,19 +1472,18 @@ namespace Avalonia.Win32
                 {
                     case WindowDecorations.Full:
                         style |= WindowStyles.WS_BORDER | WindowStyles.WS_CAPTION | WindowStyles.WS_SYSMENU;
-
-                        if (newProperties.IsMinimizable)
-                            style |= WindowStyles.WS_MINIMIZEBOX;
-
-                        if (newProperties.IsMaximizable || (newProperties.WindowState == WindowState.Maximized && newProperties.IsResizable))
-                            style |= WindowStyles.WS_MAXIMIZEBOX;
-
                         break;
 
                     case WindowDecorations.BorderOnly:
                         style |= WindowStyles.WS_BORDER;
                         break;
                 }
+
+                if (newProperties.IsMinimizable)
+                    style |= WindowStyles.WS_MINIMIZEBOX;
+
+                if (newProperties.IsMaximizable || (newProperties.WindowState == WindowState.Maximized && newProperties.IsResizable))
+                    style |= WindowStyles.WS_MAXIMIZEBOX;
 
                 if (newProperties.Decorations != WindowDecorations.None && newProperties.IsResizable)
                     style |= WindowStyles.WS_THICKFRAME;


### PR DESCRIPTION
## What does the pull request do?
This PR fixes Windows "Snap" not working in `BorderOnly` mode.
See #20916 for details.

## How was the solution implemented (if it's not obvious)?
The `WS_MAXIMIZEBOX` is now set unconditionally as it's necessary (in addition to `WS_THICKFRAME`) for Snap to work.

Even though the [documentation](https://learn.microsoft.com/en-us/windows/win32/winmsg/window-styles) states that `WS_SYSMENU` and `WS_CAPTION` should be specified when `WS_MAXIMIZEBOX` is, this isn't the case in practice, and modern Windows versions seem to rely on `WS_MAXIMIZEBOX` alone.

## Fixed issues
 - Fixes #20916 (the `BorderOnly` part)