### PR TITLE
Fix DrawingImage invalidation around internal drawing signals

### DIFF
--- a/src/Avalonia.Base/Media/Drawing.cs
+++ b/src/Avalonia.Base/Media/Drawing.cs
@@ -1,15 +1,37 @@
-﻿namespace Avalonia.Media
+﻿using System;
+using Avalonia.Reactive;
+using Avalonia.Utilities;
+
+namespace Avalonia.Media
 {
     /// <summary>
     /// Abstract class that describes a 2-D drawing.
     /// </summary>
     public abstract class Drawing : AvaloniaObject
     {
+        private static readonly WeakEvent<IAffectsRender, EventArgs> s_renderResourceInvalidatedWeakEvent =
+            WeakEvent.Register<IAffectsRender>(
+                (source, handler) => source.Invalidated += handler,
+                (source, handler) => source.Invalidated -= handler);
+
+        internal static readonly WeakEvent<Drawing, EventArgs> InvalidatedWeakEvent =
+            WeakEvent.Register<Drawing>(
+                (source, handler) => source.Invalidated += handler,
+                (source, handler) => source.Invalidated -= handler);
+
+        private EventHandler? _invalidated;
+        private TargetWeakEventSubscriber<Drawing, EventArgs>? _affectsRenderWeakSubscriber;
+
         internal Drawing()
         {
-            
         }
-        
+
+        internal event EventHandler? Invalidated
+        {
+            add => _invalidated += value;
+            remove => _invalidated -= value;
+        }
+
         /// <summary>
         /// Draws this drawing to the given <see cref="DrawingContext"/>.
         /// </summary>
@@ -22,5 +44,60 @@
         /// Gets the drawing's bounding rectangle.
         /// </summary>
         public abstract Rect GetBounds();
+
+        /// <summary>
+        /// Registers properties that mutate this drawing's rendered content.
+        /// </summary>
+        /// <remarks>
+        /// This is an internal invalidation-graph hook for the drawing tree, not a public
+        /// rendering-resource contract. Values that implement <see cref="IAffectsRender"/>
+        /// are observed weakly so nested media resources can invalidate the owning drawing
+        /// without pinning shared instances.
+        /// </remarks>
+        protected static void AffectsDrawingContent<T>(params AvaloniaProperty[] properties)
+            where T : Drawing
+        {
+            var invalidateObserver = new AnonymousObserver<AvaloniaPropertyChangedEventArgs>(
+                static e => (e.Sender as T)?.RaiseInvalidated());
+
+            var invalidateAndSubscribeObserver = new AnonymousObserver<AvaloniaPropertyChangedEventArgs>(
+                static e =>
+                {
+                    if (e.Sender is not T sender)
+                    {
+                        return;
+                    }
+
+                    if (e.OldValue is IAffectsRender oldValue && sender._affectsRenderWeakSubscriber is not null)
+                    {
+                        s_renderResourceInvalidatedWeakEvent.Unsubscribe(oldValue, sender._affectsRenderWeakSubscriber);
+                    }
+
+                    if (e.NewValue is IAffectsRender newValue)
+                    {
+                        sender._affectsRenderWeakSubscriber ??=
+                            new TargetWeakEventSubscriber<Drawing, EventArgs>(
+                                sender,
+                                static (target, _, _, _) => target.RaiseInvalidated());
+                        s_renderResourceInvalidatedWeakEvent.Subscribe(newValue, sender._affectsRenderWeakSubscriber);
+                    }
+
+                    sender.RaiseInvalidated();
+                });
+
+            foreach (var property in properties)
+            {
+                if (property.CanValueAffectRender())
+                {
+                    property.Changed.Subscribe(invalidateAndSubscribeObserver);
+                }
+                else
+                {
+                    property.Changed.Subscribe(invalidateObserver);
+                }
+            }
+        }
+
+        protected void RaiseInvalidated() => _invalidated?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/Avalonia.Base/Media/DrawingGroup.cs
+++ b/src/Avalonia.Base/Media/DrawingGroup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using Avalonia.Metadata;
 using Avalonia.Platform;
 using Avalonia.Rendering.SceneGraph;
@@ -28,6 +29,24 @@ namespace Avalonia.Media
                 (o, v) => o.Children = v);
 
         private DrawingCollection _children = new DrawingCollection();
+        private List<Drawing>? _subscribedChildren;
+        private TargetWeakEventSubscriber<DrawingGroup, EventArgs>? _childInvalidatedSubscriber;
+        private TargetWeakEventSubscriber<DrawingGroup, NotifyCollectionChangedEventArgs>? _childrenCollectionChangedSubscriber;
+
+        static DrawingGroup()
+        {
+            AffectsDrawingContent<DrawingGroup>(
+                OpacityProperty,
+                TransformProperty,
+                ClipGeometryProperty,
+                OpacityMaskProperty,
+                ChildrenProperty);
+        }
+
+        public DrawingGroup()
+        {
+            SubscribeToChildren(_children);
+        }
 
         public double Opacity
         {
@@ -69,7 +88,141 @@ namespace Avalonia.Media
             }
         }
 
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == ChildrenProperty)
+            {
+                var (oldChildren, newChildren) = change.GetOldAndNewValue<DrawingCollection>();
+
+                if (oldChildren is not null)
+                {
+                    UnsubscribeFromChildren(oldChildren);
+                }
+
+                if (newChildren is not null)
+                {
+                    SubscribeToChildren(newChildren);
+                }
+            }
+        }
+
         public DrawingContext Open() => new DrawingGroupDrawingContext(this);
