### PR TITLE
Expose allowed titlebar button actions from the platform implementation and respect them from drawn decorations

### DIFF
--- a/src/Avalonia.Controls/Chrome/WindowDrawnDecorations.cs
+++ b/src/Avalonia.Controls/Chrome/WindowDrawnDecorations.cs
@@ -1,6 +1,7 @@
 using System;
 using Avalonia.Automation;
 using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;
 using Avalonia.Layout;
 using Avalonia.LogicalTree;
@@ -15,7 +16,8 @@ namespace Avalonia.Controls.Chrome;
 /// TopLevelHost extracts overlay/underlay/popover visuals from the template content
 /// and inserts them into its own visual tree.
 /// </summary>
-[PseudoClasses(pcNormal, pcMaximized, pcFullscreen, pcHasShadow, pcHasBorder, pcHasTitlebar)]
+[PseudoClasses(pcNormal, pcMaximized, pcFullscreen, pcHasShadow, pcHasBorder, pcHasTitlebar,
+    pcHasMaximize, pcHasFullscreen, pcHasMinimize)]
 [TemplatePart(PART_CloseButton, typeof(Button))]
 [TemplatePart(PART_MinimizeButton, typeof(Button))]
 [TemplatePart(PART_MaximizeButton, typeof(Button))]
@@ -31,6 +33,9 @@ public class WindowDrawnDecorations : StyledElement
     internal const string pcHasShadow = ":has-shadow";
     internal const string pcHasBorder = ":has-border";
     internal const string pcHasTitlebar = ":has-titlebar";
+    internal const string pcHasMaximize = ":has-maximize";
+    internal const string pcHasFullscreen = ":has-fullscreen";
+    internal const string pcHasMinimize = ":has-minimize";
 
     // Template part names for caption buttons
     internal const string PART_CloseButton = "PART_CloseButton";
@@ -383,8 +388,11 @@ public class WindowDrawnDecorations : StyledElement
         Detach();
         _hostWindow = window;
 
+        window.AllowedWindowActionsChanged += OnAllowedWindowActionsChanged;
+
         _windowSubscriptions = new CompositeDisposable
         {
+            Disposable.Create(() => window.AllowedWindowActionsChanged -= OnAllowedWindowActionsChanged),
             window.GetObservable(Window.TitleProperty)
                 .Subscribe(title => SetCurrentValue(TitleProperty, title)),
             window.GetObservable(Window.CanMaximizeProperty)
@@ -407,6 +415,7 @@ public class WindowDrawnDecorations : StyledElement
                 }),
         };
 
+        UpdateAllowedActionsPseudoClasses();
         UpdateMaximizeButtonState();
         UpdateMinimizeButtonState();
         UpdateFullScreenButtonState();
@@ -547,32 +556,54 @@ public class WindowDrawnDecorations : StyledElement
         e.Handled = true;
     }
 
