### PR TITLE
Bump Tmds.DBus.Protocol

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,7 +60,7 @@
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="System.Text.Json" Version="10.0.0" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.90.3" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
     <PackageVersion Include="Tmds.DBus.SourceGenerator" Version="0.0.22" />
     <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.7.1.3" />
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0.2" />


### PR DESCRIPTION
There's an advisory for the current version of Tmds.DBus.Protocol we're using, https://github.com/advisories/GHSA-xrw6-gwf8-vvr9

This bumps it to the newest version.
