### PR TITLE
Win32: fix None/BorderOnly maximized position on secondary screens

### DIFF
--- a/samples/ControlCatalog/Pages/WindowCustomizationsPage.xaml
+++ b/samples/ControlCatalog/Pages/WindowCustomizationsPage.xaml
@@ -7,7 +7,8 @@
              Header="Window Customizations"
              x:Class="ControlCatalog.Pages.WindowCustomizationsPage"
              x:DataType="viewModels:MainWindowViewModel"
-             x:CompileBindings="True">
+             x:CompileBindings="True"
+             DataContext="{Binding $parent[Window].DataContext}">
   <StackPanel>
 
     <StackPanel

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -798,40 +798,14 @@ namespace Avalonia.Win32
 
                         // A window without a caption (i.e. None and BorderOnly decorations) maximizes to the whole screen
                         // by default. Adjust that to the screen's working area instead.
-                        var style = GetStyle();
-                        if (!style.HasAllFlags(WindowStyles.WS_CAPTION | WindowStyles.WS_THICKFRAME))
+                        if (TryGetCaptionlessMaximizedRect() is { } maximizedRect)
                         {
-                            var screen = Screen.ScreenFromHwnd(Hwnd, MONITOR.MONITOR_DEFAULTTONEAREST);
-                            if (screen?.WorkingArea is { } workingArea)
-                            {
-                                var x = workingArea.X;
-                                var y = workingArea.Y;
-                                var cx = workingArea.Width;
-                                var cy = workingArea.Height;
-
-                                var adjuster = CreateWindowRectAdjuster();
-                                var borderThickness = new RECT();
-
-                                var adjustedStyle = style & ~WindowStyles.WS_CAPTION;
-
-                                if (style.HasAllFlags(WindowStyles.WS_BORDER))
-                                    adjustedStyle |= WindowStyles.WS_BORDER;
-
-                                if (style.HasAllFlags(WindowStyles.WS_CAPTION))
-                                    adjustedStyle |= WindowStyles.WS_THICKFRAME;
-
-                                adjuster.Adjust(ref borderThickness, adjustedStyle, 0);
-
-                                x += borderThickness.left;
-                                y += borderThickness.top;
-                                cx += -borderThickness.left + borderThickness.right;
-                                cy += -borderThickness.top + borderThickness.bottom;
-
-                                mmi.ptMaxPosition.X = x;
-                                mmi.ptMaxPosition.Y = y;
-                                mmi.ptMaxSize.X = cx;
-                                mmi.ptMaxSize.Y = cy;
-                            }
+                            // We aren't changing ptMaxPosition because its coordinates must always target the primary screen.
+                            // We can't do that, since the work area might not be the same for all screens.
+                            // Instead, only set the desired max size here.
+                            // WM_WINDOWPOSCHANGING moves the window to the correct position.
+                            mmi.ptMaxSize.X = maximizedRect.Width;
+                            mmi.ptMaxSize.Y = maximizedRect.Height;
                         }
 
                         if (_minSize.Width > 0)
@@ -860,6 +834,29 @@ namespace Avalonia.Win32
 
                         Marshal.StructureToPtr(mmi, lParam, true);
                         return IntPtr.Zero;
+                    }
+
+                case WindowsMessage.WM_WINDOWPOSCHANGING:
+                    {
+                        var windowPos = (WINDOWPOS*)lParam;
+                        var style = GetStyle();
+                        var flags = (SetWindowPosFlags)windowPos->flags;
+
+                        // A window without a caption (i.e. None and BorderOnly decorations) maximizes to the whole screen
+                        // by default. Adjust that to the screen's working area instead.
+                        if (style.HasAllFlags(WindowStyles.WS_MAXIMIZE) &&
+                            !_isFullScreenActive &&
+                            !flags.HasAllFlags(SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE) &&
+                            TryGetCaptionlessMaximizedRect() is { } maximizedRect)
+                        {
+                            windowPos->x = maximizedRect.X;
+                            windowPos->y = maximizedRect.Y;
+                            windowPos->cx = maximizedRect.Width;
+                            windowPos->cy = maximizedRect.Height;
+                            return IntPtr.Zero;
+                        }
+
+                        break;
                     }
 
                 case WindowsMessage.WM_DISPLAYCHANGE:
