### PR TITLE
Fix TabbedPage samples wrong icon

### DIFF
--- a/samples/ControlCatalog/Pages/CarouselPage/CareCompanionAppPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/CarouselPage/CareCompanionAppPage.xaml.cs
@@ -703,7 +703,7 @@ public partial class CareCompanionAppPage : UserControl
 
         var home = BuildHomeTab();
         home.Header = "Home";
-        home.Icon = Geometry.Parse("M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z");
+        home.Icon = new PathIcon { Data = Geometry.Parse("M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z") };
 
         tp.Pages = new ObservableCollection<Page>
         {
@@ -729,7 +729,7 @@ public partial class CareCompanionAppPage : UserControl
         => new ContentPage
         {
             Header = header,
-            Icon = Geometry.Parse(iconData),
+            Icon = new PathIcon { Data = Geometry.Parse(iconData) },
             Background = new SolidColorBrush(BgLight),
             Content = new StackPanel
             {

--- a/samples/ControlCatalog/Pages/CarouselPage/SanctuaryMainPage.xaml
+++ b/samples/ControlCatalog/Pages/CarouselPage/SanctuaryMainPage.xaml
@@ -93,7 +93,7 @@
       <ContentPage Header="Home"
                    Background="#221710">
         <ContentPage.Icon>
-          <StreamGeometry>M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z</StreamGeometry>
+          <PathIcon Data="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
         </ContentPage.Icon>
         <ScrollViewer HorizontalScrollBarVisibility="Disabled"
                       VerticalScrollBarVisibility="Hidden">
@@ -243,7 +243,7 @@
       <ContentPage Header="Explore"
                    Background="#221710">
         <ContentPage.Icon>
-          <StreamGeometry>M12 10.9c-.61 0-1.1.49-1.1 1.1s.49 1.1 1.1 1.1c.61 0 1.1-.49 1.1-1.1s-.49-1.1-1.1-1.1zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm2.19 12.19L6 18l3.81-8.19L18 6l-3.81 8.19z</StreamGeometry>
+          <PathIcon Data="M12 10.9c-.61 0-1.1.49-1.1 1.1s.49 1.1 1.1 1.1c.61 0 1.1-.49 1.1-1.1s-.49-1.1-1.1-1.1zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm2.19 12.19L6 18l3.81-8.19L18 6l-3.81 8.19z" />
         </ContentPage.Icon>
         <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
                     Spacing="12" Margin="32">
@@ -260,7 +260,7 @@
       <ContentPage Header="Saved"
                    Background="#221710">
         <ContentPage.Icon>
-          <StreamGeometry>M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z</StreamGeometry>
+          <PathIcon Data="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
         </ContentPage.Icon>
         <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
                     Spacing="12" Margin="32">
@@ -277,7 +277,7 @@
       <ContentPage Header="Profile"
                    Background="#221710">
         <ContentPage.Icon>
-          <StreamGeometry>M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z</StreamGeometry>
+          <PathIcon Data="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
         </ContentPage.Icon>
         <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
                     Spacing="12" Margin="32">

--- a/samples/ControlCatalog/Pages/DrawerPage/DrawerPageCustomizationPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DrawerPage/DrawerPageCustomizationPage.xaml.cs
@@ -143,7 +143,7 @@ namespace ControlCatalog.Pages
         {
             if (!_isLoaded)
                 return;
-            DemoDrawer.DrawerIcon = Geometry.Parse(_iconPaths[IconCombo.SelectedIndex]);
+            DemoDrawer.DrawerIcon = new PathIcon { Data = Geometry.Parse(_iconPaths[IconCombo.SelectedIndex]) };
         }
 
         private void OnBackdropChanged(object? sender, SelectionChangedEventArgs e)

--- a/samples/ControlCatalog/Pages/DrawerPage/EcoTrackerAppPage.xaml
+++ b/samples/ControlCatalog/Pages/DrawerPage/EcoTrackerAppPage.xaml
@@ -52,13 +52,9 @@
         </DrawerPage.Resources>
 
         <DrawerPage.DrawerIcon>
-          <StreamGeometry>M12 3C9 6 6 9 6 13C6 17.4 8.7 21 12 22C15.3 21 18 17.4 18 13C18 9 15 6 12 3Z</StreamGeometry>
+          <PathIcon Width="22" Height="22"
+                    Data="M12 3C9 6 6 9 6 13C6 17.4 8.7 21 12 22C15.3 21 18 17.4 18 13C18 9 15 6 12 3Z" />
         </DrawerPage.DrawerIcon>
-        <DrawerPage.DrawerIconTemplate>
-          <DataTemplate DataType="Geometry">
-            <PathIcon Width="22" Height="22" Data="{Binding}" />
-          </DataTemplate>
-        </DrawerPage.DrawerIconTemplate>
 
         <DrawerPage.DrawerHeader>
           <StackPanel Background="{StaticResource EcoDrawerBg}" Margin="0,0,0,8">

--- a/samples/ControlCatalog/Pages/NavigationPage/LAvenirAppPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/NavigationPage/LAvenirAppPage.xaml.cs
@@ -59,26 +59,6 @@ public partial class LAvenirAppPage : UserControl
             _infoPanel.IsVisible = Bounds.Width >= 650;
     }
 
-    void ApplyRootNavigationBarAppearance()
-    {
-        if (_navPage == null)
-            return;
-
-        _navPage.Background = new SolidColorBrush(BgLight);
-        _navPage.Resources["NavigationBarBackground"] = new SolidColorBrush(BgLight);
-        _navPage.Resources["NavigationBarForeground"] = new SolidColorBrush(TextDark);
-    }
-
-    void ApplyDetailNavigationBarAppearance()
-    {
-        if (_navPage == null)
-            return;
-
-        _navPage.Background = new SolidColorBrush(BgDark);
-        _navPage.Resources["NavigationBarBackground"] = new SolidColorBrush(BgDark);
-        _navPage.Resources["NavigationBarForeground"] = Brushes.White;
-    }
-
     TabbedPage BuildMenuTabbedPage()
     {
         var tp = new TabbedPage
@@ -112,7 +92,6 @@ public partial class LAvenirAppPage : UserControl
             VerticalAlignment = VerticalAlignment.Center,
             TextAlignment     = TextAlignment.Center,
         };
-        ApplyRootNavigationBarAppearance();
 
         NavigationPage.SetTopCommandBar(tp, new Button
         {
@@ -140,7 +119,7 @@ public partial class LAvenirAppPage : UserControl
             Content    = menuView,
             Background = new SolidColorBrush(BgLight),
             Header     = "Menu",
-            Icon       = Geometry.Parse("M11 9H9V2H7v7H5V2H3v7c0 2.12 1.66 3.84 3.75 3.97V22h2.5v-9.03C11.34 12.84 13 11.12 13 9V2h-2v7zm5-3v8h2.5v8H21V2c-2.76 0-5 2.24-5 4z"),
+            Icon       = new PathIcon { Data = Geometry.Parse("M11 9H9V2H7v7H5V2H3v7c0 2.12 1.66 3.84 3.75 3.97V22h2.5v-9.03C11.34 12.84 13 11.12 13 9V2h-2v7zm5-3v8h2.5v8H21V2c-2.76 0-5 2.24-5 4z") },
         };
 
         var reservationsPage = new ContentPage
@@ -148,7 +127,7 @@ public partial class LAvenirAppPage : UserControl
             Content    = new LAvenirReservationsView(),
             Background = new SolidColorBrush(BgLight),
             Header     = "Reservations",
-            Icon       = Geometry.Parse("M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM9 10H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2z"),
+            Icon       = new PathIcon { Data = Geometry.Parse("M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM9 10H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2z") },
         };
 
         var profilePage = new ContentPage
@@ -156,7 +135,7 @@ public partial class LAvenirAppPage : UserControl
             Content    = new LAvenirProfileView(),
             Background = new SolidColorBrush(BgLight),
             Header     = "Profile",
-            Icon       = Geometry.Parse("M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"),
+            Icon       = new PathIcon { Data = Geometry.Parse("M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z") },
         };
 
         tp.Pages = new ObservableCollection<Page> { menuPage, reservationsPage, profilePage };
@@ -165,8 +144,7 @@ public partial class LAvenirAppPage : UserControl
 
     async void PushDishDetail(string name, string price, string description, string imageFile)
     {
-        if (_navPage == null)
-            return;
+        if (_navPage == null) return;
 
         var detail = new ContentPage
         {
@@ -175,19 +153,22 @@ public partial class LAvenirAppPage : UserControl
             Header     = name,
         };
         NavigationPage.SetBottomCommandBar(detail, BuildFloatingBar(price));
-        detail.Navigating += args =>
-        {
-            if (args.NavigationType == NavigationType.Pop)
-                ApplyRootNavigationBarAppearance();
 
-            return Task.CompletedTask;
+        _navPage.Background = new SolidColorBrush(BgDark);
+        _navPage.Resources["NavigationBarBackground"] = new SolidColorBrush(BgDark);
+        _navPage.Resources["NavigationBarForeground"] = Brushes.White;
+
+        detail.NavigatedFrom += (_, _) =>
+        {
+            if (_navPage != null)
+            {
+                _navPage.Background = new SolidColorBrush(BgLight);
+                _navPage.Resources["NavigationBarBackground"] = new SolidColorBrush(BgLight);
+                _navPage.Resources["NavigationBarForeground"] = new SolidColorBrush(TextDark);
+            }
         };
 
-        ApplyDetailNavigationBarAppearance();
         await _navPage.PushAsync(detail);
-
-        if (!ReferenceEquals(_navPage.CurrentPage, detail))
-            ApplyRootNavigationBarAppearance();
     }
 
     Border BuildFloatingBar(string price)

--- a/samples/ControlCatalog/Pages/NavigationPage/PulseAppPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/NavigationPage/PulseAppPage.xaml.cs
@@ -99,7 +99,7 @@ public partial class PulseAppPage : UserControl
             Content    = homeView,
             Background = new SolidColorBrush(BgDashboard),
             Header     = "Home",
-            Icon       = Geometry.Parse("M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"),
+            Icon       = new PathIcon { Data = Geometry.Parse("M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z") },
         };
 
         var workoutsPage = new ContentPage
@@ -107,7 +107,7 @@ public partial class PulseAppPage : UserControl
             Content    = new PulseWorkoutsView(),
             Background = new SolidColorBrush(BgDashboard),
             Header     = "Workouts",
-            Icon       = Geometry.Parse("M20.57 14.86L22 13.43 20.57 12 17 15.57 8.43 7 12 3.43 10.57 2 9.14 3.43 7.71 2 5.57 4.14 4.14 2.71 2.71 4.14l1.43 1.43L2 7.71l1.43 1.43L2 10.57 3.43 12 7 8.43 15.57 17 12 20.57 13.43 22l1.43-1.43L16.29 22l2.14-2.14 1.43 1.43 1.43-1.43-1.43-1.43L22 16.29z"),
+            Icon       = new PathIcon { Data = Geometry.Parse("M20.57 14.86L22 13.43 20.57 12 17 15.57 8.43 7 12 3.43 10.57 2 9.14 3.43 7.71 2 5.57 4.14 4.14 2.71 2.71 4.14l1.43 1.43L2 7.71l1.43 1.43L2 10.57 3.43 12 7 8.43 15.57 17 12 20.57 13.43 22l1.43-1.43L16.29 22l2.14-2.14 1.43 1.43 1.43-1.43-1.43-1.43L22 16.29z") },
         };
 
         var profilePage = new ContentPage
