### PR TITLE
Prevent toggle controls from changing state when commands cannot execute

### DIFF
--- a/src/Avalonia.Controls/Primitives/ToggleButton.cs
+++ b/src/Avalonia.Controls/Primitives/ToggleButton.cs
@@ -72,6 +72,11 @@ namespace Avalonia.Controls.Primitives
 
         protected override void OnClick()
         {
+            if (!IsEffectivelyEnabled)
+            {
+                return;
+            }
+
             Toggle();
             base.OnClick();
         }

--- a/tests/Avalonia.Base.UnitTests/Input/TouchDeviceTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/TouchDeviceTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Windows.Input;
 using Avalonia.Base.UnitTests.Input;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input.Raw;
 using Avalonia.Platform;
 using Avalonia.Rendering;
@@ -242,6 +244,47 @@ namespace Avalonia.Input.UnitTests
             Assert.Equal(3, doubleTappedExecutedTimes);
         }
 
+        [Fact]
+        public void ToggleButton_Does_Not_Toggle_When_Command_Becomes_Disabled_Between_TouchBegin_And_TouchEnd()
+        {
+            using var app = UnitTestApp(new TimeSpan(200));
+
+            var renderer = new Mock<IHitTester>();
+            var impl = CreateTopLevelImplMock();
+            var command = new TestCommand(true);
+            var target = new ToggleButton
+            {
+                Width = 100,
+                Height = 100,
+                Command = command,
+            };
+            var root = CreateInputRoot(impl.Object, target, renderer.Object);
+            var device = new TouchDevice();
+            var touchBegin = new RawPointerEventArgs(device, 0, root.PresentationSource, RawPointerEventType.TouchBegin, new Point(50, 50), RawInputModifiers.None)
+            {
+                RawPointerId = 1
+            };
+            var touchEnd = new RawPointerEventArgs(device, 1, root.PresentationSource, RawPointerEventType.TouchEnd, new Point(50, 50), RawInputModifiers.None)
+            {
+                RawPointerId = 1
+            };
+
+            SetHit(renderer, target);
+
+            impl.Object.Input!(touchBegin);
+
+            Assert.True(target.IsPressed);
+            Assert.False(target.IsChecked ?? false);
+
+            command.IsEnabled = false;
+
+            Assert.False(target.IsEffectivelyEnabled);
+
+            impl.Object.Input!(touchEnd);
+
+            Assert.False(target.IsChecked ?? false);
+        }
+
         private IDisposable UnitTestApp(TimeSpan doubleClickTime = new TimeSpan())
         {
             var unitTestApp = UnitTestApplication.Start(
@@ -299,6 +342,44 @@ namespace Avalonia.Input.UnitTests
             {
                 RawPointerId = touchPointId
             });
+        }
+
+        private sealed class TestCommand : ICommand
+        {
+            private bool _enabled;
+            private EventHandler? _canExecuteChanged;
+
+            public TestCommand(bool enabled)
+            {
+                _enabled = enabled;
+            }
+
+            public bool IsEnabled
+            {
+                get => _enabled;
+                set
+                {
+                    if (_enabled == value)
+                    {
+                        return;
+                    }
+
+                    _enabled = value;
+                    _canExecuteChanged?.Invoke(this, EventArgs.Empty);
+                }
+            }
+
+            public event EventHandler? CanExecuteChanged
+            {
+                add => _canExecuteChanged += value;
+                remove => _canExecuteChanged -= value;
+            }
+
+            public bool CanExecute(object? parameter) => _enabled;
+
+            public void Execute(object? parameter)
+            {
+            }
         }
 
         private class TestTopLevel(ITopLevelImpl impl) : TopLevel(impl)

--- a/tests/Avalonia.Controls.UnitTests/Primitives/ToggleButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/ToggleButtonTests.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Data;
+﻿using Avalonia.Controls.UnitTests.Utils;
+using Avalonia.Data;
+using Avalonia.Input;
 using Avalonia.UnitTests;
 using Xunit;
 