@@ -994,6 +991,46 @@ namespace Avalonia.Win32
             }
 
             return DefWindowProc(hWnd, msg, wParam, lParam);
+        }
+
+
+        /// <summary>
+        /// Gets the expected maximized rect for a window without a caption.
+        /// </summary>
+        private PixelRect? TryGetCaptionlessMaximizedRect()
+        {
+            var style = GetStyle();
+            if (style.HasAllFlags(WindowStyles.WS_CAPTION | WindowStyles.WS_THICKFRAME))
+                return null;
+
+            var screen = Screen.ScreenFromHwnd(Hwnd, MONITOR.MONITOR_DEFAULTTONEAREST);
+            if (screen?.WorkingArea is not { } workingArea)
+                return null;
+
+            var x = workingArea.X;
+            var y = workingArea.Y;
+            var cx = workingArea.Width;
+            var cy = workingArea.Height;
+
+            var adjuster = CreateWindowRectAdjuster();
+            var borderThickness = new RECT();
+
+            var adjustedStyle = style & ~WindowStyles.WS_CAPTION;
+
+            if (style.HasAllFlags(WindowStyles.WS_BORDER))
+                adjustedStyle |= WindowStyles.WS_BORDER;
+
+            if (style.HasAllFlags(WindowStyles.WS_CAPTION))
+                adjustedStyle |= WindowStyles.WS_THICKFRAME;
+
+            adjuster.Adjust(ref borderThickness, adjustedStyle, 0);
+
+            x += borderThickness.left;
+            y += borderThickness.top;
+            cx += -borderThickness.left + borderThickness.right;
+            cy += -borderThickness.top + borderThickness.bottom;
+
+            return new PixelRect(x, y, cx, cy);
         }
 
         internal bool IsOurWindow(IntPtr hwnd)

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -798,8 +798,11 @@ namespace Avalonia.Win32
 
                         // A window without a caption (i.e. None and BorderOnly decorations) maximizes to the whole screen
                         // by default. Adjust that to the screen's working area instead.