+    private PlatformAllowedWindowActions EffectiveAllowedActions =>
+        _hostWindow?.AllowedWindowActions ?? PlatformAllowedWindowActions.All;
+
     private void UpdateMaximizeButtonState()
     {
         if (_maximizeButton == null)
             return;
-        _maximizeButton.IsEnabled = _hostWindow?.WindowState switch
-        {
-            WindowState.Maximized or WindowState.FullScreen => _hostWindow.CanResize,
-            WindowState.Normal => _hostWindow.CanMaximize,
-            _ => true
-        };
+        _maximizeButton.IsEnabled = EffectiveAllowedActions.HasFlag(PlatformAllowedWindowActions.Maximize)
+            && (_hostWindow?.WindowState switch
+            {
+                WindowState.Maximized or WindowState.FullScreen => _hostWindow.CanResize,
+                WindowState.Normal => _hostWindow.CanMaximize,
+                _ => true
+            });
     }
 
     private void UpdateMinimizeButtonState()
     {
         if (_minimizeButton == null)
             return;
-        _minimizeButton.IsEnabled = _hostWindow?.CanMinimize ?? true;
+        _minimizeButton.IsEnabled = EffectiveAllowedActions.HasFlag(PlatformAllowedWindowActions.Minimize)
+            && (_hostWindow?.CanMinimize ?? true);
     }
 
     private void UpdateFullScreenButtonState()
     {
         if (_fullScreenButton == null)
             return;
-        _fullScreenButton.IsEnabled = _hostWindow?.WindowState == WindowState.FullScreen
-            ? _hostWindow.CanResize
-            : _hostWindow?.CanMaximize ?? true;
+        _fullScreenButton.IsEnabled = EffectiveAllowedActions.HasFlag(PlatformAllowedWindowActions.Fullscreen)
+            && (_hostWindow?.WindowState == WindowState.FullScreen
+                ? _hostWindow.CanResize
+                : _hostWindow?.CanMaximize ?? true);
+    }
+
+    private void OnAllowedWindowActionsChanged(PlatformAllowedWindowActions actions)
+    {
+        UpdateAllowedActionsPseudoClasses();
+        UpdateMaximizeButtonState();
+        UpdateMinimizeButtonState();
+        UpdateFullScreenButtonState();
+    }
+
+    private void UpdateAllowedActionsPseudoClasses()
+    {
+        var actions = EffectiveAllowedActions;
+        PseudoClasses.Set(pcHasMaximize, actions.HasFlag(PlatformAllowedWindowActions.Maximize));
+        PseudoClasses.Set(pcHasFullscreen, actions.HasFlag(PlatformAllowedWindowActions.Fullscreen));
+        PseudoClasses.Set(pcHasMinimize, actions.HasFlag(PlatformAllowedWindowActions.Minimize));
     }
 
     private void UpdateEffectiveGeometry()

--- a/src/Avalonia.Controls/Platform/IWindowImpl.cs
+++ b/src/Avalonia.Controls/Platform/IWindowImpl.cs
@@ -162,5 +162,15 @@ namespace Avalonia.Platform
         /// </summary>
         /// <param name="titleBarHeight">-1 for platform default, otherwise the height in DIPs.</param>
         void SetExtendClientAreaTitleBarHeightHint(double titleBarHeight);
+
+        /// <summary>
+        /// Gets the window actions that the underlying platform currently allows.
+        /// </summary>
+        PlatformAllowedWindowActions AllowedWindowActions => PlatformAllowedWindowActions.All;
+
+        /// <summary>
+        /// Gets or sets a callback invoked when <see cref="AllowedWindowActions"/> changes.
+        /// </summary>
+        Action<PlatformAllowedWindowActions>? AllowedWindowActionsChanged { get => null; set { } }
     }
 }

--- a/src/Avalonia.Controls/Platform/PlatformAllowedWindowActions.cs
+++ b/src/Avalonia.Controls/Platform/PlatformAllowedWindowActions.cs
@@ -1,0 +1,33 @@
+using System;
+using Avalonia.Metadata;
+
+namespace Avalonia.Controls.Platform;
+
+/// <summary>
+/// Flags indicating which window actions the underlying platform supports.
+/// </summary>
+[Flags, PrivateApi]
+public enum PlatformAllowedWindowActions
+{
+    None = 0,
+
+    /// <summary>
+    /// The underlying platform supports maximizing/unmaximizing windows.
+    /// </summary>
+    Maximize = 1 << 1,
+
+    /// <summary>
+    /// The underlying platform supports fullscreen mode.
+    /// </summary>
+    Fullscreen = 1 << 2,
+
+    /// <summary>
+    /// The underlying platform supports minimizing windows.
+    /// </summary>
+    Minimize = 1 << 3,
+
+    /// <summary>
+    /// All actions are supported (default when the underlying platform does not report capabilities).
+    /// </summary>
+    All = Maximize | Fullscreen | Minimize,
+}

--- a/src/Avalonia.Controls/Platform/PlatformAllowedWindowActions.cs
+++ b/src/Avalonia.Controls/Platform/PlatformAllowedWindowActions.cs
@@ -14,17 +14,17 @@ public enum PlatformAllowedWindowActions
     /// <summary>
     /// The underlying platform supports maximizing/unmaximizing windows.
     /// </summary>
-    Maximize = 1 << 1,
+    Maximize = 1 << 0,
 
     /// <summary>
     /// The underlying platform supports fullscreen mode.
     /// </summary>
-    Fullscreen = 1 << 2,
+    Fullscreen = 1 << 1,
 
     /// <summary>
     /// The underlying platform supports minimizing windows.
     /// </summary>
