### PR TITLE
Improve ControlCatalog sidebar search

### DIFF
--- a/samples/ControlCatalog/ViewModels/MainWindowViewModel_PageList.cs
+++ b/samples/ControlCatalog/ViewModels/MainWindowViewModel_PageList.cs
@@ -7,6 +7,8 @@ using Avalonia;
 using MiniMvvm;
 using Avalonia.Collections;
 using ControlCatalog.Pages;
+using System.Globalization;
+using System.Text;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
@@ -105,10 +107,29 @@ namespace ControlCatalog.ViewModels
                 _ignoreListChange = true;
                 Pages.Clear();
 
-                if (!string.IsNullOrWhiteSpace(query))
-                    Pages.AddRange(_items.Where(x => x.Header.Contains(query)));
-                else
+                if (string.IsNullOrWhiteSpace(query))
+                {
                     Pages.AddRange(_items);
+                }
+                else
+                {
+                    var querySearchKey = PageItem.CreateSearchKey(query);
+
+                    if (querySearchKey.Length == 0)
+                    {
+                        Pages.AddRange(_items);
+                    }
+                    else
+                    {
+                        foreach (var item in _items)
+                        {
+                            if (item.MatchesSearch(querySearchKey))
+                            {
+                                Pages.Add(item);
+                            }
+                        }
+                    }
+                }
             }
             finally
             {
@@ -190,7 +211,38 @@ namespace ControlCatalog.ViewModels
         public string Header { get; } = header;
         public Func<object> Factory { get; } = factory;
         public string? IconData { get; } = iconData;
+        private string SearchKey { get; } = CreateSearchKey(header);
 
         public bool IsVisible { get; set; } = true;
+
+        public bool MatchesSearch(string searchKey)
+        {
+            return SearchKey.Contains(searchKey, StringComparison.Ordinal);
+        }
+
+        public static string CreateSearchKey(string value)
+        {
+            var normalizedValue = value.Normalize(NormalizationForm.FormKD);
+            var builder = new StringBuilder(normalizedValue.Length);
+
+            foreach (var c in normalizedValue)
+            {
+                var category = CharUnicodeInfo.GetUnicodeCategory(c);
+
+                if (category is UnicodeCategory.NonSpacingMark or
+                    UnicodeCategory.SpacingCombiningMark or
+                    UnicodeCategory.EnclosingMark)
+                {
+                    continue;
+                }
+
+                if (char.IsLetterOrDigit(c))
+                {
+                    builder.Append(char.ToUpperInvariant(c));
+                }
+            }
+
+            return builder.ToString();
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Improves the ControlCatalog sidebar search so page names can be found even when the query uses different separators, casing, or accent/combining mark forms.

For example, searches like `date-time`, `date time`, `date/time`, `drag-drop`, `drag+drop`, `data-grid`, and `calendar-date-picker` can match the existing page names.

<img width="2044" height="1584" alt="image" src="https://github.com/user-attachments/assets/dfaf1fcc-2969-4f08-b5c6-9df369ec19a5" />

## What is the current behavior?

The ControlCatalog sidebar search uses direct text matching, so the query must closely match the page header. Queries that use different separators or spacing do not find pages such as `Date/Time Picker`, `Drag+Drop`, `DataGrid`, or `CalendarDatePicker`.

## What is the updated/expected behavior with this PR?

The sidebar search normalizes both the query and page headers before comparing them. Separator symbols, whitespace differences, casing, and combining marks are ignored, making search easier to use.

## How was the solution implemented (if it's not obvious)?

Each page header is normalized into a cached uppercase alphanumeric search key. The user query is normalized the same way before matching. This keeps the change local to the ControlCatalog sample search behavior and avoids changing page metadata or navigation.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

None.