### PR TITLE
Fix: Preserve WS_CAPTION, WS_MINIMIZEBOX, WS_MAXIMIZEBOX for BorderOn…

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -929,6 +929,24 @@ namespace Avalonia.Win32.Interop
             GWL_USERDATA = -21
         }
 
+        public enum GWLP
+        {
+            GWL_WNDPROC = -4,
+            GWL_HINSTANCE = -6,
+            GWL_HWNDPARENT = -8,
+            GWL_ID = -12,
+            GWL_STYLE = -16,
+            GWL_EXSTYLE = -20,
+            GWL_USERDATA = -21
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct STYLESTRUCT
+        {
+            public WindowStyles styleOld;
+            public WindowStyles styleNew;
+        }
+
         public enum MenuCharParam
         {
             MNC_IGNORE = 0,

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -132,6 +132,33 @@ namespace Avalonia.Win32
                         break;
                     }
 
+                case WindowsMessage.WM_STYLECHANGING:
+                    {
+                        // When using BorderOnly decorations with extended client area, we need to preserve
+                        // WS_CAPTION, WS_MINIMIZEBOX, and WS_MAXIMIZEBOX to maintain native Windows
+                        // minimize/maximize/close animations. Without these styles, the animations are lost
+                        // even though the window appears correct. We only preserve these styles if they're
+                        // present in the old style but not in the new style (i.e., when Windows is trying
+                        // to remove them). We skip this in FullScreen mode to avoid breaking FullScreen behavior.
+                        if (_isClientAreaExtended && _windowProperties.Decorations == WindowDecorations.BorderOnly && !_isFullScreenActive)
+                        {
+                            if ((GWLP)wParam == GWLP.GWL_STYLE)
+                            {
+                                var ss = Marshal.PtrToStructure<STYLESTRUCT>(lParam);
+                                
+                                // Only preserve styles if they're being removed
+                                if (ss.styleOld.HasAllFlags(WindowStyles.WS_CAPTION) && !ss.styleNew.HasAllFlags(WindowStyles.WS_CAPTION))
+                                    ss.styleNew |= WindowStyles.WS_CAPTION;
+                                if (_windowProperties.IsMinimizable && ss.styleOld.HasAllFlags(WindowStyles.WS_MINIMIZEBOX) && !ss.styleNew.HasAllFlags(WindowStyles.WS_MINIMIZEBOX))
+                                    ss.styleNew |= WindowStyles.WS_MINIMIZEBOX;
+                                if (_windowProperties.IsMaximizable && ss.styleOld.HasAllFlags(WindowStyles.WS_MAXIMIZEBOX) && !ss.styleNew.HasAllFlags(WindowStyles.WS_MAXIMIZEBOX))
+                                    ss.styleNew |= WindowStyles.WS_MAXIMIZEBOX;
+                                Marshal.StructureToPtr(ss, lParam, false);
+                            }
+                        }
+                        break;
+                    }
+
                 case WindowsMessage.WM_CLOSE:
                     {
                         bool? preventClosing = Closing?.Invoke(WindowCloseReason.WindowClosing);


### PR DESCRIPTION
Fix: Preserve WS_CAPTION, WS_MINIMIZEBOX, WS_MAXIMIZEBOX for BorderOnly decorations with extended client area to restore native Windows animations.

## Problem
When using `WindowDecorations="BorderOnly"` with `ExtendClientAreaToDecorationsHint="True"`, the caption-style bits (WS_CAPTION, WS_MINIMIZEBOX, WS_MAXIMIZEBOX) that DWM uses to trigger minimize/maximize/close animations were being stripped, causing instant transitions instead of native Windows animations.

## Solution
Added a WM_STYLECHANGING handler that preserves these styles when they're being removed, while skipping FullScreen mode to avoid breaking FullScreen behavior.

## Changes
- Added `GWLP` enum and [STYLESTRUCT](cci:2://file:///d:/Projects/Avalonia/Avalonia/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs:942:8-947:9) struct to [UnmanagedMethods.cs](cci:7://file:///d:/Projects/Avalonia/Avalonia/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs:0:0-0:0)
- Added WM_STYLECHANGING handler in [WindowImpl.AppWndProc.cs](cci:7://file:///d:/Projects/Avalonia/Avalonia/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs:0:0-0:0) that preserves:
  - WS_CAPTION (always)
  - WS_MINIMIZEBOX (when window is minimizable)
  - WS_MAXIMIZEBOX (when window is maximizable)

## Testing
All 120 Win32 integration tests pass, including window sizing tests for BorderOnly decorations.

Fixes https://github.com/AvaloniaUI/Avalonia/issues/21160 , Fixes https://github.com/AvaloniaUI/Avalonia/issues/21212