### PR TITLE
Ensure thread-safe font cache with deterministic lookup order

### DIFF
--- a/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
+++ b/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
@@ -17,6 +17,7 @@ namespace Avalonia.Media.Fonts
 
         // Make this internal for testing purposes
         internal readonly ConcurrentDictionary<string, ConcurrentDictionary<FontCollectionKey, GlyphTypeface?>> _glyphTypefaceCache = new();
+        internal readonly ConcurrentQueue<string> _fontInsertionSequence = new();
 
         private readonly object _fontFamiliesLock = new();
         private volatile FontFamily[] _fontFamilies = Array.Empty<FontFamily>();
@@ -34,6 +35,15 @@ namespace Avalonia.Media.Fonts
         public int Count => _fontFamilies.Length;
 
         public FontFamily this[int index] => _fontFamilies[index];
+
+        private IEnumerable<KeyValuePair<string, ConcurrentDictionary<FontCollectionKey, GlyphTypeface?>>> GetGlyphTypefaceCacheInOrder()
+        {
+            foreach (var key in _fontInsertionSequence)
+            {
+                if (_glyphTypefaceCache.TryGetValue(key, out var value))
+                    yield return new KeyValuePair<string, ConcurrentDictionary<FontCollectionKey, GlyphTypeface?>>(key, value);
+            }
+        }
 
         public virtual bool TryMatchCharacter(int codepoint, FontStyle style, FontWeight weight, FontStretch stretch,
             string? familyName, CultureInfo? culture, out Typeface match)
@@ -62,7 +72,7 @@ namespace Avalonia.Media.Fonts
             bool TryMatchInAnyFamily(bool isLastResort, out Typeface match)
             {
                 //Try to find a match in any font family
-                foreach (var pair in _glyphTypefaceCache)
+                foreach (var pair in GetGlyphTypefaceCacheInOrder())
                 {
                     if (pair.Key == familyName)
                     {
@@ -702,7 +712,7 @@ namespace Avalonia.Media.Fonts
 
             // GetOrAdd will return the instance that ended up in the dictionary. If it's our
             // newDict instance then we won the race to add the family and should publish it.
-            var dict = _glyphTypefaceCache.GetOrAdd(familyName, newDict);
+            var dict = GetOrAdd(familyName, newDict);
 
             if (ReferenceEquals(dict, newDict))
             {
@@ -725,6 +735,17 @@ namespace Avalonia.Media.Fonts
             }
 
             return dict.TryAdd(key, glyphTypeface);
+
+            ConcurrentDictionary<FontCollectionKey, GlyphTypeface?> GetOrAdd(string familyName, ConcurrentDictionary<FontCollectionKey, GlyphTypeface?> dict)
+            {
+                if (_glyphTypefaceCache.TryAdd(familyName, dict))
+                {
+                    _fontInsertionSequence.Enqueue(familyName);
+                    return dict;
+                }
+
+                return _glyphTypefaceCache[familyName];
+            }
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
+++ b/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
@@ -19,6 +19,7 @@ namespace Avalonia.Media.Fonts
         internal readonly ConcurrentDictionary<string, ConcurrentDictionary<FontCollectionKey, GlyphTypeface?>> _glyphTypefaceCache = new();
         internal readonly ConcurrentQueue<string> _fontInsertionSequence = new();
 
+        private readonly object _glyphCacheInsertLock = new();
         private readonly object _fontFamiliesLock = new();
         private volatile FontFamily[] _fontFamilies = Array.Empty<FontFamily>();
         private readonly IFontManagerImpl _fontManagerImpl;
@@ -738,13 +739,15 @@ namespace Avalonia.Media.Fonts
 
             ConcurrentDictionary<FontCollectionKey, GlyphTypeface?> GetOrAdd(string familyName, ConcurrentDictionary<FontCollectionKey, GlyphTypeface?> dict)
             {
-                if (_glyphTypefaceCache.TryAdd(familyName, dict))
+                lock (_glyphCacheInsertLock)
                 {
+                    if (_glyphTypefaceCache.TryGetValue(familyName, out var existing))
+                        return existing;
+
+                    _glyphTypefaceCache[familyName] = dict;
                     _fontInsertionSequence.Enqueue(familyName);
                     return dict;
                 }
-
-                return _glyphTypefaceCache[familyName];
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

This pull request guarantees font cache lookup order strictly follows insertion order.
It prevents the issue where, once a font fallback occurs, other characters may be rendered with the incorrectly added fallback font, causing layout inconsistencies.

## What is the current behavior?

### Reproduction Scenario

1. **Initialization**: Enter characters like "あいうえお"  
   → All are contained in Yu Gothic UI, so they render normally with Yu Gothic UI

2. **Font Fallback Triggered**: Enter a unicode character like "◈"  
   → Not contained in Yu Gothic UI, so it renders using the fallback font Meiryo UI

3. **Cache State**  
   ```
   ConcurrentDictionary:
   {
       {"Meiryo UI", ...},     ← Added in this order
       {"Yu Gothic UI", ...}
   }
   ```

4. **Problem - Enumerator Order is Unstable**  
   Due to ConcurrentDictionary's internal implementation, the Enumerator does not guarantee insertion order.  
   As a result, Meiryo UI may be evaluated **before** Yu Gothic UI.

5. **Crisis - Previously Correct Characters Get Replaced**  
   Meiryo UI also contains "あいうえお", so those characters that were originally rendered correctly with Yu Gothic UI  
   get unified into Meiryo UI.  
   → **Layout Breaking (font inconsistency causing line height changes, etc.)**

## What is the updated/expected behavior with this PR?

### After This Fix

After this PR, the order in which characters are added to the cache (Yu Gothic UI → Meiryo UI) is strictly guaranteed,  
and font lookup will **always evaluate in that exact order**.

**Result:**
- "あいうえお" will be searched in Yu Gothic UI (added first) → found, so rendered with Yu Gothic UI
- "◈" will be searched in Meiryo UI (added later) → found, so rendered with Meiryo UI
- Each character is rendered with its intended font, and layout breaks no longer occur

## How was the solution implemented (if it's not obvious)?

- **Introduced ConcurrentQueue<string>** to record the order in which font cache keys are added
- During cache lookup, keys are dequeued from the ConcurrentQueue in order and ConcurrentDictionary is evaluated in that same order
- Serialized cache insertion and insertion-order recording under **the same lock**, guaranteeing strict insertion order  
  → Even under concurrent access, "insertion order" and "lookup order" always match
- Refactored the insertion logic to maintain this ordering guarantee

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #20496