-    Minimize = 1 << 3,
+    Minimize = 1 << 2
 
     /// <summary>
     /// All actions are supported (default when the underlying platform does not report capabilities).

--- a/src/Avalonia.Controls/Platform/PlatformAllowedWindowActions.cs
+++ b/src/Avalonia.Controls/Platform/PlatformAllowedWindowActions.cs
@@ -24,7 +24,7 @@ public enum PlatformAllowedWindowActions
     /// <summary>
     /// The underlying platform supports minimizing windows.
     /// </summary>
-    Minimize = 1 << 2
+    Minimize = 1 << 2,
 
     /// <summary>
     /// All actions are supported (default when the underlying platform does not report capabilities).

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -220,6 +220,7 @@ namespace Avalonia.Controls
         private bool _positionWasSet;
         private bool _wasShownBefore;
         private IDisposable? _modalSubscription;
+        private PlatformAllowedWindowActions _allowedWindowActions = PlatformAllowedWindowActions.All;
 
         /// <summary>
         /// Initializes static members of the <see cref="Window"/> class.
@@ -250,6 +251,8 @@ namespace Avalonia.Controls
             impl.WindowStateChanged = HandleWindowStateChanged;
             _maxPlatformClientSize = PlatformImpl?.MaxAutoSizeHint ?? default(Size);
             impl.ExtendClientAreaToDecorationsChanged = ExtendClientAreaToDecorationsChanged;
+            impl.AllowedWindowActionsChanged = OnAllowedWindowActionsChanged;
+            _allowedWindowActions = impl.AllowedWindowActions;
             this.GetObservable(ClientSizeProperty).Skip(1).Subscribe(x =>
             {
                 ResizePlatformImpl(x, WindowResizeReason.Application);
@@ -486,6 +489,11 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
+        /// Gets the window actions currently allowed by the underlying platform.
+        /// </summary>
+        internal PlatformAllowedWindowActions AllowedWindowActions => _allowedWindowActions;
+
+        /// <summary>
         /// Gets or sets the icon of the window.
         /// </summary>
         public WindowIcon? Icon
@@ -671,6 +679,14 @@ namespace Avalonia.Controls
 
             // Update decoration parts and fullscreen popover state for the new window state
             UpdateDrawnDecorationParts();
+        }
+
+        internal event Action<PlatformAllowedWindowActions>? AllowedWindowActionsChanged;
+
+        private void OnAllowedWindowActionsChanged(PlatformAllowedWindowActions actions)
+        {
+            _allowedWindowActions = actions;
+            AllowedWindowActionsChanged?.Invoke(actions);
         }
 
         private void ExtendClientAreaToDecorationsChanged(bool isExtended)

--- a/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
@@ -196,6 +196,20 @@
       <Setter Property="Opacity" Value="0.2"/>
     </Style>
 
+    <!-- Hide caption buttons when the platform does not support the action -->
+    <Style Selector="^:not(:has-minimize) /template/ Button#PART_MinimizeButton">
+      <Setter Property="IsVisible" Value="False"/>
+    </Style>
+    <Style Selector="^:not(:has-maximize) /template/ Button#PART_MaximizeButton">
+      <Setter Property="IsVisible" Value="False"/>
+    </Style>
+    <Style Selector="^:not(:has-fullscreen) /template/ Button#PART_FullScreenButton">
+      <Setter Property="IsVisible" Value="False"/>
+    </Style>
+    <Style Selector="^:not(:has-fullscreen) /template/ Button#PART_PopoverFullScreenButton">
+      <Setter Property="IsVisible" Value="False"/>
+    </Style>
+
     <!-- Fullscreen: hide overlay and titlebar (popover takes over) -->
     <Style Selector="^:fullscreen /template/ Panel#PART_TitleTextPanel">
       <Setter Property="IsVisible" Value="False" />

--- a/src/Avalonia.Themes.Simple/Controls/WindowDrawnDecorations.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/WindowDrawnDecorations.xaml
@@ -202,6 +202,20 @@
       <Setter Property="Opacity" Value="0.2"/>
     </Style>
 
+    <!-- Hide caption buttons when the platform does not support the action -->
+    <Style Selector="^:not(:has-minimize) /template/ Button#PART_MinimizeButton">
+      <Setter Property="IsVisible" Value="False"/>
+    </Style>
+    <Style Selector="^:not(:has-maximize) /template/ Button#PART_MaximizeButton">
+      <Setter Property="IsVisible" Value="False"/>
+    </Style>
+    <Style Selector="^:not(:has-fullscreen) /template/ Button#PART_FullScreenButton">
+      <Setter Property="IsVisible" Value="False"/>
+    </Style>
+    <Style Selector="^:not(:has-fullscreen) /template/ Button#PART_PopoverFullScreenButton">
+      <Setter Property="IsVisible" Value="False"/>
+    </Style>
+
     <!-- Fullscreen: hide overlay and titlebar (popover takes over) -->
     <Style Selector="^:fullscreen /template/ Panel#PART_TitleTextPanel">
       <Setter Property="IsVisible" Value="False" />

--- a/src/Avalonia.X11/X11Atoms.cs
+++ b/src/Avalonia.X11/X11Atoms.cs
@@ -144,6 +144,10 @@ namespace Avalonia.X11
         public IntPtr _NET_WM_WINDOW_TYPE;
         public IntPtr _NET_WM_STATE;
         public IntPtr _NET_WM_ALLOWED_ACTIONS;
+        public IntPtr _NET_WM_ACTION_MAXIMIZE_VERT;
+        public IntPtr _NET_WM_ACTION_MAXIMIZE_HORZ;
+        public IntPtr _NET_WM_ACTION_FULLSCREEN;
+        public IntPtr _NET_WM_ACTION_MINIMIZE;
         public IntPtr _NET_WM_STRUT;
         public IntPtr _NET_WM_STRUT_PARTIAL;
         public IntPtr _NET_WM_ICON_GEOMETRY;

--- a/src/Avalonia.X11/X11Globals.cs
+++ b/src/Avalonia.X11/X11Globals.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Avalonia.Controls.Platform;
 using static Avalonia.X11.XLib;
 
 namespace Avalonia.X11
@@ -17,6 +18,7 @@ namespace Avalonia.X11
         private IntPtr _compositionAtomOwner;
         private bool _isCompositionEnabled;
         private WindowActivationTrackingMode _activationTrackingMode;
+        private PlatformAllowedWindowActions _allowedActions = PlatformAllowedWindowActions.All;
 
         public event Action? WindowManagerChanged;
         public event Action? CompositionChanged;
@@ -24,6 +26,7 @@ namespace Avalonia.X11
         public event Action? NetActiveWindowPropertyChanged;
         public event Action? RootGeometryChangedChanged;
         public event Action? WindowActivationTrackingModeChanged;
+        public event Action? AllowedActionsChanged;
         
         public enum WindowActivationTrackingMode
         {
@@ -101,6 +104,19 @@ namespace Avalonia.X11
                 {
                     _activationTrackingMode = value;
                     WindowActivationTrackingModeChanged?.Invoke();
+                }
+            }
+        }
+
+        public PlatformAllowedWindowActions AllowedActions
+        {
+            get => _allowedActions;
+            private set
+            {
+                if (_allowedActions != value)
+                {
+                    _allowedActions = value;
+                    AllowedActionsChanged?.Invoke();
                 }
             }
         }
@@ -187,17 +203,15 @@ namespace Avalonia.X11
             }
         }
 
-        private WindowActivationTrackingMode GetWindowActivityTrackingMode(IntPtr wm)
+        private WindowActivationTrackingMode GetWindowActivityTrackingMode(IntPtr wm, IntPtr[]? supportedFeatures)
         {
             if (Environment.GetEnvironmentVariable("AVALONIA_DEBUG_FORCE_X11_ACTIVATION_TRACKING_MODE") is
                     { } forcedModeString
                 && Enum.TryParse<WindowActivationTrackingMode>(forcedModeString, true, out var forcedMode))
                 return forcedMode;
             
-            if (wm == IntPtr.Zero)
+            if (wm == IntPtr.Zero || supportedFeatures == null)
                 return WindowActivationTrackingMode.FocusEvents;
-            var supportedFeatures = XGetWindowPropertyAsIntPtrArray(_x11.Display, _x11.RootWindow,
-                _x11.Atoms._NET_SUPPORTED, _x11.Atoms.ATOM) ?? [];
 
             if (supportedFeatures.Contains(_x11.Atoms._NET_WM_STATE_FOCUSED))
                 return WindowActivationTrackingMode._NET_WM_STATE_FOCUSED;
@@ -208,11 +222,36 @@ namespace Avalonia.X11
             return WindowActivationTrackingMode.FocusEvents;
         }
 