@@ -103,6 +105,46 @@ namespace Avalonia.Controls.Primitives.UnitTests
             threeStateButton.Toggle();
             Assert.Equal(3, changeCount);
             Assert.False(threeStateButton.IsChecked);
+        }
+
+        [Fact]
+        public void ToggleButton_With_NonExecutable_Command_Does_Not_Toggle_On_Click()
+        {
+            var target = new ToggleButton
+            {
+                Command = new TestCommand(false),
+            };
+            var root = new TestRoot
+            {
+                Child = target,
+            };
+
+            Assert.False(target.IsChecked);
+            Assert.False(target.IsEffectivelyEnabled);
+
+            (target as IClickableControl).RaiseClick();
+
+            Assert.False(target.IsChecked);
+        }
+
+        [Fact]
+        public void ToggleButton_With_Executable_Command_Toggles_On_Click()
+        {
+            var target = new ToggleButton
+            {
+                Command = new TestCommand(true),
+            };
+            var root = new TestRoot
+            {
+                Child = target,
+            };
+
+            Assert.False(target.IsChecked);
+            Assert.True(target.IsEffectivelyEnabled);
+
+            (target as IClickableControl).RaiseClick();
+
+            Assert.True(target.IsChecked);
         }
 
         private class Class1 : NotifyingBase

--- a/tests/Avalonia.Controls.UnitTests/Primitives/ToggleButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/ToggleButtonTests.cs
@@ -1,8 +1,15 @@
-﻿using Avalonia.Controls.UnitTests.Utils;
+﻿using System;
+using Avalonia.Controls.UnitTests.Utils;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Platform;
+using Avalonia.Rendering;
 using Avalonia.UnitTests;
+using Avalonia.VisualTree;
+using Moq;
 using Xunit;
+using MouseButton = Avalonia.Input.MouseButton;
 
 namespace Avalonia.Controls.Primitives.UnitTests
 {
@@ -11,6 +18,7 @@ namespace Avalonia.Controls.Primitives.UnitTests
         private const string uncheckedClass = ":unchecked";
         private const string checkedClass = ":checked";
         private const string indeterminateClass = ":indeterminate";
+        private readonly MouseTestHelper _mouse = new();
 
         [Theory]
         [InlineData(false, uncheckedClass, false)]
@@ -108,43 +116,96 @@ namespace Avalonia.Controls.Primitives.UnitTests
         }
 
         [Fact]
-        public void ToggleButton_With_NonExecutable_Command_Does_Not_Toggle_On_Click()
+        public void ToggleButton_Does_Not_Toggle_When_Command_Becomes_Disabled_Between_Press_And_Release()
         {
-            var target = new ToggleButton
-            {
-                Command = new TestCommand(false),
-            };
-            var root = new TestRoot
-            {
-                Child = target,
-            };
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
 
+            var command = new TestCommand(true);
+            var target = CreateToggleButton(command);
+            var root = CreateRoot(target);
+            var point = new Point(50, 50);
+
+            RaisePointerEntered(target);
+            RaisePointerMove(target, point);
+            RaisePointerPressed(target, 1, MouseButton.Left, point);
+
+            Assert.True(target.IsPressed);
             Assert.False(target.IsChecked);
+
+            command.IsEnabled = false;
+
             Assert.False(target.IsEffectivelyEnabled);
 
-            (target as IClickableControl).RaiseClick();
+            RaisePointerReleased(target, MouseButton.Left, point);
 
             Assert.False(target.IsChecked);
         }
 
         [Fact]
