### PR TITLE
Combine Ready/Corrupted into a single passthrough struct

### DIFF
--- a/api/Avalonia.Skia.nupkg.xml
+++ b/api/Avalonia.Skia.nupkg.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
@@ -63,6 +63,18 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Skia.ISkiaGpuRenderTarget.get_IsCorrupted</Target>
+    <Left>baseline/Avalonia.Skia/lib/net10.0/Avalonia.Skia.dll</Left>
+    <Right>current/Avalonia.Skia/lib/net10.0/Avalonia.Skia.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Skia.ISkiaGpuRenderTarget.get_IsReady</Target>
+    <Left>baseline/Avalonia.Skia/lib/net10.0/Avalonia.Skia.dll</Left>
+    <Right>current/Avalonia.Skia/lib/net10.0/Avalonia.Skia.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Skia.Helpers.DrawingContextHelper.WrapSkiaCanvas(SkiaSharp.SKCanvas,Avalonia.Vector)</Target>
     <Left>baseline/Avalonia.Skia/lib/net8.0/Avalonia.Skia.dll</Left>
     <Right>current/Avalonia.Skia/lib/net8.0/Avalonia.Skia.dll</Right>
@@ -82,6 +94,18 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Skia.ISkiaGpuRenderTarget.BeginRenderingSession(System.Nullable{Avalonia.PixelSize})</Target>
+    <Left>baseline/Avalonia.Skia/lib/net8.0/Avalonia.Skia.dll</Left>
+    <Right>current/Avalonia.Skia/lib/net8.0/Avalonia.Skia.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Skia.ISkiaGpuRenderTarget.get_IsCorrupted</Target>
+    <Left>baseline/Avalonia.Skia/lib/net8.0/Avalonia.Skia.dll</Left>
+    <Right>current/Avalonia.Skia/lib/net8.0/Avalonia.Skia.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Skia.ISkiaGpuRenderTarget.get_IsReady</Target>
     <Left>baseline/Avalonia.Skia/lib/net8.0/Avalonia.Skia.dll</Left>
     <Right>current/Avalonia.Skia/lib/net8.0/Avalonia.Skia.dll</Right>
   </Suppression>

--- a/api/Avalonia.Win32.nupkg.xml
+++ b/api/Avalonia.Win32.nupkg.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Win32.DirectX.IDirect3D11TextureRenderTarget.get_IsCorrupted</Target>
+    <Left>baseline/Avalonia.Win32/lib/net10.0/Avalonia.Win32.dll</Left>
+    <Right>current/Avalonia.Win32/lib/net10.0/Avalonia.Win32.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Win32.DirectX.IDirect3D11TextureRenderTarget.get_IsCorrupted</Target>
+    <Left>baseline/Avalonia.Win32/lib/net8.0/Avalonia.Win32.dll</Left>
+    <Right>current/Avalonia.Win32/lib/net8.0/Avalonia.Win32.dll</Right>
+  </Suppression>
+</Suppressions>

--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -1695,7 +1695,25 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.IRenderTarget.get_IsCorrupted</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.IRenderTarget.get_IsReady</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Platform.LockedFramebuffer.#ctor(System.IntPtr,Avalonia.PixelSize,System.Int32,Avalonia.Vector,Avalonia.Platform.PixelFormat,System.Action)</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.Surfaces.IPlatformRenderSurfaceRenderTarget.get_IsReady</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
   </Suppression>
@@ -2589,6 +2607,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.OpenGL.Surfaces.IGlPlatformSurfaceRenderTarget.get_IsCorrupted</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.OpenGL.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.OpenGL.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Vulkan.IVulkanKhrSurfacePlatformSurfaceFactory.CanRenderToSurface(Avalonia.Vulkan.IVulkanPlatformGraphicsContext,System.Object)</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Vulkan.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Vulkan.dll</Right>
@@ -3369,7 +3393,25 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.IRenderTarget.get_IsCorrupted</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.IRenderTarget.get_IsReady</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Platform.LockedFramebuffer.#ctor(System.IntPtr,Avalonia.PixelSize,System.Int32,Avalonia.Vector,Avalonia.Platform.PixelFormat,System.Action)</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.Surfaces.IPlatformRenderSurfaceRenderTarget.get_IsReady</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
   </Suppression>
