### PR TITLE
Win32: Run file picker on dedicated STA thread to avoid MTA deadlock

### DIFF
--- a/src/Windows/Avalonia.Win32/Win32StorageProvider.cs
+++ b/src/Windows/Avalonia.Win32/Win32StorageProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls.Utils;
 using Avalonia.Platform.Storage;
@@ -96,7 +97,10 @@ namespace Avalonia.Win32
             Func<string, TStorageItem> convert)
             where TStorageItem : IStorageItem
         {
-            return Task.Factory.StartNew(() =>
+            var tcs = new TaskCompletionSource<(IReadOnlyList<TStorageItem>, int)>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var thread = new Thread(() =>
             {
                 IReadOnlyList<TStorageItem> result = [];
                 try
@@ -179,7 +183,8 @@ namespace Avalonia.Win32
 
                     if ((uint)showResult == (uint)UnmanagedMethods.HRESULT.E_CANCELLED)
                     {
-                        return (result, typeIndex);
+                        tcs.SetResult((result, typeIndex));
+                        return;
                     }
                     else if ((uint)showResult != (uint)UnmanagedMethods.HRESULT.S_OK)
                     {
@@ -210,14 +215,23 @@ namespace Avalonia.Win32
                         result = [convert(singleResult)];
                     }
 
-                    return (result, typeIndex);
+                    tcs.SetResult((result, typeIndex));
                 }
                 catch (COMException ex)
                 {
                     var message = new Win32Exception(ex.HResult).Message;
-                    throw new COMException(message, ex);
+                    tcs.SetException(new COMException(message, ex));
                 }
-            }, TaskCreationOptions.LongRunning);
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.IsBackground = true;
+            thread.Start();
+
+            return tcs.Task;
         }
 
         private static string? GetParsingName(IShellItem shellItem)

--- a/src/Windows/Avalonia.Win32/Win32StorageProvider.cs
+++ b/src/Windows/Avalonia.Win32/Win32StorageProvider.cs
@@ -97,6 +97,9 @@ namespace Avalonia.Win32
             Func<string, TStorageItem> convert)
             where TStorageItem : IStorageItem
         {
+            // TODO13: verify that we're on the correct dispatcher, matching other platforms' implementations.
+            // We should then be able to remove the dedicated thread and simply use IFileDialog directly (needs to be reconfirmed).
+
             var tcs = new TaskCompletionSource<(IReadOnlyList<TStorageItem>, int)>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
 


### PR DESCRIPTION
## What does the pull request do?
Fixes a deadlock in the Win32 file/folder picker.

`Task.Factory.StartNew` ran the picker on an MTA thread-pool. Since `IFileDialog` is apartment-threaded, COM hosted it in the main STA (the UI thread) and proxied every call across apartments. If the UI thread had queued work from a recently closed modal (`AfterCloseCleanup` post, async `WM_ACTIVATE`/`WM_SETFOCUS` from `BeforeCloseCleanup`), the picker could hang. The exact wait state inside COM isn't fully traced.

Switching to `Dispatcher.UIThread.InvokeAsync` keeps the picker on the existing STA, removes the cross-apartment jump, and ends the race. `IFileDialog::Show` already runs its own modal pump, so this now the same model as WPF.

Covers all four picker entry points, they they all use `ShowFilePicker`.

## What is the current behavior?
Calling a picker shortly after a modal `ShowDialog` closes can deadlock the app at random. The only known and working workaround is `await Task.Delay(250)` which I currently use to eliminate/hide the bug.

## What is the updated/expected behavior with this PR?
Picker no longer hangs regardless of prior UI-thread state. Verified on a project that previously hung randomly after a using any file picker type; to confirm the change works the workaround was removed and no more dead locks.

## Testing:
- Open a modal dialog via `Window.ShowDialog(this)` and from a button click inside that dialog (or immediately after it closes) call `StorageProvider.SaveFilePickerAsync` / `OpenFilePickerAsync` / `OpenFolderPickerAsync`. Repeat several times.
- Confirm the picker opens every time, the parent stays responsive, and the app does not freeze.

## Fixed issues
Fixes #18969
Fixes #12412
Fixes #19250