### PR TITLE
Remove OnLoaded/OnUnloaded virtual methods from public API

### DIFF
--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -1983,6 +1983,18 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Controls.Control.OnLoaded(Avalonia.Interactivity.RoutedEventArgs)</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Controls.Control.OnUnloaded(Avalonia.Interactivity.RoutedEventArgs)</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Controls.Design.CreatePreviewWithControl(System.Object)</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Controls.dll</Right>
@@ -3652,6 +3664,18 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Controls.ContextMenu.set_PlacementMode(Avalonia.Controls.PlacementMode)</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Controls.Control.OnLoaded(Avalonia.Interactivity.RoutedEventArgs)</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Controls.Control.OnUnloaded(Avalonia.Interactivity.RoutedEventArgs)</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Controls.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Controls.dll</Right>
   </Suppression>

--- a/samples/ControlCatalog/Pages/CarouselPage/CareCompanionAppPage.xaml
+++ b/samples/ControlCatalog/Pages/CarouselPage/CareCompanionAppPage.xaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.CareCompanionAppPage">
+             x:Class="ControlCatalog.Pages.CareCompanionAppPage"
+             Loaded="OnControlLoaded">
   <UserControl.Styles>
     <Style Selector="PipsPager /template/ ListBox ListBoxItem">
       <Setter Property="Width" Value="24" />

--- a/samples/ControlCatalog/Pages/CarouselPage/CareCompanionAppPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/CarouselPage/CareCompanionAppPage.xaml.cs
@@ -35,9 +35,8 @@ public partial class CareCompanionAppPage : UserControl
         InitializeComponent();
     }
 
-    protected override void OnLoaded(RoutedEventArgs e)
+    private void OnControlLoaded(object? sender, RoutedEventArgs e)
     {
-        base.OnLoaded(e);
         _infoPanel = this.FindControl<ScrollViewer>("InfoPanel");
         UpdateInfoVisibility();
 

--- a/samples/ControlCatalog/Pages/CarouselPage/CarouselGalleryAppPage.xaml
+++ b/samples/ControlCatalog/Pages/CarouselPage/CarouselGalleryAppPage.xaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="ControlCatalog.Pages.CarouselGalleryAppPage"
+             Loaded="OnControlLoaded"
              Background="#F8F9FB">
   <UserControl.Resources>
     <!-- White pip colors for the hero dark background -->

--- a/samples/ControlCatalog/Pages/CarouselPage/CarouselGalleryAppPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/CarouselPage/CarouselGalleryAppPage.xaml.cs
@@ -23,9 +23,8 @@ namespace ControlCatalog.Pages
             HeroPager.SelectedIndexChanged += OnPagerIndexChanged;
         }
 
-        protected override void OnLoaded(RoutedEventArgs e)
+        private void OnControlLoaded(object? sender, RoutedEventArgs e)
         {
-            base.OnLoaded(e);
             UpdateInfoPanelVisibility();
         }
 

--- a/samples/ControlCatalog/Pages/ContentPage/ContentPagePerformancePage.xaml
+++ b/samples/ControlCatalog/Pages/ContentPage/ContentPagePerformancePage.xaml
@@ -1,6 +1,8 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.ContentPagePerformancePage">
+             x:Class="ControlCatalog.Pages.ContentPagePerformancePage"
+             Loaded="OnControlLoaded"
+             Unloaded="OnControlUnloaded">
   <Grid ColumnDefinitions="*,300">
 
     <!-- Left: NavigationPage + log -->

--- a/samples/ControlCatalog/Pages/ContentPage/ContentPagePerformancePage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ContentPage/ContentPagePerformancePage.xaml.cs
@@ -20,10 +20,8 @@ namespace ControlCatalog.Pages
             InitializeComponent();
         }
 
