### PR TITLE
Observe potential DBus exception in UnregisterWindowAsync

### DIFF
--- a/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
+++ b/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
@@ -132,16 +132,10 @@ namespace Avalonia.FreeDesktop
                 // Fire and forget
                 _ = _registrar?.UnregisterWindowAsync(_xid)?.ContinueWith(t =>
                 {
-                    try
+                    if (t.Exception != null)
                     {
-                        if (t.Exception != null)
-                        {
-                            Logger.TryGet(LogEventLevel.Warning, LogArea.Platform)
-                                ?.Log(this, "DBusMenu UnregisterWindowAsync failed: {Exception}", t.Exception);
-                        }
-                    }
-                    catch
-                    {
+                        Logger.TryGet(LogEventLevel.Warning, LogArea.Platform)
+                            ?.Log(this, "DBusMenu UnregisterWindowAsync failed: {Exception}", t.Exception);
                     }
                 }, TaskContinuationOptions.OnlyOnFaulted);
                 _pathHandler.Remove(this);

--- a/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
+++ b/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
@@ -10,6 +10,7 @@ using Avalonia.Controls.Platform;
 using Avalonia.Input;
 using Avalonia.Platform;
 using Avalonia.Threading;
+using Avalonia.Logging;
 using Tmds.DBus.Protocol;
 using Tmds.DBus.SourceGenerator;
 
@@ -129,7 +130,20 @@ namespace Avalonia.FreeDesktop
                     return;
                 _disposed = true;
                 // Fire and forget
-                _ = _registrar?.UnregisterWindowAsync(_xid);
+                _ = _registrar?.UnregisterWindowAsync(_xid)?.ContinueWith(t =>
+                {
+                    try
+                    {
+                        if (t.Exception != null)
+                        {
+                            Logger.TryGet(LogEventLevel.Warning, LogArea.Platform)
+                                ?.Log(this, "DBusMenu UnregisterWindowAsync failed: " + t.Exception);
+                        }
+                    }
+                    catch
+                    {
+                    }
+                }, TaskContinuationOptions.OnlyOnFaulted);
                 _pathHandler.Remove(this);
                 Connection.RemoveMethodHandler(_pathHandler.Path);
             }

--- a/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
+++ b/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
@@ -137,7 +137,7 @@ namespace Avalonia.FreeDesktop
                         if (t.Exception != null)
                         {
                             Logger.TryGet(LogEventLevel.Warning, LogArea.Platform)
-                                ?.Log(this, "DBusMenu UnregisterWindowAsync failed: " + t.Exception);
+                                ?.Log(this, "DBusMenu UnregisterWindowAsync failed: {Exception}", t.Exception);
                         }
                     }
                     catch


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fix https://github.com/AvaloniaUI/Avalonia/issues/17616


## What is the current behavior?
`TaskScheduler.UnobservedTaskException` catch an unexpected execption: org.freedesktop.DBus.Error.ServiceUnknown


## What is the updated/expected behavior with this PR?
catch the execption: org.freedesktop.DBus.Error.ServiceUnknown


## How was the solution implemented (if it's not obvious)?
use `ContinueWith`  to  catch and log the exception

## Fixed issues
Fix https://github.com/AvaloniaUI/Avalonia/issues/17616