+        private static PlatformAllowedWindowActions GetAllowedActions(IntPtr wm, IntPtr[]? supportedFeatures, X11Atoms atoms)
+        {
+            if (wm == IntPtr.Zero || supportedFeatures == null)
+                return PlatformAllowedWindowActions.All;
+
+            var actions = PlatformAllowedWindowActions.None;
+
+            if (supportedFeatures.Contains(atoms._NET_WM_ACTION_MAXIMIZE_VERT)
+                && supportedFeatures.Contains(atoms._NET_WM_ACTION_MAXIMIZE_HORZ))
+                actions |= PlatformAllowedWindowActions.Maximize;
+
+            if (supportedFeatures.Contains(atoms._NET_WM_ACTION_FULLSCREEN))
+                actions |= PlatformAllowedWindowActions.Fullscreen;
+
+            if (supportedFeatures.Contains(atoms._NET_WM_ACTION_MINIMIZE))
+                actions |= PlatformAllowedWindowActions.Minimize;
+
+            return actions;
+        }
+
         private void OnNewWindowManager()
         {
             var wm = GetActiveWm();
+            var supportedFeatures = wm != IntPtr.Zero
+                ? XGetWindowPropertyAsIntPtrArray(_x11.Display, _x11.RootWindow,
+                    _x11.Atoms._NET_SUPPORTED, _x11.Atoms.ATOM)
+                : null;
             WmName = GetWmName(wm);
-            ActivationTrackingMode = GetWindowActivityTrackingMode(wm);
+            ActivationTrackingMode = GetWindowActivityTrackingMode(wm, supportedFeatures);
+            AllowedActions = GetAllowedActions(wm, supportedFeatures, _x11.Atoms);
         }
         
         private void OnRootWindowEvent(ref XEvent ev)

--- a/src/Avalonia.X11/X11Globals.cs
+++ b/src/Avalonia.X11/X11Globals.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Avalonia.Controls.Platform;
 using static Avalonia.X11.XLib;
 
 namespace Avalonia.X11
@@ -18,7 +17,7 @@ namespace Avalonia.X11
         private IntPtr _compositionAtomOwner;
         private bool _isCompositionEnabled;
         private WindowActivationTrackingMode _activationTrackingMode;
-        private PlatformAllowedWindowActions _allowedActions = PlatformAllowedWindowActions.All;
+        private IntPtr[]? _netSupported;
 
         public event Action? WindowManagerChanged;
         public event Action? CompositionChanged;
@@ -26,7 +25,7 @@ namespace Avalonia.X11
         public event Action? NetActiveWindowPropertyChanged;
         public event Action? RootGeometryChangedChanged;
         public event Action? WindowActivationTrackingModeChanged;
-        public event Action? AllowedActionsChanged;
+        public event Action? NetSupportedChanged;
         
         public enum WindowActivationTrackingMode
         {
@@ -108,16 +107,13 @@ namespace Avalonia.X11
             }
         }
 
-        public PlatformAllowedWindowActions AllowedActions
+        public IntPtr[]? NetSupported
         {
-            get => _allowedActions;
+            get => _netSupported;
             private set
             {
-                if (_allowedActions != value)
-                {
-                    _allowedActions = value;
-                    AllowedActionsChanged?.Invoke();
-                }
+                _netSupported = value;
+                NetSupportedChanged?.Invoke();
             }
         }
 
@@ -222,26 +218,6 @@ namespace Avalonia.X11
             return WindowActivationTrackingMode.FocusEvents;
         }
 
