### PR TITLE
Remove UnstableAttribute from several RoutedEventArgs

### DIFF
--- a/src/Avalonia.Base/Input/DragEventArgs.cs
+++ b/src/Avalonia.Base/Input/DragEventArgs.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Avalonia.Interactivity;
-using Avalonia.Metadata;
 
 namespace Avalonia.Input
 {
@@ -25,7 +24,6 @@ namespace Avalonia.Input
             return _target.TranslatePoint(_targetLocation, relativeTo) ?? new Point(0, 0);
         }
 
-        [Unstable("This constructor might be removed in 12.0. For unit testing, consider using DragDrop.DoDragDrop or IHeadlessWindow.DragDrop.")]
         public DragEventArgs(
             RoutedEvent<DragEventArgs>? routedEvent,
             IDataTransfer dataTransfer,

--- a/src/Avalonia.Base/Input/PointerDeltaEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerDeltaEventArgs.cs
@@ -1,7 +1,4 @@
-using System;
 using Avalonia.Interactivity;
-using Avalonia.Metadata;
-using Avalonia.VisualTree;
 
 namespace Avalonia.Input
 {
@@ -9,7 +6,6 @@ namespace Avalonia.Input
     {
         public Vector Delta { get; }
 
-        [Unstable("This constructor might be removed in 12.0.")]
         public PointerDeltaEventArgs(RoutedEvent? routedEvent, object? source,
             IPointer pointer, Visual rootVisual, Point rootVisualPosition, ulong timestamp,
             PointerPointProperties properties, KeyModifiers modifiers, Vector delta) 

--- a/src/Avalonia.Base/Input/PointerEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerEventArgs.cs
@@ -14,7 +14,6 @@ namespace Avalonia.Input
         private readonly PointerPointProperties _properties;
         private readonly Lazy<IReadOnlyList<RawPointerPoint>?>? _previousPoints;
 
-        [Unstable("This constructor might be removed in 12.0. For unit testing, consider using IHeadlessWindow mouse methods.")]
         public PointerEventArgs(RoutedEvent? routedEvent,
             object? source,
             IPointer pointer,
@@ -32,8 +31,9 @@ namespace Avalonia.Input
             Timestamp = timestamp;
             KeyModifiers = modifiers;
         }
-        
-        internal PointerEventArgs(RoutedEvent? routedEvent,
+
+        [PrivateApi]
+        public PointerEventArgs(RoutedEvent? routedEvent,
             object? source,
             IPointer pointer,
             Visual? rootVisual, Point rootVisualPosition,
@@ -41,9 +41,7 @@ namespace Avalonia.Input
             PointerPointProperties properties,
             KeyModifiers modifiers,
             Lazy<IReadOnlyList<RawPointerPoint>?>? previousPoints)
-#pragma warning disable CS0618
             : this(routedEvent, source, pointer, rootVisual, rootVisualPosition, timestamp, properties, modifiers)
-#pragma warning restore CS0618
         {
             _previousPoints = previousPoints;
         }
@@ -160,9 +158,8 @@ namespace Avalonia.Input
 
     public class PointerPressedEventArgs : PointerEventArgs
     {
-        [Unstable("This constructor might be removed in 12.0. For unit testing, consider using IHeadlessWindow mouse methods.")]
         public PointerPressedEventArgs(
-            object source,
+            object? source,
             IPointer pointer,
             Visual rootVisual, Point rootVisualPosition,
             ulong timestamp,
@@ -180,9 +177,8 @@ namespace Avalonia.Input
 
     public class PointerReleasedEventArgs : PointerEventArgs
     {
-        [Unstable("This constructor might be removed in 12.0. For unit testing, consider using IHeadlessWindow mouse methods.")]
         public PointerReleasedEventArgs(
-            object source, IPointer pointer,
+            object? source, IPointer pointer,
             Visual rootVisual, Point rootVisualPosition, ulong timestamp,
             PointerPointProperties properties, KeyModifiers modifiers,
             MouseButton initialPressMouseButton)
@@ -202,8 +198,7 @@ namespace Avalonia.Input
     {
         public IPointer Pointer { get; }
 
-        [Unstable("This constructor might be removed in 12.0. If you need to remove capture, use stable methods on the IPointer instance.")]
-        public PointerCaptureLostEventArgs(object source, IPointer pointer) : base(InputElement.PointerCaptureLostEvent)
+        public PointerCaptureLostEventArgs(object? source, IPointer pointer) : base(InputElement.PointerCaptureLostEvent)
         {
             Pointer = pointer;
             Source = source;
@@ -216,7 +211,7 @@ namespace Avalonia.Input
         public CaptureSource CaptureSource { get; }
         public IInputElement? NewValue { get; }
 
-        internal PointerCaptureChangingEventArgs(object source, IPointer pointer, IInputElement? newValue, CaptureSource captureSource) : base(InputElement.PointerCaptureChangingEvent)
+        internal PointerCaptureChangingEventArgs(object? source, IPointer pointer, IInputElement? newValue, CaptureSource captureSource) : base(InputElement.PointerCaptureChangingEvent)
         {
             Pointer = pointer;
             Source = source;

--- a/src/Avalonia.Base/Input/PointerWheelEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerWheelEventArgs.cs
@@ -1,16 +1,10 @@
-using System;
-using Avalonia.Interactivity;
-using Avalonia.Metadata;
-using Avalonia.VisualTree;
-
 namespace Avalonia.Input
 {
     public class PointerWheelEventArgs : PointerEventArgs
     {
         public Vector Delta { get; }
 
-        [Unstable("This constructor might be removed in 12.0. For unit testing, consider using IHeadlessWindow.MouseWheel.")]
-        public PointerWheelEventArgs(object source, IPointer pointer, Visual rootVisual,
+        public PointerWheelEventArgs(object? source, IPointer pointer, Visual rootVisual,
             Point rootVisualPosition, ulong timestamp,
             PointerPointProperties properties, KeyModifiers modifiers, Vector delta)
             : base(InputElement.PointerWheelChangedEvent, source, pointer, rootVisual, rootVisualPosition,


### PR DESCRIPTION
## What does the pull request do?
This PR removes `[Unstable]` from several classes derived from `RoutedEventArgs`.

While we want to steer users toward Avalonia's headless platform for unit testing, event arguments should remain simple, record-like structures, usable by users who want to trigger routed events manually.