@@ -4264,6 +4306,12 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.OpenGL.Surfaces.IGlPlatformSurfaceRenderTarget.BeginDraw(System.Nullable{Avalonia.PixelSize})</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.OpenGL.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.OpenGL.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.OpenGL.Surfaces.IGlPlatformSurfaceRenderTarget.get_IsCorrupted</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.OpenGL.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.OpenGL.dll</Right>
   </Suppression>

--- a/src/Avalonia.Base/Platform/IRenderTarget.cs
+++ b/src/Avalonia.Base/Platform/IRenderTarget.cs
@@ -13,11 +13,6 @@ namespace Avalonia.Platform
     public interface IRenderTarget : IDisposable
     {
         /// <summary>
-        /// Indicates if the render target is no longer usable and needs to be recreated
-        /// </summary>
-        bool IsCorrupted { get; }
-
-        /// <summary>
         /// Gets the properties of the render target.
         /// </summary>
         RenderTargetProperties Properties { get; }
@@ -33,9 +28,9 @@ namespace Avalonia.Platform
         IDrawingContextImpl CreateDrawingContext(RenderTargetSceneInfo sceneInfo, out RenderTargetDrawingContextProperties properties);
 
         /// <summary>
-        /// Indicates if the render target is currently ready to be rendered to
+        /// Gets the current readiness state of the render target.
         /// </summary>
-        bool IsReady => true;
+        PlatformRenderTargetState PlatformRenderTargetState => PlatformRenderTargetState.Ready;
         
         public record struct RenderTargetSceneInfo(PixelSize Size, double Scaling);
     }

--- a/src/Avalonia.Base/Platform/RenderTargetProperties.cs
+++ b/src/Avalonia.Base/Platform/RenderTargetProperties.cs
@@ -3,6 +3,36 @@ using Avalonia.Metadata;
 
 namespace Avalonia.Platform;
 
