### PR TITLE
Clarify that ElementRole is dependent on ExtendClientAreaToDecorationsHint

### DIFF
--- a/src/Avalonia.Controls/Chrome/WindowDecorationProperties.cs
+++ b/src/Avalonia.Controls/Chrome/WindowDecorationProperties.cs
@@ -12,6 +12,7 @@ public static class WindowDecorationProperties
     /// Marks a visual element with a specific role for non-client hit-testing.
     /// Can be applied to any element in the visual tree, not limited to decoration children.
     /// </summary>
+    /// <remarks>Setting an element role only has an effect if <see cref="Window.ExtendClientAreaToDecorationsHint"/> is true.</remarks>
     public static readonly AttachedProperty<WindowDecorationsElementRole> ElementRoleProperty =
         AvaloniaProperty.RegisterAttached<Visual, WindowDecorationsElementRole>("ElementRole", typeof(WindowDecorationProperties));
 
@@ -23,5 +24,6 @@ public static class WindowDecorationProperties
     /// <summary>
     /// Sets the <see cref="WindowDecorationsElementRole"/> for the specified element.
     /// </summary>
+    /// <remarks>Setting an element role only has an effect if <see cref="Window.ExtendClientAreaToDecorationsHint"/> is true.</remarks>
     public static void SetElementRole(Visual element, WindowDecorationsElementRole value) => element.SetValue(ElementRoleProperty, value);
 }


### PR DESCRIPTION
## What does the pull request do?
This PR adjusts the XML documentation of `WindowDecorationProperties.ElementRole` to clarify that such a role only has an effect if `Window.ExtendClientAreaToDecorationsHint == true`.