-        public void ToggleButton_With_Executable_Command_Toggles_On_Click()
+        public void ToggleButton_Toggles_When_Command_Remains_Executable_Through_Release()
         {
-            var target = new ToggleButton
-            {
-                Command = new TestCommand(true),
-            };
-            var root = new TestRoot
-            {
-                Child = target,
-            };
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
 
-            Assert.False(target.IsChecked);
+            var target = CreateToggleButton(new TestCommand(true));
+            var root = CreateRoot(target);
+            var point = new Point(50, 50);
+
+            RaisePointerEntered(target);
+            RaisePointerMove(target, point);
+            RaisePointerPressed(target, 1, MouseButton.Left, point);
+
+            Assert.True(target.IsPressed);
             Assert.True(target.IsEffectivelyEnabled);
 
-            (target as IClickableControl).RaiseClick();
+            RaisePointerReleased(target, MouseButton.Left, point);
 
             Assert.True(target.IsChecked);
+        }
+
+        private Window CreateRoot(ToggleButton target)
+        {
+            var renderer = new Mock<IHitTester>();
+
+            renderer
+                .Setup(r => r.HitTest(It.IsAny<Point>(), It.IsAny<Visual>(), It.IsAny<Func<Visual, bool>>()))
+                .Returns<Point, Visual, Func<Visual, bool>>((point, root, filter) =>
+                    root.Bounds.Contains(point) ? new Visual[] { root } : Array.Empty<Visual>());
+
+            var root = new Window { HitTesterOverride = renderer.Object, Content = target };
+            root.Show();
+            return root;
+        }
+
+        private ToggleButton CreateToggleButton(TestCommand command)
+        {
+            return new ToggleButton
+            {
+                Width = 100,
+                Height = 100,
+                VerticalAlignment = VerticalAlignment.Top,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                Command = command,
+            };
+        }
+
+        private void RaisePointerPressed(ToggleButton button, int clickCount, MouseButton mouseButton, Point position)
+        {
+            _mouse.Down(button, mouseButton, position, clickCount: clickCount);
+        }
+
+        private void RaisePointerReleased(ToggleButton button, MouseButton mouseButton, Point position)
+        {
+            _mouse.Up(button, mouseButton, position);
+        }
+
+        private void RaisePointerEntered(ToggleButton button)
+        {
+            _mouse.Enter(button);
+        }
+
+        private void RaisePointerMove(ToggleButton button, Point position)
+        {
+            _mouse.Move(button, position);
         }
 
         private class Class1 : NotifyingBase

--- a/tests/Avalonia.Controls.UnitTests/Primitives/ToggleButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/ToggleButtonTests.cs
@@ -1,15 +1,8 @@
 ﻿using System;
 using Avalonia.Controls.UnitTests.Utils;
 using Avalonia.Data;
-using Avalonia.Input;
-using Avalonia.Layout;
-using Avalonia.Platform;
-using Avalonia.Rendering;
 using Avalonia.UnitTests;
-using Avalonia.VisualTree;
-using Moq;
 using Xunit;
-using MouseButton = Avalonia.Input.MouseButton;
 
 namespace Avalonia.Controls.Primitives.UnitTests
 {
@@ -18,7 +11,6 @@ namespace Avalonia.Controls.Primitives.UnitTests
         private const string uncheckedClass = ":unchecked";
         private const string checkedClass = ":checked";
         private const string indeterminateClass = ":indeterminate";
-        private readonly MouseTestHelper _mouse = new();
 
         [Theory]
         [InlineData(false, uncheckedClass, false)]
@@ -113,99 +105,6 @@ namespace Avalonia.Controls.Primitives.UnitTests
             threeStateButton.Toggle();
             Assert.Equal(3, changeCount);
             Assert.False(threeStateButton.IsChecked);
-        }
-
-        [Fact]
-        public void ToggleButton_Does_Not_Toggle_When_Command_Becomes_Disabled_Between_Press_And_Release()
-        {
-            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
-
-            var command = new TestCommand(true);
-            var target = CreateToggleButton(command);
-            var root = CreateRoot(target);
-            var point = new Point(50, 50);
-
-            RaisePointerEntered(target);
-            RaisePointerMove(target, point);
-            RaisePointerPressed(target, 1, MouseButton.Left, point);
-
-            Assert.True(target.IsPressed);
-            Assert.False(target.IsChecked);
-
-            command.IsEnabled = false;
-
-            Assert.False(target.IsEffectivelyEnabled);
-
-            RaisePointerReleased(target, MouseButton.Left, point);
-
-            Assert.False(target.IsChecked);
-        }
-
-        [Fact]
-        public void ToggleButton_Toggles_When_Command_Remains_Executable_Through_Release()
-        {
-            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
-
-            var target = CreateToggleButton(new TestCommand(true));
-            var root = CreateRoot(target);
-            var point = new Point(50, 50);
-
-            RaisePointerEntered(target);
-            RaisePointerMove(target, point);
-            RaisePointerPressed(target, 1, MouseButton.Left, point);
-
-            Assert.True(target.IsPressed);
-            Assert.True(target.IsEffectivelyEnabled);
-
-            RaisePointerReleased(target, MouseButton.Left, point);
-
-            Assert.True(target.IsChecked);
-        }
-
-        private Window CreateRoot(ToggleButton target)
-        {
-            var renderer = new Mock<IHitTester>();
-
-            renderer
-                .Setup(r => r.HitTest(It.IsAny<Point>(), It.IsAny<Visual>(), It.IsAny<Func<Visual, bool>>()))
-                .Returns<Point, Visual, Func<Visual, bool>>((point, root, filter) =>
-                    root.Bounds.Contains(point) ? new Visual[] { root } : Array.Empty<Visual>());
-
-            var root = new Window { HitTesterOverride = renderer.Object, Content = target };
-            root.Show();
-            return root;
-        }
-
-        private ToggleButton CreateToggleButton(TestCommand command)
-        {
-            return new ToggleButton
-            {
-                Width = 100,
-                Height = 100,
-                VerticalAlignment = VerticalAlignment.Top,
-                HorizontalAlignment = HorizontalAlignment.Left,
-                Command = command,
-            };
-        }
-
-        private void RaisePointerPressed(ToggleButton button, int clickCount, MouseButton mouseButton, Point position)
-        {
-            _mouse.Down(button, mouseButton, position, clickCount: clickCount);
-        }
-
-        private void RaisePointerReleased(ToggleButton button, MouseButton mouseButton, Point position)
-        {
-            _mouse.Up(button, mouseButton, position);
-        }
-
-        private void RaisePointerEntered(ToggleButton button)
-        {
-            _mouse.Enter(button);
-        }
-
-        private void RaisePointerMove(ToggleButton button, Point position)
-        {
-            _mouse.Move(button, position);
         }
 
         private class Class1 : NotifyingBase

--- a/tests/Avalonia.Controls.UnitTests/RadioButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/RadioButtonTests.cs
@@ -1,6 +1,4 @@
-﻿using Avalonia.Controls.UnitTests.Utils;
-using Avalonia.Input;
-using Avalonia.Markup.Data;
+﻿using Avalonia.Markup.Data;
 using Avalonia.UnitTests;
 
 using Xunit;
@@ -71,40 +69,6 @@ namespace Avalonia.Controls.UnitTests
             Assert.False(radioButton1.IsChecked);
             Assert.False(radioButton2.IsChecked);
             Assert.True(radioButton3.IsChecked);
-        }
-
-        [Fact]
-        public void RadioButton_With_NonExecutable_Command_Does_Not_Uncheck_Checked_Sibling()
-        {
-            var parent = new Panel();
-            var selected = new RadioButton
-            {
-                GroupName = "A",
-                IsChecked = true,
-            };
-            var blocked = new RadioButton
-            {
-                GroupName = "A",
-                IsChecked = false,
-                Command = new TestCommand(false),
-            };
-
-            parent.Children.Add(selected);
-            parent.Children.Add(blocked);
-
-            var root = new TestRoot
-            {
-                Child = parent,
-            };
-
-            Assert.True(selected.IsChecked);
-            Assert.False(blocked.IsChecked);
-            Assert.False(blocked.IsEffectivelyEnabled);
-
-            (blocked as IClickableControl).RaiseClick();
-
-            Assert.True(selected.IsChecked);
-            Assert.False(blocked.IsChecked);
         }
 
         [Fact]