@@ -115,7 +115,7 @@ public partial class PulseAppPage : UserControl
             Content    = new PulseProfileView(),
             Background = new SolidColorBrush(BgDashboard),
             Header     = "Profile",
-            Icon       = Geometry.Parse("M12 2C9.243 2 7 4.243 7 7s2.243 5 5 5 5-2.243 5-5-2.243-5-5-5zM12 14c-5.523 0-10 3.582-10 8a1 1 0 001 1h18a1 1 0 001-1c0-4.418-4.477-8-10-8z"),
+            Icon       = new PathIcon { Data = Geometry.Parse("M12 2C9.243 2 7 4.243 7 7s2.243 5 5 5 5-2.243 5-5-2.243-5-5-5zM12 14c-5.523 0-10 3.582-10 8a1 1 0 001 1h18a1 1 0 001-1c0-4.418-4.477-8-10-8z") },
         };
 
         tp.Pages = new ObservableCollection<Page> { homePage, workoutsPage, profilePage };

--- a/samples/ControlCatalog/Pages/NavigationPage/RetroGamingAppPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/NavigationPage/RetroGamingAppPage.xaml.cs
@@ -51,30 +51,11 @@ public partial class RetroGamingAppPage : UserControl
             _infoPanel.IsVisible = Bounds.Width >= 650;
     }
 
