### PR TITLE
Fix DatePickerPresenter focusing wrong selector for day-first locales

### DIFF
--- a/src/Avalonia.Controls/DateTimePickers/DatePickerPresenter.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DatePickerPresenter.cs
@@ -473,22 +473,30 @@ namespace Avalonia.Controls
 
         private void SetInitialFocus(TemplateItems items)
         {
-            int monthCol = MonthVisible ? Grid.GetColumn(items._monthHost) : int.MaxValue;
-            int dayCol = DayVisible ? Grid.GetColumn(items._dayHost) : int.MaxValue;
-            int yearCol = YearVisible ? Grid.GetColumn(items._yearHost) : int.MaxValue;
+            ReadOnlySpan<(bool visible, Panel host, DateTimePickerPanel selector)> candidates =
+            [
+                (MonthVisible, items._monthHost, items._monthSelector),
+                (DayVisible, items._dayHost, items._daySelector),
+                (YearVisible, items._yearHost, items._yearSelector),
+            ];
 
-            if (monthCol < dayCol && monthCol < yearCol)
+            DateTimePickerPanel? leftmost = null;
+            var minCol = int.MaxValue;
+
+            foreach (var (visible, host, selector) in candidates)
             {
-                items._monthSelector.Focus(NavigationMethod.Pointer);
+                if (!visible)
+                    continue;
+
+                var col = Grid.GetColumn(host);
+                if (col < minCol)
+                {
+                    minCol = col;
+                    leftmost = selector;
+                }
             }
-            else if (dayCol < monthCol && dayCol < yearCol)
-            {
-                items._monthSelector.Focus(NavigationMethod.Pointer);
-            }
-            else if (yearCol < monthCol && yearCol < dayCol)
-            {
-                items._yearSelector.Focus(NavigationMethod.Pointer);
-            }
+
+            leftmost?.Focus(NavigationMethod.Pointer);
         }
 
         private void OnDismissButtonClicked(object? sender, RoutedEventArgs e)

--- a/tests/Avalonia.Controls.UnitTests/DatePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DatePickerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Reactive.Subjects;
 using Avalonia.Controls.Primitives;
@@ -7,6 +8,7 @@ using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Harfbuzz;
 using Avalonia.Headless;
+using Avalonia.Input;
 using Avalonia.Platform;
 using Avalonia.Threading;
 using Avalonia.UnitTests;
@@ -272,11 +274,53 @@ namespace Avalonia.Controls.UnitTests
             Assert.NotEqual(previousOffset, panel.Offset);
         }
 
+        [Fact]
+        public void SetInitialFocus_Should_Focus_Day_Selector_For_Day_First_Locale()
+        {
+            var previousCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                // en-GB uses dd/MM/yyyy — day appears first in the short date pattern
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-GB");
+
+                using (UnitTestApplication.Start(FocusServices))
+                {
+                    var presenter = new DatePickerPresenter { Template = CreatePickerTemplate() };
+                    var root = new TestRoot(presenter);
+                    root.LayoutManager.ExecuteInitialLayoutPass();
+
+                    // Trigger InitPicker again now that the visual tree is fully connected,
+                    // so SetInitialFocus can successfully call Focus().
+                    presenter.Date = new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeSpan.Zero);
+
+                    var daySelector = presenter
+                        .GetVisualDescendants()
+                        .OfType<DateTimePickerPanel>()
+                        .First(p => p.Name == "PART_DaySelector");
+
+                    Assert.Same(daySelector, root.FocusManager.GetFocusedElement());
+                }
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = previousCulture;
+            }
+        }
+
         private static TestServices Services => TestServices.MockThreadingInterface.With(
             fontManagerImpl: new HeadlessFontManagerStub(),
             standardCursorFactory: Mock.Of<ICursorFactory>(),
             textShaperImpl: new HarfBuzzTextShaper(),
             renderInterface: new HeadlessPlatformRenderInterface());
+
+        private static TestServices FocusServices => TestServices.MockThreadingInterface.With(
+            fontManagerImpl: new HeadlessFontManagerStub(),
+            standardCursorFactory: Mock.Of<ICursorFactory>(),
+            textShaperImpl: new HarfBuzzTextShaper(),
+            renderInterface: new HeadlessPlatformRenderInterface(),
+            keyboardDevice: () => new KeyboardDevice(),
+            keyboardNavigation: () => new KeyboardNavigationHandler(),
+            inputManager: new InputManager());
 
         private static IControlTemplate CreateTemplate()
         {


### PR DESCRIPTION
## What does the pull request do?
Fixes `DatePickerPresenter.SetInitialFocus` focusing the month selector instead of the day selector when the day column is leftmost (e.g. `dd/MM/yyyy` locales).

## What is the current behavior?
Copy-paste bug: the `dayCol < monthCol && dayCol < yearCol` branch calls `_monthSelector.Focus()` instead of `_daySelector.Focus()`. Users in day-first locales (UK, Europe, Australia, India, etc.) get the wrong selector focused when the picker opens.

## What is the updated/expected behavior with this PR?
Replaced the three if/else branches with a data-driven loop that pairs each `(visible, host, selector)` tuple and focuses the leftmost visible column. This fixes the bug and makes the same class of copy-paste error structurally impossible.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation