### PR TITLE
Fix TextBox caret overlapping last glyph at end of line

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -477,9 +477,12 @@ namespace Avalonia.Controls.Presenters
             var y = Math.Floor(_caretBounds.Y) + 0.5;
             var b = Math.Ceiling(_caretBounds.Bottom) - 0.5;
 
+            // When the caret is at the trailing edge of the last character on a line,
+            // snap to the next pixel boundary so it doesn't visually overlap the glyph.
+            // MeasureOverride reserves 2 extra pixels of width to prevent clipping.
             if (_caretBounds.X > 0 && _caretBounds.X >= textLine.WidthIncludingTrailingWhitespace)
             {
-                x -= 1;
+                x = Math.Ceiling(_caretBounds.X) + 0.5;
             }
 
             return (new Point(x, y), new Point(x, b));
@@ -647,8 +650,11 @@ namespace Avalonia.Controls.Presenters
             InvalidateArrange();
 
             // The textWidth used here is matching that TextBlock uses to measure the text.
+            // +2: reserve space for the caret at end-of-line so it is not clipped by
+            // the control boundary.  GetCaretPoints() uses Math.Ceiling(X) + 0.5 at the
+            // trailing edge, which can extend up to ~1.5px past the text width.
             var textWidth = TextLayout.OverhangLeading + TextLayout.WidthIncludingTrailingWhitespace + TextLayout.OverhangTrailing;
-            return new Size(textWidth, TextLayout.Height);
+            return new Size(textWidth + 2, TextLayout.Height);
         }
 
         protected override Size ArrangeOverride(Size finalSize)


### PR DESCRIPTION
## Summary

`GetCaretPoints()` subtracts 1px from the caret X position when the caret
is at or past the line width, to prevent clipping at the control boundary.
This causes the caret to render **on top of the last character** instead
of after it — visible at all font sizes and font families.

### Changes

- **`GetCaretPoints()`**: Replace `x -= 1` with
  `x = Math.Ceiling(X) + 0.5` so the caret snaps to the next pixel
  boundary past the glyph, guaranteeing visible separation.
- **`MeasureOverride()`**: Reserve 2 extra pixels of width
  (`textWidth + 2`) so the caret is not clipped by the control boundary.

### Diagnostic evidence

Minimal repro app traces `_lastCharacterHit` and `_caretBounds` via
reflection. For text "rrrrrrr" at FontSize 23:

    _caretBounds.X=56.0  lineWidth=56.0

The CharacterHit logic resolves correctly. The only corruption is
`x -= 1` in `GetCaretPoints()`:

    Math.Floor(56.0) + 0.5 = 56.5  →  x -= 1  →  55.5  (inside the glyph)

### Repro

Any Avalonia app with a TextBox — type text and observe the caret at
the end of the string overlaps the last character. Tested on Windows
with Avalonia 11.3.12, 11.3.13, .NET 9, .NET 10, multiple fonts and
font sizes.

Fixes #12809