-        private static PlatformAllowedWindowActions GetAllowedActions(IntPtr wm, IntPtr[]? supportedFeatures, X11Atoms atoms)
-        {
-            if (wm == IntPtr.Zero || supportedFeatures == null)
-                return PlatformAllowedWindowActions.All;
-
-            var actions = PlatformAllowedWindowActions.None;
-
-            if (supportedFeatures.Contains(atoms._NET_WM_ACTION_MAXIMIZE_VERT)
-                && supportedFeatures.Contains(atoms._NET_WM_ACTION_MAXIMIZE_HORZ))
-                actions |= PlatformAllowedWindowActions.Maximize;
-
-            if (supportedFeatures.Contains(atoms._NET_WM_ACTION_FULLSCREEN))
-                actions |= PlatformAllowedWindowActions.Fullscreen;
-
-            if (supportedFeatures.Contains(atoms._NET_WM_ACTION_MINIMIZE))
-                actions |= PlatformAllowedWindowActions.Minimize;
-
-            return actions;
-        }
-
         private void OnNewWindowManager()
         {
             var wm = GetActiveWm();
@@ -251,7 +227,7 @@ namespace Avalonia.X11
                 : null;
             WmName = GetWmName(wm);
             ActivationTrackingMode = GetWindowActivityTrackingMode(wm, supportedFeatures);
-            AllowedActions = GetAllowedActions(wm, supportedFeatures, _x11.Atoms);
+            NetSupported = supportedFeatures;
         }
         
         private void OnRootWindowEvent(ref XEvent ev)

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -240,7 +240,7 @@ namespace Avalonia.X11
             _activationTracker = new(_platform, this);
             _activationTracker.ActivationChanged += HandleActivation;
 
-            _platform.Globals.AllowedActionsChanged += OnAllowedActionsChanged;
+            _platform.Globals.NetSupportedChanged += OnNetSupportedChanged;
 
             CreateIC();
 
@@ -514,14 +514,34 @@ namespace Avalonia.X11
         public Action<PixelPoint>? PositionChanged { get; set; }
         public Action? LostFocus { get; set; }
 
-        public PlatformAllowedWindowActions AllowedWindowActions => _platform.Globals.AllowedActions;
+        public PlatformAllowedWindowActions AllowedWindowActions => GetAllowedActions(_platform.Globals.NetSupported);
 
         public Action<PlatformAllowedWindowActions>? AllowedWindowActionsChanged { get; set; }
 
         public Compositor Compositor => _platform.Compositor;
 
-        private void OnAllowedActionsChanged() =>
-            AllowedWindowActionsChanged?.Invoke(_platform.Globals.AllowedActions);
+        private PlatformAllowedWindowActions GetAllowedActions(IntPtr[]? netSupported)
+        {
+            if (netSupported == null)
+                return PlatformAllowedWindowActions.All;
+
+            var actions = PlatformAllowedWindowActions.None;
+
+            if (netSupported.Contains(_x11.Atoms._NET_WM_ACTION_MAXIMIZE_VERT)
+                && netSupported.Contains(_x11.Atoms._NET_WM_ACTION_MAXIMIZE_HORZ))
+                actions |= PlatformAllowedWindowActions.Maximize;
+
+            if (netSupported.Contains(_x11.Atoms._NET_WM_ACTION_FULLSCREEN))
+                actions |= PlatformAllowedWindowActions.Fullscreen;
+
+            if (netSupported.Contains(_x11.Atoms._NET_WM_ACTION_MINIMIZE))
+                actions |= PlatformAllowedWindowActions.Minimize;
+
+            return actions;
+        }
+
+        private void OnNetSupportedChanged() =>
+            AllowedWindowActionsChanged?.Invoke(AllowedWindowActions);
         
         private void OnEvent(ref XEvent ev)
         {
@@ -1141,7 +1161,7 @@ namespace Avalonia.X11
             }
 
             _platform.X11Screens.Changed -= OnScreensChanged;
