### PR TITLE
Fix Avalonia.DesignerSupport build on win-arm64

### DIFF
--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -135,15 +135,25 @@ partial class Build : NukeBuild
         }
     });
 
-    // Ensure that Bun.Official.Tool is downloaded at least once on CI to work around https://github.com/dotnet/sdk/issues/51831
+    // Ensure that Bun is available and dependencies are installed.
+    // Uses Bun.Unofficial.Tool via dnx when supported, falls back to system-installed bun (e.g. on win-arm64).
+    // See https://github.com/dotnet/sdk/issues/51831
     Target InitDnx => _ => _
         .Executes(() =>
         {
-            var process = ProcessTasks.StartProcess(
-                "dnx",
-                "Bun.Unofficial.Tool --yes -- install",
-                $"{RootDirectory}/src/Browser/Avalonia.Browser/webapp");
-            process.AssertZeroExitCode();
+            var webappDir = $"{RootDirectory}/src/Browser/Avalonia.Browser/webapp";
+            try
+            {
+                ProcessTasks.StartProcess(
+                    "dnx",
+                    "Bun.Unofficial.Tool --yes -- install",
+                    webappDir).AssertZeroExitCode();
+            }
+            catch
+            {
+                Information("Bun.Unofficial.Tool not supported on this platform, using system-installed bun");
+                ProcessTasks.StartProcess("bun", "install", webappDir).AssertZeroExitCode();
+            }
         });
 
     Target CompileNative => _ => _

--- a/src/Avalonia.DesignerSupport/Avalonia.DesignerSupport.csproj
+++ b/src/Avalonia.DesignerSupport/Avalonia.DesignerSupport.csproj
@@ -21,14 +21,26 @@
     <ProjectReference Include="..\Avalonia.Controls\Avalonia.Controls.csproj" />
   </ItemGroup>
 
-  <Target Name="BunInstall" Inputs="$(WebAppDir)\package.json" Outputs="$(WebAppDir)\node_modules\.install-stamp">
+  <Target Name="DetectBun" BeforeTargets="BunInstall">
+    <!-- Try to use Bun.Unofficial.Tool via dnx, but fall back to system-installed bun if unsupported (e.g. win-arm64) -->
+    <Exec Command="dnx Bun.Unofficial.Tool --yes -- --version" IgnoreExitCode="true" ConsoleToMsBuild="true" StandardOutputImportance="Low">
+      <Output TaskParameter="ExitCode" PropertyName="_BunToolExitCode" />
+    </Exec>
+    <PropertyGroup>
+      <_UseDnxBun Condition="'$(_BunToolExitCode)' == '0'">true</_UseDnxBun>
+      <_UseDnxBun Condition="'$(_BunToolExitCode)' != '0'">false</_UseDnxBun>
+      <_BunCommand Condition="'$(_UseDnxBun)' == 'true'">dnx Bun.Unofficial.Tool --yes --</_BunCommand>
+      <_BunCommand Condition="'$(_UseDnxBun)' == 'false'">bun</_BunCommand>
+    </PropertyGroup>
+  </Target>
+  <Target Name="BunInstall" DependsOnTargets="DetectBun" Inputs="$(WebAppDir)\package.json" Outputs="$(WebAppDir)\node_modules\.install-stamp">
     <!-- We use bun packages as .NET tool, to avoid preinstalled node.js dependency -->
-    <Exec Command="dnx Bun.Unofficial.Tool --yes -- install" WorkingDirectory="$(WebAppDir)" />
+    <Exec Command="$(_BunCommand) install" WorkingDirectory="$(WebAppDir)" />
     <!-- Write the stamp file, so incremental builds work -->
     <Touch Files="$(WebAppDir)\node_modules\.install-stamp" AlwaysCreate="true" />
   </Target>
   <Target Name="BunRunBuild" DependsOnTargets="BunInstall" BeforeTargets="DispatchToInnerBuilds">
