### PR TITLE
Win32: fall back to pixel location when GetPointerDeviceRects is unavailable

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -1363,14 +1363,34 @@ namespace Avalonia.Win32
 
             Imm32InputMethod.Current.SetLanguageAndWindow(this, Hwnd, hkl);
         }
+        
+        // GetPointerDeviceRects is part of the WM_POINTER API (Windows 8+) but is not implemented
+        // by Wine/Proton. Probe once and fall back to the integer pixel location when missing,
+        // otherwise the P/Invoke throws EntryPointNotFoundException for every pointer message.
+        // See https://github.com/AvaloniaUI/Avalonia/issues/21081.
+        private static readonly bool s_isGetPointerDeviceRectsAvailable = ProbeGetPointerDeviceRects();
+
+        private static bool ProbeGetPointerDeviceRects()
+        {
+            var user32 = LoadLibrary("user32.dll");
+            return user32 != IntPtr.Zero
+                && GetProcAddress(user32, nameof(GetPointerDeviceRects)) != IntPtr.Zero;
+        }
 
         /// <summary>
-        /// Get the location of the pointer in himetric units.
+        /// Get the location of the pointer in screen coordinates with HIMETRIC sub-pixel precision
+        /// when supported, falling back to the integer pixel location on platforms that do not
+        /// implement <c>GetPointerDeviceRects</c> (e.g. Wine/Proton).
         /// </summary>
         /// <param name="info">The pointer info.</param>
-        /// <returns>The location of the pointer in himetric units.</returns>
+        /// <returns>The pointer location in screen pixels.</returns>
         private Point GetHimetricLocation(POINTER_INFO info)
         {
+            if (!s_isGetPointerDeviceRectsAvailable)
+            {
+                return new Point(info.ptPixelLocationX, info.ptPixelLocationY);
+            }
+
             GetPointerDeviceRects(info.sourceDevice, out var pointerDeviceRect, out var displayRect);
             var himetricLocation = new Point(
                 info.ptHimetricLocationRawX * displayRect.Width / (double)pointerDeviceRect.Width + displayRect.left,


### PR DESCRIPTION
## What does the pull request do?

Adds a one-time probe for `user32.dll!GetPointerDeviceRects` and falls back to
`POINTER_INFO.ptPixelLocation` when the export is missing. This stops Avalonia
from crashing on the **first WM_POINTER message** under Wine/Proton, where that
WM_POINTER ancillary API has never been implemented.

Fixes #21081.

## What is the current behavior?

`WindowImpl.GetHimetricLocation` (added in #16850) unconditionally P/Invokes
`GetPointerDeviceRects` to convert `ptHimetricLocationRaw` into screen pixels.
Wine/Proton's `user32.dll` does not export this function, so on the first
touch/click the runtime throws:

```
System.EntryPointNotFoundException: Unable to find an entry point named
'GetPointerDeviceRects' in native library 'user32.dll'.
```

The exception is fatal in NativeAOT builds (the original report) and in any
configuration where the Win32 message pump's exception isn't being swallowed,
which on Steam Deck means the very first tap on the window's close button
crashes the app.

## How was the solution implemented (if it's not obvious)?

The probe uses the same `LoadLibrary` + `GetProcAddress` pattern that
`Win32Platform.SetDpiAwareness` already uses for
`SetProcessDpiAwarenessContext` i.e., the established Avalonia way of
dealing with optional Win32 entry points without paying for try/catch on a
hot path