-            _platform.Globals.AllowedActionsChanged -= OnAllowedActionsChanged;
+            _platform.Globals.NetSupportedChanged -= OnNetSupportedChanged;
             
             if (_useRenderWindow && _renderHandle != IntPtr.Zero)
             {                

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -72,6 +72,7 @@ namespace Avalonia.X11
         private bool _usePositioningFlags = false;
         private X11WindowMode _mode;
         private IWindowIconImpl? _iconImpl;
+        private Action<PlatformAllowedWindowActions>? _allowedWindowActionsChanged;
 
         private enum XSyncState
         {
@@ -512,7 +513,25 @@ namespace Avalonia.X11
         public Action<PixelPoint>? PositionChanged { get; set; }
         public Action? LostFocus { get; set; }
 
+        public PlatformAllowedWindowActions AllowedWindowActions => _platform.Globals.AllowedActions;
+
+        public Action<PlatformAllowedWindowActions>? AllowedWindowActionsChanged
+        {
+            get => _allowedWindowActionsChanged;
+            set
+            {
+                if (_allowedWindowActionsChanged != null)
+                    _platform.Globals.AllowedActionsChanged -= OnAllowedActionsChanged;
+                _allowedWindowActionsChanged = value;
+                if (_allowedWindowActionsChanged != null)
+                    _platform.Globals.AllowedActionsChanged += OnAllowedActionsChanged;
+            }
+        }
+
         public Compositor Compositor => _platform.Compositor;
+
+        private void OnAllowedActionsChanged() =>
+            _allowedWindowActionsChanged?.Invoke(_platform.Globals.AllowedActions);
         
         private void OnEvent(ref XEvent ev)
         {
@@ -1132,6 +1151,7 @@ namespace Avalonia.X11
             }
 
             _platform.X11Screens.Changed -= OnScreensChanged;
+            AllowedWindowActionsChanged = null;
             
             if (_useRenderWindow && _renderHandle != IntPtr.Zero)
             {                

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -72,7 +72,6 @@ namespace Avalonia.X11
         private bool _usePositioningFlags = false;
         private X11WindowMode _mode;
         private IWindowIconImpl? _iconImpl;
-        private Action<PlatformAllowedWindowActions>? _allowedWindowActionsChanged;
 
         private enum XSyncState
         {
@@ -240,6 +239,8 @@ namespace Avalonia.X11
 
             _activationTracker = new(_platform, this);
             _activationTracker.ActivationChanged += HandleActivation;
+
+            _platform.Globals.AllowedActionsChanged += OnAllowedActionsChanged;
 
             CreateIC();
 
@@ -515,23 +516,12 @@ namespace Avalonia.X11
 
         public PlatformAllowedWindowActions AllowedWindowActions => _platform.Globals.AllowedActions;
 
-        public Action<PlatformAllowedWindowActions>? AllowedWindowActionsChanged
-        {
-            get => _allowedWindowActionsChanged;
-            set
-            {
-                if (_allowedWindowActionsChanged != null)
-                    _platform.Globals.AllowedActionsChanged -= OnAllowedActionsChanged;
-                _allowedWindowActionsChanged = value;
-                if (_allowedWindowActionsChanged != null)
-                    _platform.Globals.AllowedActionsChanged += OnAllowedActionsChanged;
-            }
-        }
+        public Action<PlatformAllowedWindowActions>? AllowedWindowActionsChanged { get; set; }
 
         public Compositor Compositor => _platform.Compositor;
 
         private void OnAllowedActionsChanged() =>
-            _allowedWindowActionsChanged?.Invoke(_platform.Globals.AllowedActions);
+            AllowedWindowActionsChanged?.Invoke(_platform.Globals.AllowedActions);
         
         private void OnEvent(ref XEvent ev)
         {
@@ -1151,7 +1141,7 @@ namespace Avalonia.X11
             }
 
             _platform.X11Screens.Changed -= OnScreensChanged;
-            AllowedWindowActionsChanged = null;
+            _platform.Globals.AllowedActionsChanged -= OnAllowedActionsChanged;
             
             if (_useRenderWindow && _renderHandle != IntPtr.Zero)
             {                

--- a/src/Avalonia.X11/X11WindowModes/DefaultWindowMode.cs
+++ b/src/Avalonia.X11/X11WindowModes/DefaultWindowMode.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace Avalonia.X11;
 
@@ -9,7 +10,7 @@ partial class X11Window
     {
         public override void Activate()
         {
-            if (X11.Atoms._NET_ACTIVE_WINDOW != IntPtr.Zero)
+            if (Platform.Globals.NetSupported?.Contains(X11.Atoms._NET_ACTIVE_WINDOW) == true)
             {
                 Window.SendNetWMMessage(X11.Atoms._NET_ACTIVE_WINDOW, (IntPtr)1, X11.LastActivityTimestamp,
                     IntPtr.Zero);


### PR DESCRIPTION
Linux has various environments where minimize, maximize and fullscreen don't make any sense (e. g. i3). This PR detects it for X11 and hides corresponding titlebar buttons.

On wayland this will be mapped to xdg_toplevel::wm_capabilities