### PR TITLE
Pass shadow extents from drawn decorations to the underlying render target

### DIFF
--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -1695,6 +1695,18 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.IRenderTarget.RenderTargetSceneInfo.#ctor(Avalonia.PixelSize,System.Double)</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.IRenderTarget.RenderTargetSceneInfo.Deconstruct(Avalonia.PixelSize@,System.Double@)</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Platform.LockedFramebuffer.#ctor(System.IntPtr,Avalonia.PixelSize,System.Int32,Avalonia.Vector,Avalonia.Platform.PixelFormat,System.Action)</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
@@ -3364,6 +3376,18 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Platform.IRenderTarget.CreateDrawingContext(System.Boolean)</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.IRenderTarget.RenderTargetSceneInfo.#ctor(Avalonia.PixelSize,System.Double)</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.IRenderTarget.RenderTargetSceneInfo.Deconstruct(Avalonia.PixelSize@,System.Double@)</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
   </Suppression>

--- a/src/Avalonia.Base/Platform/IRenderTarget.cs
+++ b/src/Avalonia.Base/Platform/IRenderTarget.cs
@@ -37,6 +37,6 @@ namespace Avalonia.Platform
         /// </summary>
         bool IsReady => true;
         
-        public record struct RenderTargetSceneInfo(PixelSize Size, double Scaling);
+        public record struct RenderTargetSceneInfo(PixelSize Size, double Scaling, Thickness ShadowExtents = default);
     }
 }

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -189,7 +189,7 @@ namespace Avalonia.Rendering.Composition.Server
                             || !(_renderTarget.Properties.RetainsPreviousFrameContents
                                  && _renderTarget.Properties.IsSuitableForDirectRendering);
             
-            using (var renderTargetContext = _renderTarget.CreateDrawingContext(new(PixelSize, Scaling), out var properties))
+            using (var renderTargetContext = _renderTarget.CreateDrawingContext(new(PixelSize, Scaling, ShadowExtents), out var properties))
             using (var renderTiming = Diagnostic.BeginCompositorRenderPass())
             {
                 var fullRedraw = false;

--- a/src/Avalonia.Base/composition-schema.xml
+++ b/src/Avalonia.Base/composition-schema.xml
@@ -59,6 +59,7 @@
         <Property Name="LastLayoutPassTiming" Type="LayoutPassTiming" Internal="true"/>
         <Property Name="Scaling" Type="double"/>
         <Property Name="PixelSize" Type="PixelSize" />
+        <Property Name="ShadowExtents" Type="Thickness" Internal="true"/>
     </Object>
     <KeyFrameAnimation Name="Scalar" Type="float"/>
     <KeyFrameAnimation Name="Double" Type="double"/>

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -774,6 +774,7 @@ namespace Avalonia.Controls
                 // Only use platform margins if drawn decorations are not active
                 WindowDecorationMargin = PlatformImpl?.ExtendedMargins ?? default;
                 TopLevelHost.DecorationInset = default;
+                Renderer.CompositionTarget.ShadowExtents = default;
                 return;
             }
 
@@ -784,6 +785,8 @@ namespace Avalonia.Controls
                 ? decorations.FrameThickness : default;
             var shadow = parts.HasFlag(Chrome.DrawnWindowDecorationParts.Shadow)
                 ? decorations.ShadowThickness : default;