+/// <summary>
+/// Describes the current readiness state of a platform render target.
+/// Flows through the entire rendering pipeline from platform to compositor.
+/// </summary>
+[PrivateApi]
+[SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Private API, not meant to be compared")]
+public readonly struct PlatformRenderTargetState
+{
+    /// <summary>
+    /// Indicates if the render target is currently ready to be rendered to.
+    /// </summary>
+    public bool IsReady { get; init; }
+    
+    /// <summary>
+    /// Indicates if the render target is no longer usable and needs to be recreated
+    /// </summary>
+    public bool IsCorrupted { get; init; }
+    
+    /// <summary>
+    /// A readiness state indicating the target is ready to render.
+    /// </summary>
+    public static PlatformRenderTargetState Ready => new() { IsReady = true };
+
+    public static PlatformRenderTargetState NotReadyTryLater => default;
+    
+    public static PlatformRenderTargetState Corrupted => new() { IsCorrupted = true, IsReady = true};
+
+    public static PlatformRenderTargetState Disposed => new() { IsCorrupted = true};
+}
+
 [PrivateApi]
 [SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Private API, not meant to be compared")]
 public struct RenderTargetProperties

--- a/src/Avalonia.Base/Platform/Surfaces/IPlatformRenderSurface.cs
+++ b/src/Avalonia.Base/Platform/Surfaces/IPlatformRenderSurface.cs
@@ -11,5 +11,5 @@ public interface IPlatformRenderSurface
 [PrivateApi]
 public interface IPlatformRenderSurfaceRenderTarget
 {
-    bool IsReady => true;
+    PlatformRenderTargetState State => PlatformRenderTargetState.Ready;
 }

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -138,7 +138,7 @@ namespace Avalonia.Rendering.Composition.Server
             if (Root == null) 
                 return;
 
-            if (_renderTarget?.IsCorrupted == true)
+            if (_renderTarget?.PlatformRenderTargetState.IsCorrupted == true)
             {
                 _layer?.Dispose();
                 _layer = null;
@@ -178,7 +178,7 @@ namespace Avalonia.Rendering.Composition.Server
             if (!_redrawRequested)
                 return;
             
-            if (!_renderTarget.IsReady)
+            if (!_renderTarget.PlatformRenderTargetState.IsReady)
             {
                 IsWaitingForReadyRenderTarget = IsEnabled;
                 return;

--- a/src/Avalonia.Native/AvaloniaNativeGlPlatformGraphics.cs
+++ b/src/Avalonia.Native/AvaloniaNativeGlPlatformGraphics.cs
@@ -173,7 +173,7 @@ namespace Avalonia.Native
             _context = context;
         }
 
-        public bool IsCorrupted => false;
+        public PlatformRenderTargetState State => PlatformRenderTargetState.Ready;
 
         public IGlPlatformSurfaceRenderingSession BeginDraw(IRenderTarget.RenderTargetSceneInfo sceneInfo)
         {

--- a/src/Avalonia.OpenGL/Egl/EglGlPlatformSurfaceBase.cs
+++ b/src/Avalonia.OpenGL/Egl/EglGlPlatformSurfaceBase.cs
@@ -110,6 +110,9 @@ namespace Avalonia.OpenGL.Egl
             public bool IsYFlipped { get; }
         }
 
+        public virtual PlatformRenderTargetState State =>
+            IsCorrupted ? PlatformRenderTargetState.Corrupted : PlatformRenderTargetState.Ready;
+        
         public virtual bool IsCorrupted => Context.IsLost;
     }
 }

--- a/src/Avalonia.OpenGL/Surfaces/IGlPlatformSurfaceRenderTarget.cs
+++ b/src/Avalonia.OpenGL/Surfaces/IGlPlatformSurfaceRenderTarget.cs
@@ -8,7 +8,6 @@ namespace Avalonia.OpenGL.Surfaces
     [PrivateApi]
     public interface IGlPlatformSurfaceRenderTarget : IDisposable, IPlatformRenderSurfaceRenderTarget
     {
-        bool IsCorrupted { get; }
         IGlPlatformSurfaceRenderingSession BeginDraw(IRenderTarget.RenderTargetSceneInfo sceneInfo);
     }
 }

--- a/src/Avalonia.Vulkan/VulkanKhrSurfaceRenderTarget.cs
+++ b/src/Avalonia.Vulkan/VulkanKhrSurfaceRenderTarget.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia.Platform;
 using Avalonia.Vulkan.Interop;
 using Avalonia.Vulkan.UnmanagedInterop;
 
@@ -26,6 +27,8 @@ internal class VulkanKhrRenderTarget : IVulkanRenderTarget
         Format = IsRgba ? VkFormat.VK_FORMAT_R8G8B8A8_UNORM : VkFormat.VK_FORMAT_B8G8R8A8_UNORM;
     }
 
+    public PlatformRenderTargetState State => PlatformRenderTargetState.Ready;
+    
     private void CreateImage()
     {
         _image = new VulkanImage(_context, _display.CommandBufferPool, Format, _display.Size);

--- a/src/Avalonia.X11/Glx/GlxGlPlatformSurface.cs
+++ b/src/Avalonia.X11/Glx/GlxGlPlatformSurface.cs
@@ -39,7 +39,7 @@ namespace Avalonia.X11.Glx
                 // No-op
             }
             
-            public bool IsCorrupted => false;
+            public PlatformRenderTargetState State => PlatformRenderTargetState.Ready;
             public IGlPlatformSurfaceRenderingSession BeginDraw(IRenderTarget.RenderTargetSceneInfo sceneInfo)
             {
                 var size = sceneInfo.Size;

--- a/src/Headless/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
@@ -608,8 +608,6 @@ namespace Avalonia.Headless
                 properties = default;
                 return new HeadlessDrawingContextStub();
             }
