### PR TITLE
Fix macOS StorageProvider null pointer bugs

### DIFF
--- a/native/Avalonia.Native/src/OSX/StorageProvider.mm
+++ b/native/Avalonia.Native/src/OSX/StorageProvider.mm
@@ -398,7 +398,7 @@ public:
         }
         
         auto filePathUri = [fileUri filePathURL];
-        if (fileUri == nil)
+        if (filePathUri == nil)
         {
             *ret = nullptr;
             return S_OK;

--- a/native/Avalonia.Native/src/OSX/StorageProvider.mm
+++ b/native/Avalonia.Native/src/OSX/StorageProvider.mm
@@ -82,6 +82,8 @@ public:
             if(ppv == nullptr)
                 return E_POINTER;
 
+            *ppv = nullptr;
+
             NSError* error = nil;
             auto fileUri = [NSURL URLWithString: GetNSStringAndRelease(fileUriStr)];
             auto bookmarkData = [fileUri bookmarkDataWithOptions:NSURLBookmarkCreationWithSecurityScope includingResourceValuesForKeys:nil relativeToURL:nil error:&error];
@@ -89,7 +91,7 @@ public:
             {
                 *ppv = CreateByteArray((void*)bookmarkData.bytes, (int)bookmarkData.length);
             }
-            else if (error != nil)
+            else if (error != nil && err != nullptr)
             {
                 *err = CreateAvnString([error localizedDescription]);
             }

--- a/native/Avalonia.Native/src/OSX/StorageProvider.mm
+++ b/native/Avalonia.Native/src/OSX/StorageProvider.mm
@@ -82,14 +82,14 @@ public:
             if(ppv == nullptr)
                 return E_POINTER;
 
-            NSError* error;
+            NSError* error = nil;
             auto fileUri = [NSURL URLWithString: GetNSStringAndRelease(fileUriStr)];
             auto bookmarkData = [fileUri bookmarkDataWithOptions:NSURLBookmarkCreationWithSecurityScope includingResourceValuesForKeys:nil relativeToURL:nil error:&error];
             if (bookmarkData)
             {
                 *ppv = CreateByteArray((void*)bookmarkData.bytes, (int)bookmarkData.length);
             }
-            if (error != nil)
+            else if (error != nil)
             {
                 *err = CreateAvnString([error localizedDescription]);
             }


### PR DESCRIPTION
## What does the pull request do?
Fixes null pointer bugs in `StorageProvider.mm`.

## What is the current behavior?
1. In `TryResolveFileReferenceUri`, the null check on line 401 tests `fileUri` (already checked on line 394) instead of `filePathUri`. The guard is dead code, and passing a non-file URL crashes.
2. In `SaveBookmarkToBytes`, `NSError* error` is uninitialized. On the success path, the `if (error != nil)` check reads stack garbage, which can intermittently crash.
3. In `SaveBookmarkToBytes`, `*ppv` is never written when `fileUri` is nil or `bookmarkData` is nil, leaving the caller with garbage. Also, `*err` is written without checking `err` for nullptr.

## What is the updated/expected behavior with this PR?
1. The null check now tests `filePathUri`, returning early when `filePathURL` returns nil.
2. `NSError* error` is initialized to `nil`, and is only inspected on the failure path (`else if`).
3. `*ppv` is initialized to `nullptr` on entry. `*err` is guarded with `err != nullptr`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation