### PR TITLE
Fix subtree input hit test coordinates

### DIFF
--- a/src/Avalonia.Base/Rendering/IRenderer.cs
+++ b/src/Avalonia.Base/Rendering/IRenderer.cs
@@ -84,7 +84,7 @@ namespace Avalonia.Rendering
         /// <para>⚠️ This method is low-level and <b>DOES NOT respect <see cref="Input.InputElement.IsHitTestVisible"/></b>.</para>
         /// <para>Use  <see cref="Input.InputExtensions"/> to perform input hit testing, or provide your own <paramref name="filter"/> function.</para>
         /// </remarks>
-        /// <param name="p">The point, in client coordinates.</param>
+        /// <param name="p">The point, in coordinates relative to <paramref name="root"/>.</param>
         /// <param name="root">The root of the subtree to search.</param>
         /// <param name="filter">
         /// A filter predicate. If the predicate returns false then the visual and all its

--- a/src/Avalonia.Base/VisualTree/VisualExtensions.cs
+++ b/src/Avalonia.Base/VisualTree/VisualExtensions.cs
@@ -334,21 +334,12 @@ namespace Avalonia.VisualTree
             ThrowHelper.ThrowIfNull(visual, nameof(visual));
 
             var source = visual.GetPresentationSource();
-            var root = source?.RootVisual;
-
-            if (source is null || root is null)
+            if (source is null)
             {
                 return null;
             }
 
-            var rootPoint = visual.TranslatePoint(p, (Visual)root);
-
-            if (rootPoint.HasValue)
-            {
-                return source.HitTester.HitTestFirst(rootPoint.Value, visual, filter);
-            }
-
-            return null;
+            return source.HitTester.HitTestFirst(p, visual, filter);
         }
 
         /// <summary>

--- a/tests/Avalonia.Base.UnitTests/Input/InputExtensionsTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/InputExtensionsTests.cs
@@ -1,0 +1,49 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Input;
+
+public class InputExtensionsTests
+{
+    [Fact]
+    public void InputHitTest_Should_Use_Coordinates_Relative_To_The_Subtree_Root()
+    {
+        Border target;
+        using var services = new CompositorTestServices(new Size(200, 200))
+        {
+            TopLevel =
+            {
+                Content = new StackPanel
+                {
+                    Background = Brushes.White,
+                    Children =
+                    {
+                        new Border
+                        {
+                            Width = 100,
+                            Height = 200,
+                            Background = Brushes.Red,
+                        },
+                        (target = new Border
+                        {
+                            Width = 100,
+                            Height = 200,
+                            Background = Brushes.Green,
+                        })
+                    },
+                    Orientation = Orientation.Horizontal,
+                }
+            }
+        };
+
+        services.RunJobs();
+
+        var result = target.InputHitTest(new Point(50, 50), enabledElementsOnly: false);
+
+        Assert.Same(target, result);
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Fixes subtree input hit testing so `GetVisualAt` and `InputHitTest` use coordinates relative to the subtree root. The PR also updates the stale `IHitTester` XML comment to describe the actual coordinate-space contract.

## What is the current behavior?

`GetVisualAt` translates the input point into presentation-root coordinates before calling `HitTestFirst`, while subtree hit testing expects coordinates relative to the subtree root. As a result, `Control.InputHitTest` can miss or return the wrong child when the control being queried is offset inside its parent.

## What is the updated/expected behavior with this PR?

Subtree hit testing now treats the input point consistently as local to the subtree root for both `GetVisualAt` and `GetVisualsAt`.

Tested with:

- `dotnet run --project tests/Avalonia.Base.UnitTests/Avalonia.Base.UnitTests.csproj -- --filter-method "Avalonia.Base.UnitTests.Input.InputExtensionsTests.InputHitTest_Should_Use_Coordinates_Relative_To_The_Subtree_Root"`
- `dotnet run --project tests/Avalonia.Base.UnitTests/Avalonia.Base.UnitTests.csproj -- --filter-namespace "Avalonia.Base.UnitTests.VisualTree"`

## How was the solution implemented (if it's not obvious)?

The fix removes the extra translation in `VisualExtensions.GetVisualAt` and passes the point through unchanged to `HitTestFirst`, matching the existing `GetVisualsAt` path and the compositor hit-test implementation. A regression test covers an offset child control calling `InputHitTest` on itself.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

