### PR TITLE
Add Window.WindowDecorationsTheme property

### DIFF
--- a/src/Avalonia.Controls/TopLevelHost.Decorations.cs
+++ b/src/Avalonia.Controls/TopLevelHost.Decorations.cs
@@ -6,6 +6,7 @@ using Avalonia.Automation.Peers;
 using Avalonia.Controls.Chrome;
 using Avalonia.Input;
 using Avalonia.Reactive;
+using Avalonia.Styling;
 
 namespace Avalonia.Controls;
 
@@ -53,7 +54,7 @@ internal partial class TopLevelHost
     /// When non-null (including <see cref="DrawnWindowDecorationParts.None"/>), the decoration
     /// infrastructure is kept alive and parts/fullscreen state are updated.
     /// </summary>
-    internal void UpdateDrawnDecorations(DrawnWindowDecorationParts? parts, WindowState windowState)
+    internal void UpdateDrawnDecorations(DrawnWindowDecorationParts? parts, WindowState windowState, ControlTheme? theme)
     {
         if (parts == null)
         {
@@ -68,6 +69,14 @@ internal partial class TopLevelHost
             // Layers persist across part changes; pseudo-classes driven by EnabledParts
             // control visibility of individual decoration elements in the theme.
             _decorations.EnabledParts = enabledParts;
+
+            var oldTheme = _decorations.Theme;
+            if (oldTheme != theme)
+            {
+                _decorations.Theme = theme;
+                _decorations.ApplyStyling();
+            }
+
             if (_resizeGrips != null)
                 _resizeGrips.IsVisible = enabledParts.HasFlag(DrawnWindowDecorationParts.ResizeGrips);
         }
@@ -75,6 +84,7 @@ internal partial class TopLevelHost
         {
             _decorations = new WindowDrawnDecorations();
             _decorations.EnabledParts = enabledParts;
+            _decorations.Theme = theme;
 
             // Set up logical parenting
             LogicalChildren.Add(_decorations);
@@ -161,6 +171,7 @@ internal partial class TopLevelHost
         if (_decorations == null)
             return;
 
+        _decorations.ApplyStyling();
         _decorations.ApplyTemplate();
 
         var content = _decorations.Content;

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -141,6 +141,12 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<Window, WindowDecorations>(nameof(WindowDecorations), WindowDecorations.Full);
 
         /// <summary>
+        /// Defines the <see cref="WindowDecorationsTheme"/> property.
+        /// </summary>
+        public static readonly StyledProperty<ControlTheme?> WindowDecorationsThemeProperty =
+            AvaloniaProperty.Register<Window, ControlTheme?>(nameof(WindowDecorationsTheme));
+
+        /// <summary>
         /// Defines the <see cref="ShowActivated"/> property.
         /// </summary>
         public static readonly StyledProperty<bool> ShowActivatedProperty =
@@ -374,6 +380,15 @@ namespace Avalonia.Controls
         {
             get => GetValue(WindowDecorationsProperty);
             set => SetValue(WindowDecorationsProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the theme used to render the window decorations when they are not drawn by the system.
+        /// </summary>
+        public ControlTheme? WindowDecorationsTheme
+        {
+            get => GetValue(WindowDecorationsThemeProperty);
+            set => SetValue(WindowDecorationsThemeProperty, value);
         }
 
         [Obsolete("Use WindowDecorations instead.")]
@@ -704,7 +719,7 @@ namespace Avalonia.Controls
             // Detect forced mode: platform needs managed decorations but app hasn't opted in
             _isForcedDecorationMode = parts != null && !IsExtendedIntoWindowDecorations;
 
-            TopLevelHost.UpdateDrawnDecorations(parts, WindowState);
+            TopLevelHost.UpdateDrawnDecorations(parts, WindowState, WindowDecorationsTheme);
 
             if (parts != null)
             {
@@ -739,7 +754,7 @@ namespace Avalonia.Controls
             if (TopLevelHost.Decorations == null)
                 return;
 
-            TopLevelHost.UpdateDrawnDecorations(ComputeDecorationParts(), WindowState);
+            TopLevelHost.UpdateDrawnDecorations(ComputeDecorationParts(), WindowState, WindowDecorationsTheme);
         }
 
         private Chrome.DrawnWindowDecorationParts? ComputeDecorationParts()
@@ -1493,11 +1508,17 @@ namespace Avalonia.Controls
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
             base.OnPropertyChanged(change);
+
             if (change.Property == WindowDecorationsProperty)
             {
                 var (_, typedNewValue) = change.GetOldAndNewValue<WindowDecorations>();
 
                 PlatformImpl?.SetWindowDecorations(typedNewValue);
+            }
+
+            else if (change.Property == WindowDecorationsThemeProperty)
+            {
+                UpdateDrawnDecorations();
             }
 
             else if (change.Property == OwnerProperty)

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -2,9 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using Avalonia.Controls.Chrome;
 using Avalonia.Controls.Platform;
+using Avalonia.Controls.Templates;
+using Avalonia.Markup.Xaml.Templates;
 using Avalonia.Media;
 using Avalonia.Platform;
+using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Avalonia.VisualTree;
@@ -1587,6 +1591,54 @@ namespace Avalonia.Controls.UnitTests
 
                 // Platform getter should never be called in legacy mode
                 windowImpl.VerifyGet(x => x.WindowState, Times.Never());
+            }
+        }
+
+        [Fact]
+        public void WindowDecorationsTheme_Should_Apply_To_Decorations()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+            var windowImpl = MockWindowingPlatform.CreateWindowMock();
+            windowImpl.Setup(x => x.NeedsManagedDecorations).Returns(true);
+            windowImpl.Setup(x => x.RequestedDrawnDecorations).Returns(
+                PlatformRequestedDrawnDecoration.TitleBar | PlatformRequestedDrawnDecoration.Border);
+
+            var window = new Window(windowImpl.Object);
+
+            var (theme1, content1) = CreateTheme();
+            window.WindowDecorationsTheme = theme1;
+            window.Show();
+
+            var decorations = window.TopLevelHost.Decorations;
+            Assert.NotNull(decorations);
+            Assert.Same(theme1, decorations.Theme);
+            Assert.Same(content1, decorations.Content);
+
+            var (theme2, content2) = CreateTheme();
+            window.WindowDecorationsTheme = theme2;
+
+            Assert.Same(theme2, decorations.Theme);
+            Assert.Same(content2, decorations.Content);
+
+            static (ControlTheme theme, WindowDrawnDecorationsContent content) CreateTheme()
+            {
+                var content = new WindowDrawnDecorationsContent();
+
+                var template = new WindowDrawnDecorationsTemplate
+                {
+                    Content = (IServiceProvider? _) => new TemplateResult<WindowDrawnDecorationsContent>(content, new NameScope())
+                };
+
+                var theme = new ControlTheme(typeof(WindowDrawnDecorations))
+                {
+                    Setters =
+                    {
+                        new Setter(WindowDrawnDecorations.TemplateProperty, template)
+                    }
+                };
+
+                return (theme, content);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
This PR adds a new `Window.WindowDecorationsTheme` property that allows users to easily set a specific theme for `WindowDrawnDecorations` on a given window, or to set it as part of a `ControlTheme` for `Window`.

Plus, it fixes an issue where changing `WindowDrawnDecorations.Theme` after it was applied didn't take effect.

## Fixed issues
 - Fixes #20911