-                        if (TryGetCaptionlessMaximizedRect() is { } maximizedRect)
+                        var style = GetStyle();
+                        if (!style.HasAllFlags(WindowStyles.WS_CAPTION | WindowStyles.WS_THICKFRAME) &&
+                            Screen.ScreenFromHwnd(Hwnd, MONITOR.MONITOR_DEFAULTTONEAREST) is { } screen)
                         {
+                            var maximizedRect = GetCaptionlessMaximizedRect(style, screen.WorkingArea);
                             // We aren't changing ptMaxPosition because its coordinates must always target the primary screen.
                             // We can't do that, since the work area might not be the same for all screens.
                             // Instead, only set the desired max size here.
@@ -838,24 +841,25 @@ namespace Avalonia.Win32
 
                 case WindowsMessage.WM_WINDOWPOSCHANGING:
                     {
-                        var windowPos = (WINDOWPOS*)lParam;
+                        var pos = (WINDOWPOS*)lParam;
                         var style = GetStyle();
-                        var flags = (SetWindowPosFlags)windowPos->flags;
+                        var flags = (SetWindowPosFlags)pos->flags;
 
                         // A window without a caption (i.e. None and BorderOnly decorations) maximizes to the whole screen
                         // by default. Adjust that to the screen's working area instead.
-                        if (style.HasAllFlags(WindowStyles.WS_MAXIMIZE) &&
+                        if (!style.HasAllFlags(WindowStyles.WS_CAPTION | WindowStyles.WS_THICKFRAME) &&
+                            style.HasAllFlags(WindowStyles.WS_MAXIMIZE) &&
                             !_isFullScreenActive &&
                             !flags.HasAllFlags(SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE) &&
-                            TryGetCaptionlessMaximizedRect() is { } maximizedRect)
+                            Screen.ScreenFromRect(new PixelRect(pos->x, pos->y, pos->cx, pos->cy)) is { } screen)
                         {
-                            windowPos->x = maximizedRect.X;
-                            windowPos->y = maximizedRect.Y;
-                            windowPos->cx = maximizedRect.Width;
-                            windowPos->cy = maximizedRect.Height;
+                            var maximizedRect = GetCaptionlessMaximizedRect(style, screen.WorkingArea);
+                            pos->x = maximizedRect.X;
+                            pos->y = maximizedRect.Y;
+                            pos->cx = maximizedRect.Width;
+                            pos->cy = maximizedRect.Height;
                             return IntPtr.Zero;
                         }
-
                         break;
                     }
 
@@ -997,16 +1001,8 @@ namespace Avalonia.Win32
         /// <summary>
         /// Gets the expected maximized rect for a window without a caption.
         /// </summary>
-        private PixelRect? TryGetCaptionlessMaximizedRect()
+        private PixelRect GetCaptionlessMaximizedRect(WindowStyles style, PixelRect workingArea)
         {
-            var style = GetStyle();
-            if (style.HasAllFlags(WindowStyles.WS_CAPTION | WindowStyles.WS_THICKFRAME))
-                return null;
-
-            var screen = Screen.ScreenFromHwnd(Hwnd, MONITOR.MONITOR_DEFAULTTONEAREST);
-            if (screen?.WorkingArea is not { } workingArea)
-                return null;
-
             var x = workingArea.X;
             var y = workingArea.Y;
             var cx = workingArea.Width;

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -850,15 +850,22 @@ namespace Avalonia.Win32
                         if (!style.HasAllFlags(WindowStyles.WS_CAPTION | WindowStyles.WS_THICKFRAME) &&
                             style.HasAllFlags(WindowStyles.WS_MAXIMIZE) &&
                             !_isFullScreenActive &&
-                            !flags.HasAllFlags(SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE) &&
-                            Screen.ScreenFromRect(new PixelRect(pos->x, pos->y, pos->cx, pos->cy)) is { } screen)
+                            !flags.HasAllFlags(SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE))
                         {
-                            var maximizedRect = GetCaptionlessMaximizedRect(style, screen.WorkingArea);
-                            pos->x = maximizedRect.X;
-                            pos->y = maximizedRect.Y;
-                            pos->cx = maximizedRect.Width;
-                            pos->cy = maximizedRect.Height;
-                            return IntPtr.Zero;
+                            // Prefer ScreenFromRect as it contains the new position.
+                            // If the window was minimized, ScreenFromHwnd won't return the correct monitor at this point.
+                            var screen = Screen.ScreenFromRect(new PixelRect(pos->x, pos->y, pos->cx, pos->cy))
+                                ?? Screen.ScreenFromHwnd(Hwnd, MONITOR.MONITOR_DEFAULTTONEAREST);
+
+                            if (screen is not null)
+                            {
+                                var maximizedRect = GetCaptionlessMaximizedRect(style, screen.WorkingArea);
+                                pos->x = maximizedRect.X;
+                                pos->y = maximizedRect.Y;
+                                pos->cx = maximizedRect.Width;
+                                pos->cy = maximizedRect.Height;
+                                return IntPtr.Zero;
+                            }
                         }
                         break;
                     }


### PR DESCRIPTION
## What does the pull request do?
On Windows, this PR fixes maximizing windows on secondary screens when `WindowDecorations` is `None` or `BorderOnly`.

## What is the current behavior?
The window is invisible. It's actually placed outside of the screen bounds.

## What is the updated/expected behavior with this PR?
The window is correctly visible.

## How was the solution implemented (if it's not obvious)?
Since #20217, `WM_GETMINMAXINFO` is used to tell the OS the expected maximized size and position of the window for `None` or `BorderOnly` decorations. (Otherwise, the screen's working area isn't respected.)

There's a quirk, though. For reasons, the position must always be as if the window were on the primary screen.
Which is not quite possible when the screen's working area might be different per screen.

Instead, this PR uses `WM_WINDOWPOSCHANGING` to set the correct position when the window is maximized.

Unfortunately, our CI does not support multiple screens, so it's not possible to add new tests to the `IntegrationTests.Win32` project.

## Fixed issues
 - Fixes #21127
