### PR TITLE
Suppress ExecutionContext flow for render scheduling

### DIFF
--- a/src/Avalonia.Base/Media/MediaContext.cs
+++ b/src/Avalonia.Base/Media/MediaContext.cs
@@ -82,39 +82,28 @@ internal partial class MediaContext : ICompositorScheduler
                 _nextRenderOp.Priority = DispatcherPriority.Render;
             return;
         }
+        // Sometimes our animation, layout and render passes might be taking more than a frame to complete
+        // which can cause a "freeze"-like state when UI is being updated, but input is never being processed
+        // So here we inject an operation with Input priority to check if Input wasn't being processed
+        // for a long time. If that's the case the next rendering operation will be scheduled to happen after all pending input
         
-        // Suppress flow because the context should not flow to next render op.
-        var shouldRestoreFlow = !ExecutionContext.IsFlowSuppressed();
-        var flowControl = shouldRestoreFlow ? ExecutionContext.SuppressFlow() : default;
-
-        try
+        var priority = DispatcherPriority.Render;
+        
+        if (_inputMarkerOp == null)
         {
-            // Sometimes our animation, layout and render passes might be taking more than a frame to complete
-            // which can cause a "freeze"-like state when UI is being updated, but input is never being processed
-            // So here we inject an operation with Input priority to check if Input wasn't being processed
-            // for a long time. If that's the case the next rendering operation will be scheduled to happen after all pending input
-            
-            var priority = DispatcherPriority.Render;
-
-            if (_inputMarkerOp == null)
-            {
-                _inputMarkerOp = _dispatcher.InvokeAsync(_inputMarkerHandler, DispatcherPriority.Input);
-                _inputMarkerAddedAt = _time.Elapsed;
-            }
-            else if (!now && (_time.Elapsed - _inputMarkerAddedAt).TotalSeconds > MaxSecondsWithoutInput)
-            {
-                priority = DispatcherPriority.Input;
-            }
-
-            var renderOp = new DispatcherOperation(_dispatcher, priority, _render, throwOnUiThread: true);
-            _nextRenderOp = renderOp;
-            _dispatcher.InvokeAsyncImpl(renderOp, CancellationToken.None);
+            _inputMarkerOp = new DispatcherOperation(_dispatcher, DispatcherPriority.Input, _inputMarkerHandler,
+                throwOnUiThread: true, captureExecutionContext: false);
+            _dispatcher.InvokeAsyncImpl(_inputMarkerOp, CancellationToken.None);
+            _inputMarkerAddedAt = _time.Elapsed;
         }
-        finally
+        else if (!now && (_time.Elapsed - _inputMarkerAddedAt).TotalSeconds > MaxSecondsWithoutInput)
         {
-            if (shouldRestoreFlow)
-                flowControl.Undo();
+            priority = DispatcherPriority.Input;
         }
+
+        var renderOp = new DispatcherOperation(_dispatcher, priority, _render, throwOnUiThread: true, captureExecutionContext: false);
+        _nextRenderOp = renderOp;
+        _dispatcher.InvokeAsyncImpl(renderOp, CancellationToken.None);
     }
     
     /// <summary>

--- a/src/Avalonia.Base/Media/MediaContext.cs
+++ b/src/Avalonia.Base/Media/MediaContext.cs
@@ -82,26 +82,39 @@ internal partial class MediaContext : ICompositorScheduler
                 _nextRenderOp.Priority = DispatcherPriority.Render;
             return;
         }
-        // Sometimes our animation, layout and render passes might be taking more than a frame to complete
-        // which can cause a "freeze"-like state when UI is being updated, but input is never being processed
-        // So here we inject an operation with Input priority to check if Input wasn't being processed
-        // for a long time. If that's the case the next rendering operation will be scheduled to happen after all pending input
         
