### PR TITLE
Add back Design.SetPreviewWith(AvaloniaObject, Control) overload

### DIFF
--- a/src/Avalonia.Controls/Design.cs
+++ b/src/Avalonia.Controls/Design.cs
@@ -15,6 +15,20 @@ namespace Avalonia.Controls
         private static Dictionary<object, ITemplate<Control>?> s_previewWith = [];
         private static Dictionary<object, object?> s_templateDataContext = [];
 
+        private static ITemplate<Control> InvalidVisualTemplate
+            => field ??= new FuncTemplate<Control>(() => new StackPanel
+            {
+                Children =
+                {
+                    new TextBlock { Text = "A Template must be specified to use Design.PreviewWith on a Visual. Example:" },
+                    new TextBlock { Text = "<Design.PreviewWith>" },
+                    new TextBlock { Text = "    <Template>" },
+                    new TextBlock { Text = "        <Border Padding=\"20\"><!-- YOUR CONTROL FOR PREVIEW HERE --></Border>" },
+                    new TextBlock { Text = "    </Template>" },
+                    new TextBlock { Text = "</Design.PreviewWith>" }
+                }
+            });
+
         /// <summary>
         /// Gets a value indicating whether the application is running in design mode.
         /// </summary>
@@ -140,6 +154,41 @@ namespace Avalonia.Controls
         public static void SetPreviewWith(AvaloniaObject target, ITemplate<Control>? template)
         {
             s_previewWith[target] = template;
+        }
+
+        /// <summary>
+        /// Sets a preview control for the specified <see cref="AvaloniaObject"/> at design-time.
+        /// </summary>
+        /// <param name="target">The target object.</param>
+        /// <param name="control">The preview control.</param>
+        public static void SetPreviewWith(AvaloniaObject target, Control? control)
+        {
+            if (control is null)
+            {
+                s_previewWith[target] = null;
+                return;
+            }
+
+            switch (target)
+            {
+                case ResourceDictionary resourceDictionary:
+                    SetPreviewWith(resourceDictionary, control);
+                    break;
+                case IDataTemplate dataTemplate:
+                    SetPreviewWith(dataTemplate, control);
+                    break;
+                case IStyle style:
+                    SetPreviewWith(style, control);
+                    break;
+                case Visual visual:
+                    s_previewWith[target] = null;
+                    // TODO: restore once ITemplate overloads are correctly handled in the XAML compiler.
+                    //SetPreviewWith(visual, InvalidVisualTemplate);
+                    break;
+                default:
+                    SetPreviewWith(target, new FuncTemplate<Control>(() => control));
+                    break;
+            }
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Design.cs
+++ b/src/Avalonia.Controls/Design.cs
@@ -15,20 +15,6 @@ namespace Avalonia.Controls
         private static Dictionary<object, ITemplate<Control>?> s_previewWith = [];
         private static Dictionary<object, object?> s_templateDataContext = [];
 
-        private static ITemplate<Control> InvalidVisualTemplate
-            => field ??= new FuncTemplate<Control>(() => new StackPanel
-            {
-                Children =
-                {
-                    new TextBlock { Text = "A Template must be specified to use Design.PreviewWith on a Visual. Example:" },
-                    new TextBlock { Text = "<Design.PreviewWith>" },
-                    new TextBlock { Text = "    <Template>" },
-                    new TextBlock { Text = "        <Border Padding=\"20\"><!-- YOUR CONTROL FOR PREVIEW HERE --></Border>" },
-                    new TextBlock { Text = "    </Template>" },
-                    new TextBlock { Text = "</Design.PreviewWith>" }
-                }
-            });
-
         /// <summary>
         /// Gets a value indicating whether the application is running in design mode.
         /// </summary>
@@ -180,10 +166,9 @@ namespace Avalonia.Controls
                 case IStyle style:
                     SetPreviewWith(style, control);
                     break;
-                case Visual visual:
+                case Visual:
+                    // Not a supported scenario without templates; causes stack overflows.
                     s_previewWith[target] = null;
-                    // TODO: restore once ITemplate overloads are correctly handled in the XAML compiler.
-                    //SetPreviewWith(visual, InvalidVisualTemplate);
                     break;
                 default:
                     SetPreviewWith(target, new FuncTemplate<Control>(() => control));

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/DesignModeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/DesignModeTests.cs
@@ -33,23 +33,19 @@ public class DesignModeTests : XamlTestBase
     }
 
     [Fact]
-    public void Design_Mode_PreviewWith_Works_With_Control_Template()
+    public void Design_Mode_PreviewWith_Returns_Original_Control()
     {
         using (UnitTestApplication.Start(TestServices.MockWindowingPlatform))
         {
             var obj = (Control)AvaloniaRuntimeXamlLoader.Load(@"
 <Button xmlns='https://github.com/avaloniaui'>
     <Design.PreviewWith>
-        <Template>
-            <Border>
-                <Button />
-            </Border>
-        </Template>
+        <Border />
     </Design.PreviewWith>
 </Button>", designMode: true);
             var preview = Design.CreatePreviewWithControl(obj);
-            var previewBorder = Assert.IsType<Border>(preview);
-            Assert.IsType<Button>(previewBorder.Child);
+            // Should return the original control, not the preview, as this is not supported to avoid stack overflows.
+            Assert.Same(obj, preview);
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?
This PR adds back the `Design.SetPreviewWith(AvaloniaObject, Control?)` overload that was removed in Avalonia 12, to avoid unexpected exceptions in the previewer.

Contrary to #21147, this PR ignores the preview for types deriving from `Control`, matching what happened in Avalonia 11. Otherwise, stack overflow exceptions occur if the control is previewed with itself.

`<Template>` should be used instead. The original goal of this PR was to display an "error" preview in this case, telling the user to prefer `<Template>`. However, we currently have a real overload issue with the XAML compiler, preventing the template overload from being chosen.

Since the template overloads are new and mostly unused, for now, let's revert to the Avalonia 11 behavior.
~Proper overload support will be added in another PR.~ Edit: unlikely to occur, this is invalid according to the XAML spec.