### PR TITLE
Ensure system back event is passed to child page once

### DIFF
--- a/src/Avalonia.Controls/Page/CarouselPage.cs
+++ b/src/Avalonia.Controls/Page/CarouselPage.cs
@@ -60,19 +60,12 @@ namespace Avalonia.Controls
                 if (eventArgs.Handled)
                     return;
 
-                if (sender.OnSystemBackButtonPressed())
+                var pageEvent = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);
+                sender.CurrentPage?.RaiseEvent(pageEvent);
+
+                if (pageEvent.Handled)
                 {
                     eventArgs.Handled = true;
-                }
-                else
-                {
-                    var pageEvent = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);
-                    sender.CurrentPage?.RaiseEvent(pageEvent);
-
-                    if (pageEvent.Handled)
-                    {
-                        eventArgs.Handled = true;
-                    }
                 }
             });
         }

--- a/src/Avalonia.Controls/Page/CarouselPage.cs
+++ b/src/Avalonia.Controls/Page/CarouselPage.cs
@@ -55,6 +55,26 @@ namespace Avalonia.Controls
         {
             ItemsPanelProperty.OverrideDefaultValue<CarouselPage>(DefaultPanel);
             FocusableProperty.OverrideDefaultValue<CarouselPage>(true);
+            PageNavigationSystemBackButtonPressedEvent.AddClassHandler<CarouselPage>((sender, eventArgs) =>
+            {
+                if (eventArgs.Handled)
+                    return;
+
+                if (sender.OnSystemBackButtonPressed())
+                {
+                    eventArgs.Handled = true;
+                }
+                else
+                {
+                    var pageEvent = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);
+                    sender.CurrentPage?.RaiseEvent(pageEvent);
+
+                    if (pageEvent.Handled)
+                    {
+                        eventArgs.Handled = true;
+                    }
+                }
+            });
         }
 
         public CarouselPage()

--- a/src/Avalonia.Controls/Page/ContentPage.cs
+++ b/src/Avalonia.Controls/Page/ContentPage.cs
@@ -74,16 +74,6 @@ namespace Avalonia.Controls
         static ContentPage()
         {
             ContentProperty.Changed.AddClassHandler<ContentPage>((x, e) => x.ContentChanged(e));
-            PageNavigationSystemBackButtonPressedEvent.AddClassHandler<ContentPage>((sender, eventArgs) =>
-            {
-                if (eventArgs.Handled)
-                    return;
-
-                if (sender.OnSystemBackButtonPressed())
-                {
-                    eventArgs.Handled = true;
-                }
-            });
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Page/ContentPage.cs
+++ b/src/Avalonia.Controls/Page/ContentPage.cs
@@ -74,6 +74,16 @@ namespace Avalonia.Controls
         static ContentPage()
         {
             ContentProperty.Changed.AddClassHandler<ContentPage>((x, e) => x.ContentChanged(e));
+            PageNavigationSystemBackButtonPressedEvent.AddClassHandler<ContentPage>((sender, eventArgs) =>
+            {
+                if (eventArgs.Handled)
+                    return;
+
+                if (sender.OnSystemBackButtonPressed())
+                {
+                    eventArgs.Handled = true;
+                }
+            });
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Page/DrawerPage.cs
+++ b/src/Avalonia.Controls/Page/DrawerPage.cs
@@ -295,6 +295,9 @@ namespace Avalonia.Controls
         {
             PageNavigationSystemBackButtonPressedEvent.AddClassHandler<DrawerPage>((sender, eventArgs) =>
             {
+                if (eventArgs.Handled)
+                    return;
+
                 if (sender.IsOpen
                     && sender.DrawerBehavior != DrawerBehavior.Locked
                     && sender.DrawerBehavior != DrawerBehavior.Disabled)
@@ -302,6 +305,21 @@ namespace Avalonia.Controls
                     sender.IsOpen = false;
                     eventArgs.Handled = true;
                 }
+                else if (sender.OnSystemBackButtonPressed())
+                {
+                    eventArgs.Handled = true;
+                }
+                else
+                {
+                    var pageEvent = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);
+                    sender.CurrentPage?.RaiseEvent(pageEvent);
+
+                    if(pageEvent.Handled)
+                    {
+                        eventArgs.Handled = true;
+                    }
+                }
+
             });
         }
 

--- a/src/Avalonia.Controls/Page/DrawerPage.cs
+++ b/src/Avalonia.Controls/Page/DrawerPage.cs
@@ -314,7 +314,7 @@ namespace Avalonia.Controls
                     var pageEvent = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);
                     sender.CurrentPage?.RaiseEvent(pageEvent);
 
-                    if(pageEvent.Handled)
+                    if (pageEvent.Handled)
                     {
                         eventArgs.Handled = true;
                     }

--- a/src/Avalonia.Controls/Page/DrawerPage.cs
+++ b/src/Avalonia.Controls/Page/DrawerPage.cs
@@ -305,10 +305,6 @@ namespace Avalonia.Controls
                     sender.IsOpen = false;
                     eventArgs.Handled = true;
                 }
-                else if (sender.OnSystemBackButtonPressed())
-                {
-                    eventArgs.Handled = true;
-                }
                 else
                 {
                     var pageEvent = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);
@@ -319,7 +315,6 @@ namespace Avalonia.Controls
                         eventArgs.Handled = true;
                     }
                 }
-
             });
         }
 

--- a/src/Avalonia.Controls/Page/NavigationPage.cs
+++ b/src/Avalonia.Controls/Page/NavigationPage.cs
@@ -221,6 +221,18 @@ namespace Avalonia.Controls
                 if (eventArgs.Handled)
                     return;
 
+                if(sender.CurrentPage != null)
+                {
+                    var forwarded = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);
+                    sender.CurrentPage.RaiseEvent(forwarded);
+
+                    if (forwarded.Handled)
+                        eventArgs.Handled = true;
+                }
+
+                if (eventArgs.Handled)
+                    return;
+
                 if (sender._modalStack.Count > 0)
                 {
                     var forwarded = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);

--- a/src/Avalonia.Controls/Page/NavigationPage.cs
+++ b/src/Avalonia.Controls/Page/NavigationPage.cs
@@ -221,18 +221,6 @@ namespace Avalonia.Controls
                 if (eventArgs.Handled)
                     return;
 
-                if(sender.CurrentPage != null)
-                {
-                    var forwarded = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);
-                    sender.CurrentPage.RaiseEvent(forwarded);
-
-                    if (forwarded.Handled)
-                        eventArgs.Handled = true;
-                }
-
-                if (eventArgs.Handled)
-                    return;
-
                 if (sender._modalStack.Count > 0)
                 {
                     var forwarded = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);
@@ -245,6 +233,18 @@ namespace Avalonia.Controls
 
                     return;
                 }
+
+                if (sender.CurrentPage != null)
+                {
+                    var forwarded = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);
+                    sender.CurrentPage.RaiseEvent(forwarded);
+
+                    if (forwarded.Handled)
+                        eventArgs.Handled = true;
+                }
+
+                if (eventArgs.Handled)
+                    return;
 
                 if (sender.StackDepth > 1)
                 {

--- a/src/Avalonia.Controls/Page/Page.cs
+++ b/src/Avalonia.Controls/Page/Page.cs
@@ -62,7 +62,7 @@ namespace Avalonia.Controls
         public static readonly RoutedEvent<RoutedEventArgs> PageNavigationSystemBackButtonPressedEvent =
             RoutedEvent.Register<Page, RoutedEventArgs>(
                 nameof(PageNavigationSystemBackButtonPressed),
-                RoutingStrategies.Bubble);
+                RoutingStrategies.Direct);
 
         /// <summary>
         /// Defines the <see cref="Navigation"/> property.
@@ -75,17 +75,6 @@ namespace Avalonia.Controls
 
         static Page()
         {
-            PageNavigationSystemBackButtonPressedEvent.AddClassHandler<Page>((page, args) =>
-            {
-                if (!args.Handled && page.OnSystemBackButtonPressed())
-                {
-                    args.Handled = true;
-                    return;
-                }
-
-                page.CurrentPage?.RaiseEvent(args);
-            });
-
             AffectsMeasure<Page>(SafeAreaPaddingProperty);
         }
 

--- a/src/Avalonia.Controls/Page/Page.cs
+++ b/src/Avalonia.Controls/Page/Page.cs
@@ -76,6 +76,16 @@ namespace Avalonia.Controls
         static Page()
         {
             AffectsMeasure<Page>(SafeAreaPaddingProperty);
+            PageNavigationSystemBackButtonPressedEvent.AddClassHandler<Page>((sender, eventArgs) =>
+            {
+                if (eventArgs.Handled)
+                    return;
+
+                if (sender.OnSystemBackButtonPressed())
+                {
+                    eventArgs.Handled = true;
+                }
+            });
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Page/TabbedPage.cs
+++ b/src/Avalonia.Controls/Page/TabbedPage.cs
@@ -9,6 +9,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Input.GestureRecognizers;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
 
 namespace Avalonia.Controls
@@ -87,6 +88,26 @@ namespace Avalonia.Controls
         static TabbedPage()
         {
             FocusableProperty.OverrideDefaultValue<TabbedPage>(true);
+            PageNavigationSystemBackButtonPressedEvent.AddClassHandler<TabbedPage>((sender, eventArgs) =>
+            {
+                if (eventArgs.Handled)
+                    return;
+
+                if (sender.OnSystemBackButtonPressed())
+                {
+                    eventArgs.Handled = true;
+                }
+                else
+                {
+                    var forwarded = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);
+                    sender.CurrentPage?.RaiseEvent(forwarded);
+
+                    if (forwarded.Handled)
+                    {
+                        eventArgs.Handled = true;
+                    }
+                }
+            });
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Page/TabbedPage.cs
+++ b/src/Avalonia.Controls/Page/TabbedPage.cs
@@ -93,19 +93,12 @@ namespace Avalonia.Controls
                 if (eventArgs.Handled)
                     return;
 
-                if (sender.OnSystemBackButtonPressed())
+                var forwarded = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);
+                sender.CurrentPage?.RaiseEvent(forwarded);
+
+                if (forwarded.Handled)
                 {
                     eventArgs.Handled = true;
-                }
-                else
-                {
-                    var forwarded = new RoutedEventArgs(PageNavigationSystemBackButtonPressedEvent);
-                    sender.CurrentPage?.RaiseEvent(forwarded);
-
-                    if (forwarded.Handled)
-                    {
-                        eventArgs.Handled = true;
-                    }
                 }
             });
         }
@@ -310,13 +303,15 @@ namespace Avalonia.Controls
                 if (target < 0)
                 {
                     _ignoringDisabledSelection = true;
-                    try { _tabControl.SelectedIndex = SelectedIndex; }
+                    try
+                    { _tabControl.SelectedIndex = SelectedIndex; }
                     finally { _ignoringDisabledSelection = false; }
                     return;
                 }
 
                 _ignoringDisabledSelection = true;
-                try { _tabControl.SelectedIndex = target; }
+                try
+                { _tabControl.SelectedIndex = target; }
                 finally { _ignoringDisabledSelection = false; }
 
                 if (target == SelectedIndex)
@@ -679,12 +674,12 @@ namespace Avalonia.Controls
 
             int delta = (e.SwipeDirection, isHorizontal, isRtl) switch
             {
-                (SwipeDirection.Left,  true,  false) => +1,
-                (SwipeDirection.Right, true,  false) => -1,
-                (SwipeDirection.Left,  true,  true)  => -1,
-                (SwipeDirection.Right, true,  true)  => +1,
-                (SwipeDirection.Up,    false, _)     => -1,
-                (SwipeDirection.Down,  false, _)     => +1,
+                (SwipeDirection.Left, true, false) => +1,
+                (SwipeDirection.Right, true, false) => -1,
+                (SwipeDirection.Left, true, true) => -1,
+                (SwipeDirection.Right, true, true) => +1,
+                (SwipeDirection.Up, false, _) => -1,
+                (SwipeDirection.Down, false, _) => +1,
                 _ => 0
             };
 

--- a/tests/Avalonia.Controls.UnitTests/CarouselPageTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CarouselPageTests.cs
@@ -11,10 +11,11 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Input.GestureRecognizers;
-using Avalonia.Threading;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
+using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Avalonia.VisualTree;
 using Xunit;
@@ -539,6 +540,35 @@ public class CarouselPageTests
 
             Assert.NotNull(args);
             Assert.Equal(NavigationType.Replace, args!.NavigationType);
+        }
+    }
+
+    public class SystemBackButtonTests : ScopedTestBase
+    {
+        private static RoutedEventArgs RaiseBackButton(Page dp)
+        {
+            var args = new RoutedEventArgs(Page.PageNavigationSystemBackButtonPressedEvent);
+            dp.RaiseEvent(args);
+            return args;
+        }
+
+        [Fact]
+        public void Back_Event_Is_Forwarded_To_Content()
+        {
+            var cp = new CarouselPage();
+            var page = new ContentPage();
+            bool isRaised = false;
+            page.PageNavigationSystemBackButtonPressed += (s, e) =>
+            {
+                isRaised = true;
+            };
+            var root = new TestRoot { Child = cp };
+            ((AvaloniaList<Page>)cp.Pages!).Add(page);
+
+            var args = RaiseBackButton(cp);
+
+            Assert.True(isRaised);
+            Assert.False(args.Handled);
         }
     }
 

--- a/tests/Avalonia.Controls.UnitTests/DrawerPageTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DrawerPageTests.cs
@@ -1106,6 +1106,25 @@ public class DrawerPageTests
         }
 
         [Fact]
+        public void Back_Event_Is_Forwarded_To_Content()
+        {
+            var dp = new DrawerPage();
+            var page = new ContentPage();
+            bool isRaised = false;
+            page.PageNavigationSystemBackButtonPressed += (s, e) =>
+            {
+                isRaised = true;
+            };
+            var root = new TestRoot { Child = dp };
+            dp.CurrentPage = page;
+
+            var args = RaiseBackButton(dp);
+
+            Assert.True(isRaised);
+            Assert.False(args.Handled);
+        }
+
+        [Fact]
         public void BackButton_ClosesOpenDrawer()
         {
             var dp = new DrawerPage { IsOpen = true };

--- a/tests/Avalonia.Controls.UnitTests/DrawerPageTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DrawerPageTests.cs
@@ -1175,6 +1175,62 @@ public class DrawerPageTests
             Assert.False(dp.IsOpen);
             Assert.False(args.Handled);
         }
+
+        [Fact]
+        public async Task BackButton_ForwardsThroughNavigationPageToModalBeforeCoveredPage()
+        {
+            var dp = new DrawerPage();
+            var nav = new NavigationPage();
+            var coveredPage = new BackHandlingPage { HandleBack = true };
+            var modal = new BackHandlingPage();
+            await nav.PushAsync(coveredPage);
+            await nav.PushModalAsync(modal);
+            dp.Content = nav;
+            var root = new TestRoot { Child = dp };
+
+            var args = RaiseBackButton(dp);
+
+            Assert.True(args.Handled);
+            Assert.Equal(0, coveredPage.BackButtonPressCount);
+            Assert.Equal(1, modal.BackButtonPressCount);
+            Assert.Empty(nav.ModalStack);
+            Assert.Same(coveredPage, nav.CurrentPage);
+        }
+
+        [Fact]
+        public async Task BackButton_ClosesOpenDrawerBeforeForwardingToNestedNavigationPage()
+        {
+            var dp = new DrawerPage { IsOpen = true };
+            var nav = new NavigationPage();
+            var coveredPage = new BackHandlingPage { HandleBack = true };
+            var modal = new BackHandlingPage();
+            await nav.PushAsync(coveredPage);
+            await nav.PushModalAsync(modal);
+            dp.Content = nav;
+            var root = new TestRoot { Child = dp };
+
+            var args = RaiseBackButton(dp);
+
+            Assert.True(args.Handled);
+            Assert.False(dp.IsOpen);
+            Assert.Equal(0, coveredPage.BackButtonPressCount);
+            Assert.Equal(0, modal.BackButtonPressCount);
+            Assert.Single(nav.ModalStack);
+            Assert.Same(modal, nav.ModalStack[0]);
+        }
+
+        private sealed class BackHandlingPage : ContentPage
+        {
+            public int BackButtonPressCount { get; private set; }
+
+            public bool HandleBack { get; set; }
+
+            protected override bool OnSystemBackButtonPressed()
+            {
+                BackButtonPressCount++;
+                return HandleBack;
+            }
+        }
     }
 
     public class IconTests : ScopedTestBase

--- a/tests/Avalonia.Controls.UnitTests/NavigationPageTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NavigationPageTests.cs
@@ -1354,6 +1354,43 @@ public class NavigationPageTests
             Assert.Same(modal, nav.ModalStack[0]);
         }
 
+        [Fact]
+        public async Task BackButton_WithModal_DoesNotForwardToCoveredCurrentPage()
+        {
+            var nav = new NavigationPage();
+            var root = new BackHandlingPage { HandleBack = true };
+            var modal = new BackHandlingPage();
+            await nav.PushAsync(root);
+            await nav.PushModalAsync(modal);
+
+            var args = RaiseBackButton(nav);
+
+            Assert.True(args.Handled);
+            Assert.Equal(0, root.BackButtonPressCount);
+            Assert.Equal(1, modal.BackButtonPressCount);
+            Assert.Empty(nav.ModalStack);
+            Assert.Equal(1, nav.StackDepth);
+            Assert.Same(root, nav.CurrentPage);
+        }
+
+        [Fact]
+        public async Task BackButton_WithHandledModal_DoesNotForwardToCoveredCurrentPage()
+        {
+            var nav = new NavigationPage();
+            var root = new BackHandlingPage { HandleBack = true };
+            var modal = new BackHandlingPage { HandleBack = true };
+            await nav.PushAsync(root);
+            await nav.PushModalAsync(modal);
+
+            var args = RaiseBackButton(nav);
+
+            Assert.True(args.Handled);
+            Assert.Equal(0, root.BackButtonPressCount);
+            Assert.Equal(1, modal.BackButtonPressCount);
+            Assert.Single(nav.ModalStack);
+            Assert.Same(modal, nav.ModalStack[0]);
+        }
+
         private sealed class BackHandlingPage : ContentPage
         {
             public int BackButtonPressCount { get; private set; }

--- a/tests/Avalonia.Controls.UnitTests/PageNavigationHostTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/PageNavigationHostTests.cs
@@ -1,3 +1,5 @@
+using Avalonia.Collections;
+using Avalonia.Interactivity;
 using Avalonia.UnitTests;
 using Xunit;
 
@@ -161,6 +163,44 @@ public class PageNavigationHostTests
             Assert.Equal(default, first.SafeAreaPadding);
             Assert.NotNull(host.Presenter);
             Assert.Same(second, host.Presenter!.Child);
+        }
+    }
+
+    public class SystemBackButtonTests : ScopedTestBase
+    {
+        [Fact]
+        public void BackRequested_ForwardsToNestedCurrentPageOnce()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+            var child = new ContentPage { Header = "Child" };
+            var parent = new CarouselPage
+            {
+                Pages = new AvaloniaList<Page> { child }
+            };
+            var host = new PageNavigationHost { Page = parent };
+            var window = new Window
+            {
+                Width = 400,
+                Height = 300,
+                Content = host
+            };
+            var raiseCount = 0;
+            child.PageNavigationSystemBackButtonPressed += (_, e) =>
+            {
+                raiseCount++;
+                e.Handled = true;
+            };
+
+            window.Show();
+
+            Assert.Same(child, parent.CurrentPage);
+            Assert.Same(parent, host.Presenter?.Child);
+
+            var args = new RoutedEventArgs(TopLevel.BackRequestedEvent);
+            window.RaiseEvent(args);
+
+            Assert.Equal(1, raiseCount);
+            Assert.True(args.Handled);
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/TabbedPageTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabbedPageTests.cs
@@ -1423,6 +1423,52 @@ public class TabbedPageTests
         }
     }
 
