### PR TITLE
Make Dispatcher.Yield use the current dispatcher

### DIFF
--- a/src/Avalonia.Base/Threading/Dispatcher.Invoke.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.Invoke.cs
@@ -737,9 +737,6 @@ public partial class Dispatcher
     /// </exception>
     public static DispatcherPriorityAwaitable Yield(DispatcherPriority priority)
     {
-        // TODO12: Update to use Dispatcher.CurrentDispatcher once multi-dispatcher support is merged
-        var current = UIThread;
-        current.VerifyAccess();
-        return UIThread.Resume(priority);
+        return CurrentDispatcher.Resume(priority);
     }
 }

--- a/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
+++ b/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
@@ -512,76 +512,59 @@ public partial class DispatcherTests
 
 
     [Fact]
-    public async Task DispatcherResumeContinuesOnUIThread()
+    public async Task DispatcherResumeContinuesOnCurrentThread()
     {
         using var services = new DispatcherServices(new SimpleControlledDispatcherImpl());
 
         var tokenSource = new CancellationTokenSource();
-        var workload = Dispatcher.UIThread.InvokeAsync(
+        var dispatcher = Dispatcher.CurrentDispatcher;
+
+        var workload = dispatcher.InvokeAsync(
             async () =>
             {
-                Assert.True(Dispatcher.UIThread.CheckAccess());
+                Assert.True(dispatcher.CheckAccess());
 
                 await Task.Delay(1).ConfigureAwait(false);
-                Assert.False(Dispatcher.UIThread.CheckAccess());
+                Assert.False(dispatcher.CheckAccess());
 
-                await Dispatcher.UIThread.Resume();
-                Assert.True(Dispatcher.UIThread.CheckAccess());
+                await dispatcher.Resume();
+                Assert.True(dispatcher.CheckAccess());
 
                 tokenSource.Cancel();
             });
 
-        Dispatcher.UIThread.MainLoop(tokenSource.Token);
+        dispatcher.MainLoop(tokenSource.Token);
     }
 
     [Fact]
-    public async Task DispatcherYieldContinuesOnUIThread()
+    public async Task DispatcherYieldContinuesOnCurrentThread()
     {
         using var services = new DispatcherServices(new SimpleControlledDispatcherImpl());
 
         var tokenSource = new CancellationTokenSource();
-        var workload = Dispatcher.UIThread.InvokeAsync(
+        var dispatcher = Dispatcher.CurrentDispatcher;
+
+        var workload = dispatcher.InvokeAsync(
             async () =>
             {
-                Assert.True(Dispatcher.UIThread.CheckAccess());
+                Assert.True(dispatcher.CheckAccess());
 
                 await Dispatcher.Yield();
-                Assert.True(Dispatcher.UIThread.CheckAccess());
+                Assert.True(dispatcher.CheckAccess());
 
                 tokenSource.Cancel();
             });
 
-        Dispatcher.UIThread.MainLoop(tokenSource.Token);
+        dispatcher.MainLoop(tokenSource.Token);
     }
 
     [Fact]
-    public async Task DispatcherYieldThrowsOnNonUIThread()
+    public async Task AwaitWithPriorityRunsOnCurrentThread()
     {
-        using var services = new DispatcherServices(new SimpleControlledDispatcherImpl());
-
-        var tokenSource = new CancellationTokenSource();
-        var workload = Dispatcher.UIThread.InvokeAsync(
-            async () =>
-            {
-                Assert.True(Dispatcher.UIThread.CheckAccess());
-
-                await Task.Delay(1).ConfigureAwait(false);
-                Assert.False(Dispatcher.UIThread.CheckAccess());
-                await Assert.ThrowsAsync<InvalidOperationException>(async () => await Dispatcher.Yield());
-
-                tokenSource.Cancel();
-            });
-
-        Dispatcher.UIThread.MainLoop(tokenSource.Token);
-    }
-
-    [Fact]
-    public async Task AwaitWithPriorityRunsOnUIThread()
-    {
-        static async Task<int> Workload()
+        static async Task<int> Workload(Dispatcher dispatcher)
         {
             await Task.Delay(1).ConfigureAwait(false);
-            Assert.False(Dispatcher.UIThread.CheckAccess());
+            Assert.False(dispatcher.CheckAccess());
 
             return Thread.CurrentThread.ManagedThreadId;
         }
@@ -589,25 +572,27 @@ public partial class DispatcherTests
         using var services = new DispatcherServices(new SimpleControlledDispatcherImpl());
 
         var tokenSource = new CancellationTokenSource();
-        var workload = Dispatcher.UIThread.InvokeAsync(
+        var dispatcher = Dispatcher.CurrentDispatcher;
+
+        var workload = dispatcher.InvokeAsync(
             async () =>
             {
-                Assert.True(Dispatcher.UIThread.CheckAccess());
-                Task taskWithoutResult = Workload();
+                Assert.True(dispatcher.CheckAccess());
+                Task taskWithoutResult = Workload(dispatcher);
 
-                await Dispatcher.UIThread.AwaitWithPriority(taskWithoutResult, DispatcherPriority.Default);
+                await dispatcher.AwaitWithPriority(taskWithoutResult, DispatcherPriority.Default);
 
-                Assert.True(Dispatcher.UIThread.CheckAccess());
-                Task<int> taskWithResult = Workload();
+                Assert.True(dispatcher.CheckAccess());
+                Task<int> taskWithResult = Workload(dispatcher);
 
-                await Dispatcher.UIThread.AwaitWithPriority(taskWithResult, DispatcherPriority.Default);
+                await dispatcher.AwaitWithPriority(taskWithResult, DispatcherPriority.Default);
 
-                Assert.True(Dispatcher.UIThread.CheckAccess());
+                Assert.True(dispatcher.CheckAccess());
 
                 tokenSource.Cancel();
             });
 
-        Dispatcher.UIThread.MainLoop(tokenSource.Token);
+        dispatcher.MainLoop(tokenSource.Token);
     }
 
     private class AsyncLocalTestClass


### PR DESCRIPTION
## What does the pull request do?
This PR fixes `Dispatcher.Yield` to correctly use the `CurrentDispatcher` instead of the `UIThread` dispatcher.