-        var priority = DispatcherPriority.Render;
-        
-        if (_inputMarkerOp == null)
-        {
-            _inputMarkerOp = _dispatcher.InvokeAsync(_inputMarkerHandler, DispatcherPriority.Input);
-            _inputMarkerAddedAt = _time.Elapsed;
-        }
-        else if (!now && (_time.Elapsed - _inputMarkerAddedAt).TotalSeconds > MaxSecondsWithoutInput)
-        {
-            priority = DispatcherPriority.Input;
-        }
+        // Suppress flow because the context should not flow to next render op.
+        var shouldRestoreFlow = !ExecutionContext.IsFlowSuppressed();
+        var flowControl = shouldRestoreFlow ? ExecutionContext.SuppressFlow() : default;
 
-        var renderOp = new DispatcherOperation(_dispatcher, priority, _render, throwOnUiThread: true);
-        _nextRenderOp = renderOp;
-        _dispatcher.InvokeAsyncImpl(renderOp, CancellationToken.None);
+        try
+        {
+            // Sometimes our animation, layout and render passes might be taking more than a frame to complete
+            // which can cause a "freeze"-like state when UI is being updated, but input is never being processed
+            // So here we inject an operation with Input priority to check if Input wasn't being processed
+            // for a long time. If that's the case the next rendering operation will be scheduled to happen after all pending input
+            
+            var priority = DispatcherPriority.Render;
+
+            if (_inputMarkerOp == null)
+            {
+                _inputMarkerOp = _dispatcher.InvokeAsync(_inputMarkerHandler, DispatcherPriority.Input);
+                _inputMarkerAddedAt = _time.Elapsed;
+            }
+            else if (!now && (_time.Elapsed - _inputMarkerAddedAt).TotalSeconds > MaxSecondsWithoutInput)
+            {
+                priority = DispatcherPriority.Input;
+            }
+
+            var renderOp = new DispatcherOperation(_dispatcher, priority, _render, throwOnUiThread: true);
+            _nextRenderOp = renderOp;
+            _dispatcher.InvokeAsyncImpl(renderOp, CancellationToken.None);
+        }
+        finally
+        {
+            if (shouldRestoreFlow)
+                flowControl.Undo();
+        }
     }
     
     /// <summary>

--- a/src/Avalonia.Base/Threading/DispatcherOperation.cs
+++ b/src/Avalonia.Base/Threading/DispatcherOperation.cs
@@ -44,18 +44,20 @@ public class DispatcherOperation
     private DispatcherPriority _priority;
     private readonly ExecutionContext? _executionContext;
 
-    internal DispatcherOperation(Dispatcher dispatcher, DispatcherPriority priority, Action callback, bool throwOnUiThread) :
-        this(dispatcher, priority, throwOnUiThread)
+    internal DispatcherOperation(Dispatcher dispatcher, DispatcherPriority priority, Action callback, bool throwOnUiThread,
+        bool captureExecutionContext = true) :
+        this(dispatcher, priority, throwOnUiThread, captureExecutionContext)
     {
         Callback = callback;
     }
 
-    private protected DispatcherOperation(Dispatcher dispatcher, DispatcherPriority priority, bool throwOnUiThread)
+    private protected DispatcherOperation(Dispatcher dispatcher, DispatcherPriority priority, bool throwOnUiThread,
+        bool captureExecutionContext = true)
     {
         ThrowOnUiThread = throwOnUiThread;
         Priority = priority;
         Dispatcher = dispatcher;
-        _executionContext = ExecutionContext.Capture();
+        _executionContext = captureExecutionContext ? ExecutionContext.Capture() : null;
     }
 
     internal string DebugDisplay

--- a/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
+++ b/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Controls;
 using Avalonia.Controls.Platform;
 using Avalonia.Threading;
 using Avalonia.UnitTests;
@@ -600,6 +601,19 @@ public partial class DispatcherTests
         public AsyncLocal<string?> AsyncLocalField { get; set; } = new AsyncLocal<string?>();
     }
 