-        protected override async void OnLoaded(RoutedEventArgs e)
+        private async void OnControlLoaded(object? sender, RoutedEventArgs e)
         {
-            base.OnLoaded(e);
-
             NavPage.Pushed       += OnStackChanged;
             NavPage.Popped       += OnStackChanged;
             NavPage.PoppedToRoot += OnStackChanged;
@@ -34,9 +32,8 @@ namespace ControlCatalog.Pages
             Log("Init", "Pushed root page");
         }
 
-        protected override void OnUnloaded(RoutedEventArgs e)
+        private void OnControlUnloaded(object? sender, RoutedEventArgs e)
         {
-            base.OnUnloaded(e);
             _perf.StopAutoRefresh();
         }
 

--- a/samples/ControlCatalog/Pages/DrawerPage/DrawerPageBreakpointPage.xaml
+++ b/samples/ControlCatalog/Pages/DrawerPage/DrawerPageBreakpointPage.xaml
@@ -1,6 +1,8 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.DrawerPageBreakpointPage">
+             x:Class="ControlCatalog.Pages.DrawerPageBreakpointPage"
+             Loaded="OnControlLoaded"
+             Unloaded="OnControlUnloaded">
   <DockPanel>
     <ScrollViewer DockPanel.Dock="Right" Width="240">
       <StackPanel Margin="12" Spacing="8">

--- a/samples/ControlCatalog/Pages/DrawerPage/DrawerPageBreakpointPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DrawerPage/DrawerPageBreakpointPage.xaml.cs
@@ -13,17 +13,15 @@ namespace ControlCatalog.Pages
             InitializeComponent();
         }
 
-        protected override void OnLoaded(RoutedEventArgs e)
+        private void OnControlLoaded(object? sender, RoutedEventArgs e)
         {
-            base.OnLoaded(e);
             _isLoaded = true;
             DemoDrawer.PropertyChanged += OnDrawerPropertyChanged;
             UpdateStatus();
         }
 
-        protected override void OnUnloaded(RoutedEventArgs e)
+        private void OnControlUnloaded(object? sender, RoutedEventArgs e)
         {
-            base.OnUnloaded(e);
             DemoDrawer.PropertyChanged -= OnDrawerPropertyChanged;
         }
 

--- a/samples/ControlCatalog/Pages/DrawerPage/DrawerPageCompactPage.xaml
+++ b/samples/ControlCatalog/Pages/DrawerPage/DrawerPageCompactPage.xaml
@@ -1,6 +1,8 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.DrawerPageCompactPage">
+             x:Class="ControlCatalog.Pages.DrawerPageCompactPage"
+             Loaded="OnControlLoaded"
+             Unloaded="OnControlUnloaded">
   <DockPanel>
     <ScrollViewer DockPanel.Dock="Right" Width="240">
       <StackPanel Margin="12" Spacing="8">

--- a/samples/ControlCatalog/Pages/DrawerPage/DrawerPageCompactPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DrawerPage/DrawerPageCompactPage.xaml.cs
@@ -13,17 +13,15 @@ namespace ControlCatalog.Pages
             InitializeComponent();
         }
 
-        protected override void OnLoaded(RoutedEventArgs e)
+        private void OnControlLoaded(object? sender, RoutedEventArgs e)
         {
-            base.OnLoaded(e);
             _isLoaded = true;
             DemoDrawer.Opened += OnDrawerStatusChanged;
             DemoDrawer.Closed += OnDrawerStatusChanged;
         }
 
-        protected override void OnUnloaded(RoutedEventArgs e)
+        private void OnControlUnloaded(object? sender, RoutedEventArgs e)
         {
-            base.OnUnloaded(e);
             DemoDrawer.Opened -= OnDrawerStatusChanged;
             DemoDrawer.Closed -= OnDrawerStatusChanged;
         }

