### PR TITLE
Fix access keys not working when KeySymbol is null

### DIFF
--- a/src/Windows/Avalonia.Win32/Input/KeyInterop.cs
+++ b/src/Windows/Avalonia.Win32/Input/KeyInterop.cs
@@ -494,6 +494,24 @@ namespace Avalonia.Win32.Input
         }
 
         /// <summary>
+        /// Gets a key symbol from a Windows virtual-key using MapVirtualKey.
+        /// Unlike <see cref="GetKeySymbol"/>, this does not call ToUnicodeEx and is safe to use
+        /// during WM_SYSKEYDOWN/UP where ToUnicodeEx would corrupt keyboard state.
+        /// </summary>
+        /// <param name="virtualKey">The Windows virtual-key.</param>
+        /// <returns>A key symbol, or null if none matched.</returns>
+        public static string? GetKeySymbolFromVirtualKey(int virtualKey)
+        {
+            var ch = MapVirtualKey((uint)virtualKey, (uint)MapVirtualKeyMapTypes.MAPVK_VK_TO_CHAR);
+            if (ch == 0)
+                return null;
+
+            // Bit 31 is set for dead keys — strip it to get the base character.
+            var c = (char)(ch & 0x7FFFFFFF);
+            return KeySymbolHelper.IsAllowedAsciiKeySymbol(c) ? c.ToString() : null;
+        }
+
+        /// <summary>
         /// Gets a key symbol from a Windows virtual-key and key data.
         /// </summary>
         /// <param name="virtualKey">The Windows virtual-key.</param>

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -1446,8 +1446,11 @@ namespace Avalonia.Win32
             var physicalKey = KeyInterop.PhysicalKeyFromVirtualKey(virtualKey, keyData);
 
             // Avoid calling GetKeySymbol() for WM_SYSKEYDOWN/UP:
-            // it ultimately calls User32!ToUnicodeEx, which messes up the keyboard state in this case.
-            var keySymbol = useKeySymbol ? KeyInterop.GetKeySymbol(virtualKey, keyData) : null;
+            // it ultimately calls ToUnicodeEx, which corrupts keyboard state for system key events.
+            // Use MapVirtualKey-based fallback instead — it's layout-aware without touching keyboard state.
+            var keySymbol = useKeySymbol
+                ? KeyInterop.GetKeySymbol(virtualKey, keyData)
+                : KeyInterop.GetKeySymbolFromVirtualKey(virtualKey);
 
             if (key == Key.None && physicalKey == PhysicalKey.None && string.IsNullOrWhiteSpace(keySymbol))
                 return null;

--- a/tests/Avalonia.Base.UnitTests/Input/AccessKeyHandlerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/AccessKeyHandlerTests.cs
@@ -234,6 +234,33 @@ namespace Avalonia.Base.UnitTests.Input
         }
 
         [Fact]
+        public void Should_Raise_AccessKey_For_System_Key_Event_With_KeySymbol()
+        {
+            // Regression test for #20961: on Windows, WM_SYSKEYDOWN (Alt+key) previously
+            // left KeySymbol null, breaking access keys. MapVirtualKey now provides KeySymbol.
+            using (UnitTestApplication.Start(TestServices.RealFocus))
+            {
+                var button = new Button();
+                var root = new TestRoot(button);
+                var target = new AccessKeyHandler();
+                var raised = 0;
+
+                KeyboardDevice.Instance?.SetFocusedElement(button, NavigationMethod.Unspecified, KeyModifiers.None);
+
+                target.SetOwner(root);
+                target.Register("F", button);
+                button.AddHandler(AccessKeyHandler.AccessKeyEvent, (s, e) => ++raised);
+
+                KeyDown(root, Key.LeftAlt);
+                Assert.Equal(0, raised);
+
+                // MapVirtualKey provides lowercase KeySymbol for system key events
+                KeyDown(root, Key.F, "f", KeyModifiers.Alt);
+                Assert.Equal(1, raised);
+            }
+        }
+
+        [Fact]
         public void Should_Open_MainMenu_On_Alt_KeyUp()
         {
             using (UnitTestApplication.Start(TestServices.RealFocus))


### PR DESCRIPTION
## What does the pull request do?

Fixes a regression where Label access keys (Alt+letter) stopped working on Windows. The issue was introduced in #20662, which switched `AccessKeyHandler` from using `Key` to `KeySymbol` for keyboard-layout-aware matching.

## What is the current behavior?

Pressing Alt+F in the ControlCatalog Labels page does not focus the FirstName TextBox. Access keys are completely broken on Windows.

**Root cause:** On Windows, `WM_SYSKEYDOWN` (sent when Alt is held) intentionally skips `ToUnicodeEx` to avoid corrupting keyboard state, leaving `KeySymbol = null`. After #20662, `AccessKeyHandler.OnKeyDown` passes `e.KeySymbol` (which is `null`) to `ProcessKey`, which immediately returns `false`.

## What is the updated/expected behavior with this PR?

Access keys work correctly again. For `WM_SYSKEYDOWN`/`WM_SYSKEYUP`, `KeySymbol` is now resolved via `MapVirtualKey(VK, MAPVK_VK_TO_CHAR)` instead of being left as `null`. This is layout-aware and does not call `ToUnicodeEx`, so it won't corrupt keyboard state.

## How was the solution implemented (if it's not obvious)?

`MapVirtualKey` with `MAPVK_VK_TO_CHAR` translates a virtual-key to its associated character using the current keyboard layout, without touching keyboard state. Unlike `ToUnicodeEx`, it's safe to call during system key events. It doesn't handle dead keys or complex composites, but for access keys we only need the base character.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Fixed issues

Fixes #20961