### PR TITLE
Fix DeviceLuid byte ordering on MacOS GPU interop

### DIFF
--- a/src/Avalonia.Native/AvaloniaNativeGlPlatformGraphics.cs
+++ b/src/Avalonia.Native/AvaloniaNativeGlPlatformGraphics.cs
@@ -264,7 +264,7 @@ namespace Avalonia.Native
             {
                 // We are reversing bytes to match MoltenVK (LUID is a Vulkan term after all)
                 var bytes = BitConverter.GetBytes(registryId);
-                bytes.Reverse();
+                bytes.AsSpan().Reverse();
                 DeviceLuid = bytes;
             }
         }

--- a/src/Avalonia.Native/Metal.cs
+++ b/src/Avalonia.Native/Metal.cs
@@ -102,7 +102,7 @@ internal class MetalExternalObjectsFeature : IMetalExternalObjectsFeature
         if (_device.GetIOKitRegistryId(&registryId) != 0)
         {
             var bytes = BitConverter.GetBytes(registryId);
-            bytes.Reverse();
+            bytes.AsSpan().Reverse();
             DeviceLuid = bytes;
         }
     }


### PR DESCRIPTION
Fixes #21291 

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

MetalExternalObjectsFeature.DeviceLuid is supposed to be byte-equal to VkPhysicalDeviceVulkan11Properties.deviceLUID returned by MoltenVK. In Avalonia 12 it ends up byte-reversed.

The problem was that bytes.Reverse() in MetalExternalObjectsFeature constructor was resolving to `System.Linq.Enumerable.Reverse<T>()`. This PRs calls AsSpan() to remove the ambiguity and resolve to `MemoryExtensions.Reverse<T>(this Span<T>)`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Avalonia's DeviceLuid bytes are in reverse order when compared to what MoltenVK exposes.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Avalonia's DeviceLuid bytes are in the same order of what MoltenVK exposes.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #21291 