### PR TITLE
Fix SelectionChanged not raised on collection Reset

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -145,6 +145,8 @@ namespace Avalonia.Controls.Primitives
         private int _oldSelectedIndex;
         private WeakReference _oldSelectedItem = new(null);
         private WeakReference<IList?> _oldSelectedItems = new(null);
+        private object?[] _selectedItemsSnapshot = Array.Empty<object>();
+        private object?[]? _selectedItemsBeforeReset;
         private bool _ignoreContainerSelectionChanged;
         private UpdateState? _updateState;
         private bool _hasScrolledToSelectedItem;
@@ -153,7 +155,9 @@ namespace Avalonia.Controls.Primitives
 
         public SelectingItemsControl()
         {
-            ((ItemCollection)ItemsView).SourceChanged += OnItemsViewSourceChanged;
+            var items = (ItemCollection)ItemsView;
+            items.SourceChanged += OnItemsViewSourceChanged;
+            items.PreCollectionChanged += OnItemsViewPreCollectionChanged;
         }
 
         /// <summary>
@@ -462,6 +466,14 @@ namespace Avalonia.Controls.Primitives
             if (AlwaysSelected && SelectedIndex == -1 && ItemCount > 0)
             {
                 SelectedIndex = 0;
+            }
+        }
+
+        private void OnItemsViewPreCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.Action == NotifyCollectionChangedAction.Reset && _selectedItemsSnapshot.Length > 0)
+            {
+                _selectedItemsBeforeReset = _selectedItemsSnapshot;
             }
         }
 
@@ -1013,6 +1025,9 @@ namespace Avalonia.Controls.Primitives
                 UpdateSelectedValueFromItem();
             }
 
+            _selectedItemsSnapshot = Selection.SelectedItems.ToArray();
+            _selectedItemsBeforeReset = null;
+
             var route = BuildEventRoute(SelectionChangedEvent);
 
             if (route.HasHandlers)
@@ -1033,6 +1048,15 @@ namespace Avalonia.Controls.Primitives
         /// <param name="e">The event args.</param>
         private void OnSelectionModelLostSelection(object? sender, EventArgs e)
         {
+            if (_selectedItemsBeforeReset?.Length > 0)
+            {
+                RaiseEvent(new SelectionChangedEventArgs(
+                    SelectionChangedEvent,
+                    _selectedItemsBeforeReset,
+                    Array.Empty<object>()));
+                _selectedItemsBeforeReset = null;
+            }
+
             if (AlwaysSelected && ItemsView.Count > 0)
             {
                 SelectedIndex = 0;
@@ -1248,6 +1272,7 @@ namespace Avalonia.Controls.Primitives
 
             _oldSelectedIndex = model.SelectedIndex;
             _oldSelectedItem.Target = model.SelectedItem;
+            _selectedItemsSnapshot = model.SelectedItems.ToArray();
 
             if (_updateState is null && AlwaysSelected && model.Count == 0)
             {

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -474,6 +474,8 @@ namespace Avalonia.Controls.Primitives
         {
             if (e.Action == NotifyCollectionChangedAction.Reset && _selectedItemsSnapshot.Count > 0)
             {
+                // The snapshot is always consumed by either OnSelectionModelSelectionChanged
+                // (selection preserved) or OnSelectionModelLostSelection (selection lost).
                 _selectedItemsBeforeReset = _selectedItemsSnapshot.ToArray();
             }
         }
@@ -1030,16 +1032,7 @@ namespace Avalonia.Controls.Primitives
             _selectedItemsSnapshot.AddRange(Selection.SelectedItems);
             _selectedItemsBeforeReset = null;
 
-            var route = BuildEventRoute(SelectionChangedEvent);
-
-            if (route.HasHandlers)
-            {
-                var ev = new SelectionChangedEventArgs(
-                    SelectionChangedEvent,
-                    e.DeselectedItems.ToArray(),
-                    e.SelectedItems.ToArray());
-                RaiseEvent(ev);
-            }
+            RaiseSelectionChanged(e.DeselectedItems.ToArray(), e.SelectedItems.ToArray());
         }
 
         /// <summary>
@@ -1052,23 +1045,30 @@ namespace Avalonia.Controls.Primitives
         {
             if (_selectedItemsBeforeReset?.Length > 0)
             {
-                var route = BuildEventRoute(SelectionChangedEvent);
-
-                if (route.HasHandlers)
-                {
-                    var ev = new SelectionChangedEventArgs(
-                        SelectionChangedEvent,
-                        _selectedItemsBeforeReset,
-                        Array.Empty<object?>());
-                    RaiseEvent(ev);
-                }
-
-                _selectedItemsBeforeReset = null;
+                RaiseSelectionChanged(_selectedItemsBeforeReset, Array.Empty<object?>());
             }
+
+            _selectedItemsBeforeReset = null;
 
             if (AlwaysSelected && ItemsView.Count > 0)
             {
                 SelectedIndex = 0;
+            }
+        }
+
+        /// <summary>
+        /// Raises the <see cref="SelectionChangedEvent"/> if there are registered handlers.
+        /// </summary>
+        /// <param name="removedItems">The items removed from the selection.</param>
+        /// <param name="addedItems">The items added to the selection.</param>
+        private void RaiseSelectionChanged(IList removedItems, IList addedItems)
+        {
+            var route = BuildEventRoute(SelectionChangedEvent);
+
+            if (route.HasHandlers)
+            {
+                var ev = new SelectionChangedEventArgs(SelectionChangedEvent, removedItems, addedItems);
+                RaiseEvent(ev);
             }
         }
 

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -145,7 +146,7 @@ namespace Avalonia.Controls.Primitives
         private int _oldSelectedIndex;
         private WeakReference _oldSelectedItem = new(null);
         private WeakReference<IList?> _oldSelectedItems = new(null);
-        private object?[] _selectedItemsSnapshot = Array.Empty<object>();
+        private readonly List<object?> _selectedItemsSnapshot = new();
         private object?[]? _selectedItemsBeforeReset;
         private bool _ignoreContainerSelectionChanged;
         private UpdateState? _updateState;
@@ -471,9 +472,9 @@ namespace Avalonia.Controls.Primitives
 
         private void OnItemsViewPreCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
-            if (e.Action == NotifyCollectionChangedAction.Reset && _selectedItemsSnapshot.Length > 0)
+            if (e.Action == NotifyCollectionChangedAction.Reset && _selectedItemsSnapshot.Count > 0)
             {
-                _selectedItemsBeforeReset = _selectedItemsSnapshot;
+                _selectedItemsBeforeReset = _selectedItemsSnapshot.ToArray();
             }
         }
 
@@ -1025,7 +1026,8 @@ namespace Avalonia.Controls.Primitives
                 UpdateSelectedValueFromItem();
             }
 
