### PR TITLE
Make Window.WindowState a direct property with (on some platforms) reliable values

### DIFF
--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -1941,6 +1941,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Avalonia.Controls.Window.WindowStateProperty</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.AppBuilder.get_LifetimeOverride</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
@@ -3598,6 +3604,12 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:Avalonia.Controls.Window.SystemDecorationsProperty</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Avalonia.Controls.Window.WindowStateProperty</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
   </Suppression>

--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -4575,6 +4575,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Avalonia.Platform.IWindowImpl.WindowStateGetterIsUsable</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Avalonia.OpenGL.IGlPlatformSurfaceRenderTargetFactory.CanRenderToSurface(Avalonia.OpenGL.IGlContext,Avalonia.Platform.Surfaces.IPlatformRenderSurface)</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.OpenGL.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.OpenGL.dll</Right>
@@ -4924,6 +4930,12 @@
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
     <Target>P:Avalonia.Platform.IWindowImpl.RequestedDrawnDecorations</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Avalonia.Platform.IWindowImpl.WindowStateGetterIsUsable</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
   </Suppression>

--- a/src/Avalonia.Controls/Platform/IWindowImpl.cs
+++ b/src/Avalonia.Controls/Platform/IWindowImpl.cs
@@ -16,6 +16,14 @@ namespace Avalonia.Platform
         /// Gets or sets the minimized/maximized state of the window.
         /// </summary>
         WindowState WindowState { get; set; }
+        
+        /// <summary>
+        /// Indicates if platform implementation has a working getter for <see cref="WindowState"/> that produces
+        /// consistent results with WindowStateChanged callback.
+        /// If false, Window will not call the getter and will only use the setter and
+        /// <see cref="WindowStateChanged"/> callback to track window state.
+        /// </summary>
+        bool WindowStateGetterIsUsable { get; }
 
         /// <summary>
         /// Gets or sets a method called when the minimized/maximized state of the window changes.

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -653,7 +653,7 @@ namespace Avalonia.Controls
             // Check if platform impl doesn't lie about get_WindowState being usable
             Debug.Assert(PlatformImpl is not { WindowStateGetterIsUsable: true } || PlatformImpl.WindowState == state);
             
-            SetAndRaise(WindowStateProperty, ref _lastWindowState, WindowState);
+            SetAndRaise(WindowStateProperty, ref _lastWindowState, state);
 
             if (state == WindowState.Minimized)
             {

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -157,10 +158,12 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<Window, WindowClosingBehavior>(nameof(ClosingBehavior));
 
         /// <summary>
-        /// Represents the current window state (normal, minimized, maximized)
+        /// Represents the currently effective window state (normal, minimized, maximized)
         /// </summary>
-        public static readonly StyledProperty<WindowState> WindowStateProperty =
-            AvaloniaProperty.Register<Window, WindowState>(nameof(WindowState));
+        public static readonly DirectProperty<Window, WindowState> WindowStateProperty =
+            AvaloniaProperty.RegisterDirect<Window, WindowState>(
+                nameof(WindowState), o => o.WindowState,
+                (o, v) => o.WindowState = v);
 
         /// <summary>
         /// Defines the <see cref="Title"/> property.
@@ -254,8 +257,7 @@ namespace Avalonia.Controls
             CreatePlatformImplBinding(CanMinimizeProperty, canMinimize => PlatformImpl!.SetCanMinimize(canMinimize));
             CreatePlatformImplBinding(CanMaximizeProperty, canMaximize => PlatformImpl!.SetCanMaximize(canMaximize));
             CreatePlatformImplBinding(ShowInTaskbarProperty, show => PlatformImpl!.ShowTaskbarIcon(show));
-
-            CreatePlatformImplBinding(WindowStateProperty, state => PlatformImpl!.WindowState = state);
+            
             CreatePlatformImplBinding(ExtendClientAreaToDecorationsHintProperty, hint => PlatformImpl!.SetExtendClientAreaToDecorationsHint(hint));
             CreatePlatformImplBinding(ExtendClientAreaTitleBarHeightHintProperty, height => PlatformImpl!.SetExtendClientAreaTitleBarHeightHint(height));
 
@@ -402,13 +404,43 @@ namespace Avalonia.Controls
             set => SetValue(ClosingBehaviorProperty, value);
         }
 
+        private WindowState _windowStateForPropertyNotifications;
         /// <summary>