-    void ApplyHomeNavigationBarAppearance()
-    {
-        if (_nav == null)
-            return;
-
-        _nav.Resources["NavigationBarBackground"] = new SolidColorBrush(SurfaceColor);
-        _nav.Resources["NavigationBarForeground"] = new SolidColorBrush(CyanColor);
-    }
-
-    void ApplyDetailNavigationBarAppearance()
-    {
-        if (_nav == null)
-            return;
-
-        _nav.Resources["NavigationBarBackground"] = Brushes.Transparent;
-        _nav.Resources["NavigationBarForeground"] = new SolidColorBrush(CyanColor);
-    }
-
     ContentPage BuildHomePage()
     {
         var page = new ContentPage { Background = new SolidColorBrush(BgColor) };
         page.Header = BuildPixelArcadeLogo();
         NavigationPage.SetTopCommandBar(page, BuildNavBarRight());
-        ApplyHomeNavigationBarAppearance();
 
         var panel = new Panel();
         panel.Children.Add(BuildHomeTabbedPage());
@@ -193,7 +174,7 @@ public partial class RetroGamingAppPage : UserControl
         var homeTab = new ContentPage
         {
             Header     = "Home",
-            Icon       = Geometry.Parse("M10,20V14H14V20H19V12H22L12,3L2,12H5V20H10Z"),
+            Icon       = new PathIcon { Data = Geometry.Parse("M10,20V14H14V20H19V12H22L12,3L2,12H5V20H10Z") },
             Background = new SolidColorBrush(BgColor),
             Content    = homeView,
         };
@@ -204,7 +185,7 @@ public partial class RetroGamingAppPage : UserControl
         var gamesTab = new ContentPage
         {
             Header     = "Games",
-            Icon       = Geometry.Parse("M7.97,16L5,19C4.67,19.3 4.23,19.5 3.75,19.5A1.75,1.75 0 0,1 2,17.75V17.5L3,10.12C3.21,7.81 5.14,6 7.5,6H16.5C18.86,6 20.79,7.81 21,10.12L22,17.5V17.75A1.75,1.75 0 0,1 20.25,19.5C19.77,19.5 19.33,19.3 19,19L16.03,16H7.97M7,9V11H5V13H7V15H9V13H11V11H9V9H7M14.5,12A1.5,1.5 0 0,0 13,13.5A1.5,1.5 0 0,0 14.5,15A1.5,1.5 0 0,0 16,13.5A1.5,1.5 0 0,0 14.5,12M17.5,9A1.5,1.5 0 0,0 16,10.5A1.5,1.5 0 0,0 17.5,12A1.5,1.5 0 0,0 19,10.5A1.5,1.5 0 0,0 17.5,9Z"),
+            Icon       = new PathIcon { Data = Geometry.Parse("M7.97,16L5,19C4.67,19.3 4.23,19.5 3.75,19.5A1.75,1.75 0 0,1 2,17.75V17.5L3,10.12C3.21,7.81 5.14,6 7.5,6H16.5C18.86,6 20.79,7.81 21,10.12L22,17.5V17.75A1.75,1.75 0 0,1 20.25,19.5C19.77,19.5 19.33,19.3 19,19L16.03,16H7.97M7,9V11H5V13H7V15H9V13H11V11H9V9H7M14.5,12A1.5,1.5 0 0,0 13,13.5A1.5,1.5 0 0,0 14.5,15A1.5,1.5 0 0,0 16,13.5A1.5,1.5 0 0,0 14.5,12M17.5,9A1.5,1.5 0 0,0 16,10.5A1.5,1.5 0 0,0 17.5,12A1.5,1.5 0 0,0 19,10.5A1.5,1.5 0 0,0 17.5,9Z") },
             Background = new SolidColorBrush(BgColor),
             Content    = gamesView,
         };
@@ -212,7 +193,7 @@ public partial class RetroGamingAppPage : UserControl
         var favTab = new ContentPage
         {
             Header     = "Favorites",
-            Icon       = Geometry.Parse("M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"),
+            Icon       = new PathIcon { Data = Geometry.Parse("M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z") },
             Background = new SolidColorBrush(BgColor),
             Content    = new RetroGamingFavoritesView(),
         };
@@ -220,7 +201,7 @@ public partial class RetroGamingAppPage : UserControl
         var profileTab = new ContentPage
         {
             Header     = "Profile",
-            Icon       = Geometry.Parse("M12,4A4,4 0 0,1 16,8A4,4 0 0,1 12,12A4,4 0 0,1 8,8A4,4 0 0,1 12,4M12,14C16.42,14 20,15.79 20,18V20H4V18C4,15.79 7.58,14 12,14Z"),
+            Icon       = new PathIcon { Data = Geometry.Parse("M12,4A4,4 0 0,1 16,8A4,4 0 0,1 12,12A4,4 0 0,1 8,8A4,4 0 0,1 12,4M12,14C16.42,14 20,15.79 20,18V20H4V18C4,15.79 7.58,14 12,14Z") },
             Background = new SolidColorBrush(BgColor),
             Content    = new RetroGamingProfileView(),
         };
@@ -279,8 +260,7 @@ public partial class RetroGamingAppPage : UserControl
 
     async void PushDetailPage(string gameTitle)
     {
-        if (_nav == null)
-            return;
+        if (_nav == null) return;
 
         var detailView = new RetroGamingDetailView(gameTitle);
 
@@ -291,13 +271,8 @@ public partial class RetroGamingAppPage : UserControl
         };
 
         NavigationPage.SetBarLayoutBehavior(page, BarLayoutBehavior.Overlay);
-        page.Navigating += args =>
-        {
-            if (args.NavigationType == NavigationType.Pop)
-                ApplyHomeNavigationBarAppearance();
-
-            return Task.CompletedTask;
-        };
+        page.NavigatedTo   += (_, _) => { if (_nav != null) _nav.Resources["NavigationBarBackground"] = Brushes.Transparent; };
+        page.NavigatedFrom += (_, _) => { if (_nav != null) _nav.Resources["NavigationBarBackground"] = new SolidColorBrush(SurfaceColor); };
 
         var cmdBar = new StackPanel
         {
@@ -326,10 +301,6 @@ public partial class RetroGamingAppPage : UserControl
         cmdBar.Children.Add(shareBtn);
         NavigationPage.SetTopCommandBar(page, cmdBar);
 
-        ApplyDetailNavigationBarAppearance();
         await _nav.PushAsync(page);
-
-        if (!ReferenceEquals(_nav.CurrentPage, page))
-            ApplyHomeNavigationBarAppearance();
     }
 }

