### PR TITLE
Fix OpenGL Lease page not showing in ControlCatalog

### DIFF
--- a/samples/ControlCatalog/Pages/OpenGl/OpenGlLeasePage.xaml
+++ b/samples/ControlCatalog/Pages/OpenGl/OpenGlLeasePage.xaml
@@ -1,10 +1,9 @@
-<UserControl xmlns="https://github.com/avaloniaui"
+<ContentPage xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="ControlCatalog.Pages.OpenGlLeasePage"
-             xmlns:pages="using:ControlCatalog.Pages"
              xmlns:openGl="clr-namespace:ControlCatalog.Pages.OpenGl">
     <Grid>
         <Control x:Name="Viewport" AttachedToVisualTree="ViewportAttachedToVisualTree" DetachedFromVisualTree="ViewportDetachedFromVisualTree"/>
         <openGl:GlPageKnobs x:Name="Knobs" PropertyChanged="KnobsPropertyChanged" />
     </Grid>
-</UserControl>
+</ContentPage>

--- a/samples/ControlCatalog/Pages/OpenGl/OpenGlLeasePage.xaml.cs
+++ b/samples/ControlCatalog/Pages/OpenGl/OpenGlLeasePage.xaml.cs
@@ -12,7 +12,7 @@ using static Avalonia.OpenGL.GlConsts;
 
 namespace ControlCatalog.Pages;
 
-public partial class OpenGlLeasePage : UserControl
+public partial class OpenGlLeasePage : ContentPage
 {
     private CompositionCustomVisual? _visual;
 


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the OpenGL Lease page not being displayed in our samples, because it was of the wrong type.
