### PR TITLE
Fix Android crash on surface destroyed

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/InvalidationAwareSurfaceView.cs
@@ -38,6 +38,9 @@ namespace Avalonia.Android
 
         protected override void Dispose(bool disposing)
         {
+            if (disposing)
+                Holder?.RemoveCallback(this);
+
             ReleaseNativeWindowHandle();
             base.Dispose(disposing);
         }


### PR DESCRIPTION
## What does the pull request do?

Fixes an issue related to but not the same as #20883. I've only seen it once in a crash report generated on a customer's user device and I cannot reproduce it.

```
System.NotSupportedException: Unable to activate instance of type Avalonia.Android.Platform.SkiaPlatform.TopLevelImpl+SurfaceViewImpl from native handle 0x7fc401e948 (key_handle 0x1446895).
 ---> System.MissingMethodException: No constructor found for Avalonia.Android.Platform.SkiaPlatform.TopLevelImpl+SurfaceViewImpl::.ctor(System.IntPtr, Android.Runtime.JniHandleOwnership)
 ---> Java.Interop.JavaLocationException: Exception_WasThrown, Java.Interop.JavaLocationException
Java.Lang.Error: Exception_WasThrown, Java.Lang.Error

  --- End of managed Java.Lang.Error stack trace ---
java.lang.Error

   Exception_EndOfInnerExceptionStack
   at Java.Interop.TypeManager.CreateProxy(Type , IntPtr, JniHandleOwnership)
   at Java.Interop.TypeManager.CreateInstance(IntPtr, JniHandleOwnership, Type)
   Exception_EndOfInnerExceptionStack
   at Java.Interop.TypeManager.CreateInstance(IntPtr, JniHandleOwnership, Type)
   at Android.Runtime.AndroidValueManager.CreatePeer(JniObjectReference&, JniObjectReferenceOptions, Type )
   at Java.Interop.JniRuntime.JniValueManager.GetPeer(JniObjectReference, Type )
   at Java.Lang.Object.<GetObject>g__GetPeer|29_0(IntPtr, Type)
   at Java.Lang.Object.GetObject(IntPtr, JniHandleOwnership, Type )
   at Java.Lang.Object._GetObject[ISurfaceHolderCallback](IntPtr, JniHandleOwnership)
   at Java.Lang.Object.GetObject[ISurfaceHolderCallback](IntPtr handle, JniHandleOwnership transfer)
   at Java.Lang.Object.GetObject[ISurfaceHolderCallback](IntPtr jnienv, IntPtr handle, JniHandleOwnership transfer)
   at Android.Views.ISurfaceHolderCallbackInvoker.n_SurfaceDestroyed_Landroid_view_SurfaceHolder_(IntPtr jnienv, IntPtr native__this, IntPtr native_holder)
```

## What is the current behavior?

Rare crash on back pressed on some devices?

## What is the updated/expected behavior with this PR?

No crash.

## How was the solution implemented (if it's not obvious)?

Added the constructors required for Java interop. Also made `_tl` nullable just in case any of the methods still happen to be called and find `null`. As far as I can tell there's no penalty for the `null` checks because none of this is called during normal rendering passes.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation