### PR TITLE
QoL for ControlCatalog: add sidebar search, auto-sort, and default page selection

### DIFF
--- a/samples/ControlCatalog/MainView.xaml
+++ b/samples/ControlCatalog/MainView.xaml
@@ -16,7 +16,7 @@
       </Style>
     </Grid.Styles>
     <controls:HamburgerMenu Name="Sidebar">
-      <TabItem Header="Composition">
+      <TabItem Header="Composition" controls:HamburgerMenu.IsDefaultPage="True">
         <pages:CompositionPage />
       </TabItem>
       <TabItem Header="Accelerator">

--- a/samples/ControlCatalog/MainView.xaml
+++ b/samples/ControlCatalog/MainView.xaml
@@ -16,7 +16,7 @@
       </Style>
     </Grid.Styles>
     <controls:HamburgerMenu Name="Sidebar">
-      <TabItem Header="Composition" controls:HamburgerMenu.IsDefaultPage="True">
+      <TabItem Header="Composition" IsSelected="True">
         <pages:CompositionPage />
       </TabItem>
       <TabItem Header="Accelerator">

--- a/samples/SampleControls/HamburgerMenu/HamburgerMenu.cs
+++ b/samples/SampleControls/HamburgerMenu/HamburgerMenu.cs
@@ -40,12 +40,6 @@ namespace ControlSamples
             set => SetValue(ExpandedModeThresholdWidthProperty, value);
         }
 
-        public static readonly AttachedProperty<bool> IsDefaultPageProperty =
-            AvaloniaProperty.RegisterAttached<HamburgerMenu, TabItem, bool>("IsDefaultPage");
-
-        public static bool GetIsDefaultPage(TabItem element) => element.GetValue(IsDefaultPageProperty);
-        public static void SetIsDefaultPage(TabItem element, bool value) => element.SetValue(IsDefaultPageProperty, value);
-
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
             base.OnApplyTemplate(e);
@@ -67,7 +61,6 @@ namespace ControlSamples
             {
                 _initialized = true;
                 SortItems();
-                SelectDefaultPage();
             }
         }
 
@@ -93,18 +86,6 @@ namespace ControlSamples
                 foreach (var item in sorted)
                 {
                     Items.Add(item);
-                }
-            }
-        }
-
-        private void SelectDefaultPage()
-        {
-            foreach (var item in Items.OfType<TabItem>())
-            {
-                if (GetIsDefaultPage(item))
-                {
-                    SelectedItem = item;
-                    return;
                 }
             }
         }

--- a/samples/SampleControls/HamburgerMenu/HamburgerMenu.cs
+++ b/samples/SampleControls/HamburgerMenu/HamburgerMenu.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia;
+﻿using System;
+using System.Linq;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Media;
@@ -8,6 +10,8 @@ namespace ControlSamples
     public class HamburgerMenu : TabControl
     {
         private SplitView? _splitView;
+        private TextBox? _searchBox;
+        private bool _initialized;
 
         public static readonly StyledProperty<IBrush?> PaneBackgroundProperty =
             SplitView.PaneBackgroundProperty.AddOwner<HamburgerMenu>();
@@ -36,11 +40,92 @@ namespace ControlSamples
             set => SetValue(ExpandedModeThresholdWidthProperty, value);
         }
 
+        public static readonly AttachedProperty<bool> IsDefaultPageProperty =
+            AvaloniaProperty.RegisterAttached<HamburgerMenu, TabItem, bool>("IsDefaultPage");
+
+        public static bool GetIsDefaultPage(TabItem element) => element.GetValue(IsDefaultPageProperty);
+        public static void SetIsDefaultPage(TabItem element, bool value) => element.SetValue(IsDefaultPageProperty, value);
+
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
             base.OnApplyTemplate(e);
 
             _splitView = e.NameScope.Find<SplitView>("PART_NavigationPane");
+            _searchBox = e.NameScope.Find<TextBox>("PART_SearchBox");
+
+            if (_searchBox is not null)
+            {
+                _searchBox.TextChanged += OnSearchTextChanged;
+            }
+        }
+
+        protected override void OnLoaded(Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+
+            if (!_initialized)
+            {
+                _initialized = true;
+                SortItems();
+                SelectDefaultPage();
+            }
+        }
+
+        private void SortItems()
+        {
+            var items = Items.OfType<TabItem>().ToList();
+            var sorted = items.OrderBy(t => t.Header?.ToString() ?? "", StringComparer.OrdinalIgnoreCase).ToList();
+
+            // Only reorder if needed
+            bool needsSort = false;
+            for (int i = 0; i < items.Count; i++)
+            {
+                if (!ReferenceEquals(items[i], sorted[i]))
+                {
+                    needsSort = true;
+                    break;
+                }
+            }
+
+            if (needsSort)
+            {
+                Items.Clear();
+                foreach (var item in sorted)
+                {
+                    Items.Add(item);
+                }
+            }
+        }
+
+        private void SelectDefaultPage()
+        {
+            foreach (var item in Items.OfType<TabItem>())
+            {
+                if (GetIsDefaultPage(item))
+                {
+                    SelectedItem = item;
+                    return;
+                }
+            }
+        }
+
+        private void OnSearchTextChanged(object? sender, TextChangedEventArgs e)
+        {
+            var searchText = _searchBox?.Text;
+            var hasFilter = !string.IsNullOrWhiteSpace(searchText);
+
+            foreach (var item in Items.OfType<TabItem>())
+            {
+                if (hasFilter)
+                {
+                    var header = item.Header?.ToString() ?? "";
+                    item.IsVisible = header.Contains(searchText!, StringComparison.OrdinalIgnoreCase);
+                }
+                else
+                {
+                    item.IsVisible = true;
+                }
+            }
         }
 
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)

--- a/samples/SampleControls/HamburgerMenu/HamburgerMenu.xaml
+++ b/samples/SampleControls/HamburgerMenu/HamburgerMenu.xaml
@@ -175,10 +175,21 @@
                      OpenPaneLength="{StaticResource PaneExpandWidth}"
                      PaneBackground="Transparent">
             <SplitView.Pane>
-              <Grid Margin="0,0,1,5" RowDefinitions="Auto, *, Auto">
+              <Grid Margin="0,0,1,5" RowDefinitions="Auto, Auto, *, Auto">
                 <Panel Height="{StaticResource HeaderHeight}" />
+                <TextBox x:Name="PART_SearchBox"
+                         Grid.Row="1"
+                         PlaceholderText="Search…"
+                         Margin="4,0,8,4"
+                         VerticalContentAlignment="Center">
+                  <TextBox.InnerLeftContent>
+                    <PathIcon Width="14" Height="14" Margin="6,0,0,0"
+                              VerticalAlignment="Center"
+                              Data="M10 2.5a7.5 7.5 0 0 1 5.964 12.048l4.743 4.745a1 1 0 0 1-1.32 1.497l-.094-.083-4.745-4.743A7.5 7.5 0 1 1 10 2.5Zm0 2a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11Z" />
+                  </TextBox.InnerLeftContent>
+                </TextBox>
                 <ScrollViewer x:Name="PART_ScrollViewer"
-                              Grid.Row="1"
+                              Grid.Row="2"
                               HorizontalAlignment="Stretch"
                               HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                               VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
@@ -195,7 +206,7 @@
                   </ItemsPresenter>
                 </ScrollViewer>
                 <Button x:Name="SettingsButton"
-                        Grid.Row="2"
+                        Grid.Row="3"
                         Theme="{StaticResource NavigationButton}"
                         Content="Settings"
                         Flyout="{TemplateBinding (FlyoutBase.AttachedFlyout)}"


### PR DESCRIPTION
It's currently hard to find a particular page in the control catalog and one has to reorder them manually to preselect the page they are currently working with.

1) items are now force-sorted
2) there is a search box