### PR TITLE
Bump SharpCompress from 0.41.0 to 0.48.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="Quamotion.RemoteViewing" Version="1.1.211" />
-    <PackageVersion Include="SharpCompress" Version="0.41.0" />
+    <PackageVersion Include="SharpCompress" Version="0.48.0" />
     <PackageVersion Include="Silk.NET.Direct3D.Compilers" Version="2.22.0" />
     <PackageVersion Include="Silk.NET.Direct3D11" Version="2.22.0" />
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.22.0" />


### PR DESCRIPTION
Bumps SharpCompress version due to path traversal vulnerability GHSA-6c8g-7p36-r338 (CVE in IArchive.WriteToDirectory) which affects all versions <= 0.47.4. 
Version 0.48.0 is the first non-vulnerable release per the NuGet vulnerability API.


Avalonia does NOT use file operations from that library, The library is only used for stream compression by VNC backend for the headless platform if it's enabled.

Your apps are NOT affected unless they are using the vulnerable code path in some other way than through Avalonia.

Note: manually verified that VNC backend still works with new version.