-    <Exec Command="dnx Bun.Unofficial.Tool build.js" WorkingDirectory="$(WebAppDir)" />
+    <Exec Command="$(_BunCommand) build.js" WorkingDirectory="$(WebAppDir)" />
   </Target>
 
 </Project>

--- a/src/Avalonia.DesignerSupport/Remote/HtmlTransport/webapp/build.js
+++ b/src/Avalonia.DesignerSupport/Remote/HtmlTransport/webapp/build.js
@@ -1,10 +1,11 @@
 import { build } from 'esbuild';
-import htmlPlugin from '@chialab/esbuild-plugin-html';
 import { compress } from 'esbuild-plugin-compress';
+import { readFileSync } from 'fs';
+import { resolve, basename } from 'path';
 
+// Bundle the TypeScript entry point
 build({
-    entryPoints: ['src/index.html'],
-    chunkNames: '[name]-[hash]',
+    entryPoints: ['src/index.tsx'],
     logLevel: "warning",
     outdir: "./build",
     bundle: true,
@@ -15,9 +16,32 @@ build({
     target: "es6",
     platform: "browser",
     sourcemap: "linked",
+    entryNames: '[name]-[hash]',
     loader: {".ts": "tsx"},
     plugins: [
-        htmlPlugin(),
+        {
+            name: 'html',
+            setup(pluginBuild) {
+                pluginBuild.onEnd(result => {
+                    if (result.errors.length > 0) return;
+
+                    // Find the JS output file name
+                    const jsFile = result.outputFiles.find(f => f.path.endsWith('.js'));
+                    const jsName = basename(jsFile.path);
+
+                    // Read the HTML template and replace the script reference
+                    let html = readFileSync('src/index.html', 'utf8');
+                    html = html.replace('src="index.tsx"', `src="${jsName}" type="module"`);
+
+                    // Add the HTML to outputFiles so the compress plugin handles it
+                    result.outputFiles.push({
+                        path: resolve('./build/index.html'),
+                        contents: new TextEncoder().encode(html),
+                        text: html,
+                    });
+                });
+            }
+        },
         compress({
             brotli: false,
             gzip: true

--- a/src/Avalonia.DesignerSupport/Remote/HtmlTransport/webapp/bun.lock
+++ b/src/Avalonia.DesignerSupport/Remote/HtmlTransport/webapp/bun.lock
@@ -13,29 +13,68 @@
         "react-dom": "^17.0.2",
       },
       "devDependencies": {
-        "@chialab/esbuild-plugin-html": "^0.17.0",
-        "esbuild": "^0.14.54",
+        "esbuild": "^0.25.0",
         "esbuild-plugin-compress": "^0.4.0",
         "typescript": "^4.7.4",
       },
     },
   },
   "packages": {
-    "@chialab/esbuild-plugin-html": ["@chialab/esbuild-plugin-html@0.17.3", "", { "dependencies": { "@chialab/esbuild-rna": "^0.17.8", "@chialab/node-resolve": "^0.17.1" } }, "sha512-Q9ztdU/wJ0em7LHA+CeB/xqmhIoI5Gk4Y+gCiGmxVrHaT6AkkfAjYVojlyAA91JlpvXmtDIhUaVcJyhtmcip7g=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
-    "@chialab/esbuild-rna": ["@chialab/esbuild-rna@0.17.8", "", { "dependencies": { "@chialab/estransform": "^0.17.4", "@chialab/node-resolve": "^0.17.1" } }, "sha512-hovU4W5zlyMnbJjexdczpQ9mcUfFsJuv9FWUhzpXiQwPprlp5lul+frTed9s8AyVDTDq2yq3Gx2Ac411QsXYGA=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
 
-    "@chialab/estransform": ["@chialab/estransform@0.17.5", "", { "dependencies": { "@parcel/source-map": "^2.0.0" } }, "sha512-maJUFkwk0ie0L4VvDO74NDYyRvaTQAI0qmSmrms8bZxUkZ+zQZd1ByWKDCYTRwtR6AOzTvgEOl2ZvEG+OUKv/A=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
 
-    "@chialab/node-resolve": ["@chialab/node-resolve@0.17.1", "", {}, "sha512-YWaK0MKKeB0FILI6j7qiAlGoSC9MqJZDFXzlAgfOaMCbn8Feqh6njxv7mI3oVkdi7QwV6zPRaTN6hKig/NriMA=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.14.54", "", { "os": "linux", "cpu": "none" }, "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
 
-    "@parcel/source-map": ["@parcel/source-map@2.1.1", "", { "dependencies": { "detect-libc": "^1.0.3" } }, "sha512-Ejx1P/mj+kMjQb8/y5XxDUn4reGdr+WyKYloBljpppUy8gs42T+BNoEOuRYqDVdgPc6NxduzIDoJS9pOFfV5Ew=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
-    "@types/react": ["@types/react@17.0.90", "", { "dependencies": { "@types/prop-types": "*", "@types/scheduler": "^0.16", "csstype": "^3.2.2" } }, "sha512-P9beVR/x06U9rCJzSxtENnOr4BrbJ6VrsrDTc+73TtHv9XHhryXKbjGRB+6oooB2r0G/pQkD/S4dHo/7jUfwFw=="],
+    "@types/react": ["@types/react@17.0.91", "", { "dependencies": { "@types/prop-types": "*", "@types/scheduler": "^0.16", "csstype": "^3.2.2" } }, "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA=="],
 
     "@types/react-dom": ["@types/react-dom@17.0.26", "", { "peerDependencies": { "@types/react": "^17.0.0" } }, "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg=="],
 
@@ -51,51 +90,9 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
-    "detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
-
-    "esbuild": ["esbuild@0.14.54", "", { "optionalDependencies": { "@esbuild/linux-loong64": "0.14.54", "esbuild-android-64": "0.14.54", "esbuild-android-arm64": "0.14.54", "esbuild-darwin-64": "0.14.54", "esbuild-darwin-arm64": "0.14.54", "esbuild-freebsd-64": "0.14.54", "esbuild-freebsd-arm64": "0.14.54", "esbuild-linux-32": "0.14.54", "esbuild-linux-64": "0.14.54", "esbuild-linux-arm": "0.14.54", "esbuild-linux-arm64": "0.14.54", "esbuild-linux-mips64le": "0.14.54", "esbuild-linux-ppc64le": "0.14.54", "esbuild-linux-riscv64": "0.14.54", "esbuild-linux-s390x": "0.14.54", "esbuild-netbsd-64": "0.14.54", "esbuild-openbsd-64": "0.14.54", "esbuild-sunos-64": "0.14.54", "esbuild-windows-32": "0.14.54", "esbuild-windows-64": "0.14.54", "esbuild-windows-arm64": "0.14.54" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA=="],
-
-    "esbuild-android-64": ["esbuild-android-64@0.14.54", "", { "os": "android", "cpu": "x64" }, "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ=="],
-
-    "esbuild-android-arm64": ["esbuild-android-arm64@0.14.54", "", { "os": "android", "cpu": "arm64" }, "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg=="],
-
-    "esbuild-darwin-64": ["esbuild-darwin-64@0.14.54", "", { "os": "darwin", "cpu": "x64" }, "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug=="],
-
-    "esbuild-darwin-arm64": ["esbuild-darwin-arm64@0.14.54", "", { "os": "darwin", "cpu": "arm64" }, "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw=="],
-
-    "esbuild-freebsd-64": ["esbuild-freebsd-64@0.14.54", "", { "os": "freebsd", "cpu": "x64" }, "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg=="],
-
-    "esbuild-freebsd-arm64": ["esbuild-freebsd-arm64@0.14.54", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q=="],
-
-    "esbuild-linux-32": ["esbuild-linux-32@0.14.54", "", { "os": "linux", "cpu": "ia32" }, "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw=="],
-
-    "esbuild-linux-64": ["esbuild-linux-64@0.14.54", "", { "os": "linux", "cpu": "x64" }, "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg=="],
-
-    "esbuild-linux-arm": ["esbuild-linux-arm@0.14.54", "", { "os": "linux", "cpu": "arm" }, "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw=="],
-
-    "esbuild-linux-arm64": ["esbuild-linux-arm64@0.14.54", "", { "os": "linux", "cpu": "arm64" }, "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig=="],
-
-    "esbuild-linux-mips64le": ["esbuild-linux-mips64le@0.14.54", "", { "os": "linux", "cpu": "none" }, "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw=="],
-
-    "esbuild-linux-ppc64le": ["esbuild-linux-ppc64le@0.14.54", "", { "os": "linux", "cpu": "ppc64" }, "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ=="],
-
-    "esbuild-linux-riscv64": ["esbuild-linux-riscv64@0.14.54", "", { "os": "linux", "cpu": "none" }, "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg=="],
-
-    "esbuild-linux-s390x": ["esbuild-linux-s390x@0.14.54", "", { "os": "linux", "cpu": "s390x" }, "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA=="],
-
-    "esbuild-netbsd-64": ["esbuild-netbsd-64@0.14.54", "", { "os": "none", "cpu": "x64" }, "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w=="],
-
-    "esbuild-openbsd-64": ["esbuild-openbsd-64@0.14.54", "", { "os": "openbsd", "cpu": "x64" }, "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw=="],
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "esbuild-plugin-compress": ["esbuild-plugin-compress@0.4.0", "", { "dependencies": { "chalk": "^4.1.2", "fs-extra": "^10.0.0" }, "peerDependencies": { "esbuild": "^0.14.0" } }, "sha512-W9L9f9ClfJe32y9850vkSpd2ib7klFszOyVoMa5imI3CSdW/UbxPBhb1ZaVKPnNCZqZisw8KtTiJTQdVawPB9w=="],
-
-    "esbuild-sunos-64": ["esbuild-sunos-64@0.14.54", "", { "os": "sunos", "cpu": "x64" }, "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw=="],
-
-    "esbuild-windows-32": ["esbuild-windows-32@0.14.54", "", { "os": "win32", "cpu": "ia32" }, "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w=="],
-
-    "esbuild-windows-64": ["esbuild-windows-64@0.14.54", "", { "os": "win32", "cpu": "x64" }, "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ=="],
-
-    "esbuild-windows-arm64": ["esbuild-windows-arm64@0.14.54", "", { "os": "win32", "cpu": "arm64" }, "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg=="],
 
     "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 

--- a/src/Avalonia.DesignerSupport/Remote/HtmlTransport/webapp/package.json
+++ b/src/Avalonia.DesignerSupport/Remote/HtmlTransport/webapp/package.json
@@ -1,8 +1,7 @@
 {
   "name": "previewer",
   "devDependencies": {
-    "@chialab/esbuild-plugin-html": "^0.17.0",
-    "esbuild": "^0.14.54",
+    "esbuild": "^0.25.0",
     "esbuild-plugin-compress": "^0.4.0",
     "typescript": "^4.7.4"
   },

--- a/src/Browser/Avalonia.Browser/Avalonia.Browser.csproj
+++ b/src/Browser/Avalonia.Browser/Avalonia.Browser.csproj
@@ -43,14 +43,26 @@
     </Content>
   </ItemGroup>
 
-  <Target Name="BunInstall" Inputs="$(WebAppDir)/package.json" Outputs="$(WebAppDir)/node_modules/.install-stamp">
+  <Target Name="DetectBun" BeforeTargets="BunInstall">
+    <!-- Try to use Bun.Unofficial.Tool via dnx, but fall back to system-installed bun if unsupported (e.g. win-arm64) -->
+    <Exec Command="dnx Bun.Unofficial.Tool --yes -- --version" IgnoreExitCode="true" ConsoleToMsBuild="true" StandardOutputImportance="Low">
+      <Output TaskParameter="ExitCode" PropertyName="_BunToolExitCode" />
+    </Exec>
+    <PropertyGroup>
+      <_UseDnxBun Condition="'$(_BunToolExitCode)' == '0'">true</_UseDnxBun>
+      <_UseDnxBun Condition="'$(_BunToolExitCode)' != '0'">false</_UseDnxBun>
+      <_BunCommand Condition="'$(_UseDnxBun)' == 'true'">dnx Bun.Unofficial.Tool --yes --</_BunCommand>
+      <_BunCommand Condition="'$(_UseDnxBun)' == 'false'">bun</_BunCommand>
+    </PropertyGroup>
+  </Target>
+  <Target Name="BunInstall" DependsOnTargets="DetectBun" Inputs="$(WebAppDir)/package.json" Outputs="$(WebAppDir)/node_modules/.install-stamp">
     <!-- We use bun packages as .NET tool, to avoid preinstalled node.js dependency -->
-    <Exec Command="dnx Bun.Unofficial.Tool --yes -- install" WorkingDirectory="$(WebAppDir)" />
+    <Exec Command="$(_BunCommand) install" WorkingDirectory="$(WebAppDir)" />
     <!-- Write the stamp file, so incremental builds work -->
     <Touch Files="$(WebAppDir)/node_modules/.install-stamp" AlwaysCreate="true" />
   </Target>
   <Target Name="BunRunBuild" DependsOnTargets="BunInstall" BeforeTargets="DispatchToInnerBuilds">
-    <Exec Command="dnx Bun.Unofficial.Tool build.js" WorkingDirectory="$(WebAppDir)" />
+    <Exec Command="$(_BunCommand) build.js" WorkingDirectory="$(WebAppDir)" />
   </Target>
 
   <ItemGroup>

--- a/src/Browser/Avalonia.Browser/webapp/bun.lock
+++ b/src/Browser/Avalonia.Browser/webapp/bun.lock
@@ -344,7 +344,7 @@
 
     "ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
-    "native-file-system-adapter": ["native-file-system-adapter@github:jimmywarting/native-file-system-adapter#d1a158f", { "optionalDependencies": { "fetch-blob": "^3.2.0" } }, "jimmywarting-native-file-system-adapter-d1a158f"],
+    "native-file-system-adapter": ["native-file-system-adapter@github:jimmywarting/native-file-system-adapter#d1a158f", { "optionalDependencies": { "fetch-blob": "^3.2.0" } }, "jimmywarting-native-file-system-adapter-d1a158f", "sha512-8PxJJl5P4dGMuBwREF6yuWgZ8weiiboWVDiJbqehdMXHWp40cPWjb9zBjEmDIrFq3jlaC1DCj+sdbiA0svXICg=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -503,10 +503,6 @@
     "eslint-plugin-import/doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
     "eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@2.1.0", "", {}, "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="],
-
-    "esquery/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
-
-    "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/tests/Avalonia.DesignerSupport.Tests/Avalonia.DesignerSupport.Tests.csproj
+++ b/tests/Avalonia.DesignerSupport.Tests/Avalonia.DesignerSupport.Tests.csproj
@@ -21,14 +21,26 @@
   </ItemGroup>
 
 
-  <Target Name="BunInstall" Inputs="$(WebAppDir)\package.json" Outputs="$(WebAppDir)\node_modules\.install-stamp">
+  <Target Name="DetectBun" BeforeTargets="BunInstall">
+    <!-- Try to use Bun.Unofficial.Tool via dnx, but fall back to system-installed bun if unsupported (e.g. win-arm64) -->
+    <Exec Command="dnx Bun.Unofficial.Tool --yes -- --version" IgnoreExitCode="true" ConsoleToMsBuild="true" StandardOutputImportance="Low">
+      <Output TaskParameter="ExitCode" PropertyName="_BunToolExitCode" />
+    </Exec>
+    <PropertyGroup>
+      <_UseDnxBun Condition="'$(_BunToolExitCode)' == '0'">true</_UseDnxBun>
+      <_UseDnxBun Condition="'$(_BunToolExitCode)' != '0'">false</_UseDnxBun>
+      <_BunCommand Condition="'$(_UseDnxBun)' == 'true'">dnx Bun.Unofficial.Tool --yes --</_BunCommand>
+      <_BunCommand Condition="'$(_UseDnxBun)' == 'false'">bun</_BunCommand>
+    </PropertyGroup>
+  </Target>
+  <Target Name="BunInstall" DependsOnTargets="DetectBun" Inputs="$(WebAppDir)\package.json" Outputs="$(WebAppDir)\node_modules\.install-stamp">
     <!-- We use bun packages as .NET tool, to avoid preinstalled node.js dependency -->
-    <Exec Command="dnx Bun.Unofficial.Tool --yes -- install --silent" WorkingDirectory="$(WebAppDir)" />
+    <Exec Command="$(_BunCommand) install --silent" WorkingDirectory="$(WebAppDir)" />
     <!-- Write the stamp file, so incremental builds work -->
     <Touch Files="$(WebAppDir)/node_modules/.install-stamp" AlwaysCreate="true" />
   </Target>
   <Target Name="BunRunTests" DependsOnTargets="BunInstall">
-    <Exec Command="dnx Bun.Unofficial.Tool run test" WorkingDirectory="$(WebAppDir)" />
+    <Exec Command="$(_BunCommand) run test" WorkingDirectory="$(WebAppDir)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
TL;DR When building on Windows ARM64, there were two problems:

1. Bun.Unofficial.Tool doesn't support win-arm64, so it would fail to build when trying to pull it in.
2. The nodejs build.js included `@chialab/esbuild-plugin-html`, which build in dependencies that wouldn't work on win-arm64.

This PR refactors it so:

- If you're on win-arm64, you need to install Bun on your system. If you don't have it, it'll throw an error telling you to install it.
- The build.js and webapp code so it uses an up-to-date esbuild and doesn't require the other plugins, so now it _should_ work on all platforms and not depend on native components.

Checking the gz HTML and JS embedded between 12.0.0-rc1 and the local build on my ARM laptop, as far as I can tell, they look the same and are functionally the same.

**Copilot stuff below:**

This pull request improves cross-platform compatibility for Bun usage in build scripts, updates the webapp build process, and removes an unnecessary dependency. The changes ensure that the build works seamlessly on platforms where `Bun.Unofficial.Tool` is unsupported (such as Windows ARM64) by falling back to a system-installed `bun` binary. Additionally, the webapp build process is modernized and simplified.

**Cross-platform Bun detection and usage:**

* Updated all relevant `.csproj` files and the Nuke build script to attempt using `Bun.Unofficial.Tool` via `dnx` first, and fall back to a system-installed `bun` if not supported. This logic is now centralized and consistent across the build, designer support, and test projects, improving reliability on platforms like win-arm64. [[1]](diffhunk://#diff-f38159a1db10ccd9929859ef6ff9db927bb5dc321f2437fdae84f8956305dad9L46-R65) [[2]](diffhunk://#diff-d328aa2f47cc77a72cfa49466f081205a54ea458ef0a7089d4545c363913efcaL24-R43) [[3]](diffhunk://#diff-686086519dcbaaf14f51a8ce6e55944b96ad2964c9391c775735c10ce0b20e84L24-R43) [[4]](diffhunk://#diff-68675e7080605fa8e9a7aeafd068bb9719dee1e4e9265c6562dd1f2c39cae505L138-R156)

**Webapp build process improvements:**

* Changed the webapp build entry point from `index.html` to `index.tsx`, and replaced the `@chialab/esbuild-plugin-html` plugin with a custom inline HTML plugin to generate the final `index.html`. This simplifies the build process and ensures the output HTML references the correct hashed JS bundle. [[1]](diffhunk://#diff-d47b0ab714c0937b030799aea4e4d736ebc2afbd4bdb4fbe6df7cf8e74ea6218L2-R8) [[2]](diffhunk://#diff-d47b0ab714c0937b030799aea4e4d736ebc2afbd4bdb4fbe6df7cf8e74ea6218R19-R44)
* Updated the `esbuild` version in `package.json` to `^0.25.0` and removed the now-unused `@chialab/esbuild-plugin-html` dependency.


closes https://github.com/AvaloniaUI/Avalonia/issues/20853