### PR TITLE
Do not update composition target when rendering is stopped

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
@@ -2,18 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
-using Avalonia.Collections;
-using Avalonia.Collections.Pooled;
 using Avalonia.Diagnostics;
-using Avalonia.Platform;
 using Avalonia.Platform.Surfaces;
 using Avalonia.Media;
 using Avalonia.Rendering.Composition.Drawing;
 using Avalonia.Threading;
-using Avalonia.VisualTree;
 
 namespace Avalonia.Rendering.Composition;
 
@@ -201,6 +196,13 @@ internal class CompositingRenderer : IRendererWithCompositor, IHitTester
     {
         if(_updating)
             return;
+
+        if (!CompositionTarget.IsEnabled)
+        {
+            _queuedUpdate = false;
+            return;
+        }
+
         _updating = true;
         try
         {
@@ -237,6 +239,9 @@ internal class CompositingRenderer : IRendererWithCompositor, IHitTester
             return;
 
         CompositionTarget.IsEnabled = true;
+
+        if (_dirty.Count > 0 || _recalculateChildren.Count > 0)
+            QueueUpdate();
     }
 
     /// <inheritdoc />

--- a/tests/Avalonia.Base.UnitTests/Rendering/CompositorLifetimeTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/CompositorLifetimeTests.cs
@@ -27,8 +27,7 @@ public class CompositorLifetimeTests : CompositorTestsBase
 
         Assert.Equal(new PixelSize(200, 200), compositionTarget.PixelSize);
 
-        // Check that restarting the rendering still works.
-        services.TopLevel.InvalidateVisual();
+        // Check that restarting rendering re-queues the pending invalidation
         services.TopLevel.StartRendering();
         services.RunJobs();
 

--- a/tests/Avalonia.Base.UnitTests/Rendering/CompositorLifetimeTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/CompositorLifetimeTests.cs
@@ -1,0 +1,37 @@
+﻿using Avalonia.Rendering.Composition;
+using Avalonia.UnitTests;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Rendering;
+
+public class CompositorLifetimeTests : CompositorTestsBase
+{
+    [Fact]
+    public void InvalidateVisual_Does_Not_Update_RenderingTarget_When_Rendering_Stopped()
+    {
+        using var services = new CompositorTestServices(new Size(200, 200));
+
+        var presentationSource = services.TopLevel.GetPresentationSource();
+        Assert.NotNull(presentationSource);
+
+        var compositionTarget = ((CompositingRenderer)presentationSource.Renderer).CompositionTarget;
+        Assert.True(compositionTarget.IsEnabled);
+        Assert.Equal(new PixelSize(200, 200), compositionTarget.PixelSize);
+
+        // Stop rendering and invalidate a visual: this should not result in an update
+        services.TopLevel.StopRendering();
+        ((CompositorTestServices.TopLevelImpl)services.TopLevel.PlatformImpl!).ClientSize = new Size(300, 300);
+        services.TopLevel.InvalidateVisual();
+        services.RunJobs();
+
+        Assert.Equal(new PixelSize(200, 200), compositionTarget.PixelSize);
+
+        // Check that restarting the rendering still works.
+        services.TopLevel.InvalidateVisual();
+        services.TopLevel.StartRendering();
+        services.RunJobs();
+
+        Assert.Equal(new PixelSize(300, 300), compositionTarget.PixelSize);
+    }
+}

--- a/tests/Avalonia.UnitTests/CompositorTestServices.cs
+++ b/tests/Avalonia.UnitTests/CompositorTestServices.cs
@@ -142,7 +142,7 @@ public class CompositorTestServices : IDisposable
         public void TriggerTick() => Tick?.Invoke(TimeSpan.Zero);
     }
 
-    class TopLevelImpl : ITopLevelImpl
+    public class TopLevelImpl : ITopLevelImpl
     {
         private readonly Compositor _compositor;
 
@@ -159,7 +159,7 @@ public class CompositorTestServices : IDisposable
 
         public double DesktopScaling => 1;
         public IPlatformHandle? Handle => null;
-        public Size ClientSize { get; }
+        public Size ClientSize { get; set; }
         public double RenderScaling => 1;
         public IPlatformRenderSurface[] Surfaces { get; } = [new DummyFramebufferSurface()];
         public Action<RawInputEventArgs>? Input { get; set; }


### PR DESCRIPTION
## What does the pull request do?
This PR avoids updating a `CompositionTarget` when it's not enabled (because `StopRendering` has been called).

## What is the current behavior?
A composition target update might have been requested (for example, via `InvalidateVisual`), but during the time it took for `CompositionTarget.Update` to be actually invoked, `StopRendering` may have been called. In this case, the update runs for nothing. Worse, it can access members of its `TopLevel`, which might not be in a good state, causing a crash (case on Android).

## What is the updated/expected behavior with this PR?
When an update of the composition target occurs, it does nothing if the target isn't enabled. When `StartRendering()` is called again, the update is scheduled again.

## Fixed issues
 - Fixes #20883