+    public class SystemBackButtonTests : ScopedTestBase
+    {
+        private static RoutedEventArgs RaiseBackButton(Page dp)
+        {
+            var args = new RoutedEventArgs(Page.PageNavigationSystemBackButtonPressedEvent);
+            dp.RaiseEvent(args);
+            return args;
+        }
+
+        [Fact]
+        public void Back_Event_Is_Forwarded_To_Content()
+        {
+            var tp = new TestableTabbedPage();
+            var page1 = new ContentPage { Header = "Page1" };
+            var page2 = new ContentPage { Header = "Page2" };
+            var page3 = new ContentPage { Header = "Page3" };
+            var pages = new AvaloniaList<Page> { page1, page2, page3 };
+            tp.Pages = pages;
+
+            NotifyCollectionChangedEventArgs? received = null;
+            tp.PagesChanged += (_, e) => received = e;
+            bool isRaisedOnPage1 = false, isRaisedOnPage2 = false, isRaisedOnPage3 = false;
+            page1.PageNavigationSystemBackButtonPressed += (s, e) =>
+            {
+                isRaisedOnPage1 = true;
+            };
+            page2.PageNavigationSystemBackButtonPressed += (s, e) =>
+            {
+                isRaisedOnPage2 = true;
+            };
+            page3.PageNavigationSystemBackButtonPressed += (s, e) =>
+            {
+                isRaisedOnPage3 = true;
+            };
+            var root = new TestRoot { Child = tp };
+            tp.CallCommitSelection(1, page2);
+
+            var args = RaiseBackButton(tp);
+
+            Assert.False(isRaisedOnPage1);
+            Assert.True(isRaisedOnPage2);
+            Assert.False(isRaisedOnPage3);
+            Assert.False(args.Handled);
+        }
+    }
+
     private sealed class TestableTabbedPage : TabbedPage
     {
         public void CallCommitSelection(int index, Page? page) => CommitSelection(index, page);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR changes the routing strategy for `PageNavigationSystemBackButtonPressedEvent`, and updates handlers for all current page types. Pages that host other pages will generate an event for that child page and raise it. This fixes a StackOverflow that occurs on pages hosted in a `PageNavigationHost`.

## What is the current behavior?
When Back system buttons is pressed, `PageNavigationHost` generates a `PageNavigationSystemBackButtonPressedEvent` and raises it on the child page. The global `Page` handler for this event receives it and raises it again on the current page's child page. Because `PageNavigationSystemBackButtonPressedEvent` routing strategy is `Bubble`, this event is raised on the parent again if the child doesn't handle it. The global `Page` handler grabs this and raises it again on the child. This causes a closed loop and ends up in a StackOverflow.


## What is the updated/expected behavior with this PR?
The global `Page` handler for `PageNavigationSystemBackButtonPressedEvent` is removed. `ContentPage`, which is the only non-hosting `Page` will not forward this event to `CurrentPage`, since it has no logic to set that property. Other pages that host pages will check if they have special behavior when back is requested, like closing the drawer in `DrawerPage`, before raising the event on their `CurrentPage`.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
