### PR TITLE
Fix System.InvalidCastException in PageNavigationHost

### DIFF
--- a/src/Avalonia.Controls/Page/PageNavigationHost.cs
+++ b/src/Avalonia.Controls/Page/PageNavigationHost.cs
@@ -114,8 +114,8 @@ namespace Avalonia.Controls
 
             if (change.Property == PageProperty)
             {
-                var oldPage = change.GetOldValue<Page?>();
-                var newPage = change.GetNewValue<Page?>();
+                var oldPage = change.OldValue as Page;
+                var newPage = change.NewValue as Page;
 
                 SetCurrentValue(ContentProperty, newPage);
 
@@ -132,10 +132,10 @@ namespace Avalonia.Controls
             if (e.Property != ContentPresenter.ChildProperty)
                 return;
 
-            if (e.GetOldValue<object?>() is Page oldPage)
+            if (e.OldValue is Page oldPage)
                 oldPage.SafeAreaPadding = default;
 
-            if (e.GetNewValue<object?>() is Page newPage && _insetManager != null)
+            if (e.NewValue is Page newPage && _insetManager != null)
                 newPage.SafeAreaPadding = _insetManager.SafeAreaPadding;
         }
 

--- a/tests/Avalonia.Controls.UnitTests/PageNavigationHostTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/PageNavigationHostTests.cs
@@ -129,5 +129,38 @@ public class PageNavigationHostTests
             Assert.Equal("NavigatedFrom", order[0]);
             Assert.Equal("NavigatedTo",   order[1]);
         }
+
+        [Fact]
+        public void InitialLayout_WithExistingPage_DoesNotThrow_WhenContentPresenterChildIsAssigned()
+        {
+            var page = new ContentPage { Header = "Home" };
+            var host = new PageNavigationHost { Page = page };
+            var root = new TestRoot { Child = host };
+
+            var exception = Record.Exception(() => root.LayoutManager.ExecuteInitialLayoutPass());
+
+            Assert.Null(exception);
+            Assert.NotNull(host.Presenter);
+            Assert.Same(page, host.Presenter!.Child);
+        }
+
+        [Fact]
+        public void ReplacingPage_ResetsOldPresenterChildSafeAreaPadding()
+        {
+            var first = new ContentPage { Header = "First" };
+            var second = new ContentPage { Header = "Second" };
+            var host = new PageNavigationHost { Page = first };
+            var root = new TestRoot { Child = host };
+
+            root.LayoutManager.ExecuteInitialLayoutPass();
+            first.SafeAreaPadding = new Thickness(1, 2, 3, 4);
+
+            var exception = Record.Exception(() => host.Page = second);
+
+            Assert.Null(exception);
+            Assert.Equal(default, first.SafeAreaPadding);
+            Assert.NotNull(host.Presenter);
+            Assert.Same(second, host.Presenter!.Child);
+        }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR fixes an `System.InvalidCastException` that occurs when using `PageNavigationHost`.


## What is the current behavior?
App crashes with the following exception, using the ControlCatalog sample.
```
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): android.runtime.JavaProxyThrowable: [System.InvalidCastException]: Specified cast is not valid.
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.AvaloniaPropertyChangedExtensions.GetOldValue(D:\ryujinx\Avalonia\src\Avalonia.Base\AvaloniaPropertyChangedExtensions.cs:16)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Controls.PageNavigationHost.ContentPresenter_PropertyChanged(D:\ryujinx\Avalonia\src\Avalonia.Controls\Page\PageNavigationHost.cs:135)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Unknown.Unknown(Unknown Source)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.AvaloniaObject.RaisePropertyChanged(D:\ryujinx\Avalonia\src\Avalonia.Base\AvaloniaObject.cs:803)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.AvaloniaObject.SetAndRaise(D:\ryujinx\Avalonia\src\Avalonia.Base\AvaloniaObject.cs:830)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Controls.Presenters.ContentPresenter.set_Child(D:\ryujinx\Avalonia\src\Avalonia.Controls\Presenters\ContentPresenter.cs:361)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Controls.Presenters.ContentPresenter.UpdateChild(D:\ryujinx\Avalonia\src\Avalonia.Controls\Presenters\ContentPresenter.cs:550)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Controls.Presenters.ContentPresenter.UpdateChild(D:\ryujinx\Avalonia\src\Avalonia.Controls\Presenters\ContentPresenter.cs:499)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Controls.Presenters.ContentPresenter.ApplyTemplate(D:\ryujinx\Avalonia\src\Avalonia.Controls\Presenters\ContentPresenter.cs:462)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Layout.Layoutable.MeasureCore(D:\ryujinx\Avalonia\src\Avalonia.Base\Layout\Layoutable.cs:559)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Layout.Layoutable.Measure(D:\ryujinx\Avalonia\src\Avalonia.Base\Layout\Layoutable.cs:387)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Layout.Layoutable.MeasureOverride(D:\ryujinx\Avalonia\src\Avalonia.Base\Layout\Layoutable.cs:647)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Layout.Layoutable.MeasureCore(D:\ryujinx\Avalonia\src\Avalonia.Base\Layout\Layoutable.cs:577)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Layout.Layoutable.Measure(D:\ryujinx\Avalonia\src\Avalonia.Base\Layout\Layoutable.cs:387)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Layout.LayoutHelper.MeasureChild(D:\ryujinx\Avalonia\src\Avalonia.Base\Layout\LayoutHelper.cs:48)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Controls.Presenters.ContentPresenter.MeasureOverride(D:\ryujinx\Avalonia\src\Avalonia.Controls\Presenters\ContentPresenter.cs:663)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Layout.Layoutable.MeasureCore(D:\ryujinx\Avalonia\src\Avalonia.Base\Layout\Layoutable.cs:577)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Layout.Layoutable.Measure(D:\ryujinx\Avalonia\src\Avalonia.Base\Layout\Layoutable.cs:387)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Layout.LayoutManager.Measure(D:\ryujinx\Avalonia\src\Avalonia.Base\Layout\LayoutManager.cs:312)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Layout.LayoutManager.ExecuteMeasurePass(D:\ryujinx\Avalonia\src\Avalonia.Base\Layout\LayoutManager.cs:260)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Layout.LayoutManager.InnerLayoutPass(D:\ryujinx\Avalonia\src\Avalonia.Base\Layout\LayoutManager.cs:241)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Layout.LayoutManager.ExecuteLayoutPass(D:\ryujinx\Avalonia\src\Avalonia.Base\Layout\LayoutManager.cs:152)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Controls.TopLevel.HandleResized(D:\ryujinx\Avalonia\src\Avalonia.Controls\TopLevel.cs:701)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Android.Platform.SkiaPlatform.TopLevelImpl.Resize(D:\ryujinx\Avalonia\src\Android\Avalonia.Android\Platform\SkiaPlatform\TopLevelImpl.cs:140)
11:45:56:395	04-10 11:46:01.422 E/AndroidRuntime( 4826): 	at Avalonia.Android.AvaloniaActivity+GlobalLayoutListener.OnGlobalLayout(D:\ryujinx\Avalonia\src\Android\Avalonia.Android\AvaloniaActivity.cs:253)
```


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
