### PR TITLE
Fix NullReferenceException in X11EventDispatcher.DispatchX11Events

### DIFF
--- a/src/Avalonia.X11/Dispatching/X11EventDispatcher.cs
+++ b/src/Avalonia.X11/Dispatching/X11EventDispatcher.cs
@@ -46,8 +46,10 @@ internal class X11EventDispatcher
                         _platform.XI2.OnEvent((XIEvent*)xev.GenericEventCookie.data);
                     }
                 }
-                else if (_eventHandlers.TryGetValue(xev.AnyEvent.window, out var handler))
+                else if (_eventHandlers.TryGetValue(xev.AnyEvent.window, out var handler) && handler is not null)
+                {
                     handler(ref xev);
+                }
             }
             finally
             {


### PR DESCRIPTION
# Guard against null `handler` in `X11EventDispatcher.DispatchX11Events`

- **Repo**: `AvaloniaUI/Avalonia`
- **Fixes**: [#20293](https://github.com/AvaloniaUI/Avalonia/issues/20293)
- **Related community PRs**: [#20592](https://github.com/AvaloniaUI/Avalonia/pull/20592),
  [#20653](https://github.com/AvaloniaUI/Avalonia/pull/20653),
  [#20655](https://github.com/AvaloniaUI/Avalonia/pull/20655),
  [#20657](https://github.com/AvaloniaUI/Avalonia/pull/20657).
 

## Summary

Issue [#20293](https://github.com/AvaloniaUI/Avalonia/issues/20293) reports
random `NullReferenceException`s in
`Avalonia.X11.X11EventDispatcher.DispatchX11Events` on Linux. The reporter
narrowed the throw site to:

```csharp
else if (_eventHandlers.TryGetValue(xev.AnyEvent.window, out var handler))
    handler(ref xev)
```

`_eventHandlers` is the shared `AvaloniaX11Platform.Windows` dictionary,
which can transiently hold a `null` value for a window during teardown
(window destroyed but key not yet removed) or because of a race between
the X11 thread pulling events and another thread mutating the registry.
`Dictionary<,>.TryGetValue` happily returns `true` with `handler == null`,
and the subsequent delegate invocation throws.

Our AutoRepair tool derived the predicate `NotNull(handler)` from the
runtime trace at `X11EventDispatcher.cs:50` (detection
`forward-member-access`, the receiver of an invocation), and synthesised a
null-guard around the affected statement.

## Proposed change

```diff
--- a/src/Avalonia.X11/Dispatching/X11EventDispatcher.cs
+++ b/src/Avalonia.X11/Dispatching/X11EventDispatcher.cs
@@
-                else if (_eventHandlers.TryGetValue(xev.AnyEvent.window, out var handler))
-                    handler(ref xev);
+                else if (_eventHandlers.TryGetValue(xev.AnyEvent.window, out var handler) && handler is not null)
+                {
+                    handler(ref xev);
+                }
```

The added `handler is not null` check matches the predicate the violation
analyser produced. Behaviourally, when the entry exists but the handler
has been cleared, the event is dropped instead of crashing the dispatcher
loop (which previously tore down the entire UI thread via `MainLoop`).

## Provenance

- Detector: `NullDereferenceRule` then `forward-member-access`
- Predicate: `NotNull(handler)`
- File: `src/Avalonia.X11/Dispatching/X11EventDispatcher.cs`
- Line: 50
