### PR TITLE
Fix FocusManager.SetFocusScope not doing anything

### DIFF
--- a/src/Avalonia.Base/Input/FocusManager.cs
+++ b/src/Avalonia.Base/Input/FocusManager.cs
@@ -142,6 +142,9 @@ namespace Avalonia.Input
         [PrivateApi]
         public void SetFocusScope(IFocusScope scope)
         {
+            if (KeyboardDevice.Instance is not { } keyboardDevice)
+                return;
+
             if (GetFocusedElement(scope) is { } focused)
             {
                 Focus(focused);
@@ -152,6 +155,13 @@ namespace Avalonia.Input
                 // control, select a control that the user has specified to have default
                 // focus etc.
                 Focus(scopeElement);
+            }
+            else
+            {
+                // If the scope isn't focusable, make sure we still set it as the current focus root,
+                // otherwise it will be completely ignored
+                _focusRoot = scope as StyledElement;
+                keyboardDevice.SetFocusedElement(null, NavigationMethod.Unspecified, KeyModifiers.None, false);
             }
         }
 

--- a/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
@@ -703,6 +703,41 @@ namespace Avalonia.Base.UnitTests.Input
             Assert.Same(innerButton, focusManager.GetFocusedElement());
         }
 
+        // https://github.com/AvaloniaUI/Avalonia/issues/13134
+        [Fact]
+        public void SetFocusScope_On_Non_Focusable_Scope_Changes_Scope()
+        {
+            using var app = UnitTestApplication.Start(TestServices.RealFocus);
+
+            Button outerButton;
+            TestFocusScope innerScope;
+            var root = new TestRoot
+            {
+                Child = new StackPanel
+                {
+                    Focusable = false,
+                    Children =
+                    {
+                        (innerScope = new TestFocusScope()),
+                        (outerButton = new Button())
+                    }
+                }
+            };
+
+            outerButton.Focus();
+
+            var focusManager = Assert.IsType<FocusManager>(root.FocusManager);
+            Assert.Same(outerButton, focusManager.GetFocusedElement());
+
+            // Switch to a scope that has no previously focused element and isn't focusable itself.
+            // TestFocusScope is a Panel (Focusable = false) + IFocusScope.
+            focusManager.SetFocusScope(innerScope);
+
+            // Focus must be cleared: the scope is not focusable and has no prior focused element.
+            // Before the fix this was a no-op and outerButton would still be reported as focused.
+            Assert.Null(focusManager.GetFocusedElement());
+        }
+
         [Fact]
         public void Can_Get_First_Focusable_Element()
         {


### PR DESCRIPTION
## What does the pull request do?
This PR fixes `FocusManager.SetFocusScope` not doing anything when the scope itself isn't focusable and doesn't have any focused element.

## What is the current behavior?
`FocusManager.SetFocusScope` is a no-op when the scope isn't focusable and has no currently focused element.

On X11, this causes the focus to stay on the previous window when a new one is activated.

On Windows, this is usually unnoticeable because a platform focus loss on the previous window made things work... unless the previous window was a popup (e.g. some `Menu`).

## What is the updated/expected behavior with this PR?
`SetFocusScope` correctly sets the current focus scope, even if there's no focused element.

## Checklist
- [x] Added unit tests (if possible)?

## Fixed issues
- Fixes #13134
- Fixes #15355
- Fixes #16832
- Fixes #19231
- Fixes #19617
- Fixes #21196
