### PR TITLE
Remove obsolete int32 limit on DispatcherTimer.Interval

### DIFF
--- a/src/Avalonia.Base/Threading/DispatcherTimer.cs
+++ b/src/Avalonia.Base/Threading/DispatcherTimer.cs
@@ -154,10 +154,6 @@ public class DispatcherTimer
                 throw new ArgumentOutOfRangeException(nameof(value),
                     "TimeSpan period must be greater than or equal to zero.");
 
-            if (value.TotalMilliseconds > Int32.MaxValue)
-                throw new ArgumentOutOfRangeException(nameof(value),
-                    "TimeSpan period must be less than or equal to Int32.MaxValue.");
-
             lock (_instanceLock)
             {
                 _interval = value;


### PR DESCRIPTION
In 6a99ca39f905280a93e4470508e99cc530acf9d1, `DispatcherTimer` was refactored. The number of milliseconds until due time was stored in an `int` and `TimeSpan` values with more than `Int32.MaxValue` milliseconds were duly rejected in the setter of the `Interval` property.

Just two days later, dbbdcb95cd0ceb76f777620fa12473e764890726 refactored the type to store the number of milliseconds with `long`. But the `Int32` limit on `Interval` wasn't removed.

Because `TimeSpan.MaxValue.TotalMilliseconds` is only 0.01% of `long.MaxValue`, we needn't restrict the value at all. An `OverflowException` will be thrown by the runtime if an optimistic user tries to create a timer that elapses more than 7,978 years in the future.

## What is the current behaviour?
A `DispatcherTimer` cannot be configured to expire more than 28.8 days into the future.

## Breaking changes
None.

## Obsoletions / Deprecations
None.