### PR TITLE
Fix safe area calcs for navigation page

### DIFF
--- a/src/Avalonia.Controls/Page/NavigationPage.cs
+++ b/src/Avalonia.Controls/Page/NavigationPage.cs
@@ -750,7 +750,11 @@ namespace Avalonia.Controls
         {
             if (_contentHost != null && _navBar != null)
             {
-                _navBar.Padding = new Thickness(SafeAreaPadding.Left, SafeAreaPadding.Top, SafeAreaPadding.Right, 0);
+                var safeAreaPadding = IsNavBarEffectivelyVisible ? new Thickness(SafeAreaPadding.Left, 0, SafeAreaPadding.Right, SafeAreaPadding.Bottom) : SafeAreaPadding;
+                if (IsNavBarEffectivelyVisible)
+                {
+                    _navBar.Padding = new Thickness(SafeAreaPadding.Left, SafeAreaPadding.Top, SafeAreaPadding.Right, 0);
+                }
 
                 if (_pagePresenter != null)
                     _pagePresenter.Padding = Padding;
@@ -759,9 +763,11 @@ namespace Avalonia.Controls
 
                 if (CurrentPage != null)
                 {
-                    var remainingSafeArea = Padding.GetRemainingSafeAreaPadding(SafeAreaPadding);
-                    CurrentPage.SafeAreaPadding = new Thickness(remainingSafeArea.Left, 0, remainingSafeArea.Right, remainingSafeArea.Bottom);
+                    var remainingSafeArea = Padding.GetRemainingSafeAreaPadding(safeAreaPadding);
+                    CurrentPage.SafeAreaPadding = new Thickness(remainingSafeArea.Left, remainingSafeArea.Top, remainingSafeArea.Right, remainingSafeArea.Bottom);
                 }
+
+                UpdateEffectiveBarHeight();
 
                 foreach (var modal in _modalStack)
                     modal.SafeAreaPadding = SafeAreaPadding;
@@ -2148,7 +2154,7 @@ namespace Avalonia.Controls
 
         private void UpdateEffectiveBarHeight()
         {
-            EffectiveBarHeight = (CurrentPage != null ? GetBarHeightOverride(CurrentPage) : null) ?? BarHeight;
+            EffectiveBarHeight = ((CurrentPage != null ? GetBarHeightOverride(CurrentPage) : null) ?? BarHeight) + SafeAreaPadding.Top;
             PseudoClasses.Set(":nav-bar-compact", EffectiveBarHeight < 40);
         }
 

--- a/src/Avalonia.Controls/Page/NavigationPage.cs
+++ b/src/Avalonia.Controls/Page/NavigationPage.cs
@@ -754,10 +754,9 @@ namespace Avalonia.Controls
             if (_contentHost != null && _navBar != null)
             {
                 var safeAreaPadding = IsNavBarEffectivelyVisible ? new Thickness(SafeAreaPadding.Left, 0, SafeAreaPadding.Right, SafeAreaPadding.Bottom) : SafeAreaPadding;
-                if (IsNavBarEffectivelyVisible)
-                {
-                    _navBar.Padding = new Thickness(SafeAreaPadding.Left, SafeAreaPadding.Top, SafeAreaPadding.Right, 0);
-                }
+                _navBar.Padding = IsNavBarEffectivelyVisible
+                    ? new Thickness(SafeAreaPadding.Left, SafeAreaPadding.Top, SafeAreaPadding.Right, 0)
+                    : default;
 
                 if (_pagePresenter != null)
                     _pagePresenter.Padding = Padding;

--- a/src/Avalonia.Controls/Page/NavigationPage.cs
+++ b/src/Avalonia.Controls/Page/NavigationPage.cs
@@ -639,6 +639,9 @@ namespace Avalonia.Controls
                     "Direct assignment to NavigationPage.Pages is not supported. Use PushAsync, PopAsync, InsertPage, RemovePage, or ReplaceAsync to modify the navigation stack.");
             }
 
+            if (change.Property == SafeAreaPaddingProperty)
+                UpdateEffectiveBarHeight();
+
             base.OnPropertyChanged(change);
         }
 
@@ -766,8 +769,6 @@ namespace Avalonia.Controls
                     var remainingSafeArea = Padding.GetRemainingSafeAreaPadding(safeAreaPadding);
                     CurrentPage.SafeAreaPadding = new Thickness(remainingSafeArea.Left, remainingSafeArea.Top, remainingSafeArea.Right, remainingSafeArea.Bottom);
                 }
-
-                UpdateEffectiveBarHeight();
 
                 foreach (var modal in _modalStack)
                     modal.SafeAreaPadding = SafeAreaPadding;
@@ -2154,8 +2155,11 @@ namespace Avalonia.Controls
 
         private void UpdateEffectiveBarHeight()
         {
-            EffectiveBarHeight = ((CurrentPage != null ? GetBarHeightOverride(CurrentPage) : null) ?? BarHeight) + SafeAreaPadding.Top;
-            PseudoClasses.Set(":nav-bar-compact", EffectiveBarHeight < 40);
+            var contentBarHeight = (CurrentPage != null ? GetBarHeightOverride(CurrentPage) : null) ?? BarHeight;
+            EffectiveBarHeight = contentBarHeight + SafeAreaPadding.Top;
+            PseudoClasses.Set(":nav-bar-compact", contentBarHeight < 40);
+
+            UpdateContentSafeAreaPadding();
         }
 
         private void ApplyNavBarVisibility()

--- a/tests/Avalonia.Controls.UnitTests/NavigationPageTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NavigationPageTests.cs
@@ -1385,6 +1385,19 @@ public class NavigationPageTests
             var nav = new NavigationPage { IsGestureEnabled = value };
             Assert.Equal(value, nav.IsGestureEnabled);
         }
+
+        [Fact]
+        public async Task SafeAreaPadding_Affeccts_Nav_Bar_Height()
+        {
+            var nav = new NavigationPage()
+            {
+                SafeAreaPadding = new Thickness(10)
+            };
+            var page = new ContentPage();
+            NavigationPage.SetBarHeightOverride(page, 60.0);
+            await nav.PushAsync(page);
+            Assert.Equal(70.0, nav.EffectiveBarHeight);
+        }
     }
 
     public class AttachedPropertyTests : ScopedTestBase


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes NavigationPage safe area calculations. Safe area padding now considers the nav bar height.


## What is the current behavior?
NavBar height doesn't consider the safe area, so when it's set, the extra padding occupies most of the NavBar height, leaving little room for the header.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/21220