### PR TITLE
Measure/Arrange TextPresenter with WidthIncludingTrailingWhitespace

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -647,7 +647,7 @@ namespace Avalonia.Controls.Presenters
             InvalidateArrange();
 
             // The textWidth used here is matching that TextBlock uses to measure the text.
-            var textWidth = TextLayout.OverhangLeading + TextLayout.WidthIncludingTrailingWhitespace + TextLayout.OverhangTrailing;
+            var textWidth = TextLayout.WidthIncludingTrailingWhitespace;
             return new Size(textWidth, TextLayout.Height);
         }
 
@@ -655,7 +655,7 @@ namespace Avalonia.Controls.Presenters
         {
             var finalWidth = finalSize.Width;
 
-            var textWidth = TextLayout.OverhangLeading + TextLayout.WidthIncludingTrailingWhitespace + TextLayout.OverhangTrailing;
+            var textWidth = TextLayout.WidthIncludingTrailingWhitespace;
             textWidth = Math.Ceiling(textWidth);
 
             if (finalSize.Width < textWidth)

--- a/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
@@ -75,5 +75,30 @@ namespace Avalonia.Controls.UnitTests.Presenters
                 Assert.Equal(fontStretch, presenter.TextLayout.TextLines[0].TextRuns[0].Properties!.Typeface.Stretch);
             }
         }
+
+        [Fact]
+        public void Measure_And_Arrange_Should_Use_WidthIncludingTrailingWhitespace_For_Bounds()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var presenter = new TextPresenter
+                {
+                    Text = "fy",
+                    FontStyle = FontStyle.Italic,
+                    FontSize = 48,
+                    UseLayoutRounding = false
+                };
+
+                presenter.Measure(Size.Infinity);
+
+                var expectedSize = new Size(presenter.TextLayout.WidthIncludingTrailingWhitespace, presenter.TextLayout.Height);
+
+                Assert.Equal(expectedSize, presenter.DesiredSize);
+
+                presenter.Arrange(new Rect(default, presenter.DesiredSize));
+
+                Assert.Equal(new Rect(default, expectedSize), presenter.Bounds);
+            }
+        }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -561,6 +561,33 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Rect(0, 0, 32.45454545454545, 19.022727272727273), target.Bounds);
         }
 
+        [Fact]
+        public void Measure_And_Arrange_Should_Use_WidthIncludingTrailingWhitespace_For_Bounds()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var target = new TextBlock
+            {
+                Text = "fy",
+                FontStyle = FontStyle.Italic,
+                FontSize = 48,
+                UseLayoutRounding = false,
+                Padding = new Thickness(3, 2, 5, 4)
+            };
+
+            target.Measure(Size.Infinity);
+
+            var expectedSize =
+                new Size(target.TextLayout.WidthIncludingTrailingWhitespace, target.TextLayout.Height)
+                    .Inflate(target.Padding);
+
+            Assert.Equal(expectedSize, target.DesiredSize);
+
+            target.Arrange(new Rect(default, target.DesiredSize));
+
+            Assert.Equal(new Rect(default, expectedSize), target.Bounds);
+        }
+
         private class TestTextBlock : TextBlock
         {
             public Size Constraint => _constraint;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR fixes text measurement in TextPresenter so it matches TextBlock behavior for width calculation, and adds regression tests for both controls.

TextPresenter was measuring/arranging width as OverhangLeading + WidthIncludingTrailingWhitespace + OverhangTrailing. Since overhang values can be negative when ink does not overhang, this could shrink the computed width and make the presenter bounds too small.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
TextPresenter can report a width that is smaller than the text’s intended layout width because overhang values were added into the measured size.

This can result in an undersized bounding box in measure/arrange scenarios.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
TextPresenter now measures and arranges using WidthIncludingTrailingWhitespace (same sizing approach as TextBlock).

Expected results:

TextPresenter desired size width matches WidthIncludingTrailingWhitespace
TextPresenter arranged bounds are not reduced by negative overhang values
TextBlock behavior is validated alongside TextPresenter behavior for consistency

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Implementation changes:

Updated TextPresenter.MeasureOverride:
Replaced width calculation based on overhang sum with WidthIncludingTrailingWhitespace
Updated TextPresenter.ArrangeOverride:
Replaced minimum width calculation based on overhang sum with WidthIncludingTrailingWhitespace

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
