### PR TITLE
#21069 - ToggleButton.OnClick() desyncs IsChecked from ViewModel when…

### DIFF
--- a/src/Avalonia.Controls/Primitives/ToggleButton.cs
+++ b/src/Avalonia.Controls/Primitives/ToggleButton.cs
@@ -72,7 +72,15 @@ namespace Avalonia.Controls.Primitives
 
         protected override void OnClick()
         {
-            Toggle();
+            if (IsEffectivelyEnabled)
+            {
+                var command = Command;
+                if (command is null || command.CanExecute(CommandParameter))
+                {
+                    Toggle();
+                }
+            }
+
             base.OnClick();
         }
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/ToggleButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/ToggleButtonTests.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Data;
+﻿using Avalonia.Controls.UnitTests.Utils;
+using Avalonia.Data;
+using Avalonia.Input;
 using Avalonia.UnitTests;
 using Xunit;
 
@@ -103,6 +105,70 @@ namespace Avalonia.Controls.Primitives.UnitTests
             threeStateButton.Toggle();
             Assert.Equal(3, changeCount);
             Assert.False(threeStateButton.IsChecked);
+        }
+
+        [Fact]
+        public void Toggle_Not_Changed_When_Command_CanExecute_Is_False()
+        {
+            var command = new TestCommand(false);
+            var target = new ToggleButton
+            {
+                IsChecked = false,
+                Command = command,
+            };
+            var root = new TestRoot { Child = target };
+
+            (target as IClickableControl).RaiseClick();
+
+            Assert.False(target.IsChecked);
+        }
+
+        [Fact]
+        public void Toggle_Changed_When_Command_CanExecute_Is_True()
+        {
+            bool executed = false;
+            var command = new TestCommand(_ => true, _ => executed = true);
+            var target = new ToggleButton
+            {
+                IsChecked = false,
+                Command = command,
+            };
+            var root = new TestRoot { Child = target };
+
+            (target as IClickableControl).RaiseClick();
+
+            Assert.True(target.IsChecked);
+            Assert.True(executed);
+        }
+
+        [Fact]
+        public void Toggle_Changed_When_No_Command()
+        {
+            var target = new ToggleButton { IsChecked = false };
+            var root = new TestRoot { Child = target };
+
+            (target as IClickableControl).RaiseClick();
+
+            Assert.True(target.IsChecked);
+        }
+
+        [Fact]
+        public void Toggle_With_OneWay_Binding_Stays_In_Sync_When_Command_Cannot_Execute()
+        {
+            var source = new Class1 { Foo = false };
+            var command = new TestCommand(false);
+            var target = new ToggleButton { Command = command };
+            var root = new TestRoot { Child = target };
+
+            target.DataContext = source;
+            target.Bind(ToggleButton.IsCheckedProperty, new Binding("Foo", BindingMode.OneWay));
+
+            Assert.False(target.IsChecked);
+
+            (target as IClickableControl).RaiseClick();
+
+            Assert.False(target.IsChecked);
+            Assert.False(source.Foo);
         }
 
         private class Class1 : NotifyingBase

--- a/tests/Avalonia.Controls.UnitTests/RadioButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/RadioButtonTests.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Markup.Data;
+﻿using Avalonia.Controls.UnitTests.Utils;
+using Avalonia.Input;
+using Avalonia.Markup.Data;
 using Avalonia.UnitTests;
 
 using Xunit;
@@ -69,6 +71,39 @@ namespace Avalonia.Controls.UnitTests
             Assert.False(radioButton1.IsChecked);
             Assert.False(radioButton2.IsChecked);
             Assert.True(radioButton3.IsChecked);
