### PR TITLE
Revert MicroCom to 0.11.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,9 +15,9 @@
     <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.3" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.3" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="8.3.1.3" />
-    <PackageVersion Include="MicroCom.CodeGenerator" Version="0.11.3" />
-    <PackageVersion Include="MicroCom.CodeGenerator.MSBuild" Version="0.11.3" />
-    <PackageVersion Include="MicroCom.Runtime" Version="0.11.3" />
+    <PackageVersion Include="MicroCom.CodeGenerator" Version="0.11.0" />
+    <PackageVersion Include="MicroCom.CodeGenerator.MSBuild" Version="0.11.0" />
+    <PackageVersion Include="MicroCom.Runtime" Version="0.11.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="18.0.2" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="15.1.548" />


### PR DESCRIPTION
## What does the pull request do?
This PR reverts MicroCom to 0.11.0.

An issue exists in newer versions where a `NullReferenceException` gets thrown internally, preventing WinUI composition from initializing properly:
https://github.com/AvaloniaUI/Avalonia/blob/7a0e0c41a40baf60cce214ee6756f95ca75fd7a8/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositionUtils.cs#L92
