### PR TITLE
Post NSAccessibility notifications for property changes on macOS

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -656,6 +656,18 @@
 
 - (void)raisePropertyChanged:(AvnAutomationProperty)property
 {
+    switch (property)
+    {
+        case AutomationPeer_Name:
+            NSAccessibilityPostNotification(self, NSAccessibilityTitleChangedNotification);
+            break;
+        case AutomationPeer_BoundingRectangle:
+            NSAccessibilityPostNotification(self, NSAccessibilityMovedNotification);
+            NSAccessibilityPostNotification(self, NSAccessibilityResizedNotification);
+            break;
+        default:
+            break;
+    }
 }
 
 @end

--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -488,8 +488,32 @@
 
 - (void)raisePropertyChanged:(AvnAutomationProperty)property
 {
-    if (property == AutomationPeer_Name && _peer->GetLiveSetting() != LiveSettingOff)
-        [self raiseLiveRegionChanged];
+    switch (property)
+    {
+        case AutomationPeer_Name:
+            NSAccessibilityPostNotification(self, NSAccessibilityTitleChangedNotification);
+            if (_peer->GetLiveSetting() != LiveSettingOff)
+                [self raiseLiveRegionChanged];
+            break;
+        case ValueProvider_Value:
+        case RangeValueProvider_Value:
+            NSAccessibilityPostNotification(self, NSAccessibilityValueChangedNotification);
+            break;
+        case AutomationPeer_BoundingRectangle:
+            NSAccessibilityPostNotification(self, NSAccessibilityMovedNotification);
+            NSAccessibilityPostNotification(self, NSAccessibilityResizedNotification);
+            break;
+        case SelectionItemProvider_IsSelected:
+        case SelectionProvider_Selection:
+            NSAccessibilityPostNotification(self, NSAccessibilitySelectedChildrenChangedNotification);
+            break;
+        case ToggleProvider_ToggleState:
+        case ExpandCollapseProvider_ExpandCollapseState:
+            NSAccessibilityPostNotification(self, NSAccessibilityValueChangedNotification);
+            break;
+        default:
+            break;
+    }
 }
 
 - (void)raiseLiveRegionChanged

--- a/src/Avalonia.Native/AvnAutomationPeer.cs
+++ b/src/Avalonia.Native/AvnAutomationPeer.cs
@@ -19,6 +19,11 @@ namespace Avalonia.Native
             { AutomationElementIdentifiers.ClassNameProperty, AvnAutomationProperty.AutomationPeer_ClassName },
             { AutomationElementIdentifiers.NameProperty, AvnAutomationProperty.AutomationPeer_Name },
             { RangeValuePatternIdentifiers.ValueProperty, AvnAutomationProperty.RangeValueProvider_Value },
+            { ValuePatternIdentifiers.ValueProperty, AvnAutomationProperty.ValueProvider_Value },
+            { TogglePatternIdentifiers.ToggleStateProperty, AvnAutomationProperty.ToggleProvider_ToggleState },
+            { ExpandCollapsePatternIdentifiers.ExpandCollapseStateProperty, AvnAutomationProperty.ExpandCollapseProvider_ExpandCollapseState },
+            { SelectionItemPatternIdentifiers.IsSelectedProperty, AvnAutomationProperty.SelectionItemProvider_IsSelected },
+            { SelectionPatternIdentifiers.SelectionProperty, AvnAutomationProperty.SelectionProvider_Selection },
         };
 
         private static readonly ConditionalWeakTable<AutomationPeer, AvnAutomationPeer> s_wrappers = new();

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -403,6 +403,11 @@ enum AvnAutomationProperty
     AutomationPeer_ClassName,
     AutomationPeer_Name,
     RangeValueProvider_Value,
+    ValueProvider_Value,
+    ToggleProvider_ToggleState,
+    ExpandCollapseProvider_ExpandCollapseState,
+    SelectionItemProvider_IsSelected,
+    SelectionProvider_Selection,
 }
 
 struct AvnSize


### PR DESCRIPTION
## What does the pull request do?

Implements `NSAccessibilityPostNotification` calls for property changes on macOS. Adds five new `AvnAutomationProperty` enum values and maps them through the managed bridge so that accessibility clients receive notifications when UI element properties change.

## What is the current behavior?

`raisePropertyChanged:` in `AvnAccessibilityElement` only posts a notification for `AutomationPeer_Name` when the element has a `LiveSetting`, and ignores all other property changes. `raisePropertyChanged:` in `AvnWindow` is a complete empty stub. This means external AXObserver clients never receive `AXValueChanged`, `AXTitleChanged`, `AXSelectedChildrenChanged`, or other notifications when Avalonia UI elements change -- forcing accessibility tools to poll.

## What is the updated/expected behavior with this PR?

Property changes now post the appropriate `NSAccessibilityPostNotification`:

| Property | Notification |
|---|---|
| Name | `NSAccessibilityTitleChangedNotification` (+ LiveRegion if applicable) |
| Value (text, range) | `NSAccessibilityValueChangedNotification` |
| ToggleState, ExpandCollapseState | `NSAccessibilityValueChangedNotification` |
| BoundingRectangle | `NSAccessibilityMovedNotification` + `NSAccessibilityResizedNotification` |
| IsSelected, Selection | `NSAccessibilitySelectedChildrenChangedNotification` |
