### PR TITLE
Allow CanResize on macOS in BorderOnly mode

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -563,6 +563,10 @@ NSWindowStyleMask WindowImpl::CalculateStyleMask() {
 
         case SystemDecorationsBorderOnly:
             s = s | NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView;
+            
+            if (_canResize && _isEnabled) {
+                s = s | NSWindowStyleMaskResizable;
+            }
             break;
 
         case SystemDecorationsFull:


### PR DESCRIPTION
## What does the pull request do?
This PR allows resize handles to be displayed on macOS when `WindowDecorations == BorderOnly` and `CanResize == true`.

## What is the current behavior?
When the decorations are `BorderOnly`, the resize handles are never displayed.

## What is the updated/expected behavior with this PR?
`CanResize` is respected in `BorderOnly` mode. This matches the behavior on Windows.
Note: on all platforms, `None` still overrides `CanResize`, by design.

## Fixed issues
 - Fixes #20904
 - Fixes #20917