+            
+            Renderer.CompositionTarget.ShadowExtents = shadow;
             var margin = new Thickness(
                 frame.Left + shadow.Left,
                 titleBarHeight + frame.Top + shadow.Top,

--- a/src/Avalonia.X11/Glx/GlxGlPlatformSurface.cs
+++ b/src/Avalonia.X11/Glx/GlxGlPlatformSurface.cs
@@ -1,6 +1,5 @@
 using System;
 using Avalonia.OpenGL;
-using Avalonia.OpenGL.Egl;
 using Avalonia.OpenGL.Surfaces;
 using Avalonia.Platform;
 using static Avalonia.OpenGL.GlConsts;
@@ -10,9 +9,9 @@ namespace Avalonia.X11.Glx
     internal class GlxGlPlatformSurface: IGlPlatformSurface
     {
 
-        private readonly EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo _info;
+        private readonly X11Window.SurfaceInfo _info;
         
-        public GlxGlPlatformSurface(EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo info)
+        public GlxGlPlatformSurface(X11Window.SurfaceInfo info)
         {
             _info = info;
         }
@@ -25,10 +24,10 @@ namespace Avalonia.X11.Glx
         private class RenderTarget : IGlPlatformSurfaceRenderTarget
         {
             private readonly GlxContext _context;
-            private readonly EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo _info;
+            private readonly X11Window.SurfaceInfo _info;
             private PixelSize? _lastSize;
 
-            public RenderTarget(GlxContext context,  EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo info)
+            public RenderTarget(GlxContext context, X11Window.SurfaceInfo info)
             {
                 _context = context;
                 _info = info;
@@ -42,6 +41,9 @@ namespace Avalonia.X11.Glx
             public bool IsCorrupted => false;
             public IGlPlatformSurfaceRenderingSession BeginDraw(IRenderTarget.RenderTargetSceneInfo sceneInfo)
             {
+                _info.UpdateGtkFrameExtents(
+                    _context.Display.X11Info.DeferredDisplay, sceneInfo.ShadowExtents);
+                
                 var size = sceneInfo.Size;
                 //if (expectedSize.HasValue)
                 {
@@ -69,12 +71,12 @@ namespace Avalonia.X11.Glx
             private class Session : IGlPlatformSurfaceRenderingSession
             {
                 private readonly GlxContext _context;
-                private readonly EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo _info;
+                private readonly X11Window.SurfaceInfo _info;
                 private readonly PixelSize? _size;
                 private readonly IDisposable _clearContext;
                 public IGlContext Context => _context;
 
-                public Session(GlxContext context, EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo info,
+                public Session(GlxContext context, X11Window.SurfaceInfo info,
                     PixelSize? size,
                     IDisposable clearContext)
                 {

--- a/src/Avalonia.X11/X11Atoms.cs
+++ b/src/Avalonia.X11/X11Atoms.cs
@@ -152,6 +152,7 @@ namespace Avalonia.X11
         public IntPtr _NET_WM_HANDLED_ICONS;
         public IntPtr _NET_WM_USER_TIME;
         public IntPtr _NET_FRAME_EXTENTS;
+        public IntPtr _GTK_FRAME_EXTENTS;
         public IntPtr _NET_WM_PING;
         public IntPtr _NET_WM_SYNC_REQUEST;
         public IntPtr _NET_WM_SYNC_REQUEST_COUNTER;

--- a/src/Avalonia.X11/X11FramebufferSurface.cs
+++ b/src/Avalonia.X11/X11FramebufferSurface.cs
@@ -7,15 +7,15 @@ namespace Avalonia.X11
     internal class X11FramebufferSurface : IFramebufferPlatformSurface
     {
         private readonly IntPtr _display;
-        private readonly IntPtr _xid;
+        private readonly X11Window.SurfaceInfo _info;
         private readonly int _depth;
         private readonly bool _retain;
         private RetainedFramebuffer? _fb;
 
-        public X11FramebufferSurface(IntPtr display, IntPtr xid, int depth, bool retain)
+        public X11FramebufferSurface(IntPtr display, X11Window.SurfaceInfo info, int depth, bool retain)
         {
             _display = display;
-            _xid = xid;
+            _info = info;
             _depth = depth;
             _retain = retain;
         }
@@ -37,8 +37,8 @@ namespace Avalonia.X11
             image.bits_per_pixel = bitsPerPixel;
             XLockDisplay(_display);
             XInitImage(ref image);
-            var gc = XCreateGC(_display, _xid, 0, IntPtr.Zero);
-            XPutImage(_display, _xid, gc, ref image, 0, 0, 0, 0, (uint)fb.Size.Width, (uint)fb.Size.Height);
+            var gc = XCreateGC(_display, _info.Handle, 0, IntPtr.Zero);
+            XPutImage(_display, _info.Handle, gc, ref image, 0, 0, 0, 0, (uint)fb.Size.Width, (uint)fb.Size.Height);
             XFreeGC(_display, gc);
             XSync(_display, true);
             XUnlockDisplay(_display);
@@ -49,10 +49,12 @@ namespace Avalonia.X11
             }
         }
         
-        public ILockedFramebuffer Lock(IRenderTarget.RenderTargetSceneInfo _, out FramebufferLockProperties properties)
+        public ILockedFramebuffer Lock(IRenderTarget.RenderTargetSceneInfo sceneInfo, out FramebufferLockProperties properties)
         {
+            _info.UpdateGtkFrameExtents(_display, sceneInfo.ShadowExtents);
+            
             XLockDisplay(_display);
-            XGetGeometry(_display, _xid, out var root, out var x, out var y, out var width, out var height,
+            XGetGeometry(_display, _info.Handle, out var root, out var x, out var y, out var width, out var height,
                 out var bw, out var d);
             XUnlockDisplay(_display);
 

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -213,17 +213,18 @@ namespace Avalonia.X11
                 SetWmClass(_handle, _platform.Options.WmClass);
             }
 
+            var surfaceInfo = new SurfaceInfo(this, _x11, _handle, _renderHandle);
             var surfaces = new List<IPlatformRenderSurface>
             {
-                new X11FramebufferSurface(_x11.DeferredDisplay, _renderHandle, 
+                new X11FramebufferSurface(_x11.DeferredDisplay, surfaceInfo,
                    depth, _platform.Options.UseRetainedFramebuffer ?? false)
             };
             
             if (egl != null)
                 surfaces.Insert(0,
-                    new EglGlPlatformSurface(new SurfaceInfo(this, _x11.DeferredDisplay, _handle, _renderHandle)));
+                    new EglGlPlatformSurface(surfaceInfo));
             if (glx != null)
-                surfaces.Insert(0, new GlxGlPlatformSurface(new SurfaceInfo(this, _x11.DeferredDisplay, _handle, _renderHandle)));
+                surfaces.Insert(0, new GlxGlPlatformSurface(surfaceInfo));
 
             surfaces.Add(new SurfacePlatformHandle(this));
 
@@ -280,34 +281,58 @@ namespace Avalonia.X11
             platform.X11Screens.Changed += OnScreensChanged;
         }
 
-        private class SurfaceInfo  : EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo
+        internal class SurfaceInfo  : EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo
         {
             private readonly X11Window _window;
-            private readonly IntPtr _display;
+            private readonly X11Info _x11;
             private readonly IntPtr _parent;
 
-            public SurfaceInfo(X11Window window, IntPtr display, IntPtr parent, IntPtr xid)
+            public SurfaceInfo(X11Window window, X11Info x11, IntPtr parent, IntPtr xid)
             {
                 _window = window;
-                _display = display;
+                _x11 = x11;
                 _parent = parent;
                 Handle = xid;
             }
             public IntPtr Handle { get; }
+            public IntPtr WindowHandle => _parent;
+            public X11Info X11 => _x11;
 
             public PixelSize Size
             {
                 get
                 {
-                    XLockDisplay(_display);
-                    XGetGeometry(_display, _parent, out var geo);
-                    XResizeWindow(_display, Handle, geo.width, geo.height);
-                    XUnlockDisplay(_display);
+                    var display = _x11.DeferredDisplay;
+                    XLockDisplay(display);
+                    XGetGeometry(display, _parent, out var geo);
+                    XResizeWindow(display, Handle, geo.width, geo.height);
+                    XUnlockDisplay(display);
                     return new PixelSize(geo.width, geo.height);
                 }
             }
 
             public double Scaling => _window.RenderScaling;
+
+            private Thickness _lastShadowExtents;
+
+            internal void UpdateGtkFrameExtents(IntPtr display, Thickness shadowExtents)
+            {
+                var atoms = _x11.Atoms;
+                if (atoms._GTK_FRAME_EXTENTS == IntPtr.Zero || _lastShadowExtents == shadowExtents)
+                    return;
+
+                _lastShadowExtents = shadowExtents;
+                var extents = new IntPtr[]
+                {
+                    (IntPtr)(int)shadowExtents.Left, (IntPtr)(int)shadowExtents.Right,
+                    (IntPtr)(int)shadowExtents.Top, (IntPtr)(int)shadowExtents.Bottom
+                };
+
+                XLockDisplay(display);
+                XChangeProperty(display, _parent, atoms._GTK_FRAME_EXTENTS, atoms.CARDINAL, 32,
+                    PropertyMode.Replace, extents, 4);
+                XUnlockDisplay(display);
+            }
         }
 
         private void UpdateMotifHints()


### PR DESCRIPTION
Right now it's only supported by X11 where it sets `_GTK_FRAME_EXTENTS` (well-known property by now).
Will later be utilized for `xdg_surface::set_window_geometry`