--- a/tests/Avalonia.Controls.UnitTests/RadioButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/RadioButtonTests.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Markup.Data;
+﻿using Avalonia.Controls.UnitTests.Utils;
+using Avalonia.Input;
+using Avalonia.Markup.Data;
 using Avalonia.UnitTests;
 
 using Xunit;
@@ -69,6 +71,40 @@ namespace Avalonia.Controls.UnitTests
             Assert.False(radioButton1.IsChecked);
             Assert.False(radioButton2.IsChecked);
             Assert.True(radioButton3.IsChecked);
+        }
+
+        [Fact]
+        public void RadioButton_With_NonExecutable_Command_Does_Not_Uncheck_Checked_Sibling()
+        {
+            var parent = new Panel();
+            var selected = new RadioButton
+            {
+                GroupName = "A",
+                IsChecked = true,
+            };
+            var blocked = new RadioButton
+            {
+                GroupName = "A",
+                IsChecked = false,
+                Command = new TestCommand(false),
+            };
+
+            parent.Children.Add(selected);
+            parent.Children.Add(blocked);
+
+            var root = new TestRoot
+            {
+                Child = parent,
+            };
+
+            Assert.True(selected.IsChecked);
+            Assert.False(blocked.IsChecked);
+            Assert.False(blocked.IsEffectivelyEnabled);
+
+            (blocked as IClickableControl).RaiseClick();
+
+            Assert.True(selected.IsChecked);
+            Assert.False(blocked.IsChecked);
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?
This fixes a narrow command-gating bug in toggle controls for touch input when an interaction is already in flight.

If a `ToggleButton` receives `TouchBegin` while its command can execute, and `CanExecute` flips to `false` before `TouchEnd`, the control can still change `IsChecked` even though `Button.OnClick()` will reject the click.

## What is the current behavior?
`ToggleButton.OnClick()` calls `Toggle()` before `Button.OnClick()` applies the `IsEffectivelyEnabled` / `Command.CanExecute(...)` gate.

That normally does not matter when the control is already disabled before the interaction starts. The failing case is the mid-interaction transition on the touch path: `TouchBegin` while enabled, command becomes disabled, then `TouchEnd`. On current `master` (`cda3445d43` when this was rechecked), that sequence still toggles `IsChecked`.

## What is the updated/expected behavior with this PR?
If the command becomes non-executable between `TouchBegin` and `TouchEnd`, the toggle state no longer changes.

## How was the solution implemented (if it's not obvious)?
The fix stays in `ToggleButton.OnClick()`.

`Button.OnClick()` already has the command gate, but `ToggleButton` was mutating state before delegating to it. The change adds an early `IsEffectivelyEnabled` check so the toggle state is not updated after the command has become disabled.

The regression coverage now hangs off the real `TouchDevice` input path rather than the lower-level pointer helper tests.

Verification:
- `dotnet run --project tests/Avalonia.Base.UnitTests/Avalonia.Base.UnitTests.csproj -p:BuildInParallel=false -- --filter-method "*ToggleButton_Does_Not_Toggle_When_Command_Becomes_Disabled_Between_TouchBegin_And_TouchEnd"`
- `dotnet run --project tests/Avalonia.Base.UnitTests/Avalonia.Base.UnitTests.csproj -p:BuildInParallel=false -- --filter-class "*TouchDeviceTests"`
- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -p:BuildInParallel=false -- --filter-class "*ToggleButtonTests"`

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
None.