-            _selectedItemsSnapshot = Selection.SelectedItems.ToArray();
+            _selectedItemsSnapshot.Clear();
+            _selectedItemsSnapshot.AddRange(Selection.SelectedItems);
             _selectedItemsBeforeReset = null;
 
             var route = BuildEventRoute(SelectionChangedEvent);
@@ -1050,10 +1052,17 @@ namespace Avalonia.Controls.Primitives
         {
             if (_selectedItemsBeforeReset?.Length > 0)
             {
-                RaiseEvent(new SelectionChangedEventArgs(
-                    SelectionChangedEvent,
-                    _selectedItemsBeforeReset,
-                    Array.Empty<object>()));
+                var route = BuildEventRoute(SelectionChangedEvent);
+
+                if (route.HasHandlers)
+                {
+                    var ev = new SelectionChangedEventArgs(
+                        SelectionChangedEvent,
+                        _selectedItemsBeforeReset,
+                        Array.Empty<object?>());
+                    RaiseEvent(ev);
+                }
+
                 _selectedItemsBeforeReset = null;
             }
 
@@ -1272,7 +1281,8 @@ namespace Avalonia.Controls.Primitives
 
             _oldSelectedIndex = model.SelectedIndex;
             _oldSelectedItem.Target = model.SelectedItem;
-            _selectedItemsSnapshot = model.SelectedItems.ToArray();
+            _selectedItemsSnapshot.Clear();
+            _selectedItemsSnapshot.AddRange(model.SelectedItems);
 
             if (_updateState is null && AlwaysSelected && model.Count == 0)
             {

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -474,8 +474,6 @@ namespace Avalonia.Controls.Primitives
         {
             if (e.Action == NotifyCollectionChangedAction.Reset && _selectedItemsSnapshot.Count > 0)
             {
-                // The snapshot is always consumed by either OnSelectionModelSelectionChanged
-                // (selection preserved) or OnSelectionModelLostSelection (selection lost).
                 _selectedItemsBeforeReset = _selectedItemsSnapshot.ToArray();
             }
         }
@@ -1032,7 +1030,7 @@ namespace Avalonia.Controls.Primitives
             _selectedItemsSnapshot.AddRange(Selection.SelectedItems);
             _selectedItemsBeforeReset = null;
 
-            RaiseSelectionChanged(e.DeselectedItems.ToArray(), e.SelectedItems.ToArray());
+            RaiseSelectionChanged(e.DeselectedItems, e.SelectedItems);
         }
 
         /// <summary>
@@ -1061,14 +1059,16 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         /// <param name="removedItems">The items removed from the selection.</param>
         /// <param name="addedItems">The items added to the selection.</param>
-        private void RaiseSelectionChanged(IList removedItems, IList addedItems)
+        private void RaiseSelectionChanged(IReadOnlyList<object?> removedItems, IReadOnlyList<object?> addedItems)
         {
             var route = BuildEventRoute(SelectionChangedEvent);
 
             if (route.HasHandlers)
             {
-                var ev = new SelectionChangedEventArgs(SelectionChangedEvent, removedItems, addedItems);
-                RaiseEvent(ev);
+                RaiseEvent(new SelectionChangedEventArgs(
+                    SelectionChangedEvent,
+                    removedItems as IList ?? removedItems.ToArray(),
+                    addedItems as IList ?? addedItems.ToArray()));
             }
         }
 

--- a/src/Avalonia.Controls/Selection/InternalSelectionModel.cs
+++ b/src/Avalonia.Controls/Selection/InternalSelectionModel.cs
@@ -264,75 +264,7 @@ namespace Avalonia.Controls.Selection
             }
         }
 
