### PR TITLE
Include VisualLayerManager itself in layer lookup.

### DIFF
--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -73,7 +73,7 @@ namespace Avalonia.Controls.Primitives
         public static AdornerLayer? GetAdornerLayer(Visual visual)
         {
             // Check if the visual is inside an OverlayLayer with a dedicated AdornerLayer
-            foreach (var ancestor in visual.GetVisualAncestors())
+            foreach (var ancestor in visual.GetSelfAndVisualAncestors())
             {
                 if (GetDirectAdornerLayer(ancestor) is { } adornerLayer)
                     return adornerLayer;

--- a/src/Avalonia.Controls/Primitives/OverlayLayer.cs
+++ b/src/Avalonia.Controls/Primitives/OverlayLayer.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Controls.Primitives
         /// <returns>The <see cref="OverlayLayer"/> associated with the visual, or null if no overlay layer exists.</returns>
         public static OverlayLayer? GetOverlayLayer(Visual visual)
         {
-            foreach (var v in visual.GetVisualAncestors())
+            foreach (var v in visual.GetSelfAndVisualAncestors())
                 if (v is VisualLayerManager { OverlayLayer: { } layer })
                     return layer;
 

--- a/src/Avalonia.Controls/Primitives/PopupOverlayLayer.cs
+++ b/src/Avalonia.Controls/Primitives/PopupOverlayLayer.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Controls.Primitives
 
         public static PopupOverlayLayer? GetPopupOverlayLayer(Visual visual)
         {
-            foreach (var v in visual.GetVisualAncestors())
+            foreach (var v in visual.GetSelfAndVisualAncestors())
                 if (v is VisualLayerManager { PopupOverlayLayer: { } layer })
                     return layer;
 

--- a/src/Avalonia.Controls/Primitives/TextSelectorLayer.cs
+++ b/src/Avalonia.Controls/Primitives/TextSelectorLayer.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Controls.Primitives
 
         public static TextSelectorLayer? GetTextSelectorLayer(Visual visual)
         {
-            foreach (var v in visual.GetVisualAncestors())
+            foreach (var v in visual.GetSelfAndVisualAncestors())
                 if (v is VisualLayerManager { TextSelectorLayer: { } textSelectorLayer })
                     return textSelectorLayer;
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/VisualLayerManagerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/VisualLayerManagerTests.cs
@@ -33,5 +33,83 @@ namespace Avalonia.Controls.UnitTests.Primitives
             Assert.NotNull(mainAdornerLayer);
             Assert.NotSame(overlayAdornerLayer, mainAdornerLayer);
         }
+        
+        [Fact]
+        public void GetAdornerLayer_Returns_Same_AdornerLayer_For_VisualLayerManager()
+        {
+            var vlm = new VisualLayerManager();
+            var root = new TestRoot { Child = vlm };
+
+            root.Measure(new Size(100, 100));
+            root.Arrange(new Rect(0, 0, 100, 100));
+
+            var adornerLayer = vlm.AdornerLayer;
+            Assert.NotNull(adornerLayer);
+            
+            // The adorner layer for a control inside the OverlayLayer
+            // should be the dedicated one, not the main VLM adorner layer.
+            var target = AdornerLayer.GetAdornerLayer(vlm);
+            Assert.NotNull(target);
+            Assert.Same(adornerLayer, target);
+        }
+        
+        [Fact]
+        public void GetAdornerLayer_Returns_Same_AdornerLayer_For_Child()
+        {
+            var button = new Button();
+            var vlm = new VisualLayerManager() { Child = button };
+            var root = new TestRoot { Child = vlm };
+
+            root.Measure(new Size(100, 100));
+            root.Arrange(new Rect(0, 0, 100, 100));
+
+            var adornerLayer = vlm.AdornerLayer;
+            Assert.NotNull(adornerLayer);
+            
+            // The adorner layer for a control inside the OverlayLayer
+            // should be the dedicated one, not the main VLM adorner layer.
+            var target = AdornerLayer.GetAdornerLayer(button);
+            Assert.NotNull(target);
+            Assert.Same(adornerLayer, target);
+        }
+        
+        [Fact]
+        public void GetOverlayLayer_Returns_Same_OverlayLayer_For_VisualLayerManager()
+        {
+            var vlm = new VisualLayerManager() { EnableOverlayLayer = true };
+            var root = new TestRoot { Child = vlm };
+
+            root.Measure(new Size(100, 100));
+            root.Arrange(new Rect(0, 0, 100, 100));
+
+            var overlayLayer = vlm.OverlayLayer;
+            Assert.NotNull(overlayLayer);
+            
+            // The adorner layer for a control inside the OverlayLayer
+            // should be the dedicated one, not the main VLM adorner layer.
+            var target = OverlayLayer.GetOverlayLayer(vlm);
+            Assert.NotNull(target);
+            Assert.Same(overlayLayer, target);
+        }
+        
+        [Fact]
+        public void GetOverlayLayer_Returns_Same_OverlayLayer_For_Child()
+        {
+            var button = new Button();
+            var vlm = new VisualLayerManager() { EnableOverlayLayer = true, Child = button };
+            var root = new TestRoot { Child = vlm };
+
+            root.Measure(new Size(100, 100));
+            root.Arrange(new Rect(0, 0, 100, 100));
+
+            var overlayLayer = vlm.OverlayLayer;
+            Assert.NotNull(overlayLayer);
+            
+            // The adorner layer for a control inside the OverlayLayer
+            // should be the dedicated one, not the main VLM adorner layer.
+            var target = OverlayLayer.GetOverlayLayer(button);
+            Assert.NotNull(target);
+            Assert.Same(overlayLayer, target);
+        }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Now we can use VLM itself as the visual to lookup OverlayLayer/AdornerLayer/PopupLayer

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
It's impossible to find OverlayLayer when there is a known VLM

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
