### PR TITLE
Add StyleKeyOverride for ContentPage

### DIFF
--- a/src/Avalonia.Controls/Page/ContentPage.cs
+++ b/src/Avalonia.Controls/Page/ContentPage.cs
@@ -151,6 +151,8 @@ namespace Avalonia.Controls
 
         protected override AutomationPeer OnCreateAutomationPeer() => new ContentPageAutomationPeer(this);
 
+        protected override Type StyleKeyOverride => typeof(ContentPage);
+
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
             base.OnApplyTemplate(e);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds `StyleKeyOverride` for `ContentPage`. 


## What is the current behavior?
Views that implement `ContentPage` do not render when attached to visual tree.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/20959