+
+        private void SubscribeToChildren(DrawingCollection children)
+        {
+            _childInvalidatedSubscriber ??=
+                new TargetWeakEventSubscriber<DrawingGroup, EventArgs>(
+                    this,
+                    static (target, _, _, _) => target.RaiseInvalidated());
+            _childrenCollectionChangedSubscriber ??=
+                new TargetWeakEventSubscriber<DrawingGroup, NotifyCollectionChangedEventArgs>(
+                    this,
+                    static (target, _, _, e) => target.OnChildrenCollectionChanged(e));
+
+            foreach (var child in children)
+            {
+                SubscribeToChild(child);
+            }
+
+            WeakEvents.CollectionChanged.Subscribe(children, _childrenCollectionChangedSubscriber);
+        }
+
+        private void UnsubscribeFromChildren(DrawingCollection children)
+        {
+            if (_subscribedChildren is not null)
+            {
+                foreach (var child in _subscribedChildren)
+                {
+                    InvalidatedWeakEvent.Unsubscribe(child, _childInvalidatedSubscriber!);
+                }
+
+                _subscribedChildren.Clear();
+            }
+
+            WeakEvents.CollectionChanged.Unsubscribe(children, _childrenCollectionChangedSubscriber!);
+        }
+
+        private void OnChildrenCollectionChanged(NotifyCollectionChangedEventArgs e)
+        {
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Add:
+                    if (e.NewItems is not null)
+                    {
+                        foreach (Drawing child in e.NewItems)
+                        {
+                            SubscribeToChild(child);
+                        }
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Remove:
+                    if (e.OldItems is not null)
+                    {
+                        foreach (Drawing child in e.OldItems)
+                        {
+                            UnsubscribeFromChild(child);
+                        }
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Replace:
+                    if (e.OldItems is not null)
+                    {
+                        foreach (Drawing child in e.OldItems)
+                        {
+                            UnsubscribeFromChild(child);
+                        }
+                    }
+
+                    if (e.NewItems is not null)
+                    {
+                        foreach (Drawing child in e.NewItems)
+                        {
+                            SubscribeToChild(child);
+                        }
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Reset:
+                    ResetChildSubscriptions();
+                    break;
+                case NotifyCollectionChangedAction.Move:
+                    break;
+            }
+
+            RaiseInvalidated();
+        }
+
+        private void SubscribeToChild(Drawing child)
+        {
+            _subscribedChildren ??= new List<Drawing>();
+            _subscribedChildren.Add(child);
+            InvalidatedWeakEvent.Subscribe(child, _childInvalidatedSubscriber!);
+        }
+
+        private void UnsubscribeFromChild(Drawing child)
+        {
+            InvalidatedWeakEvent.Unsubscribe(child, _childInvalidatedSubscriber!);
+            _subscribedChildren?.Remove(child);
+        }
+
+        private void ResetChildSubscriptions()
+        {
+            if (_subscribedChildren is not null)
+            {
+                foreach (var child in _subscribedChildren)
+                {
+                    InvalidatedWeakEvent.Unsubscribe(child, _childInvalidatedSubscriber!);
+                }
+
+                _subscribedChildren.Clear();
+            }
+
+            foreach (var child in _children)
+            {
+                SubscribeToChild(child);
+            }
+        }
 
         internal override void DrawCore(DrawingContext context)
         {

--- a/src/Avalonia.Base/Media/DrawingImage.cs
+++ b/src/Avalonia.Base/Media/DrawingImage.cs
@@ -8,8 +8,10 @@ namespace Avalonia.Media
     /// </summary>
     public class DrawingImage : AvaloniaObject, IImage, IAffectsRender
     {
-        public DrawingImage() 
-        { 
+        private Utilities.TargetWeakEventSubscriber<DrawingImage, EventArgs>? _drawingInvalidatedSubscriber;
+
+        public DrawingImage()
+        {
         }
 
         public DrawingImage(Drawing drawing)
@@ -98,7 +100,27 @@ namespace Avalonia.Media
         {
             base.OnPropertyChanged(change);
 
-            if (change.Property == DrawingProperty || change.Property == ViewboxProperty)
+            if (change.Property == DrawingProperty)
+            {
+                var (oldDrawing, newDrawing) = change.GetOldAndNewValue<Drawing?>();
+
+                if (oldDrawing is not null && _drawingInvalidatedSubscriber is not null)
+                {
+                    Drawing.InvalidatedWeakEvent.Unsubscribe(oldDrawing, _drawingInvalidatedSubscriber);
+                }
+
+                if (newDrawing is not null)
+                {
+                    _drawingInvalidatedSubscriber ??=
+                        new Utilities.TargetWeakEventSubscriber<DrawingImage, EventArgs>(
+                            this,
+                            static (target, _, _, _) => target.RaiseInvalidated(EventArgs.Empty));
+                    Drawing.InvalidatedWeakEvent.Subscribe(newDrawing, _drawingInvalidatedSubscriber);
+                }
+
+                RaiseInvalidated(EventArgs.Empty);
+            }
+            else if (change.Property == ViewboxProperty)
             {
                 RaiseInvalidated(EventArgs.Empty);
             }

--- a/src/Avalonia.Base/Media/GeometryDrawing.cs
+++ b/src/Avalonia.Base/Media/GeometryDrawing.cs
@@ -12,6 +12,11 @@ namespace Avalonia.Media
         // Adding the Pen's stroke thickness here could yield wrong results due to transforms.
         private static readonly IPen s_boundsPen = new ImmutablePen(Colors.Black.ToUInt32(), 0);
 
+        static GeometryDrawing()
+        {
+            AffectsDrawingContent<GeometryDrawing>(GeometryProperty, BrushProperty, PenProperty);
+        }
+
         /// <summary>
         /// Defines the <see cref="Geometry"/> property.
         /// </summary>

--- a/src/Avalonia.Base/Media/GlyphRunDrawing.cs
+++ b/src/Avalonia.Base/Media/GlyphRunDrawing.cs
@@ -2,6 +2,11 @@
 {
     public sealed class GlyphRunDrawing : Drawing
     {
+        static GlyphRunDrawing()
+        {
+            AffectsDrawingContent<GlyphRunDrawing>(ForegroundProperty, GlyphRunProperty);
+        }
+
         public static readonly StyledProperty<IBrush?> ForegroundProperty =
             AvaloniaProperty.Register<GlyphRunDrawing, IBrush?>(nameof(Foreground));
 

--- a/src/Avalonia.Base/Media/ImageDrawing.cs
+++ b/src/Avalonia.Base/Media/ImageDrawing.cs
@@ -7,6 +7,11 @@ namespace Avalonia.Media
     /// </summary>
     public sealed class ImageDrawing : Drawing
     {
+        static ImageDrawing()
+        {
+            AffectsDrawingContent<ImageDrawing>(ImageSourceProperty, RectProperty);
+        }
+
         /// <summary>
         /// Defines the <see cref="ImageSource"/> property.
         /// </summary>

--- a/tests/Avalonia.Base.UnitTests/Media/DrawingImageTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/DrawingImageTests.cs
@@ -1,0 +1,160 @@
+using System;
+using Avalonia.Collections;
+using Avalonia.Media;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Media
+{
+    public class DrawingImageTests
+    {
+        [Fact]
+        public void Changing_GeometryDrawing_Brush_Raises_DrawingImage_Invalidated()
+        {
+            var drawing = CreateGeometryDrawing();
+
+            AssertInvalidated(drawing, () => drawing.Brush = Brushes.Red);
+        }
+
+        [Fact]
+        public void Changing_Drawing_Inside_DrawingGroup_Raises_DrawingImage_Invalidated()
+        {
+            var child = CreateGeometryDrawing();
+            var group = new DrawingGroup();
+            group.Children.Add(child);
+
+            AssertInvalidated(group, () => child.Brush = Brushes.Red);
+        }
+
+        [Fact]
+        public void Replacing_Drawing_Unsubscribes_Previous()
+        {
+            var oldDrawing = CreateGeometryDrawing();
+            var drawingImage = new DrawingImage(oldDrawing);
+
+            drawingImage.Drawing = CreateGeometryDrawing();
+
+            AssertNotInvalidated(drawingImage, () => oldDrawing.Brush = Brushes.Red);
+        }
+
+        [Fact]
+        public void Replacing_DrawingGroup_Children_Collection_Rewires_Subscriptions()
+        {
+            var oldChild = CreateGeometryDrawing();
+            var group = new DrawingGroup();
+            group.Children.Add(oldChild);
+            var drawingImage = new DrawingImage(group);
+
+            var newChild = CreateGeometryDrawing();
+            group.Children = new DrawingCollection { newChild };
+
+            AssertNotInvalidated(drawingImage, () => oldChild.Brush = Brushes.Red);
+            AssertInvalidatedOn(drawingImage, () => newChild.Brush = Brushes.Yellow);
+        }
+
+        [Fact]
+        public void ImageDrawing_Bubbles_Inner_DrawingImage_Invalidated()
+        {
+            var innerDrawing = CreateGeometryDrawing();
+            var innerImage = new DrawingImage(innerDrawing);
+            var drawing = new ImageDrawing
+            {
+                ImageSource = innerImage,
+                Rect = new Rect(0, 0, 10, 10)
+            };
+
+            AssertInvalidated(drawing, () => innerDrawing.Brush = Brushes.Red);
+        }
+
+        [Fact]
+        public void Resetting_DrawingGroup_Children_Collection_Rebuilds_Subscriptions()
+        {
+            var oldChild = CreateGeometryDrawing();
+            var children = new DrawingCollection { oldChild };
+            children.ResetBehavior = ResetBehavior.Reset;
+
+            var group = new DrawingGroup { Children = children };
+            var drawingImage = new DrawingImage(group);
+
+            var newChild = CreateGeometryDrawing();
+            children.Clear();
+            children.Add(newChild);
+
+            AssertNotInvalidated(drawingImage, () => oldChild.Brush = Brushes.Red);
+            AssertInvalidatedOn(drawingImage, () => newChild.Brush = Brushes.Yellow);
+        }
+
+        [Fact]
+        public void Shared_Drawing_Does_Not_Pin_DrawingImage()
+        {
+            var drawing = CreateGeometryDrawing();
+            var weakRef = CreateDrawingImageWeakRef(drawing);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.False(weakRef.IsAlive, "DrawingImage should have been collected");
+        }
+
+        [Fact]
+        public void Shared_Drawing_Does_Not_Pin_DrawingGroup()
+        {
+            var child = CreateGeometryDrawing();
+            var weakRef = CreateDrawingGroupWeakRef(child);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.False(weakRef.IsAlive, "DrawingGroup should have been collected while child survives");
+        }
+
+        private static GeometryDrawing CreateGeometryDrawing() => new()
+        {
+            Geometry = new RectangleGeometry(new Rect(0, 0, 10, 10)),
+            Brush = Brushes.Blue
+        };
+
+        private static void AssertInvalidated(Drawing drawing, Action mutate)
+        {
+            var drawingImage = new DrawingImage(drawing);
+
+            AssertInvalidatedOn(drawingImage, mutate);
+        }
+
+        private static void AssertInvalidatedOn(DrawingImage drawingImage, Action mutate)
+        {
+            var raised = false;
+            drawingImage.Invalidated += (_, _) => raised = true;
+
+            mutate();
+
+            Assert.True(raised);
+        }
+
+        private static void AssertNotInvalidated(DrawingImage drawingImage, Action mutate)
+        {
+            var raised = false;
+            drawingImage.Invalidated += (_, _) => raised = true;
+
+            mutate();
+
+            Assert.False(raised);
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static WeakReference CreateDrawingImageWeakRef(Drawing drawing)
+        {
+            var drawingImage = new DrawingImage(drawing);
+            return new WeakReference(drawingImage);
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static WeakReference CreateDrawingGroupWeakRef(Drawing child)
+        {
+            var group = new DrawingGroup();
+            group.Children.Add(child);
+            return new WeakReference(group);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Fixes `DrawingImage` repainting when an inner `Drawing` mutates, while keeping the 12.x design aligned with the maintainer guidance from the closed attempt in #21140.

That earlier PR fixed the symptom by making `Drawing` participate in `IAffectsRender`, but MrJul noted there that `IAffectsRender` is legacy and that the 12.x fix should move toward compositor-aware resources instead (`#11378`). This PR keeps the useful part of that work, the internal invalidation graph for the drawing tree, and reworks the bridge so `DrawingImage` remains the only `IAffectsRender` hop.

This PR supersedes #21140.

## What is the current behavior?

`DrawingImage.Invalidated` only fires when `DrawingImage.Drawing` or `DrawingImage.Viewbox` changes. Mutating the existing drawing tree in place, for example changing `GeometryDrawing.Brush` or replacing children inside a `DrawingGroup`, does not invalidate the image, so the UI can stay stale.

## What is the updated/expected behavior with this PR?

Mutations inside the drawing tree now bubble through an internal `Drawing` invalidation signal up to the root drawing, and `DrawingImage` weakly listens to that root signal to raise `Invalidated`.

That covers:
- direct leaf mutations such as `GeometryDrawing.Brush`
- `DrawingGroup` bubbling from child changes
- child collection rewiring, including reset-based rebuilds
- nested `ImageDrawing -> DrawingImage -> Drawing` invalidation

The public architectural direction stays cleaner than #21140 because `Drawing` itself is not being turned into the long-term `IAffectsRender` answer.

## How was the solution implemented (if it's not obvious)?

- `Drawing` now owns an internal invalidation event plus an internal helper for properties that affect drawing content.
- Leaf drawings (`GeometryDrawing`, `GlyphRunDrawing`, `ImageDrawing`) register their content-affecting properties with that helper.
- `DrawingGroup` weakly subscribes to child `Drawing` invalidation and to `DrawingCollection.CollectionChanged`, and rebuilds subscriptions correctly on rewiring and reset.
- `DrawingImage` weakly subscribes to the root `Drawing` invalidation and remains the bridge into the existing render invalidation pipeline.

This is intentionally a 12.x-compatible step toward the compositor-aware resource direction discussed in #11378 rather than a broader rendering-resource redesign.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None intended. The change is internal to drawing invalidation behavior.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #8767
