### PR TITLE
Add Page HeaderTemplate

### DIFF
--- a/src/Avalonia.Controls/Page/Page.cs
+++ b/src/Avalonia.Controls/Page/Page.cs
@@ -27,6 +27,12 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<Page, object?>(nameof(Header));
 
         /// <summary>
+        /// Defines the <see cref="HeaderTemplate"/> property.
+        /// </summary>
+        public static readonly StyledProperty<IDataTemplate?> HeaderTemplateProperty =
+            AvaloniaProperty.Register<Page, IDataTemplate?>(nameof(HeaderTemplate));
+
+        /// <summary>
         /// Defines the <see cref="Icon"/> property.
         /// </summary>
         public static readonly StyledProperty<object?> IconProperty =
@@ -90,6 +96,15 @@ namespace Avalonia.Controls
         {
             get => GetValue(HeaderProperty);
             set => SetValue(HeaderProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the data template used to display the header.
+        /// </summary>
+        public IDataTemplate? HeaderTemplate
+        {
+            get => GetValue(HeaderTemplateProperty);
+            set => SetValue(HeaderTemplateProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Themes.Fluent/Controls/NavigationPage.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/NavigationPage.xaml
@@ -140,6 +140,7 @@
                                 FontSize="20"
                                 Foreground="{DynamicResource NavigationBarForeground}"
                                 Content="{Binding CurrentPage?.Header, RelativeSource={RelativeSource TemplatedParent}, FallbackValue={x:Null}}"
+                                ContentTemplate="{Binding CurrentPage?.HeaderTemplate, RelativeSource={RelativeSource TemplatedParent}, FallbackValue={x:Null}}"
                                 VerticalAlignment="Center"
                                 HorizontalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"

--- a/src/Avalonia.Themes.Simple/Controls/NavigationPage.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/NavigationPage.xaml
@@ -134,6 +134,7 @@
                                 FontSize="18"
                                 Foreground="{DynamicResource NavigationBarForeground}"
                                 Content="{Binding CurrentPage?.Header, RelativeSource={RelativeSource TemplatedParent}, FallbackValue={x:Null}}"
+                                ContentTemplate="{Binding CurrentPage?.HeaderTemplate, RelativeSource={RelativeSource TemplatedParent}, FallbackValue={x:Null}}"
                                 VerticalAlignment="Center"
                                 HorizontalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds the following api to `Page`
```csharp
public IDataTemplate HeaderTemplate { get; set; }
```
This adds the ability to use a template to display a non-visual `Header`.

## What is the current behavior?
`Header` currently works only if the value can be converted to a visual, that is, a text or a visual. When using a `Visual` for custom header designs, the visual doesn't inherit the data context of the current `Page`, but instead the host of the page, which is a `NavigationPage` in this case. Thus bindings in `Header` content do not work.


## What is the updated/expected behavior with this PR?
With this change, `Header` can be set to a non-visual, such as a viewmodel, and a `DataTemplate` can now be used to generate the visual with proper bindings.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