+        }
+
+        [Fact]
+        public void RadioButton_Group_Not_Desynced_When_Command_CanExecute_False()
+        {
+            var parent = new Panel();
+
+            var command1 = new TestCommand(true);
+            var command2 = new TestCommand(false);
+
+            var radioButton1 = new RadioButton
+            {
+                IsChecked = true,
+                Command = command1,
+            };
+            var radioButton2 = new RadioButton
+            {
+                IsChecked = false,
+                Command = command2,
+            };
+
+            parent.Children.Add(radioButton1);
+            parent.Children.Add(radioButton2);
+            var root = new TestRoot { Child = parent };
+
+            Assert.True(radioButton1.IsChecked);
+            Assert.False(radioButton2.IsChecked);
+
+            // Click radioButton2 whose command can't execute - nothing should change
+            (radioButton2 as IClickableControl).RaiseClick();
+
+            Assert.True(radioButton1.IsChecked);
+            Assert.False(radioButton2.IsChecked);
         }
 
         [Fact]


### PR DESCRIPTION
## ToggleButton.OnClick() desyncs IsChecked from ViewModel when Command.CanExecute is false

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Guards `ToggleButton.Toggle()` with a `Command.CanExecute` check so that `IsChecked` only changes when the command will actually execute (or when no command is bound).

## What is the current behavior?

`ToggleButton.OnClick()` calls `Toggle()` unconditionally before `base.OnClick()` checks `Command.CanExecute()`. When the command cannot execute — e.g. a `ReactiveCommand.CreateFromTask` is still running from a previous click, or `CanExecuteChanged` hasn't propagated through the scheduler yet — `Toggle()` changes `IsChecked` via `SetCurrentValue`, but the command never fires, so the ViewModel's bound property is never updated.

With a `OneWay` binding (`IsChecked="{Binding IsSelected, Mode=OneWay}"`), the binding source doesn't change, so no value is pushed back to override the `SetCurrentValue` — leaving the UI showing a toggled state that disagrees with the ViewModel.

For `RadioButton`, the damage spreads: `RadioButtonGroupManager` unchecks siblings via `SetCurrentValue` when any radio button checks itself, so one missed command execution desyncs the entire radio group.

```
User clicks button
  │
  ▼
ToggleButton.OnClick()
  │
  ├─ Toggle()                          ← ALWAYS runs
  │    └─ SetCurrentValue(IsChecked)   ← UI immediately shows toggled
  │
  └─ base.OnClick()  (Button.OnClick)
       └─ if (command.CanExecute())    ← May be FALSE
            command.Execute()          ← Skipped!
```

## What is the updated/expected behavior with this PR?

`Toggle()` only runs when the command will actually execute (or when no command is bound). The UI stays in sync with the ViewModel at all times.

```
User clicks button
  │
  ▼
ToggleButton.OnClick()
  │
  ├─ Check: IsEffectivelyEnabled?
  ├─ Check: Command is null OR CanExecute?
  │    │
  │    ├─ YES → Toggle()              ← IsChecked changes, command will execute
  │    └─ NO  → skip                  ← Nothing changes, stays in sync
  │
  └─ base.OnClick()
       └─ command.Execute()           ← Runs (or not) consistently with Toggle
```

- **No command bound** → `Toggle()` runs unconditionally (preserves existing behavior)
- **Command can execute** → `Toggle()` runs, then command executes — both agree
- **Command can't execute** → `Toggle()` is skipped, command is skipped — both agree

## How was the solution implemented (if it's not obvious)?

The fix adds a `CanExecute` pre-check in `ToggleButton.OnClick()` before calling `Toggle()`. This means `CanExecute` is checked twice — once here and once in `Button.OnClick()`. Both calls are synchronous on the UI thread so the TOCTOU window is negligible. The alternative (restructuring `Button.OnClick`) would be far more invasive and affect all Button subclasses.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None. Existing behavior is preserved for ToggleButtons without commands. ToggleButtons with commands that return `CanExecute=true` behave identically. The only change is that `Toggle()` is now skipped when `CanExecute` is false — which is the correct behavior, since the command won't execute either.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21069

@dariostrm @Hajduk-d fyi
