### PR TITLE
[ANDROID] Make ToplevelImpl._view nullable.

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaView.cs
+++ b/src/Android/Avalonia.Android/AvaloniaView.cs
@@ -35,10 +35,10 @@ namespace Avalonia.Android
             _root = new EmbeddableControlRoot(_view);
             _root.Prepare();
 
-            this.SetBackgroundColor(global::Android.Graphics.Color.Transparent);
+            SetBackgroundColor(global::Android.Graphics.Color.Transparent);
             OnConfigurationChanged();
 
-            _view.InternalView.SurfaceWindowCreated += InternalView_SurfaceWindowCreated;
+            _view.InternalView!.SurfaceWindowCreated += InternalView_SurfaceWindowCreated;
             _view.InternalView.SurfaceWindowDestroyed += InternalView_SurfaceWindowDestroyed;
 
             _accessHelper = new AvaloniaAccessHelper(this);
@@ -141,7 +141,7 @@ namespace Avalonia.Android
         {
             public ViewImpl(AvaloniaView avaloniaView) : base(avaloniaView)
             {
-                View.FocusChange += ViewImpl_FocusChange;
+                View!.FocusChange += ViewImpl_FocusChange;
             }
 
             private void ViewImpl_FocusChange(object? sender, FocusChangeEventArgs e)

--- a/src/Android/Avalonia.Android/Platform/AndroidScreens.cs
+++ b/src/Android/Avalonia.Android/Platform/AndroidScreens.cs
@@ -125,7 +125,7 @@ internal sealed class AndroidScreens : ScreensBase<Display, AndroidScreen>, IDis
 
     protected override Screen? ScreenFromTopLevelCore(ITopLevelImpl topLevel)
     {
-        var display = ((TopLevelImpl)topLevel).View.Display;
+        var display = ((TopLevelImpl)topLevel).View?.Display;
         return display is not null && TryGetScreen(display, out var screen) ? screen : null;
     }
 

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -127,7 +127,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         {
             _systemNavigationManager.Dispose();
             _view?.Dispose();
-            _view = null!;
+            _view = null;
         }
 
         protected void OnResized(Size size)

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -79,7 +79,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         public IInputRoot? InputRoot { get; private set; }
 
         public Size ClientSize => _view?.Size.ToSize(RenderScaling) ?? default;
-        public double RenderScaling => _view?.Scaling ?? 0;
+        public double RenderScaling => _view?.Scaling ?? 1;
 
         public Action? Closed { get; set; }
 

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -19,8 +19,8 @@ using Avalonia.Input.Raw;
 using Avalonia.Input.TextInput;
 using Avalonia.OpenGL.Egl;
 using Avalonia.Platform;
-using Avalonia.Platform.Surfaces;
 using Avalonia.Platform.Storage;
+using Avalonia.Platform.Surfaces;
 using Avalonia.Rendering.Composition;
 using Java.Lang;
 using ClipboardManager = Android.Content.ClipboardManager;
@@ -39,7 +39,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         private readonly Clipboard _clipboard;
         private readonly AndroidLauncher? _launcher;
         private readonly AndroidScreens? _screens;
-        private SurfaceViewImpl _view;
+        private SurfaceViewImpl? _view;
         private WindowTransparencyLevel _transparencyLevel;
 
         public TopLevelImpl(AvaloniaView avaloniaView, bool placeOnTop = false)
@@ -78,8 +78,8 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
         public IInputRoot? InputRoot { get; private set; }
 
-        public Size ClientSize => _view.Size.ToSize(RenderScaling);
-        public double RenderScaling => _view.Scaling;
+        public Size ClientSize => _view?.Size.ToSize(RenderScaling) ?? default;
+        public double RenderScaling => _view?.Scaling ?? 0;
 
         public Action? Closed { get; set; }
 
@@ -91,9 +91,9 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
         public Action<double>? ScalingChanged { get; set; }
 
-        public View View => _view;
+        public View? View => _view;
 
-        internal InvalidationAwareSurfaceView InternalView => _view;
+        internal InvalidationAwareSurfaceView? InternalView => _view;
 
         public double DesktopScaling => RenderScaling;
         public IPlatformHandle Handle { get; }
@@ -126,7 +126,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         public virtual void Dispose()
         {
             _systemNavigationManager.Dispose();
-            _view.Dispose();
+            _view?.Dispose();
             _view = null!;
         }
 
@@ -193,7 +193,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
                 // ReSharper disable once CompareOfFloatsByEqualityOperator
                 if (newScaling != _oldScaling)
                 {
-                    _oldScaling =  newScaling;
+                    _oldScaling = newScaling;
                     _tl.ScalingChanged?.Invoke(newScaling);
                 }
             }
@@ -232,7 +232,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
         public void SetFrameThemeVariant(PlatformThemeVariant themeVariant)
         {
-            if(_insetsManager != null)
+            if (_insetsManager != null)
             {
                 _insetsManager.SystemBarTheme = themeVariant switch
                 {
@@ -245,12 +245,12 @@ namespace Avalonia.Android.Platform.SkiaPlatform
             AppCompatDelegate.DefaultNightMode = themeVariant == PlatformThemeVariant.Light ? AppCompatDelegate.ModeNightNo : AppCompatDelegate.ModeNightYes;
         }
 
-        public AcrylicPlatformCompensationLevels AcrylicCompensationLevels => new AcrylicPlatformCompensationLevels(1, 1, 1);
+        public AcrylicPlatformCompensationLevels AcrylicCompensationLevels => new(1, 1, 1);
 
-        IntPtr EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo.Handle => ((IPlatformHandle)_view).Handle;
+        IntPtr EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo.Handle => (_view as IPlatformHandle)?.Handle ?? default;
         bool EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfoWithWaitPolicy.SkipWaits => true;
-        PixelSize EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo.Size => _view.Size;
-        double EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo.Scaling => _view.Scaling;
+        PixelSize EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo.Size => _view?.Size ?? default;
+        double EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo.Scaling => _view?.Scaling ?? default;
 
         internal AndroidKeyboardEventsHelper<TopLevelImpl> KeyboardHelper => _keyboardHelper;
 
@@ -258,7 +258,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
         public void SetTransparencyLevelHint(IReadOnlyList<WindowTransparencyLevel> transparencyLevels)
         {
-            if (_view.Context is not AvaloniaActivity activity)
+            if (_view?.Context is not AvaloniaActivity activity)
                 return;
 
             foreach (var level in transparencyLevels)
@@ -341,7 +341,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
                 return _insetsManager;
             }
 
-            if(featureType == typeof(IClipboard))
+            if (featureType == typeof(IClipboard))
             {
                 return _clipboard;
             }
@@ -355,7 +355,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
             {
                 return _screens;
             }
-            
+
             return null;
         }
 
@@ -386,7 +386,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
         internal void TextInput(string text)
         {
-            if(Input != null)
+            if (Input != null)
             {
                 var args = new RawTextInputEventArgs(AndroidKeyboardDevice.Instance!, (ulong)SystemClock.UptimeMillis(), InputRoot!, text);
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
`ToplevelImpl._view` is now marked as nullable. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`ToplevelImpl._view` wasn't marked nullable, even though ti can be set to `null` in `Dispose`. This causes null related exceptions when accessing internal member while the toplevel is detached or disposed.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/21268