+    private sealed class AsyncLocalMeasureControl(Func<string?> getValue, Action<string?> setValue) : Control
+    {
+        public bool RecordMeasure { get; set; }
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            if (RecordMeasure)
+                setValue(getValue());
+
+            return new Size(1, 1);
+        }
+    }
+
     [Fact]
     public async Task ExecutionContextIsPreservedInDispatcherInvokeAsync()
     {
@@ -694,6 +708,76 @@ public partial class DispatcherTests
 
         // Assertions
         // The value should NOT flow between different InvokeAsync execution contexts.
+        Assert.Null(test);
+    }
+
+    [Fact]
+    public void MediaContextRenderSchedulingDoesNotCaptureAmbientExecutionContext()
+    {
+        var impl = new SimpleDispatcherWithBackgroundProcessingImpl();
+        using var services = new DispatcherServices(impl);
+        Dispatcher.InitializeUIThreadDispatcher(impl);
+
+        var testObject = new AsyncLocalTestClass();
+        string? test = "Not measured";
+        var control = new AsyncLocalMeasureControl(() => testObject.AsyncLocalField.Value, value => test = value);
+        var root = new TestRoot { Child = control };
+
+        root.ExecuteInitialLayoutPass();
+        control.RecordMeasure = true;
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            testObject.AsyncLocalField.Value = "Initial Value";
+            control.InvalidateMeasure();
+            testObject.AsyncLocalField.Value = null;
+        });
+
+        Assert.True(impl.AskedForSignal);
+        impl.ExecuteSignal();
+
+        Assert.Null(test);
+    }
+
+    [Fact]
+    public void MediaContextRenderSchedulingAllowsAlreadySuppressedExecutionContextFlow()
+    {
+        var impl = new SimpleDispatcherWithBackgroundProcessingImpl();
+        using var services = new DispatcherServices(impl);
+        Dispatcher.InitializeUIThreadDispatcher(impl);
+
+        var testObject = new AsyncLocalTestClass();
+        string? test = "Not measured";
+        Exception? schedulingException = null;
+        var control = new AsyncLocalMeasureControl(() => testObject.AsyncLocalField.Value, value => test = value);
+        var root = new TestRoot { Child = control };
+
+        root.ExecuteInitialLayoutPass();
+        control.RecordMeasure = true;
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            testObject.AsyncLocalField.Value = "Initial Value";
+
+            try
+            {
+                using (ExecutionContext.SuppressFlow())
+                {
+                    control.InvalidateMeasure();
+                }
+            }
+            catch (Exception e)
+            {
+                schedulingException = e;
+            }
+
+            testObject.AsyncLocalField.Value = null;
+        });
+
+        Assert.True(impl.AskedForSignal);
+        impl.ExecuteSignal();
+
+        Assert.Null(schedulingException);
         Assert.Null(test);
     }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Prevents Avalonia's internal render scheduling from inappropriately capturing the ambient `ExecutionContext`.

After PR #19163, dispatcher operations correctly capture `ExecutionContext`, which allows `AsyncLocal` values to flow through user-dispatched UI work. However, `MediaContext` also schedules Avalonia-internal render-loop work through the dispatcher. That internal scheduling should not preserve the ambient ExecutionContext, as this causes AsyncLocal values to flow into the next render loop run.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

When a render pass or layout invalidation schedules the next render operation while an `AsyncLocal` value is active, the dispatcher captures that value for Avalonia's internal render operation.

This can cause diagnostics based on `ActivitySource` / `Activity.Current` to incorrectly parent future render-loop activities, making the activity tree grow longer across frames. You can observe this issue with an OTel exporter and a span viewer (e.g. using .NET Aspire dashboard), and you can find that all spans after a certain point end up sharing the same incorrect span root.

I ran into this issue while heavily instrumenting the render loop and compositor for profiling. It makes diagnostics quite difficult because it causes spans to be associated incorrectly.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Avalonia suppresses `ExecutionContext` flow while scheduling internal render-loop dispatcher operations, so ambient `AsyncLocal` values do not flow into the next render pass.

User-created dispatcher operations still capture `ExecutionContext` normally.

Added regression coverage for render scheduling with ambient `AsyncLocal` state and for the case where execution-context flow is already suppressed.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

`MediaContext.ScheduleRender` now wraps creation/enqueueing of its internal dispatcher operations in `ExecutionContext.SuppressFlow()` scope.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