-        /// Gets or sets the minimized/maximized state of the window.
+        /// Represents the currently effective window state (normal, minimized, maximized)
         /// </summary>
         public WindowState WindowState
         {
-            get => GetValue(WindowStateProperty);
-            set => SetValue(WindowStateProperty, value);
+            get => PlatformImpl?.WindowState ?? default;
+            set
+            {
+                if (PlatformImpl != null)
+                {
+                    if (PlatformImpl.WindowStateGetterIsUsable)
+                    {
+                        // Attempt to set the window state to desired value, if it succeeds the platform will
+                        // trigger WindowStateChanged callback which will trigger SetAndRaise for the WindowState property
+                        PlatformImpl.WindowState = value;
+                        
+                        // If the request was refused - trigger a synthetic property change notification
+                        // for data bindings and user state to fix itself.
+                        if (PlatformImpl.WindowState != value)
+                        {
+                            // Since it's a force notify, we aren't checking for the old value and sometimes
+                            // trigger notification with oldValue = newValue.
+                            var oldValue = _windowStateForPropertyNotifications;
+                            _windowStateForPropertyNotifications = PlatformImpl.WindowState;
+                            RaisePropertyChanged(WindowStateProperty, oldValue, _windowStateForPropertyNotifications);
+                        }
+                    }
+                    else 
+                    {
+                        // Legacy behavior - update the property and hope for the best that the platform
+                        // will update it back to match the actual window state
+                        SetAndRaise(WindowStateProperty, ref _windowStateForPropertyNotifications, value);
+                        PlatformImpl.WindowState = _windowStateForPropertyNotifications;
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -616,7 +648,10 @@ namespace Avalonia.Controls
 
         private void HandleWindowStateChanged(WindowState state)
         {
-            WindowState = state;
+            // Check if platform impl doesn't lie about get_WindowState being usable
+            Debug.Assert(PlatformImpl is not { WindowStateGetterIsUsable: true } || PlatformImpl.WindowState == state);
+            
+            SetAndRaise(WindowStateProperty, ref _windowStateForPropertyNotifications, WindowState);
 
             if (state == WindowState.Minimized)
             {

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -404,13 +404,15 @@ namespace Avalonia.Controls
             set => SetValue(ClosingBehaviorProperty, value);
         }
 
-        private WindowState _windowStateForPropertyNotifications;
+        private WindowState _lastWindowState;
         /// <summary>
         /// Represents the currently effective window state (normal, minimized, maximized)
         /// </summary>
         public WindowState WindowState
         {
-            get => PlatformImpl?.WindowState ?? default;
+            get => PlatformImpl?.WindowStateGetterIsUsable == true ?
+                PlatformImpl.WindowState :
+                _lastWindowState;
             set
             {
                 if (PlatformImpl != null)
@@ -427,17 +429,17 @@ namespace Avalonia.Controls
                         {
                             // Since it's a force notify, we aren't checking for the old value and sometimes
                             // trigger notification with oldValue = newValue.
-                            var oldValue = _windowStateForPropertyNotifications;
-                            _windowStateForPropertyNotifications = PlatformImpl.WindowState;
-                            RaisePropertyChanged(WindowStateProperty, oldValue, _windowStateForPropertyNotifications);
+                            var oldValue = _lastWindowState;
+                            _lastWindowState = PlatformImpl.WindowState;
+                            RaisePropertyChanged(WindowStateProperty, oldValue, _lastWindowState);
                         }
                     }
                     else 
                     {
                         // Legacy behavior - update the property and hope for the best that the platform
                         // will update it back to match the actual window state
-                        SetAndRaise(WindowStateProperty, ref _windowStateForPropertyNotifications, value);
-                        PlatformImpl.WindowState = _windowStateForPropertyNotifications;
+                        SetAndRaise(WindowStateProperty, ref _lastWindowState, value);
+                        PlatformImpl.WindowState = _lastWindowState;
                     }
                 }
             }
@@ -651,7 +653,7 @@ namespace Avalonia.Controls
             // Check if platform impl doesn't lie about get_WindowState being usable
             Debug.Assert(PlatformImpl is not { WindowStateGetterIsUsable: true } || PlatformImpl.WindowState == state);
             
-            SetAndRaise(WindowStateProperty, ref _windowStateForPropertyNotifications, WindowState);
+            SetAndRaise(WindowStateProperty, ref _lastWindowState, WindowState);
 
             if (state == WindowState.Minimized)
             {

--- a/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
+++ b/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
@@ -44,6 +44,7 @@ namespace Avalonia.DesignerSupport.Remote
         public Action Activated { get; set; }
         public Func<WindowCloseReason, bool> Closing { get; set; }
         public WindowState WindowState { get; set; }
+        public bool WindowStateGetterIsUsable => false;
         public Action<WindowState> WindowStateChanged { get; set; }
         public Size MaxAutoSizeHint { get; } = new Size(4096, 4096);
 

--- a/src/Avalonia.DesignerSupport/Remote/Stubs.cs
+++ b/src/Avalonia.DesignerSupport/Remote/Stubs.cs
@@ -44,6 +44,7 @@ namespace Avalonia.DesignerSupport.Remote
         public PixelPoint Position { get; set; }
         public Action<PixelPoint>? PositionChanged { get; set; }
         public WindowState WindowState { get; set; }
+        public bool WindowStateGetterIsUsable => false;
         public Action<WindowState>? WindowStateChanged { get; set; }
 
         public Action<WindowTransparencyLevel>? TransparencyLevelChanged { get; set; }

--- a/src/Avalonia.Native/WindowImpl.cs
+++ b/src/Avalonia.Native/WindowImpl.cs
@@ -114,6 +114,7 @@ namespace Avalonia.Native
             set => _native.SetWindowState((AvnWindowState)value);
         }
 
+        public bool WindowStateGetterIsUsable => false;
         public Action<WindowState>? WindowStateChanged { get; set; }
 
         public Action<bool>? ExtendClientAreaToDecorationsChanged { get; set; }

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -828,8 +828,12 @@ namespace Avalonia.X11
 
                     XGetGeometry(_x11.Display, _handle, out var _, out var _, out var _, out var width, out var height,
                         out var _, out var _);
-                    _realSize = new(width, height);
-                    Resized?.Invoke(ClientSize, WindowResizeReason.User);
+                    var newSize = new PixelSize(width, height);
+                    if (newSize != _realSize)
+                    {
+                        _realSize = newSize;
+                        Resized?.Invoke(ClientSize, WindowResizeReason.Unspecified);
+                    }
                 }
 
                 _activationTracker?.OnNetWmStateChanged(atoms);

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -228,6 +228,7 @@ namespace Avalonia.X11
             surfaces.Add(new SurfacePlatformHandle(this));
 
             Surfaces = surfaces.ToArray();
+            UpdateEffectiveSystemDecorations();
             UpdateMotifHints();
             UpdateSizeHints(null);
 
@@ -744,6 +745,8 @@ namespace Avalonia.X11
             return false;
         }
 
+        public bool WindowStateGetterIsUsable => true;
+
         private WindowState _lastWindowState;
         public WindowState WindowState
         {
@@ -752,7 +755,6 @@ namespace Avalonia.X11
             {
                 if(_lastWindowState == value)
                     return;
-                _lastWindowState = value;
                 if (value == WindowState.Minimized)
                 {
                     XIconifyWindow(_x11.Display, _handle, _x11.DefaultScreen);
@@ -780,7 +782,6 @@ namespace Avalonia.X11
                     SendNetWMMessage(_x11.Atoms._NET_ACTIVE_WINDOW, (IntPtr)1, _x11.LastActivityTimestamp,
                         IntPtr.Zero);
                 }
-                WindowStateChanged?.Invoke(value);
             }
         }
 
@@ -795,42 +796,40 @@ namespace Avalonia.X11
 
             if (property == _x11.Atoms._NET_WM_STATE)
             {
-                WindowState state = WindowState.Normal;
                 var atoms = hasValue
                     ? XGetWindowPropertyAsIntPtrArray(_x11.Display, _handle, _x11.Atoms._NET_WM_STATE,
                           (IntPtr)Atom.XA_ATOM)
                       ?? []
                     : [];
                 int maximized = 0;
+                bool hasMinimized = false, hasFullscreen = false;
                 foreach (var atom in atoms)
                 {
-                    if (atom == _x11.Atoms._NET_WM_STATE_HIDDEN)
-                    {
-                        state = WindowState.Minimized;
-                        break;
-                    }
-
-                    if(atom == _x11.Atoms._NET_WM_STATE_FULLSCREEN)
-                    {
-                        state = WindowState.FullScreen;
-                        break;
-                    }
+                    if (atom == _x11.Atoms._NET_WM_STATE_HIDDEN) 
+                        hasMinimized = true;
 
                     if (atom == _x11.Atoms._NET_WM_STATE_MAXIMIZED_HORZ ||
-                        atom == _x11.Atoms._NET_WM_STATE_MAXIMIZED_VERT)
-                    {
+                        atom == _x11.Atoms._NET_WM_STATE_MAXIMIZED_VERT) 
                         maximized++;
-                        if (maximized == 2)
-                        {
-                            state = WindowState.Maximized;
-                            break;
-                        }
-                    }
+                    
+                    if(atom == _x11.Atoms._NET_WM_STATE_FULLSCREEN) 
+                        hasFullscreen = true;
                 }
+
+                var state = hasMinimized ? WindowState.Minimized
+                    : hasFullscreen ? WindowState.FullScreen
+                    : maximized == 2 ? WindowState.Maximized
+                    : WindowState.Normal;
+                
                 if (_lastWindowState != state)
                 {
                     _lastWindowState = state;
                     WindowStateChanged?.Invoke(state);
+
+                    XGetGeometry(_x11.Display, _handle, out var _, out var _, out var _, out var width, out var height,
+                        out var _, out var _);
+                    _realSize = new(width, height);
+                    Resized?.Invoke(ClientSize, WindowResizeReason.User);
                 }
 
                 _activationTracker?.OnNetWmStateChanged(atoms);

--- a/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -141,6 +141,7 @@ namespace Avalonia.Headless
         }
 
         public WindowState WindowState { get; set; }
+        public bool WindowStateGetterIsUsable => false;
         public Action<WindowState>? WindowStateChanged { get; set; }
         public void SetTitle(string? title)
         {

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -208,6 +208,7 @@ namespace Avalonia.Win32
 
         public Action<PixelPoint>? PositionChanged { get; set; }
 
+        public bool WindowStateGetterIsUsable => false;
         public Action<WindowState>? WindowStateChanged { get; set; }
 
         public Action? LostFocus { get; set; }

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Avalonia.Media;
 using Avalonia.Platform;
@@ -1205,6 +1206,127 @@ namespace Avalonia.Controls.UnitTests
 
                 // ShowCore should apply the default icon when no custom icon was set.
                 windowImpl.Verify(x => x.SetIcon(It.IsAny<IWindowIconImpl?>()), Times.AtLeastOnce());
+            }
+        }
+
+        [Fact]
+        public void WindowState_UsableGetter_Setter_Updates_Only_After_Platform_Callback()
+        {
+            var windowImpl = MockWindowingPlatform.CreateWindowMock();
+
+            // Simulate a platform where the getter is usable and the setter is accepted
+            var platformState = WindowState.Normal;
+            windowImpl.Setup(x => x.WindowStateGetterIsUsable).Returns(true);
+            windowImpl.Setup(x => x.WindowState).Returns(() => platformState);
+            windowImpl.SetupSet(x => x.WindowState = It.IsAny<WindowState>())
+                .Callback<WindowState>(v =>
+                {
+                    platformState = v;
+                    // Platform accepts the state and fires the callback
+                    windowImpl.Object.WindowStateChanged?.Invoke(v);
+                });
+
+            var windowingPlatform = new MockWindowingPlatform(() => windowImpl.Object);
+            using (UnitTestApplication.Start(new TestServices(windowingPlatform: windowingPlatform)))
+            {
+                var target = new Window();
+                target.Show();
+
+                var raised = new List<WindowState>();
+                target.GetObservable(Window.WindowStateProperty).Skip(1).Subscribe(s => raised.Add(s));
+
+                // Set to Maximized - platform accepts and fires callback
+                target.WindowState = WindowState.Maximized;
+                Assert.Equal(WindowState.Maximized, target.WindowState);
+                Assert.Contains(WindowState.Maximized, raised);
+
+                // Set to FullScreen - platform accepts and fires callback
+                raised.Clear();
+                target.WindowState = WindowState.FullScreen;
+                Assert.Equal(WindowState.FullScreen, target.WindowState);
+                Assert.Contains(WindowState.FullScreen, raised);
+            }
+        }
+
+        [Fact]
+        public void WindowState_UsableGetter_Setter_Raises_Synthetic_Notification_When_Platform_Refuses()
+        {
+            var windowImpl = MockWindowingPlatform.CreateWindowMock();
+
+            // Simulate a platform where the getter is usable but refuses state change requests.
+            // Start in Maximized state, then refuse a request to go Normal.
+            var platformState = WindowState.Normal;
+            windowImpl.Setup(x => x.WindowStateGetterIsUsable).Returns(true);
+            windowImpl.Setup(x => x.WindowState).Returns(() => platformState);
+            windowImpl.SetupSet(x => x.WindowState = It.IsAny<WindowState>())
+                .Callback<WindowState>(v =>
+                {
+                    // Platform accepts Maximized but refuses everything else
+                    if (v == WindowState.Maximized)
+                    {
+                        platformState = v;
+                        windowImpl.Object.WindowStateChanged?.Invoke(v);
+                    }
+                    // else: platform refuses, does not change state
+                });
+
+            var windowingPlatform = new MockWindowingPlatform(() => windowImpl.Object);
+            using (UnitTestApplication.Start(new TestServices(windowingPlatform: windowingPlatform)))
+            {
+                var target = new Window();
+                target.Show();
+
+                // First, go to Maximized (accepted by platform)
+                target.WindowState = WindowState.Maximized;
+                Assert.Equal(WindowState.Maximized, target.WindowState);
+
+                var raised = new List<AvaloniaPropertyChangedEventArgs>();
+                target.PropertyChanged += (_, e) =>
+                {
+                    if (e.Property == Window.WindowStateProperty)
+                        raised.Add(e);
+                };
+
+                // Now try to go to FullScreen - platform refuses, stays Maximized
+                target.WindowState = WindowState.FullScreen;
+
+                // The getter should still return Maximized because the platform refused
+                Assert.Equal(WindowState.Maximized, target.WindowState);
+
+                // A synthetic notification should have been raised so data bindings can recover
+                Assert.NotEmpty(raised);
+                Assert.Equal(WindowState.Maximized, raised[^1].GetNewValue<WindowState>());
+            }
+        }
+
+        [Fact]
+        public void WindowState_NonUsableGetter_Setter_Updates_Immediately()
+        {
+            var windowImpl = MockWindowingPlatform.CreateWindowMock();
+
+            // Legacy behavior: WindowStateGetterIsUsable = false
+            windowImpl.Setup(x => x.WindowStateGetterIsUsable).Returns(false);
+
+            var windowingPlatform = new MockWindowingPlatform(() => windowImpl.Object);
+            using (UnitTestApplication.Start(new TestServices(windowingPlatform: windowingPlatform)))
+            {
+                var target = new Window();
+                target.Show();
+
+                var raised = new List<WindowState>();
+                target.GetObservable(Window.WindowStateProperty).Skip(1).Subscribe(s => raised.Add(s));
+
+                // Set to Maximized - should update immediately regardless of platform behavior
+                target.WindowState = WindowState.Maximized;
+
+                Assert.Equal(WindowState.Maximized, target.WindowState);
+                Assert.Contains(WindowState.Maximized, raised);
+
+                // Verify the setter was forwarded to the platform impl
+                windowImpl.VerifySet(x => x.WindowState = WindowState.Maximized);
+
+                // Platform getter should never be called in legacy mode
+                windowImpl.VerifyGet(x => x.WindowState, Times.Never());
             }
         }
 


