### PR TITLE
Design properties not being applied for user controls

### DIFF
--- a/src/Avalonia.Controls/Design.cs
+++ b/src/Avalonia.Controls/Design.cs
@@ -303,11 +303,11 @@ namespace Avalonia.Controls
         public static void ApplyDesignModeProperties(Control target, Control source)
         {
             if (source.IsSet(WidthProperty))
-                target.Bind(Layoutable.WidthProperty, target.GetBindingObservable(WidthProperty));
+                target.Bind(Layoutable.WidthProperty, source.GetBindingObservable(WidthProperty));
             if (source.IsSet(HeightProperty))
-                target.Bind(Layoutable.HeightProperty, target.GetBindingObservable(HeightProperty));
+                target.Bind(Layoutable.HeightProperty, source.GetBindingObservable(HeightProperty));
             if (source.IsSet(DataContextProperty))
-                target.Bind(StyledElement.DataContextProperty, target.GetBindingObservable(DataContextProperty));
+                target.Bind(StyledElement.DataContextProperty, source.GetBindingObservable(DataContextProperty));
             if (source.IsSet(DesignStyleProperty))
                 target.Styles.Add(GetDesignStyle(source));
         }

--- a/src/Avalonia.Controls/Design.cs
+++ b/src/Avalonia.Controls/Design.cs
@@ -303,11 +303,11 @@ namespace Avalonia.Controls
         public static void ApplyDesignModeProperties(Control target, Control source)
         {
             if (source.IsSet(WidthProperty))
-                target.Bind(Layoutable.WidthProperty, source.GetBindingObservable(WidthProperty));
+                target.Bind(Layoutable.WidthProperty, source[!WidthProperty]);
             if (source.IsSet(HeightProperty))
-                target.Bind(Layoutable.HeightProperty, source.GetBindingObservable(HeightProperty));
+                target.Bind(Layoutable.HeightProperty, source[!HeightProperty]);
             if (source.IsSet(DataContextProperty))
-                target.Bind(StyledElement.DataContextProperty, source.GetBindingObservable(DataContextProperty));
+                target.Bind(StyledElement.DataContextProperty, source[!DataContextProperty]);
             if (source.IsSet(DesignStyleProperty))
                 target.Styles.Add(GetDesignStyle(source));
         }

--- a/tests/Avalonia.Controls.UnitTests/DesignTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DesignTests.cs
@@ -79,11 +79,14 @@ public class DesignTests : ScopedTestBase
     }
 
     [Fact]
-    public void Should_Apply_Design_Mode_Properties()
+    public void Should_Apply_Design_Mode_Properties_From_Control_To_Window()
     {
         using var _ = UnitTestApplication.Start(TestServices.StyledWindow);
 
+        // Use-case: User previews a control, which is wrapped by the window.
+        var window = new Window();
         var control = new ContentControl();
+        window.Content = control;
 
         Design.SetWidth(control, 200);
         Design.SetHeight(control, 150);
@@ -94,12 +97,12 @@ public class DesignTests : ScopedTestBase
                 Setters = { new Setter(TemplatedControl.BackgroundProperty, Brushes.Yellow) }
             });
 
-        Design.ApplyDesignModeProperties(control, control);
+        Design.ApplyDesignModeProperties(window, control);
 
-        Assert.Equal(200, control.Width);
-        Assert.Equal(150, control.Height);
-        Assert.Equal("TestDataContext", control.DataContext);
-        Assert.Contains(control.Styles,
+        Assert.Equal(200, window.Width);
+        Assert.Equal(150, window.Height);
+        Assert.Equal("TestDataContext", window.DataContext);
+        Assert.Contains(window.Styles,
             s => ((Style)s).Setters.OfType<Setter>().First().Property == TemplatedControl.BackgroundProperty);
     }
 


### PR DESCRIPTION
## What does the pull request do?

When user controls (or any non-window) are previewed, a window (target) is created and populated by these design properties from the controls (source).
After my previous Design related PR it was broken, and on target were applied properties from the same object, ignoring source.

Unrelated to the fix - but we should also bind to BindingBase instead of Observable. In this PR, it now binds to the indexer binding.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/20981