--- a/samples/ControlCatalog/Pages/DrawerPage/DrawerPageCustomizationPage.xaml
+++ b/samples/ControlCatalog/Pages/DrawerPage/DrawerPageCustomizationPage.xaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.DrawerPageCustomizationPage">
+             x:Class="ControlCatalog.Pages.DrawerPageCustomizationPage"
+             Loaded="OnControlLoaded">
   <DockPanel>
     <ScrollViewer DockPanel.Dock="Right" Width="280">
       <StackPanel Margin="12" Spacing="8">

--- a/samples/ControlCatalog/Pages/DrawerPage/DrawerPageCustomizationPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DrawerPage/DrawerPageCustomizationPage.xaml.cs
@@ -27,9 +27,8 @@ namespace ControlCatalog.Pages
             EnableMouseSwipeGesture(DemoDrawer);
         }
 
-        protected override void OnLoaded(RoutedEventArgs e)
+        private void OnControlLoaded(object? sender, RoutedEventArgs e)
         {
-            base.OnLoaded(e);
             _isLoaded = true;
         }
 

--- a/samples/ControlCatalog/Pages/DrawerPage/DrawerPageEventsPage.xaml
+++ b/samples/ControlCatalog/Pages/DrawerPage/DrawerPageEventsPage.xaml
@@ -1,6 +1,8 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.DrawerPageEventsPage">
+             x:Class="ControlCatalog.Pages.DrawerPageEventsPage"
+             Loaded="OnControlLoaded"
+             Unloaded="OnControlUnloaded">
   <DockPanel>
     <ScrollViewer DockPanel.Dock="Right" Width="260">
       <StackPanel Margin="12" Spacing="8">

--- a/samples/ControlCatalog/Pages/DrawerPage/DrawerPageEventsPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DrawerPage/DrawerPageEventsPage.xaml.cs
@@ -29,9 +29,8 @@ namespace ControlCatalog.Pages
             }
         }
 
-        protected override void OnLoaded(RoutedEventArgs e)
+        private void OnControlLoaded(object? sender, RoutedEventArgs e)
         {
-            base.OnLoaded(e);
             DemoDrawer.Opened  += OnDrawerOpened;
             DemoDrawer.Closing += OnClosing;
             DemoDrawer.Closed  += OnDrawerClosed;
@@ -40,9 +39,8 @@ namespace ControlCatalog.Pages
             DemoDrawer.Content = _sectionPages["Home"];
         }
 
-        protected override void OnUnloaded(RoutedEventArgs e)
+        private void OnControlUnloaded(object? sender, RoutedEventArgs e)
         {
-            base.OnUnloaded(e);
             DemoDrawer.Opened  -= OnDrawerOpened;
             DemoDrawer.Closing -= OnClosing;
             DemoDrawer.Closed  -= OnDrawerClosed;

--- a/samples/ControlCatalog/Pages/DrawerPage/DrawerPageFirstLookPage.xaml
+++ b/samples/ControlCatalog/Pages/DrawerPage/DrawerPageFirstLookPage.xaml
@@ -1,6 +1,8 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.DrawerPageFirstLookPage">
+             x:Class="ControlCatalog.Pages.DrawerPageFirstLookPage"
+             Loaded="OnControlLoaded"
+             Unloaded="OnControlUnloaded">
   <DockPanel>
     <ScrollViewer DockPanel.Dock="Right" Width="260">
       <StackPanel Margin="12" Spacing="8">

--- a/samples/ControlCatalog/Pages/DrawerPage/DrawerPageFirstLookPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DrawerPage/DrawerPageFirstLookPage.xaml.cs
@@ -13,16 +13,14 @@ namespace ControlCatalog.Pages
             EnableMouseSwipeGesture(DemoDrawer);
         }
 
-        protected override void OnLoaded(RoutedEventArgs e)
+        private void OnControlLoaded(object? sender, RoutedEventArgs e)
         {
-            base.OnLoaded(e);
             DemoDrawer.Opened += OnDrawerStatusChanged;
             DemoDrawer.Closed += OnDrawerStatusChanged;
         }
 
