### PR TITLE
Remove LambdaExpression.Compile from CompiledBinding.Create

### DIFF
--- a/src/Avalonia.Base/Data/Core/Parsers/BindingExpressionVisitor.cs
+++ b/src/Avalonia.Base/Data/Core/Parsers/BindingExpressionVisitor.cs
@@ -303,29 +303,14 @@ internal class BindingExpressionVisitor<TIn>(LambdaExpression expression) : Expr
         }
     }
 
-    private static Func<object, object>? CreateGetter(PropertyInfo info)
+    private static Func<object, object?>? CreateGetter(PropertyInfo info)
     {
-        if (info.GetMethod == null)
-            return null;
-        var target = Expression.Parameter(typeof(object), "target");
-        return Expression.Lambda<Func<object, object>>(
-                Expression.Convert(Expression.Call(Expression.Convert(target, info.DeclaringType!), info.GetMethod),
-                    typeof(object)),
-                target)
-            .Compile();
+        return info.CanRead ? info.GetValue : null;
     }
 
     private static Action<object, object?>? CreateSetter(PropertyInfo info)
     {
-        if (info.SetMethod == null)
-            return null;
-        var target = Expression.Parameter(typeof(object), "target");
-        var value = Expression.Parameter(typeof(object), "value");
-        return Expression.Lambda<Action<object, object?>>(
-                Expression.Call(Expression.Convert(target, info.DeclaringType!), info.SetMethod,
-                    Expression.Convert(value, info.SetMethod.GetParameters()[0].ParameterType)),
-                target, value)
-            .Compile();
+        return info.CanWrite ? info.SetValue : null;
     }
 
     private static T GetValue<T>(Expression expr)


### PR DESCRIPTION
## What does the pull request do?
#20443 added a convenience method to create compiled bindings from expression trees in C#.
However, the expression visitor used internally originally came from the unit tests, where performance was not important.

`LambdaExpression.Compile`, known to be slow and requiring the generation of dynamic code (in JIT mode) or a full interpreter (in AOT mode), was used in several places. This PR removes two common usages.

`CreateGetter/CreateSetter` now use `PropertyInfo.GetValue/SetValue` directly. The overhead of the reflection call is deemed acceptable in this case. Millions of calls at runtime would be necessary to be as slow as the initial compilation, which is very unlikely for bindings.

In one of our customers' projects, the time to initialize the compiled bindings at startup went from 135ms to <0ms with this change.