### PR TITLE
Fix DataTransferItem returning wrong data for mismatched format

### DIFF
--- a/src/Avalonia.Base/Input/DataTransferItem.cs
+++ b/src/Avalonia.Base/Input/DataTransferItem.cs
@@ -61,7 +61,7 @@ public sealed class DataTransferItem : IDataTransferItem, IAsyncDataTransferItem
         if (_accessorByFormat is not null)
             return _accessorByFormat.TryGetValue(format, out var accessor) ? accessor : null;
 
-        if (_singleItem is { } singleItem)
+        if (_singleItem is { } singleItem && singleItem.Key.Equals(format))
             return singleItem.Value;
 
         return null;

--- a/tests/Avalonia.Base.UnitTests/Input/DataFormatTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/DataFormatTests.cs
@@ -80,6 +80,16 @@ public sealed class DataFormatTests
     }
 
     [Fact]
+    public void TryGetRaw_With_Mismatched_Format_Returns_Null_For_Single_Format_Item()
+    {
+        var item = DataTransferItem.CreateText("hello");
+
+        var result = item.TryGetRaw(DataFormat.Bitmap);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
     public void InProcess_Format_Works_With_DataTransferItem_Set_And_Get()
     {
         var format = DataFormat.CreateInProcessFormat<string>("my-inprocess");


### PR DESCRIPTION
## What does the pull request do?
Fixes `DataTransferItem.FindAccessor` returning the stored value for any format query when the item holds a single format, instead of checking whether the requested format matches.

## What is the current behavior?
The single-item fast path unconditionally returns the stored accessor without comparing format keys:

```csharp
if (_singleItem is { } singleItem)
    return singleItem.Value; // no key comparison
```

This means `DataTransferItem.CreateText("hello").TryGetRaw(DataFormat.Bitmap)` returns `"hello"` instead of `null`.

## What is the updated/expected behavior with this PR?
The single-item path now checks `singleItem.Key.Equals(format)`, matching the behavior of both the dictionary path (`TryGetValue`) and `RemoveCore`.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation