### PR TITLE
Fix macOS file pickers native crash

### DIFF
--- a/native/Avalonia.Native/src/OSX/StorageProvider.mm
+++ b/native/Avalonia.Native/src/OSX/StorageProvider.mm
@@ -172,6 +172,7 @@ public:
     {
         @autoreleasepool
         {
+            ComPtr<IAvnSystemDialogEvents> ownedEvents(events); // for use in the callback
             auto panel = [NSOpenPanel openPanel];
             
             panel.allowsMultipleSelection = allowMultiple;
@@ -201,7 +202,7 @@ public:
                     if(urls.count > 0)
                     {
                         auto uriStrings = CreateAvnStringArray(urls);
-                        events->OnCompleted(uriStrings);
+                        ownedEvents->OnCompleted(uriStrings);
     
                         [panel orderOut:panel];
                         
@@ -214,7 +215,7 @@ public:
                     }
                 }
                 
-                events->OnCompleted(nullptr);
+                ownedEvents->OnCompleted(nullptr);
                 
             };
             
@@ -239,6 +240,7 @@ public:
     {
         @autoreleasepool
         {
+            ComPtr<IAvnSystemDialogEvents> ownedEvents(events); // for use in the callback
             auto panel = [NSOpenPanel openPanel];
             
             panel.allowsMultipleSelection = allowMultiple;
@@ -273,7 +275,7 @@ public:
                     if(urls.count > 0)
                     {
                         auto uriStrings = CreateAvnStringArray(urls);
-                        events->OnCompleted(uriStrings);
+                        ownedEvents->OnCompleted(uriStrings);
 
                         [panel orderOut:panel];
                         
@@ -286,7 +288,7 @@ public:
                     }
                 }
                 
-                events->OnCompleted(nullptr);
+                ownedEvents->OnCompleted(nullptr);
                 
             };
             
@@ -310,6 +312,7 @@ public:
     {
         @autoreleasepool
         {
+            ComPtr<IAvnSystemDialogEvents> ownedEvents(events); // for use in the callback
             auto panel = [NSSavePanel savePanel];
             
             if(title != nullptr)
@@ -350,7 +353,7 @@ public:
                     auto url = [panel URL];
                     auto urls = [NSArray<NSURL*> arrayWithObject:url];
                     auto uriStrings = CreateAvnStringArray(urls);
-                    events->OnCompletedWithFilter(uriStrings, selectedIndex);
+                    ownedEvents->OnCompletedWithFilter(uriStrings, selectedIndex);
 
                     [panel orderOut:panel];
                     
@@ -362,7 +365,7 @@ public:
                     return;
                 }
                 
-                events->OnCompletedWithFilter(nullptr, selectedIndex);
+                ownedEvents->OnCompletedWithFilter(nullptr, selectedIndex);
                 
             };
             


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a native crash occurring when using `IStorageProvider.OpenFilePickerAsync/SaveFilePickerAsync/OpenFolderPickerAsync` on macOS.

## What is the current behavior?
When canceling or selecting a file/folder, an access violation occurs in native code, terminating the application.

## What is the updated/expected behavior with this PR?
The pickers work as expected.

## How was the solution implemented (if it's not obvious)?
Recent versions of MicroCom (updated in #21001) are more aggressive with lifetimes.
The `IAvnSystemDialogEvents` object needs to be kept alive for use in the picker's callback method.

## Fixed issues
 - Fixes #21102
