### PR TITLE
Fixes/windows back requested

### DIFF
--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -286,7 +286,7 @@ namespace Avalonia.Controls
 
             _backGestureSubscription = _inputManager?.PreProcess.Subscribe(e =>
             {
-                if (e.Root != this)
+                if (e.Root != InputRoot)
                     return;
 
                 bool backRequested = false;

--- a/tests/Avalonia.Controls.UnitTests/TopLevelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TopLevelTests.cs
@@ -254,6 +254,36 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void XButton1Down_Should_Raise_BackRequested()
+        {
+            // Regression test: prior to this fix, the PreProcess subscription compared
+            // e.Root against 'this' (the TopLevel/Window), but e.Root is set to the
+            // PresentationSource (the IInputRoot), not the Window itself. The comparison
+            // always failed so BackRequested was never raised for XButton1Down.
+            var services = TestServices.StyledWindow.With(inputManager: new InputManager());
+
+            using (UnitTestApplication.Start(services))
+            {
+                var impl = CreateMockTopLevelImpl(true);
+                var target = new TestTopLevel(impl.Object);
+
+                var raised = false;
+                target.BackRequested += (_, _) => raised = true;
+
+                var mouseDevice = new MouseDevice(new Pointer(0, PointerType.Mouse, true));
+                impl.Object.Input!(new RawPointerEventArgs(
+                    mouseDevice,
+                    timestamp: 0,
+                    target.InputRoot,
+                    RawPointerEventType.XButton1Down,
+                    new RawPointerPoint { Position = default },
+                    RawInputModifiers.None));
+
+                Assert.True(raised);
+            }
+        }
+
+        [Fact]
         public void TopLevel_Should_Unfocus_When_Impl_Focus_Is_Lost()
         {
             using (UnitTestApplication.Start(TestServices.RealFocus))


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes an issue where the `BackRequested` isn't being fired on desktop when the `XButton1Pressed` mouse button is pressed.

It looks like `this` is no longer the correct thing to compare with `e.Root` - instead it should be `InputRoot`.


## What is the current behavior?
When pressing the back button on the mouse, `BackRequested` is not fired.

## What is the updated/expected behavior with this PR?
The back button works.


## How was the solution implemented (if it's not obvious)?


## Checklist

- [X] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Fixes #21208