### PR DESCRIPTION
With some platforms window state changes can be:
1) delayed (i. e. wayland / x11 being asynchronous)
2) refused ([some](https://www.reddit.com/r/unixporn/comments/1rw4e1z/driftwm_infinite_canvas_wayland_compositor_no/) compositor/window managers not even having a concept of "maximized" or "minimized")
3) not communicated back (wayland protocol doesn't provide apps with information about their windows being minimized or not).

This PR changes `WindowState` property to a direct property that will always return the effective value on such platforms. Unfortunately, `IWindowImpl.get_WindowState` was never actually called, which resulted in platform backends returning invalid/inconsistent values from those. Attempts to fix backends, [while being somewhat successful](https://github.com/AvaloniaUI/Avalonia/pull/20915) caused flaky tests, so `IWindowImpl.WindowStateGetterIsUsable` property is introduced. If it's false, Window.cs uses the previous logic that relied only on `WindowStateChanged` callbacks and assuming that the last value set by Window is the current value otherwise.


---

If somebody thinks that **"property that can be set but is refusing to be set" is cursed API design,** I'm more than happy to make WindowState to be read-only and have `void TrySetWindowState(WindowState state)` method instead.

This design was chosen to avoid breaking the majority of apps wanting to have two-way binding to WindowState for some reason.