### PR TITLE
[ ANDROID ] Fix File properties

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageItem.cs
+++ b/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageItem.cs
@@ -546,8 +546,7 @@ internal sealed class AndroidStorageFile : AndroidStorageItem, IStorageBookmarkF
         {
             var projection = new[]
             {
-                MediaStore.IMediaColumns.Size, MediaStore.IMediaColumns.DateAdded,
-                MediaStore.IMediaColumns.DateModified
+                Document.ColumnSize, Document.ColumnLastModified
             };
             using var cursor = Activity.ContentResolver!.Query(Uri, projection, null, null, null);
 
@@ -555,7 +554,7 @@ internal sealed class AndroidStorageFile : AndroidStorageItem, IStorageBookmarkF
             {
                 try
                 {
-                    var columnIndex = cursor.GetColumnIndex(MediaStore.IMediaColumns.Size);
+                    var columnIndex = cursor.GetColumnIndex(Document.ColumnSize);
                     if (columnIndex != -1)
                     {
                         size = (ulong)cursor.GetLong(columnIndex);
@@ -569,22 +568,7 @@ internal sealed class AndroidStorageFile : AndroidStorageItem, IStorageBookmarkF
 
                 try
                 {
-                    var columnIndex = cursor.GetColumnIndex(MediaStore.IMediaColumns.DateAdded);
-                    if (columnIndex != -1)
-                    {
-                        var longValue = cursor.GetLong(columnIndex);
-                        itemDate = longValue > 0 ? DateTimeOffset.FromUnixTimeMilliseconds(longValue) : null;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.TryGet(LogEventLevel.Verbose, LogArea.AndroidPlatform)?
-                        .Log(this, "File DateAdded metadata reader failed: '{Exception}'", ex);
-                }
-
-                try
-                {
-                    var columnIndex = cursor.GetColumnIndex(MediaStore.IMediaColumns.DateModified);
+                    var columnIndex = cursor.GetColumnIndex(Document.ColumnLastModified);
                     if (columnIndex != -1)
                     {
                         var longValue = cursor.GetLong(columnIndex);
@@ -594,7 +578,7 @@ internal sealed class AndroidStorageFile : AndroidStorageItem, IStorageBookmarkF
                 catch (Exception ex)
                 {
                     Logger.TryGet(LogEventLevel.Verbose, LogArea.AndroidPlatform)?
-                        .Log(this, "File DateAdded metadata reader failed: '{Exception}'", ex);
+                        .Log(this, "File LastModified metadata reader failed: '{Exception}'", ex);
                 }
             }
         }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes file properties returned on android for Files. 


## What is the current behavior?
`MediaStore.IMediaColumns` values seems to no longer work. This may be due to the file provider not providing values for those columns, or they are only available for specific file types or through specific media providers. This causes fiel properties to return empty values.


## What is the updated/expected behavior with this PR?
Switched `MediaStore.IMediaColumns` to `Document.ColumnX` values. This should work for all files. As a result of the change, it's not possible to read `DateAdded` property as that value is not available on the platform.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/21302