-        protected override void OnUnloaded(RoutedEventArgs e)
+        private void OnControlUnloaded(object? sender, RoutedEventArgs e)
         {
-            base.OnUnloaded(e);
             DemoDrawer.Opened -= OnDrawerStatusChanged;
             DemoDrawer.Closed -= OnDrawerStatusChanged;
         }

--- a/samples/ControlCatalog/Pages/DrawerPage/DrawerPagePerformancePage.xaml
+++ b/samples/ControlCatalog/Pages/DrawerPage/DrawerPagePerformancePage.xaml
@@ -1,6 +1,8 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.DrawerPagePerformancePage">
+             x:Class="ControlCatalog.Pages.DrawerPagePerformancePage"
+             Loaded="OnControlLoaded"
+             Unloaded="OnControlUnloaded">
   <Grid ColumnDefinitions="*,300">
 
     <DockPanel Grid.Column="0" Margin="16">

--- a/samples/ControlCatalog/Pages/DrawerPage/DrawerPagePerformancePage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DrawerPage/DrawerPagePerformancePage.xaml.cs
@@ -20,10 +20,8 @@ namespace ControlCatalog.Pages
             InitializeComponent();
         }
 
-        protected override void OnLoaded(RoutedEventArgs e)
+        private void OnControlLoaded(object? sender, RoutedEventArgs e)
         {
-            base.OnLoaded(e);
-
             _perf.InitHeap();
             _perf.OpStopwatch.Restart();
             _perf.TrackPage(DetailPage);
@@ -34,9 +32,8 @@ namespace ControlCatalog.Pages
             RefreshAll();
         }
 
-        protected override void OnUnloaded(RoutedEventArgs e)
+        private void OnControlUnloaded(object? sender, RoutedEventArgs e)
         {
-            base.OnUnloaded(e);
             _perf.StopAutoRefresh();
         }
 

--- a/samples/ControlCatalog/Pages/DrawerPage/EcoTrackerAppPage.xaml
+++ b/samples/ControlCatalog/Pages/DrawerPage/EcoTrackerAppPage.xaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.EcoTrackerAppPage">
+             x:Class="ControlCatalog.Pages.EcoTrackerAppPage"
+             Loaded="OnControlLoaded">
 
   <UserControl.Resources>
     <SolidColorBrush x:Key="EcoBgLight"   Color="#F1F8E9"/>

--- a/samples/ControlCatalog/Pages/DrawerPage/EcoTrackerAppPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DrawerPage/EcoTrackerAppPage.xaml.cs
@@ -39,9 +39,8 @@ public partial class EcoTrackerAppPage : UserControl
             _ = _navPage.PushAsync(BuildHomePage());
     }
 
-    protected override void OnLoaded(RoutedEventArgs e)
+    private void OnControlLoaded(object? sender, RoutedEventArgs e)
     {
-        base.OnLoaded(e);
         UpdateInfoPanelVisibility();
     }
 

--- a/samples/ControlCatalog/Pages/DrawerPage/ModernAppPage.xaml
+++ b/samples/ControlCatalog/Pages/DrawerPage/ModernAppPage.xaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.ModernAppPage">
+             x:Class="ControlCatalog.Pages.ModernAppPage"
+             Loaded="OnControlLoaded">
 
   <UserControl.Resources>
     <!-- Color tokens -->

--- a/samples/ControlCatalog/Pages/DrawerPage/ModernAppPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DrawerPage/ModernAppPage.xaml.cs
@@ -33,9 +33,8 @@ public partial class ModernAppPage : UserControl
             NavigateToDiscover();
     }
 
-    protected override void OnLoaded(RoutedEventArgs e)
+    private void OnControlLoaded(object? sender, RoutedEventArgs e)
     {
-        base.OnLoaded(e);
         UpdateInfoPanelVisibility();
     }
 