-
-            public bool IsCorrupted => false;
         }
 
         public void Dispose()

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
@@ -407,7 +407,7 @@ namespace Avalonia.LinuxFramebuffer.Output
                 _parent = parent;
             }
 
-            public bool IsCorrupted => false;
+            public PlatformRenderTargetState State => PlatformRenderTargetState.Ready;
 
             public void Dispose()
             {

--- a/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
@@ -47,8 +47,8 @@ namespace Avalonia.Skia
             IsSuitableForDirectRendering = true
         };
 
-
-
+        public PlatformRenderTargetState PlatformRenderTargetState =>
+            _renderTarget?.State ?? PlatformRenderTargetState.Disposed;
 
         /// <inheritdoc />
         public IDrawingContextImpl CreateDrawingContext(IRenderTarget.RenderTargetSceneInfo sceneInfo,
@@ -86,10 +86,7 @@ namespace Avalonia.Skia
             
             return new DrawingContextImpl(createInfo, _preFramebufferCopyHandler, canvas, framebuffer);
         }
-
-        public bool IsCorrupted => false;
-
-        public bool IsReady => _renderTarget is not IPlatformRenderSurfaceRenderTarget prs || prs.IsReady;
+        
 
         /// <summary>
         /// Check if two images info are compatible.

--- a/src/Skia/Avalonia.Skia/Gpu/ISkiaGpuRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/ISkiaGpuRenderTarget.cs
@@ -15,8 +15,6 @@ namespace Avalonia.Skia
         /// <returns>A render session instance.</returns>
         ISkiaGpuRenderSession BeginRenderingSession(IRenderTarget.RenderTargetSceneInfo sceneInfo);
         
-        bool IsCorrupted { get; }
-        
-        bool IsReady => true;
+        PlatformRenderTargetState State => PlatformRenderTargetState.Ready;
     }
 }

--- a/src/Skia/Avalonia.Skia/Gpu/Metal/SkiaMetalGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/Metal/SkiaMetalGpu.cs
@@ -108,9 +108,7 @@ internal class SkiaMetalGpu : ISkiaGpu
             return new SkiaMetalRenderSession(_gpu, surface, session, backendTarget);
         }
 
-        public bool IsCorrupted => false;
-
-        public bool IsReady => _target?.IsReady ?? false;
+        public PlatformRenderTargetState State => _target?.State ?? PlatformRenderTargetState.Disposed;
     }
     
     internal class SkiaMetalRenderSession : ISkiaGpuRenderSession

--- a/src/Skia/Avalonia.Skia/Gpu/OpenGl/GlRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/OpenGl/GlRenderTarget.cs
@@ -21,9 +21,7 @@ namespace Avalonia.Skia
 
         public void Dispose() => _surface.Dispose();
 
-        public bool IsCorrupted => _surface.IsCorrupted;
-
-        public bool IsReady => _surface.IsReady;
+        public PlatformRenderTargetState State => _surface.State;
 
         class GlGpuSession : ISkiaGpuRenderSession
         {

--- a/src/Skia/Avalonia.Skia/Gpu/SkiaGpuRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/SkiaGpuRenderTarget.cs
@@ -43,9 +43,8 @@ namespace Avalonia.Skia
 
             return new DrawingContextImpl(nfo, session);
         }
-
-        public bool IsCorrupted => _renderTarget.IsCorrupted;
-        public bool IsReady => _renderTarget.IsReady;
+        
+        public PlatformRenderTargetState PlatformRenderTargetState => _renderTarget.State;
         public RenderTargetProperties Properties { get; }
 
 

--- a/src/Skia/Avalonia.Skia/Gpu/Vulkan/VulkanSkiaRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/Vulkan/VulkanSkiaRenderTarget.cs
@@ -74,9 +74,7 @@ class VulkanSkiaRenderTarget : ISkiaGpuRenderTarget
         }
     }
    
