### PR TITLE
Cache ClientSize in PresentationSource

### DIFF
--- a/src/Avalonia.Controls/PresentationSource/PresentationSource.RenderRoot.cs
+++ b/src/Avalonia.Controls/PresentationSource/PresentationSource.RenderRoot.cs
@@ -14,9 +14,9 @@ internal partial class PresentationSource
     public IHitTester HitTester => HitTesterOverride ?? Renderer;
     //TODO: Can we PLEASE get rid of this abomination in tests and use actual hit-testing engine instead?
     public IHitTester? HitTesterOverride { get; set; }
-    
+
     public double RenderScaling { get; private set; } = 1.0;
-    public Size ClientSize => PlatformImpl?.ClientSize ?? default;
+    public Size ClientSize { get; private set; }
     
     public void SceneInvalidated(object? sender, SceneInvalidatedEventArgs sceneInvalidatedEventArgs)
     {
@@ -29,4 +29,6 @@ internal partial class PresentationSource
 
     private void HandleScalingChanged(double scaling)
         => RenderScaling = LayoutHelper.ValidateScaling(scaling);
+
+    private void HandleResized(Size size, WindowResizeReason reason) => ClientSize = size;
 }

--- a/src/Avalonia.Controls/PresentationSource/PresentationSource.cs
+++ b/src/Avalonia.Controls/PresentationSource/PresentationSource.cs
@@ -36,6 +36,7 @@ internal partial class PresentationSource : IPresentationSource, IInputRoot, IDi
 
         RenderScaling = LayoutHelper.ValidateScaling(platformImpl.RenderScaling);
         PlatformImpl.ScalingChanged += HandleScalingChanged;
+        PlatformImpl.Resized += HandleResized;
         
         _pointerOverPreProcessor = new PointerOverPreProcessor(this);
         _pointerOverPreProcessorSubscription = _inputManager?.PreProcess.Subscribe(_pointerOverPreProcessor);
@@ -85,6 +86,7 @@ internal partial class PresentationSource : IPresentationSource, IInputRoot, IDi
         Renderer.Dispose();
 
         PlatformImpl?.ScalingChanged -= HandleScalingChanged;
+        PlatformImpl?.Resized -= HandleResized;
         PlatformImpl = null;
         _pointerOverPreProcessor?.OnCompleted();
         _pointerOverPreProcessorSubscription?.Dispose();

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -233,7 +233,7 @@ namespace Avalonia.Controls
 
             impl.Closed = HandleClosed;
             impl.Paint = HandlePaint;
-            impl.Resized = HandleResized;
+            impl.Resized += HandleResized;
             impl.ScalingChanged += HandleScalingChanged;
             impl.TransparencyLevelChanged = HandleTransparencyLevelChanged;
 


### PR DESCRIPTION
## What does the pull request do?

Prevents crashes on Android on back press by caching a property required for an extra render pass after the Android view and surface have been disposed, although the following continues to be a hazard

https://github.com/AvaloniaUI/Avalonia/blob/ada1e72ce8dce25bfdf58fe5f848d7f6652e7b00/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs#L129

## What is the current behavior?

Crash.

## What is the updated/expected behavior with this PR?

No crash.

## How was the solution implemented (if it's not obvious)?

Analogous to https://github.com/AvaloniaUI/Avalonia/pull/20972

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/20883