--- a/samples/ControlCatalog/Pages/NavigationPage/AvaloniaFlixAppPage.xaml
+++ b/samples/ControlCatalog/Pages/NavigationPage/AvaloniaFlixAppPage.xaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.AvaloniaFlixAppPage">
+             x:Class="ControlCatalog.Pages.AvaloniaFlixAppPage"
+             Loaded="OnControlLoaded">
 
   <UserControl.Resources>
     <SolidColorBrush x:Key="FlixBg"            Color="#0A0A0A"/>

--- a/samples/ControlCatalog/Pages/NavigationPage/AvaloniaFlixAppPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/NavigationPage/AvaloniaFlixAppPage.xaml.cs
@@ -38,10 +38,8 @@ public partial class AvaloniaFlixAppPage : UserControl
         }
     }
 
-    protected override void OnLoaded(RoutedEventArgs e)
+    private void OnControlLoaded(object? sender, RoutedEventArgs e)
     {
-        base.OnLoaded(e);
-
         _infoPanel = this.FindControl<ScrollViewer>("InfoPanel");
         UpdateInfoPanelVisibility();
     }

--- a/samples/ControlCatalog/Pages/NavigationPage/LAvenirAppPage.xaml
+++ b/samples/ControlCatalog/Pages/NavigationPage/LAvenirAppPage.xaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.LAvenirAppPage">
+             x:Class="ControlCatalog.Pages.LAvenirAppPage"
+             Loaded="OnControlLoaded">
 
   <UserControl.Resources>
     <SolidColorBrush x:Key="LAvenirBg" Color="#f6f6f8"/>

--- a/samples/ControlCatalog/Pages/NavigationPage/LAvenirAppPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/NavigationPage/LAvenirAppPage.xaml.cs
@@ -38,10 +38,8 @@ public partial class LAvenirAppPage : UserControl
             _ = _navPage.PushAsync(BuildMenuTabbedPage());
     }
 
-    protected override void OnLoaded(RoutedEventArgs e)
+    private void OnControlLoaded(object? sender, RoutedEventArgs e)
     {
-        base.OnLoaded(e);
-
         _infoPanel = this.FindControl<ScrollViewer>("InfoPanel");
         UpdateInfoPanelVisibility();
     }

--- a/samples/ControlCatalog/Pages/NavigationPage/NavigationPageCurvedHeaderPage.xaml
+++ b/samples/ControlCatalog/Pages/NavigationPage/NavigationPageCurvedHeaderPage.xaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.NavigationPageCurvedHeaderPage">
+             x:Class="ControlCatalog.Pages.NavigationPageCurvedHeaderPage"
+             Loaded="OnControlLoaded">
 
   <DockPanel>
     <ScrollViewer x:Name="InfoPanel" DockPanel.Dock="Right" Width="300">

--- a/samples/ControlCatalog/Pages/NavigationPage/NavigationPageCurvedHeaderPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/NavigationPage/NavigationPageCurvedHeaderPage.xaml.cs
@@ -38,10 +38,8 @@ public partial class NavigationPageCurvedHeaderPage : UserControl
             _ = _navPage.PushAsync(BuildHomePage());
     }
 
-    protected override void OnLoaded(RoutedEventArgs e)
+    private void OnControlLoaded(object? sender, RoutedEventArgs e)
     {
-        base.OnLoaded(e);
-
         _infoPanel = this.FindControl<ScrollViewer>("InfoPanel");
         UpdateInfoPanelVisibility();
     }

--- a/samples/ControlCatalog/Pages/NavigationPage/NavigationPagePerformancePage.xaml
+++ b/samples/ControlCatalog/Pages/NavigationPage/NavigationPagePerformancePage.xaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.NavigationPagePerformancePage">
+             x:Class="ControlCatalog.Pages.NavigationPagePerformancePage"
+             Unloaded="OnControlUnloaded">
   <Grid ColumnDefinitions="*,240">
 
     <!-- Left: NavigationPage + Operation log -->

