### PR TITLE
Fix #17674: OneWay binding fails to update target after local change

### DIFF
--- a/src/Avalonia.Base/Data/Core/BindingExpression.cs
+++ b/src/Avalonia.Base/Data/Core/BindingExpression.cs
@@ -205,7 +205,7 @@ internal class BindingExpression : UntypedBindingExpressionBase, IDescription, I
                 var error = dataValidationError is not null ?
                     new BindingError(dataValidationError, BindingErrorType.DataValidationError) :
                     null;
-                ConvertAndPublishValue(value, error);
+                ConvertAndPublishValue(value, error, true);
             }
         }
         else if (_mode == BindingMode.OneWayToSource && nodeIndex == _nodes.Count - 2 && value is not null)
@@ -402,7 +402,7 @@ internal class BindingExpression : UntypedBindingExpressionBase, IDescription, I
             error);
     }
 
-    private void ConvertAndPublishValue(object? value, BindingError? error)
+    private void ConvertAndPublishValue(object? value, BindingError? error, bool forceUpdate = false)
     {
         var isTargetNullValue = false;
 
@@ -450,7 +450,7 @@ internal class BindingExpression : UntypedBindingExpressionBase, IDescription, I
             value = ConvertFallback(FallbackValue, nameof(FallbackValue));
 
         // Publish the value.
-        PublishValue(value, error);
+        PublishValue(value, error, forceUpdate);
     }
 
     private void WriteTargetValueToSource()

--- a/src/Avalonia.Base/Data/Core/BindingExpression.cs
+++ b/src/Avalonia.Base/Data/Core/BindingExpression.cs
@@ -205,7 +205,9 @@ internal class BindingExpression : UntypedBindingExpressionBase, IDescription, I
                 var error = dataValidationError is not null ?
                     new BindingError(dataValidationError, BindingErrorType.DataValidationError) :
                     null;
-                ConvertAndPublishValue(value, error, true);
+
+                var forceUpdate = _mode == BindingMode.OneWay;
+                ConvertAndPublishValue(value, error, forceUpdate);
             }
         }
         else if (_mode == BindingMode.OneWayToSource && nodeIndex == _nodes.Count - 2 && value is not null)

--- a/src/Avalonia.Base/Data/Core/UntypedBindingExpressionBase.cs
+++ b/src/Avalonia.Base/Data/Core/UntypedBindingExpressionBase.cs
@@ -406,7 +406,8 @@ public abstract class UntypedBindingExpressionBase : BindingExpressionBase,
     /// </summary>
     /// <param name="value">The new value, or <see cref="UnchangedValue"/>.</param>
     /// <param name="error">The new binding or data validation error.</param>
-    private protected void PublishValue(object? value, BindingError? error = null)
+    /// <param name="forceUpdate">If true, forces the value to be published even if it hasn't changed.</param>
+    private protected void PublishValue(object? value, BindingError? error = null, bool forceUpdate = false)
     {
         Debug.Assert(value is not BindingNotification);
         Debug.Assert(value != BindingOperations.DoNothing);
@@ -424,7 +425,7 @@ public abstract class UntypedBindingExpressionBase : BindingExpressionBase,
             value = null;
         }
 
-        var hasValueChanged = value != UnchangedValue && !TypeUtilities.IdentityEquals(value, GetValue(), TargetType);
+        var hasValueChanged = forceUpdate || (value != UnchangedValue && !TypeUtilities.IdentityEquals(value, GetValue(), TargetType));
         var hasErrorChanged = error is not null || _error is not null;
 
         if (hasValueChanged)

--- a/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.Mode.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.Mode.cs
@@ -1,8 +1,5 @@
-using System.Net.Http.Headers;
 using System.Reflection;
-using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography.X509Certificates;
 using Avalonia.Data;
 using Xunit;
 
@@ -218,7 +215,7 @@ public partial class BindingExpressionTests
 
         Assert.Equal("foo", target.String);
 
-        target.String = "bar";
+        target.SetCurrentValue(TargetClass.StringProperty, "bar");
         Assert.Equal("bar", target.String);
 
         data.RaisePropertyChanged(nameof(data.StringValue));

--- a/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.Mode.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.Mode.cs
@@ -1,3 +1,8 @@
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
 using Avalonia.Data;
 using Xunit;
 
@@ -200,5 +205,24 @@ public partial class BindingExpressionTests
         target.SetReadOnlyString("foo");
 
         Assert.Equal("foo", data.StringValue);
+    }
+
+    [Fact]
+    public void OneWay_Binding_Updates_Target_When_Changes_And_Source_Raises_PropertyChanged()
+    {
+        var data = new ViewModel { StringValue = "foo" };
+        var target = CreateTarget<ViewModel, string?>(
+            x => x.StringValue,
+            dataContext: data,
+            mode: BindingMode.OneWay);
+
+        Assert.Equal("foo", target.String);
+
+        target.String = "bar";
+        Assert.Equal("bar", target.String);
+
+        data.RaisePropertyChanged(nameof(data.StringValue));
+
+        Assert.Equal("foo", target.String);
     }
 }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a desynchronization issue with `OneWay` bindings where local changes to the target UI control permanently severed the binding's ability to receive updates from the source.

## What is the current behavior?
When a `OneWay` binding target is modified locally (e.g., via user interaction on a `ToggleButton`), subsequent `PropertyChanged` events from the source are ignored. The binding expression incorrectly suppresses the update, leaving the UI permanently inconsistent with the underlying application logic (e.g., a read-only ViewModel property).

## What is the updated/expected behavior with this PR?
The `OneWay` binding will now strictly respect the source as the single source of truth. Even if the target property is modified locally by the user, any subsequent `PropertyChanged` event from the source will successfully propagate and override the local UI changes, keeping the target in sync with the source.

## How was the solution implemented (if it's not obvious)?
The issue was located in the binding engine (`UntypedBindingExpressionBase` and `BindingExpression`). I modified the evaluation logic (updating the `ConvertAndPublishValue` call) to ensure that `OneWay` bindings do not suppress updates when triggered by the source's `PropertyChanged` event after a local change. A unit test was also added to `BindingExpressionTests.Mode.cs` to explicitly cover this scenario and prevent future regressions.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #17674