### PR TITLE
Fixed creating RenderTarget when using Vulkan backend

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -149,12 +149,16 @@ namespace Avalonia.Rendering.Composition.Server
 
             try
             {
-                if (_renderTarget == null && !_compositor.IsReadyToCreateRenderTarget(_surfaces()))
+                if (_renderTarget == null)
                 {
-                    IsWaitingForReadyRenderTarget = IsEnabled;
-                    return;
+                    if (!_compositor.IsReadyToCreateRenderTarget(_surfaces()))
+                    {
+                        IsWaitingForReadyRenderTarget = IsEnabled;
+                        return;
+                    }
+
+                    _renderTarget = _compositor.CreateRenderTarget(_surfaces());
                 }
-                _renderTarget ??= _compositor.CreateRenderTarget(_surfaces());
             }
             catch (RenderTargetNotReadyException)
             {

--- a/src/Avalonia.Vulkan/VulkanContext.cs
+++ b/src/Avalonia.Vulkan/VulkanContext.cs
@@ -41,6 +41,10 @@ internal class VulkanContext : IVulkanPlatformGraphicsContext
     {
         if (featureType == typeof(IVulkanContextExternalObjectsFeature))
             return _externalObjectsFeature;
+                
+        if (featureType == typeof(IVulkanKhrSurfacePlatformSurfaceFactory))
+            return _surfaceFactory;
+
         return null;
     }
 


### PR DESCRIPTION
## What does the pull request do?
When using the Vulkan backend in v12-preview2 or rc1, the app started, but nothing was shown.
As described in Issue #20824 this was caused because the `Vulkan.TryGetFeature<IVulkanKhrSurfacePlatformSurfaceFactory>()` returned null and this prevented the `_renderTarget` from being created.

This is fixed by the first commint in this PR that updates the `TryGetFeature` method.

The second commit is just a small improvement that reduces duplicate check for null (first in `if` and then in `??=`).

## Fixed issues
Fixes #20824