--- a/samples/ControlCatalog/Pages/NavigationPage/NavigationPagePerformancePage.xaml.cs
+++ b/samples/ControlCatalog/Pages/NavigationPage/NavigationPagePerformancePage.xaml.cs
@@ -34,9 +34,8 @@ namespace ControlCatalog.Pages
             Log("Init", "Pushed root page");
         }
 
-        protected override void OnUnloaded(RoutedEventArgs e)
+        private void OnControlUnloaded(object? sender, RoutedEventArgs e)
         {
-            base.OnUnloaded(e);
             _perf.StopAutoRefresh();
         }
 

--- a/samples/ControlCatalog/Pages/NavigationPage/PulseAppPage.xaml
+++ b/samples/ControlCatalog/Pages/NavigationPage/PulseAppPage.xaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.PulseAppPage">
+             x:Class="ControlCatalog.Pages.PulseAppPage"
+             Loaded="OnControlLoaded">
   <DockPanel>
     <ScrollViewer x:Name="InfoPanel" DockPanel.Dock="Right" Width="300">
       <StackPanel Margin="16" Spacing="16">

--- a/samples/ControlCatalog/Pages/NavigationPage/PulseAppPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/NavigationPage/PulseAppPage.xaml.cs
@@ -32,10 +32,8 @@ public partial class PulseAppPage : UserControl
         }
     }
 
-    protected override void OnLoaded(RoutedEventArgs e)
+    private void OnControlLoaded(object? sender, RoutedEventArgs e)
     {
-        base.OnLoaded(e);
-
         _infoPanel = this.FindControl<ScrollViewer>("InfoPanel");
         UpdateInfoPanelVisibility();
     }

--- a/samples/ControlCatalog/Pages/NavigationPage/RetroGamingAppPage.xaml
+++ b/samples/ControlCatalog/Pages/NavigationPage/RetroGamingAppPage.xaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="ControlCatalog.Pages.RetroGamingAppPage">
+             x:Class="ControlCatalog.Pages.RetroGamingAppPage"
+             Loaded="OnControlLoaded">
 
   <UserControl.Resources>
     <SolidColorBrush x:Key="RetroBg"      Color="#120a1f"/>

--- a/samples/ControlCatalog/Pages/NavigationPage/RetroGamingAppPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/NavigationPage/RetroGamingAppPage.xaml.cs
@@ -30,10 +30,8 @@ public partial class RetroGamingAppPage : UserControl
             _ = _nav.PushAsync(BuildHomePage());
     }
 
-    protected override void OnLoaded(RoutedEventArgs e)
+    private void OnControlLoaded(object? sender, RoutedEventArgs e)
     {
-        base.OnLoaded(e);
-
         _infoPanel = this.FindControl<ScrollViewer>("InfoPanel");
         UpdateInfoPanelVisibility();
     }

--- a/samples/SafeAreaDemo/Views/MainView.xaml
+++ b/samples/SafeAreaDemo/Views/MainView.xaml
@@ -8,6 +8,7 @@
              d:DesignHeight="450"
              x:Class="SafeAreaDemo.Views.MainView"
              x:DataType="vm:MainViewModel"
+             Loaded="OnControlLoaded"
              Background="#ccc"
              TopLevel.AutoSafeAreaPadding="{Binding AutoSafeAreaPadding, Mode=TwoWay}">
     <Grid HorizontalAlignment="Stretch"

--- a/samples/SafeAreaDemo/Views/MainView.xaml.cs
+++ b/samples/SafeAreaDemo/Views/MainView.xaml.cs
@@ -12,11 +12,8 @@ namespace SafeAreaDemo.Views
             AvaloniaXamlLoader.Load(this);
         }
 