--- a/src/Avalonia.Controls/TabItem.cs
+++ b/src/Avalonia.Controls/TabItem.cs
@@ -146,6 +146,25 @@ namespace Avalonia.Controls
 
         protected bool UpdateSelectionFromEvent(RoutedEventArgs e) => SelectingItemsControl.ItemsControlFromItemContainer(this)?.UpdateSelectionFromEvent(this, e) ?? false;
 
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+            if (change.Property == ForegroundProperty || change.Property == IconProperty)
+                UpdateIconForeground();
+        }
+
+        private void UpdateIconForeground()
+        {
+            if (Icon is IconElement icon)
+            {
+                var fg = Foreground;
+                if (fg != null)
+                    icon.SetValue(ForegroundProperty, fg);
+                else
+                    icon.ClearValue(ForegroundProperty);
+            }
+        }
+
         private void UpdateHeader(AvaloniaPropertyChangedEventArgs obj)
         {
             if (Header == null)


### PR DESCRIPTION
## What does the pull request do?
This PR fixes an issue related to `TabbedPage` icon in samples introduced after `TabItem.Icon` was widened to `object?` in #20939.

Fixes several samples that were assigning raw `Geometry` / `StreamGeometry` values directly to `object?` icon properties such as `Page.Icon` and `DrawerPage.DrawerIcon`, which caused the UI to render text like `Ava...` instead of an actual icon. 
Updated all affected samples to use `PathIcon` explicitly.

![fix-tabbedpage-customization](https://github.com/user-attachments/assets/c607f905-829b-46ce-b76e-674983894a73)

![fix-tabbedpage-samples-icon](https://github.com/user-attachments/assets/66b2d462-2891-4671-a43e-5288c68b913a)

## What is the current behavior?

**Some icons render as text instead of graphics** . Several samples assign raw `Geometry.Parse(...)` or  StreamGeometry` objects directly to icon properties typed as `object?`. Since `ContentPresenter` has no DataTemplate` for `Geometry`, it falls back to rendering `ToString()`, resulting in visible text such as `Avalonia.Media.PathGeometry` or truncated text like `Ava...`.

## What is the updated/expected behavior with this PR?

With this PR:
- `TabItem` icons now correctly follow the effective tab foreground, including selected and unselected states.
- Geometry-based icons are now wrapped in `PathIcon`, which matches the expected object-based icon usage.

### How to test

- Run the affected navigation and drawer samples.
- Verify that `TabbedPage` icons change color together with the tab foreground when selection changes.
- Verify that icons are rendered visually.

## How was the solution implemented (if it's not obvious)?

`src/Avalonia.Controls/TabItem.cs` was updated to add `UpdateIconForeground()` and invoke it when either `ForegroundProperty` or `IconProperty` changes. This follows the same approach already used by `AppBarButton`: the icon foreground is pushed using `SetValue` at **LocalValue** priority, which correctly overrides the `PathIcon` theme setter applied at Style priority.

All affected sample files were updated so raw geometry values are no longer assigned directly to `object?` icon properties. Instead, icons are now wrapped explicitly using:
- `new PathIcon { Data = ... }` in C#
- `<PathIcon Data="..." />` in XAML

In `DrawerPage/EcoTrackerAppPage.xaml`, the previous `StreamGeometry` + `DrawerIconTemplate` workaround was replaced with `PathIcon` directly.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Related to #20939