### PR TITLE
Do not use visual children enumerator in TopLevelHost

### DIFF
--- a/src/Avalonia.Controls/TopLevelHost.cs
+++ b/src/Avalonia.Controls/TopLevelHost.cs
@@ -51,11 +51,14 @@ internal partial class TopLevelHost : Control
         var hasInset = inset != default;
         var desiredSize = default(Size);
 
-        foreach (var child in VisualChildren)
+        var children = VisualChildren;
+        var childrenCount = children.Count;
+
+        for (var i = 0; i < childrenCount; i++)
         {
-            if (child is Layoutable l)
+            if (children[i] is Layoutable l)
             {
-                if (hasInset && ReferenceEquals(child, _topLevel))
+                if (hasInset && ReferenceEquals(l, _topLevel))
                 {
                     // In forced mode, measure the TopLevel with reduced size
                     var contentSize = new Size(
@@ -89,11 +92,14 @@ internal partial class TopLevelHost : Control
         var inset = _decorationInset;
         var hasInset = inset != default;
 
-        foreach (var child in VisualChildren)
+        var children = VisualChildren;
+        var childrenCount = children.Count;
+
+        for (var i = 0; i < childrenCount; i++)
         {
-            if (child is Layoutable l)
+            if (children[i] is Layoutable l)
             {
-                if (hasInset && ReferenceEquals(child, _topLevel))
+                if (hasInset && ReferenceEquals(l, _topLevel))
                 {
                     // In forced mode, arrange the TopLevel within the inset area
                     var contentSize = new Size(

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -710,6 +710,35 @@ namespace Avalonia.Controls.UnitTests
             Assert.False(visualRoot.HasMirrorTransform);
         }
 
+        [Fact]
+        public void Extending_Client_Area_To_Decorations_When_Attached_To_Visual_Tree_Works()
+        {
+            var extended = false;
+
+            var windowImpl = MockWindowingPlatform.CreateWindowMock();
+            windowImpl.Setup(w => w.NeedsManagedDecorations).Returns(() => extended);
+            windowImpl.Setup(w => w.RequestedDrawnDecorations).Returns(PlatformRequestedDrawnDecoration.TitleBar);
+
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow.With(
+                windowingPlatform: new MockWindowingPlatform(() => windowImpl.Object)));
+
+            var border = new Border();
+
+            var window = new Window
+            {
+                Content = border
+            };
+
+            border.AttachedToVisualTree +=
+                (_, _) =>
+                {
+                    extended = true;
+                    windowImpl.Object.ExtendClientAreaToDecorationsChanged?.Invoke(true);
+                };
+
+            window.Show();
+        }
+
         public class SizingTests : ScopedTestBase
         {
             [Fact]


### PR DESCRIPTION
## What does the pull request do?
This PR fixes an issue where if children are added to `TopLevelHost` dynamically while a measure pass is in progress, an `InvalidOperationException: Collection was modified; enumeration operation may not execute` is thrown.

This happens, for example, by setting `Window.ExtendClientAreaToDecorationsHint = true` in `OnAttachedToVisualTree`.

This is a general problem with the visual and logical children collection, and a solution such as #20028 will be implemented in the future.

In the meantime, change `TopLevelHost` to iterate using a plain old `for` loop, matching what's done in `MeasureOverride/ArrangeOverride` for all [other controls](https://github.com/AvaloniaUI/Avalonia/blob/80b8509bfc20015bb178ecbcd80bce348b743076/src/Avalonia.Base/Layout/Layoutable.cs#L641).
