### PR TITLE
Make RoutedEvent nullable in event arguments

### DIFF
--- a/src/Avalonia.Base/Input/DragEventArgs.cs
+++ b/src/Avalonia.Base/Input/DragEventArgs.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Input
 
         [Unstable("This constructor might be removed in 12.0. For unit testing, consider using DragDrop.DoDragDrop or IHeadlessWindow.DragDrop.")]
         public DragEventArgs(
-            RoutedEvent<DragEventArgs> routedEvent,
+            RoutedEvent<DragEventArgs>? routedEvent,
             IDataTransfer dataTransfer,
             Interactive target,
             Point targetLocation,

--- a/src/Avalonia.Base/Input/FocusChangedEventArgs.cs
+++ b/src/Avalonia.Base/Input/FocusChangedEventArgs.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Input
         /// Initializes a new instance of <see cref="FocusChangedEventArgs"/>.
         /// </summary>
         /// <param name="routedEvent">The routed event associated with these event args.</param>
-        public FocusChangedEventArgs(RoutedEvent routedEvent)
+        public FocusChangedEventArgs(RoutedEvent? routedEvent)
             : base(routedEvent)
         {
         }

--- a/src/Avalonia.Base/Input/FocusChangingEventArgs.cs
+++ b/src/Avalonia.Base/Input/FocusChangingEventArgs.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Provides data for focus changing.
         /// </summary>
-        internal FocusChangingEventArgs(RoutedEvent routedEvent) : base(routedEvent)
+        public FocusChangingEventArgs(RoutedEvent? routedEvent) : base(routedEvent)
         {
         }
 

--- a/src/Avalonia.Base/Input/PointerDeltaEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerDeltaEventArgs.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Input
         public Vector Delta { get; }
 
         [Unstable("This constructor might be removed in 12.0.")]
-        public PointerDeltaEventArgs(RoutedEvent routedEvent, object? source, 
+        public PointerDeltaEventArgs(RoutedEvent? routedEvent, object? source,
             IPointer pointer, Visual rootVisual, Point rootVisualPosition, ulong timestamp,
             PointerPointProperties properties, KeyModifiers modifiers, Vector delta) 
             : base(routedEvent, source, pointer, rootVisual, rootVisualPosition,

--- a/src/Avalonia.Base/Input/PointerEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerEventArgs.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Input
         private readonly Lazy<IReadOnlyList<RawPointerPoint>?>? _previousPoints;
 
         [Unstable("This constructor might be removed in 12.0. For unit testing, consider using IHeadlessWindow mouse methods.")]
-        public PointerEventArgs(RoutedEvent routedEvent,
+        public PointerEventArgs(RoutedEvent? routedEvent,
             object? source,
             IPointer pointer,
             Visual? rootVisual, Point rootVisualPosition,
@@ -33,7 +33,7 @@ namespace Avalonia.Input
             KeyModifiers = modifiers;
         }
         
-        internal PointerEventArgs(RoutedEvent routedEvent,
+        internal PointerEventArgs(RoutedEvent? routedEvent,
             object? source,
             IPointer pointer,
             Visual? rootVisual, Point rootVisualPosition,

--- a/src/Avalonia.Base/Input/TappedEventArgs.cs
+++ b/src/Avalonia.Base/Input/TappedEventArgs.cs
@@ -6,7 +6,7 @@ namespace Avalonia.Input
     {
         private readonly PointerEventArgs lastPointerEventArgs;
 
-        public TappedEventArgs(RoutedEvent routedEvent, PointerEventArgs lastPointerEventArgs)
+        public TappedEventArgs(RoutedEvent? routedEvent, PointerEventArgs lastPointerEventArgs)
             : base(routedEvent)
         {
             this.lastPointerEventArgs = lastPointerEventArgs;

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDownValueChangedEventArgs.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDownValueChangedEventArgs.cs
@@ -4,7 +4,7 @@ namespace Avalonia.Controls
 {
     public class NumericUpDownValueChangedEventArgs : RoutedEventArgs
     {
-        public NumericUpDownValueChangedEventArgs(RoutedEvent routedEvent, decimal? oldValue, decimal? newValue) : base(routedEvent)
+        public NumericUpDownValueChangedEventArgs(RoutedEvent? routedEvent, decimal? oldValue, decimal? newValue) : base(routedEvent)
         {
             OldValue = oldValue;
             NewValue = newValue;

--- a/src/Avalonia.Controls/Page/DrawerClosingEventArgs.cs
+++ b/src/Avalonia.Controls/Page/DrawerClosingEventArgs.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Controls
         /// Initializes a new instance of the <see cref="DrawerClosingEventArgs"/> class.
         /// </summary>
         /// <param name="routedEvent">The routed event associated with these event data.</param>
-        public DrawerClosingEventArgs(RoutedEvent routedEvent) : base(routedEvent) { }
+        public DrawerClosingEventArgs(RoutedEvent? routedEvent) : base(routedEvent) { }
 
         /// <summary>
         /// Gets or sets a value indicating whether the closing should be cancelled.

--- a/src/Avalonia.Controls/Page/PageSelectionChangedEventArgs.cs
+++ b/src/Avalonia.Controls/Page/PageSelectionChangedEventArgs.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Controls
         /// <param name="routedEvent">The routed event associated with this event args instance.</param>
         /// <param name="previousPage">The page that was selected before the change, or <see langword="null"/> if no page was selected.</param>
         /// <param name="currentPage">The page that is now selected, or <see langword="null"/> if selection was cleared.</param>
-        public PageSelectionChangedEventArgs(RoutedEvent routedEvent, Page? previousPage, Page? currentPage)
+        public PageSelectionChangedEventArgs(RoutedEvent? routedEvent, Page? previousPage, Page? currentPage)
             : base(routedEvent)
         {
             PreviousPage = previousPage;

--- a/src/Avalonia.Controls/ScrollChangedEventArgs.cs
+++ b/src/Avalonia.Controls/ScrollChangedEventArgs.cs
@@ -16,7 +16,7 @@ namespace Avalonia.Controls
         }
 
         public ScrollChangedEventArgs(
-            RoutedEvent routedEvent,
+            RoutedEvent? routedEvent,
             Vector extentDelta,
             Vector offsetDelta,
             Vector viewportDelta)

--- a/src/Avalonia.Controls/SelectionChangedEventArgs.cs
+++ b/src/Avalonia.Controls/SelectionChangedEventArgs.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Controls
         /// <param name="routedEvent">The event being raised.</param>
         /// <param name="removedItems">The items removed from the selection.</param>
         /// <param name="addedItems">The items added to the selection.</param>
-        public SelectionChangedEventArgs(RoutedEvent routedEvent, IList removedItems, IList addedItems)
+        public SelectionChangedEventArgs(RoutedEvent? routedEvent, IList removedItems, IList addedItems)
             : base(routedEvent)
         {
             RemovedItems = removedItems;

--- a/src/Avalonia.Controls/Spinner.cs
+++ b/src/Avalonia.Controls/Spinner.cs
@@ -66,7 +66,7 @@ namespace Avalonia.Controls
             Direction = direction;
         }
 
-        public SpinEventArgs(RoutedEvent routedEvent, SpinDirection direction)
+        public SpinEventArgs(RoutedEvent? routedEvent, SpinDirection direction)
             : base(routedEvent)
         {
             Direction = direction;
@@ -78,7 +78,7 @@ namespace Avalonia.Controls
             UsingMouseWheel = usingMouseWheel;
         }
 
-        public SpinEventArgs(RoutedEvent routedEvent, SpinDirection direction, bool usingMouseWheel)
+        public SpinEventArgs(RoutedEvent? routedEvent, SpinDirection direction, bool usingMouseWheel)
             : base(routedEvent)
         {
             Direction = direction;


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that all inheritors of `RoutedEventArgs` that accept a `RoutedEvent` parameter accept `null` as a value.
The base class `RoutedEventArgs` accepts null, but not all implementations were consistent.