-        private void OnSourceReset(object? sender, EventArgs e)
-        {
-            // Snapshot before sync: base.OnSourceReset already cleared the model.
-            List<object?>? previousItems = null;
-
-            if (_writableSelectedItems?.Count > 0)
-            {
-                previousItems = new List<object?>(_writableSelectedItems.Count);
-                foreach (var item in _writableSelectedItems)
-                    previousItems.Add(item);
-            }
-
-            SyncFromSelectedItems();
-
-            if (previousItems is null || previousItems.Count == 0)
-                return;
-
-            // Multiset diff: selection allows duplicates, set semantics under-reports.
-            var currentItemCounts = new Dictionary<object, int>();
-            var currentNullCount = 0;
-
-            if (_writableSelectedItems != null)
-            {
-                foreach (var item in _writableSelectedItems)
-                {
-                    if (item is null)
-                    {
-                        ++currentNullCount;
-                    }
-                    else if (currentItemCounts.TryGetValue(item, out var count))
-                    {
-                        currentItemCounts[item] = count + 1;
-                    }
-                    else
-                    {
-                        currentItemCounts[item] = 1;
-                    }
-                }
-            }
-
-            var deselectedItems = new List<object?>();
-            foreach (var item in previousItems)
-            {
-                if (item is null)
-                {
-                    if (currentNullCount > 0)
-                        --currentNullCount;
-                    else
-                        deselectedItems.Add(item);
-                }
-                else if (currentItemCounts.TryGetValue(item, out var count) && count > 0)
-                {
-                    if (count == 1)
-                        currentItemCounts.Remove(item);
-                    else
-                        currentItemCounts[item] = count - 1;
-                }
-                else
-                {
-                    deselectedItems.Add(item);
-                }
-            }
-
-            if (deselectedItems.Count == 0)
-                return;
-
-            using var update = BatchUpdate();
-            update.Operation.DeselectedItems = deselectedItems;
-        }
+        private void OnSourceReset(object? sender, EventArgs e) => SyncFromSelectedItems();
 
         private void OnSelectedItemsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {

--- a/src/Avalonia.Controls/Selection/InternalSelectionModel.cs
+++ b/src/Avalonia.Controls/Selection/InternalSelectionModel.cs
@@ -264,7 +264,46 @@ namespace Avalonia.Controls.Selection
             }
         }
 
