### PR TITLE
Android: Fix OnBackPressed being prevented for Android API 33 and above

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaActivity.cs
+++ b/src/Android/Avalonia.Android/AvaloniaActivity.cs
@@ -95,7 +95,10 @@ public class AvaloniaActivity : AppCompatActivity, IAvaloniaActivity
     public override void OnBackPressed()
     {
         if (OperatingSystem.IsAndroidVersionAtLeast(33))
+        {
+            OnBackPressedDispatcher.OnBackPressed();
             return;
+        }
 
         var eventArgs = new AndroidBackRequestedEventArgs();
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR fixes an issue that the default behavior of `OnBackPressed` on Android that is API 33 and above was being prevented no matter whether it was handled.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Using the back gesture or back button on emulator will have no reactions on Android with API 33 or higher.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The back navigation will be invoked successfully in default and be prevented if it is handled in `TopLevel.BackRequested`.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Added `OnBackPressedDispatcher.OnBackPressed()` in `AvaloniaActivity.OnBackPressed()` when it is API 33 or higher, let it be handled by the default `BackPressedCallback` in Avalonia.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
No breaking changes.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->
No obsoletions / deprecations.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #21225 .