### PR TITLE
Fix Android crash on back pressed

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -126,7 +126,6 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         {
             _systemNavigationManager.Dispose();
             _view.Dispose();
-            _view = null!;
         }
 
         protected void OnResized(Size size)


### PR DESCRIPTION
## What does the pull request do?

Fixes #20883.

## What is the current behavior?

Crash on back pressed/minimize.

## What is the updated/expected behavior with this PR?

No crash.

## How was the solution implemented (if it's not obvious)?

`_view` isn't set to `null` on `TopLevelImpl` dispose. Since the render call that causes the crash only accesses .NET resources in `AvaloniaView`, this should be fine. On the flip side, the view's Java handle might not be released immediately when the main activity is destroyed.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

No.