-        private void OnSourceReset(object? sender, EventArgs e) => SyncFromSelectedItems();
+        private void OnSourceReset(object? sender, EventArgs e)
+        {
+            // Snapshot before sync: base.OnSourceReset already cleared _selectedIndex,
+            // so the pending Operation has no record of what was lost.
+            List<object?>? previousItems = null;
+
+            if (_writableSelectedItems?.Count > 0)
+            {
+                previousItems = new List<object?>(_writableSelectedItems.Count);
+                foreach (var item in _writableSelectedItems)
+                    previousItems.Add(item);
+            }
+
+            SyncFromSelectedItems();
+
+            if (previousItems is null || previousItems.Count == 0)
+                return;
+
+            // Diff against post-sync state: a reorder Reset preserves items, only
+            // genuine losses should be reported as DeselectedItems.
+            var currentItems = new HashSet<object?>();
+            if (_writableSelectedItems != null)
+            {
+                foreach (var item in _writableSelectedItems)
+                    currentItems.Add(item);
+            }
+
+            var deselectedItems = new List<object?>();
+            foreach (var item in previousItems)
+            {
+                if (!currentItems.Contains(item))
+                    deselectedItems.Add(item);
+            }
+
+            if (deselectedItems.Count == 0)
+                return;
+
+            using var update = BatchUpdate();
+            update.Operation.DeselectedItems = deselectedItems;
+        }
 
         private void OnSelectedItemsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {

--- a/src/Avalonia.Controls/Selection/InternalSelectionModel.cs
+++ b/src/Avalonia.Controls/Selection/InternalSelectionModel.cs
@@ -266,8 +266,7 @@ namespace Avalonia.Controls.Selection
 
         private void OnSourceReset(object? sender, EventArgs e)
         {
-            // Snapshot before sync: base.OnSourceReset already cleared _selectedIndex,
-            // so the pending Operation has no record of what was lost.
+            // Snapshot before sync: base.OnSourceReset already cleared the model.
             List<object?>? previousItems = null;
 
             if (_writableSelectedItems?.Count > 0)
@@ -282,20 +281,50 @@ namespace Avalonia.Controls.Selection
             if (previousItems is null || previousItems.Count == 0)
                 return;
 
-            // Diff against post-sync state: a reorder Reset preserves items, only
-            // genuine losses should be reported as DeselectedItems.
-            var currentItems = new HashSet<object?>();
+            // Multiset diff: selection allows duplicates, set semantics under-reports.
+            var currentItemCounts = new Dictionary<object, int>();
+            var currentNullCount = 0;
+
             if (_writableSelectedItems != null)
             {
                 foreach (var item in _writableSelectedItems)
-                    currentItems.Add(item);
+                {
+                    if (item is null)
+                    {
+                        ++currentNullCount;
+                    }
+                    else if (currentItemCounts.TryGetValue(item, out var count))
+                    {
+                        currentItemCounts[item] = count + 1;
+                    }
+                    else
+                    {
+                        currentItemCounts[item] = 1;
+                    }
+                }
             }
 
             var deselectedItems = new List<object?>();
             foreach (var item in previousItems)
             {
-                if (!currentItems.Contains(item))
+                if (item is null)
+                {
+                    if (currentNullCount > 0)
+                        --currentNullCount;
+                    else
+                        deselectedItems.Add(item);
+                }
+                else if (currentItemCounts.TryGetValue(item, out var count) && count > 0)
+                {
+                    if (count == 1)
+                        currentItemCounts.Remove(item);
+                    else
+                        currentItemCounts[item] = count - 1;
+                }
+                else
+                {
                     deselectedItems.Add(item);
+                }
             }
 
             if (deselectedItems.Count == 0)

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -952,6 +952,33 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void Resetting_Items_With_Duplicate_Selections_Should_Report_Lost_Duplicates()
+        {
+            // Reset reducing duplicate count must report only the surplus as lost.
+            var items = new ResettingCollection(0);
+            items.AddRange(new[] { "Dup", "Other", "Dup" });
+
+            var target = new TestSelector
+            {
+                ItemsSource = items,
+                Template = Template(),
+                SelectionMode = SelectionMode.Multiple,
+            };
+
+            Prepare(target);
+            target.SelectedIndex = 0;
+            target.Selection.Select(2);
+
+            SelectionChangedEventArgs? receivedArgs = null;
+            target.SelectionChanged += (_, args) => receivedArgs = args;
+
+            items.Reset(new[] { "Other", "Dup" });
+
+            Assert.NotNull(receivedArgs);
+            Assert.Equal(new[] { "Dup" }, receivedArgs.RemovedItems.Cast<object>());
+        }
+
+        [Fact]
         public void Raising_IsSelectedChanged_On_Item_Should_Update_Selection()
         {
             var items = new[]

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -857,6 +857,101 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void Resetting_Items_Collection_Should_Raise_SelectionChanged()
+        {
+            var items = new ObservableCollection<Item>
+            {
+                new Item(),
+                new Item(),
+                new Item(),
+            };
+
+            var target = new SelectingItemsControl
+            {
+                ItemsSource = items,
+                Template = Template(),
+            };
+
+            Prepare(target);
+            target.SelectedIndex = 1;
+
+            var selectedItem = items[1];
+
+            SelectionChangedEventArgs? receivedArgs = null;
+            target.SelectionChanged += (_, args) => receivedArgs = args;
+
+            items.Clear();
+
+            Assert.Null(target.SelectedItem);
+            Assert.Equal(-1, target.SelectedIndex);
+            Assert.NotNull(receivedArgs);
+            Assert.Empty(receivedArgs.AddedItems);
+            Assert.Equal(new[] { selectedItem }, receivedArgs.RemovedItems);
+        }
+
+        [Fact]
+        public void Resetting_Items_To_Empty_With_Multiple_Selection_Should_Raise_SelectionChanged()
+        {
+            var items = new ObservableCollection<Item>
+            {
+                new Item(),
+                new Item(),
+                new Item(),
+            };
+
+            var target = new TestSelector
+            {
+                ItemsSource = items,
+                Template = Template(),
+                SelectionMode = SelectionMode.Multiple,
+            };
+
+            Prepare(target);
+            target.SelectedIndex = 0;
+            target.Selection.Select(2);
+
+            var selected0 = items[0];
+            var selected2 = items[2];
+
+            SelectionChangedEventArgs? receivedArgs = null;
+            target.SelectionChanged += (_, args) => receivedArgs = args;
+
+            items.Clear();
+
+            Assert.Null(target.SelectedItem);
+            Assert.Equal(-1, target.SelectedIndex);
+            Assert.NotNull(receivedArgs);
+            Assert.Empty(receivedArgs.AddedItems);
+            Assert.Equal(2, receivedArgs.RemovedItems.Count);
+            Assert.Contains(selected0, receivedArgs.RemovedItems.Cast<object>());
+            Assert.Contains(selected2, receivedArgs.RemovedItems.Cast<object>());
+        }
+
+        [Fact]
+        public void Resetting_Items_With_Preserved_Selection_Should_Not_Report_Deselection()
+        {
+            var items = new ResettingCollection(3);
+
+            var target = new SelectingItemsControl
+            {
+                ItemsSource = items,
+                Template = Template(),
+            };
+
+            target.ApplyTemplate();
+            target.SelectedIndex = 1;
+
+            SelectionChangedEventArgs? receivedArgs = null;
+            target.SelectionChanged += (_, args) => receivedArgs = args;
+
+            items.Reset(new[] { "Item2", "Item0", "Item1" });
+
+            Assert.Equal("Item1", target.SelectedItem);
+            Assert.NotNull(receivedArgs);
+            Assert.Empty(receivedArgs.RemovedItems);
+        }
+
+        [Fact]
         public void Raising_IsSelectedChanged_On_Item_Should_Update_Selection()
         {
             var items = new[]

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -952,33 +952,6 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
-        public void Resetting_Items_With_Duplicate_Selections_Should_Report_Lost_Duplicates()
-        {
-            // Reset reducing duplicate count must report only the surplus as lost.
-            var items = new ResettingCollection(0);
-            items.AddRange(new[] { "Dup", "Other", "Dup" });
-
-            var target = new TestSelector
-            {
-                ItemsSource = items,
-                Template = Template(),
-                SelectionMode = SelectionMode.Multiple,
-            };
-
-            Prepare(target);
-            target.SelectedIndex = 0;
-            target.Selection.Select(2);
-
-            SelectionChangedEventArgs? receivedArgs = null;
-            target.SelectionChanged += (_, args) => receivedArgs = args;
-
-            items.Reset(new[] { "Other", "Dup" });
-
-            Assert.NotNull(receivedArgs);
-            Assert.Equal(new[] { "Dup" }, receivedArgs.RemovedItems.Cast<object>());
-        }
-
-        [Fact]
         public void Raising_IsSelectedChanged_On_Item_Should_Update_Selection()
         {
             var items = new[]

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -877,16 +877,16 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
             var selectedItem = items[1];
 
-            SelectionChangedEventArgs? receivedArgs = null;
-            target.SelectionChanged += (_, args) => receivedArgs = args;
+            var receivedArgs = new List<SelectionChangedEventArgs>();
+            target.SelectionChanged += (_, args) => receivedArgs.Add(args);
 
             items.Clear();
 
             Assert.Null(target.SelectedItem);
             Assert.Equal(-1, target.SelectedIndex);
-            Assert.NotNull(receivedArgs);
-            Assert.Empty(receivedArgs.AddedItems);
-            Assert.Equal(new[] { selectedItem }, receivedArgs.RemovedItems);
+            Assert.Single(receivedArgs);
+            Assert.Empty(receivedArgs[0].AddedItems);
+            Assert.Equal(new[] { selectedItem }, receivedArgs[0].RemovedItems);
         }
 
         [Fact]
@@ -913,18 +913,18 @@ namespace Avalonia.Controls.UnitTests.Primitives
             var selected0 = items[0];
             var selected2 = items[2];
 
-            SelectionChangedEventArgs? receivedArgs = null;
-            target.SelectionChanged += (_, args) => receivedArgs = args;
+            var receivedArgs = new List<SelectionChangedEventArgs>();
+            target.SelectionChanged += (_, args) => receivedArgs.Add(args);
 
             items.Clear();
 
             Assert.Null(target.SelectedItem);
             Assert.Equal(-1, target.SelectedIndex);
-            Assert.NotNull(receivedArgs);
-            Assert.Empty(receivedArgs.AddedItems);
-            Assert.Equal(2, receivedArgs.RemovedItems.Count);
-            Assert.Contains(selected0, receivedArgs.RemovedItems.Cast<object>());
-            Assert.Contains(selected2, receivedArgs.RemovedItems.Cast<object>());
+            Assert.Single(receivedArgs);
+            Assert.Empty(receivedArgs[0].AddedItems);
+            Assert.Equal(2, receivedArgs[0].RemovedItems.Count);
+            Assert.Contains(selected0, receivedArgs[0].RemovedItems.Cast<object>());
+            Assert.Contains(selected2, receivedArgs[0].RemovedItems.Cast<object>());
         }
 
         [Fact]
@@ -941,14 +941,14 @@ namespace Avalonia.Controls.UnitTests.Primitives
             target.ApplyTemplate();
             target.SelectedIndex = 1;
 
-            SelectionChangedEventArgs? receivedArgs = null;
-            target.SelectionChanged += (_, args) => receivedArgs = args;
+            var receivedArgs = new List<SelectionChangedEventArgs>();
+            target.SelectionChanged += (_, args) => receivedArgs.Add(args);
 
             items.Reset(new[] { "Item2", "Item0", "Item1" });
 
             Assert.Equal("Item1", target.SelectedItem);
-            Assert.NotNull(receivedArgs);
-            Assert.Empty(receivedArgs.RemovedItems);
+            Assert.Single(receivedArgs);
+            Assert.Empty(receivedArgs[0].RemovedItems);
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?

Fixes `SelectingItemsControl.SelectionChanged` not being raised when an items collection sends a `Reset` notification that clears the current selection. This covers controls such as `ListBox` bound to an `ObservableCollection` that is cleared.

## What is the current behavior?

When a selected item is removed by a `Reset`, `SelectionModel` reports the loss through `LostSelection`. `SelectingItemsControl` only uses that callback to recover `AlwaysSelected` selection, so no public routed `SelectionChanged` event is raised for reset-to-empty cases.

## What is the updated/expected behavior with this PR?

`SelectionChanged` is raised when a reset causes the control to lose its selected items. The event reports the previously selected items in `RemovedItems` and does not report removals when a reset preserves the selection.

Validated with:

- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -- --filter-class "Avalonia.Controls.UnitTests.Primitives.SelectingItemsControlTests"`
- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -- --filter-class "Avalonia.Controls.UnitTests.Selection.InternalSelectionModelTests"`
- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -- --filter-namespace "Avalonia.Controls.UnitTests.Selection"`

## How was the solution implemented (if it's not obvious)?

`SelectingItemsControl` now keeps a snapshot of the last selected items at the control boundary. When an items `Reset` starts, the control captures that existing snapshot. If `SelectionModel.LostSelection` is committed for that reset, the control raises the routed `SelectionChanged` event using the captured items as `RemovedItems`.

This keeps `SelectionModel` reset semantics intact and avoids diffing the reset collection contents.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #20897