-        /// <inheritdoc/>
-        protected override void OnLoaded(RoutedEventArgs e)
+        private void OnControlLoaded(object? sender, RoutedEventArgs e)
         {
-            base.OnLoaded(e);
-
             var insetsManager = TopLevel.GetTopLevel(this)?.InsetsManager;
             var inputPane = TopLevel.GetTopLevel(this)?.InputPane;
             var viewModel = new MainViewModel();

--- a/samples/SampleControls/HamburgerMenu/HamburgerMenu.cs
+++ b/samples/SampleControls/HamburgerMenu/HamburgerMenu.cs
@@ -13,6 +13,11 @@ namespace ControlSamples
         private TextBox? _searchBox;
         private bool _initialized;
 
+        public HamburgerMenu()
+        {
+            Loaded += OnControlLoaded;
+        }
+
         public static readonly StyledProperty<IBrush?> PaneBackgroundProperty =
             SplitView.PaneBackgroundProperty.AddOwner<HamburgerMenu>();
 
@@ -53,10 +58,8 @@ namespace ControlSamples
             }
         }
 
-        protected override void OnLoaded(Avalonia.Interactivity.RoutedEventArgs e)
+        private void OnControlLoaded(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
-            base.OnLoaded(e);
-
             if (!_initialized)
             {
                 _initialized = true;

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -334,20 +334,16 @@ namespace Avalonia.Controls
             }
         }
 
-        /// <summary>
-        /// Raises the <see cref="Loaded"/> event.
-        /// </summary>
-        /// <param name="e">The event args.</param>
-        protected virtual void OnLoaded(RoutedEventArgs e)
+        // OnLoaded/OnUnloaded are intentionally private and non-virtual, so we could later
+        // optimize out enqueueing 99% of controls for Loaded/Unloaded callback like WPF does
+        // Controls that need to react to loaded/unloaded should subscribe to the
+        // Loaded/Unloaded events instead.
+        private void OnLoaded(RoutedEventArgs e)
         {
             RaiseEvent(e);
         }
 
-        /// <summary>
-        /// Raises the <see cref="Unloaded"/> event.
-        /// </summary>
-        /// <param name="e">The event args.</param>
-        protected virtual void OnUnloaded(RoutedEventArgs e)
+        private void OnUnloaded(RoutedEventArgs e)
         {
             RaiseEvent(e);
         }

--- a/src/Avalonia.Controls/Page/DrawerPage.cs
+++ b/src/Avalonia.Controls/Page/DrawerPage.cs
@@ -296,6 +296,14 @@ namespace Avalonia.Controls
         {
             GestureRecognizers.Add(_swipeRecognizer);
             UpdateSwipeRecognizerAxes();
+            Loaded += (_, _) =>
+            {
+                if (!_hasHadFirstPage && CurrentPage != null)
+                {
+                    _hasHadFirstPage = true;
+                    CurrentPage.SendNavigatedTo(new NavigatedToEventArgs(null, NavigationType.Push));
+                }
+            };
         }
 
         /// <summary>
@@ -725,16 +733,6 @@ namespace Avalonia.Controls
             _swipeRecognizer.CanHorizontallySwipe = !IsVerticalPlacement;
         }
 
-        protected override void OnLoaded(RoutedEventArgs e)
-        {
-            base.OnLoaded(e);
-
-            if (!_hasHadFirstPage && CurrentPage != null)
-            {
-                _hasHadFirstPage = true;
-                CurrentPage.SendNavigatedTo(new NavigatedToEventArgs(null, NavigationType.Push));
-            }
-        }
 
         private void OnSwipePointerPressed(object? sender, PointerPressedEventArgs e)
         {

--- a/src/Avalonia.Controls/Page/Page.cs
+++ b/src/Avalonia.Controls/Page/Page.cs
@@ -87,6 +87,7 @@ namespace Avalonia.Controls
             });
 
             AffectsMeasure<Page>(SafeAreaPaddingProperty);
+            LoadedEvent.AddClassHandler<Page>((x, _) => x.UpdateContentSafeAreaPadding());
         }
 
         /// <summary>
@@ -255,11 +256,6 @@ namespace Avalonia.Controls
                 AutomationProperties.SetName(this, change.GetNewValue<object?>() as string ?? string.Empty);
         }
 
