### PR TITLE
X11: Handle ShowActivated=false

### DIFF
--- a/src/Avalonia.X11/X11WindowModes/DefaultWindowMode.cs
+++ b/src/Avalonia.X11/X11WindowModes/DefaultWindowMode.cs
@@ -31,6 +31,14 @@ partial class X11Window
         public override void Show(bool activate, bool isDialog)
         {            
             Window._wasMappedAtLeastOnce = true;
+
+            if (!activate)
+            {
+                var time = IntPtr.Zero;
+                XChangeProperty(X11.Display, Handle, X11.Atoms._NET_WM_USER_TIME, X11.Atoms.CARDINAL, 32,
+                    PropertyMode.Replace, ref time, 1);
+            }
+
             XMapWindow(X11.Display, Handle);
             XFlush(X11.Display);
             base.Show(activate, isDialog);


### PR DESCRIPTION
## What does the pull request do?
This PR adds support for `Window.ShowActivated=false` on X11.

## What is the current behavior?
`ShowActivated` is not respected and always acts as if it's `true`.

## What is the updated/expected behavior with this PR?
`ShowActivated=false` works.

## How was the solution implemented (if it's not obvious)?
[_NET_WM_USER_TIME](https://specifications.freedesktop.org/wm/latest/ar01s05.html#id-1.6.16) is set to 0 before the window is displayed, as specified.
> The special value of zero on a newly mapped window can be used to request that the window not be initially focused when it is mapped. 

Tested on Mutter and KWin.

## Fixed issues
 - Fixes #17186