### PR TITLE
Make text in NumericUpDown update immediately when changing the TextC…

### DIFF
--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -605,7 +605,7 @@ namespace Avalonia.Controls
         {
             if (IsInitialized)
             {
-                SyncTextAndValueProperties(false, null);
+                SyncTextAndValueProperties(false, null, true);
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reactive.Subjects;
+using System.Text.RegularExpressions;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Data.Converters;
 using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Xunit;
@@ -97,6 +99,51 @@ namespace Avalonia.Controls.UnitTests
                 // Check that NumberFormat is applied.
                 control.NumberFormat = newNumberFormat;
                 Assert.Equal(value.ToString(newNumberFormat), control.Text);
+            });
+        }
+        
+        private class TestNumericUpDownValueConverter(string format) : IValueConverter
+        {
+            public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+            {
+                var input = value?.ToString() ?? string.Empty;
+                if (string.IsNullOrEmpty(input))
+                    return 0m;
+                var numberPattern = new Regex("[0-9.,]+");
+                var match = numberPattern.Matches(input).FirstOrDefault();
+                if (match == null)
+                    return 0m;
+                
+                return decimal.Parse(match.Value, CultureInfo.InvariantCulture);
+            }
+            
+            public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+            {
+                if (value is not decimal inputNumber)
+                    return null;
+                return inputNumber.ToString(format, CultureInfo.InvariantCulture);
+            }
+        }
+        
+        [Fact]
+        public void TextConverter_Is_Applied_Immediately()
+        {
+            RunTest((control, textbox) =>
+            {
+                const decimal value = 10.11m;
+                var initialConverter = new TestNumericUpDownValueConverter("C2");
+                var newConverter = new TestNumericUpDownValueConverter("P2");
+                
+                // Establish and verify initial conditions.
+                control.Value = value;
+                control.TextConverter = initialConverter;
+                var oldText = control.Text ?? string.Empty;
+                Assert.Equal("¤10.11", oldText);
+                
+                // Check that NumberFormat is applied.
+                control.TextConverter = newConverter;
+                var newText = control.Text ?? string.Empty;
+                Assert.Equal("1,011.00 %", newText);
             });
         }
 


### PR DESCRIPTION
…onverter.

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Resolves https://github.com/AvaloniaUI/Avalonia/issues/21316
App needs to show the updated text in NumericUpDown when changing the TextConverter.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When `TextConverter` is modified, the Text doesn't update immediately.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
When `TextConverter` is modified, the Text now updates immediately too.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Use the overload of the method `SyncTextAndValueProperties` that includes the parameter to update the text.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #21316
-->