-        protected override void OnLoaded(RoutedEventArgs e)
-        {
-            base.OnLoaded(e);
-            UpdateContentSafeAreaPadding();
-        }
 
         /// <summary>
         /// Called when the safe-area padding changes.

--- a/src/Avalonia.Controls/Primitives/TextSelectionHandle.cs
+++ b/src/Avalonia.Controls/Primitives/TextSelectionHandle.cs
@@ -27,6 +27,7 @@ namespace Avalonia.Controls.Primitives
             DragStartedEvent.AddClassHandler<TextSelectionHandle>((x, e) => x.OnDragStarted(e), RoutingStrategies.Bubble);
             DragDeltaEvent.AddClassHandler<TextSelectionHandle>((x, e) => x.OnDragDelta(e), RoutingStrategies.Bubble);
             DragCompletedEvent.AddClassHandler<TextSelectionHandle>((x, e) => x.OnDragCompleted(e), RoutingStrategies.Bubble);
+            LoadedEvent.AddClassHandler<TextSelectionHandle>((x, _) => x.InvalidateMeasure());
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -41,12 +42,6 @@ namespace Avalonia.Controls.Primitives
             RenderTransform = _transform;
         }
 
-        protected override void OnLoaded(RoutedEventArgs args)
-        {
-            base.OnLoaded(args);
-
-            InvalidateMeasure();
-        }
         protected override void OnDragStarted(VectorEventArgs e)
         {
             base.OnDragStarted(e);

--- a/src/Avalonia.Controls/ToggleSwitch.cs
+++ b/src/Avalonia.Controls/ToggleSwitch.cs
@@ -48,6 +48,7 @@ namespace Avalonia.Controls
             {
                 x.UpdateKnobTransitions();
             });
+            LoadedEvent.AddClassHandler<ToggleSwitch>((x, _) => x.UpdateKnobTransitions());
         }
 
         /// <summary>
@@ -201,12 +202,6 @@ namespace Avalonia.Controls
             }
         }
 
-        /// <inheritdoc/>
-        protected override void OnLoaded(RoutedEventArgs e)
-        {
-            base.OnLoaded(e);
-            UpdateKnobTransitions();
-        }
 
         private void UpdateKnobTransitions()
         {

--- a/tests/TestFiles/BuildTasks/PInvoke/MainWindow.axaml
+++ b/tests/TestFiles/BuildTasks/PInvoke/MainWindow.axaml
@@ -1,4 +1,5 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
-        x:Class="PInvoke.MainWindow">
+        x:Class="PInvoke.MainWindow"
+        Loaded="OnControlLoaded">
 </Window>

--- a/tests/TestFiles/BuildTasks/PInvoke/MainWindow.axaml.cs
+++ b/tests/TestFiles/BuildTasks/PInvoke/MainWindow.axaml.cs
@@ -14,9 +14,8 @@ public partial class MainWindow : Window
         InitializeComponent();
     }
 
-    protected override void OnLoaded(RoutedEventArgs e)
+    private void OnControlLoaded(object? sender, RoutedEventArgs e)
     {
-        base.OnLoaded(e);
         var x = add(1, 2);
     }
 }


### PR DESCRIPTION
WPF does some heavy lifting to avoid enqueuing a gazillion of visuals for loaded callbacks, since 99% of them don't actually need such callbacks:
https://github.com/dotnet/wpf/blob/ae2509a58028dd785d4cdd6029ad4bfa4c41b2eb/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkElement.cs#L535-L600

https://github.com/dotnet/wpf/blob/ae2509a58028dd785d4cdd6029ad4bfa4c41b2eb/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/BroadcastEventHelper.cs

For some reason we have virtual methods, so we can't just check event subscribers. This PR removes OnLoaded/OnUnloaded virtual methods to leave room for optimizations later in 12.x release cycle.

cc: @robloo 