### PR TITLE
Align Touch/Pen capture semantics with Mouse

### DIFF
--- a/src/Avalonia.Base/Input/PenDevice.cs
+++ b/src/Avalonia.Base/Input/PenDevice.cs
@@ -104,7 +104,7 @@ namespace Avalonia.Input
 
             if (source != null)
             {
-                pointer.Capture(source);
+                pointer.Capture(source, CaptureSource.Implicit);
                 var settings = (source as Interactive)?.GetPlatformSettings();
                 if (settings is not null)
                 {
@@ -173,7 +173,7 @@ namespace Avalonia.Input
                 }
                 finally
                 {
-                    pointer.Capture(null);
+                    pointer.Capture(null, CaptureSource.Implicit);
                     pointer.CaptureGestureRecognizer(null);
                     pointer.IsGestureRecognitionSkipped = false;
                     _lastMouseDownButton = default;

--- a/src/Avalonia.Base/Input/Pointer.cs
+++ b/src/Avalonia.Base/Input/Pointer.cs
@@ -136,10 +136,7 @@ namespace Avalonia.Input
 
         public void Dispose()
         {
-            if (Captured != null)
-            {
-                Capture(null);
-            }
+            // callers are responsible for calling Capture(null, source) with an appropriate source
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Input/TouchDevice.cs
+++ b/src/Avalonia.Base/Input/TouchDevice.cs
@@ -48,7 +48,7 @@ namespace Avalonia.Input
 
                 _pointers[args.RawPointerId] = pointer = new Pointer(Pointer.GetNextFreeId(),
                     PointerType.Touch, _pointers.Count == 0);
-                pointer.Capture(hit);
+                pointer.Capture(hit, CaptureSource.Implicit);
             }
 
             var target = pointer.Captured ?? args.InputHitTestResult.firstEnabledAncestor ?? args.Root.RootElement;
@@ -109,6 +109,7 @@ namespace Avalonia.Input
                     {
                         target.RaiseEvent(e);
                     }
+                    pointer?.Capture(null, CaptureSource.Implicit);
                 }
             }
 
@@ -117,7 +118,7 @@ namespace Avalonia.Input
                 _pointers.Remove(args.RawPointerId);
                 using (pointer)
                 {
-                    pointer?.Capture(null);
+                    pointer?.Capture(null, CaptureSource.Platform);
                     pointer?.CaptureGestureRecognizer(null);
                     if (pointer != null)
                         pointer.IsGestureRecognitionSkipped = false;


### PR DESCRIPTION
## What does the pull request do?
Removes `Capture(null)` from `Pointer.Disposable()`, expecting callers to call it explicitly with the appropriate source.

## What is the current behavior?
PenUp and TouchUp are treated as explicit capture loss, resulting in popups closed unexpectedly.

## What is the updated/expected behavior with this PR?
Like with mouse, the captures on down and up are marked as implicit. TouchCancel is treated as loss from platform.

## How was the solution implemented (if it's not obvious)?
`Pointer.Dispose()` is now no-op - keeping `Pointer : IDisposable` for ABI compatibility. Added explicit `Capture(null, source)` to call sites.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--
`Pointer` is public, so callers can cast it to `IDisposable` or use with `using`. We do not expect any 3rd party disposing our pointers, but to alleviate the breaking change, we could keep it `IDisposable` with empty `Dispose()` method. However, that would only mask the change of behavior that it no longer results in capture disposal.
-->

The only `Dispose()` that was not complemented with `Capture(null, source)` is in `PenDevice.ProcessRawEvent` for `shouldReleasePointer = true`, which happens on `LeaveWindow` and `XButton2Up`. The former is no-op for mouse too, and the latter is already handled in `PenUp` it calls.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