-    public bool IsCorrupted => false;
-
-    public bool IsReady => _target.IsReady;
+    public PlatformRenderTargetState State => _target.State;
 
 
     internal class VulkanSkiaRenderSession : ISkiaGpuRenderSession

--- a/src/Windows/Avalonia.Win32/DComposition/DirectCompositedWindowSurface.cs
+++ b/src/Windows/Avalonia.Win32/DComposition/DirectCompositedWindowSurface.cs
@@ -78,11 +78,11 @@ internal class DirectCompositedWindowRenderTarget : IDirect3D11TextureRenderTarg
         _d3dDevice.Dispose();
     }
 
-    public bool IsCorrupted => _context.IsLost || _lost;
-
+    public PlatformRenderTargetState State => _context.IsLost || _lost ? PlatformRenderTargetState.Corrupted : PlatformRenderTargetState.Ready;
+    
     public unsafe IDirect3D11TextureRenderTargetRenderSession BeginDraw()
     {
-        if (IsCorrupted)
+        if (State.IsCorrupted)
             throw new RenderTargetCorruptedException();
         var transaction = _window.BeginTransaction();
         bool needsEndDraw = false;

--- a/src/Windows/Avalonia.Win32/DirectX/IDirect3D11TexturePlatformSurface.cs
+++ b/src/Windows/Avalonia.Win32/DirectX/IDirect3D11TexturePlatformSurface.cs
@@ -1,5 +1,6 @@
 using System;
 using Avalonia.OpenGL;
+using Avalonia.OpenGL.Surfaces;
 using Avalonia.Platform;
 using Avalonia.Platform.Surfaces;
 
@@ -12,9 +13,8 @@ public interface IDirect3D11TexturePlatformSurface : IPlatformRenderSurface
 
 
 
-public interface IDirect3D11TextureRenderTarget : IDisposable
+public interface IDirect3D11TextureRenderTarget : IPlatformRenderSurfaceRenderTarget, IDisposable
 {
-    bool IsCorrupted { get; }
     IDirect3D11TextureRenderTargetRenderSession BeginDraw();
 }
 

--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleD3DTextureFeature.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleD3DTextureFeature.cs
@@ -83,7 +83,8 @@ internal class AngleD3DTextureFeature  : IGlPlatformSurfaceRenderTargetFactory
             base.Dispose();
         }
 
-        public override bool IsCorrupted => _target.IsCorrupted || base.IsCorrupted;
+        public override PlatformRenderTargetState State =>
+            base.IsCorrupted ? PlatformRenderTargetState.Corrupted : _target.State;
     }
     
     public IGlPlatformSurfaceRenderTarget CreateRenderTarget(IGlContext context, IPlatformRenderSurface surface)

--- a/src/Windows/Avalonia.Win32/OpenGl/WglGlPlatformSurface.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/WglGlPlatformSurface.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Win32.OpenGl
                 _hdc = context.CreateConfiguredDeviceContext(info.Handle);
             }
 
-            public bool IsCorrupted => false;
+            public PlatformRenderTargetState State => PlatformRenderTargetState.Ready;
 
             public void Dispose()
             {

--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositedWindowSurface.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositedWindowSurface.cs
@@ -114,11 +114,12 @@ namespace Avalonia.Win32.WinRT.Composition
             _d3dDevice.Dispose();
         }
 
-        public bool IsCorrupted => _context.IsLost || _lost;
+        public PlatformRenderTargetState State =>
+            _context.IsLost || _lost ? PlatformRenderTargetState.Corrupted : PlatformRenderTargetState.Ready;
 
         public unsafe IDirect3D11TextureRenderTargetRenderSession BeginDraw()
         {
-            if (IsCorrupted)
+            if (State.IsCorrupted)
                 throw new RenderTargetCorruptedException();
             var transaction = _window.BeginTransaction();
             bool needsEndDraw = false;


### PR DESCRIPTION
Replaced IsReady/IsCorrupted from IRenderTarget and replaced with a single struct.

This should streamline passing state from platform surfaces through Skia and other platform backends later.