### PR TITLE
fix: set WindowDrawnDecorations background to transparent

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
@@ -41,14 +41,14 @@
           <WindowDrawnDecorationsContent.Underlay>
             <Panel x:Name="PART_UnderlayWrapper">
               <Border x:Name="PART_WindowBorder"
-                      Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                      Background="{DynamicResource SystemControlTransparentBrush}"
                       BorderThickness="{TemplateBinding FrameThickness}"
                       BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                       IsHitTestVisible="False" />
               <!-- Titlebar: background, title text, and drag area live in underlay -->
               <Panel x:Name="PART_TitleBar" VerticalAlignment="Top"
                      Height="{TemplateBinding TitleBarHeight}"
-                     Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                     Background="{DynamicResource SystemControlTransparentBrush}"
                      IsVisible="{TemplateBinding HasTitleBar}"
                      WindowDecorationProperties.ElementRole="TitleBar" />
 

--- a/src/Avalonia.Themes.Simple/Controls/WindowDrawnDecorations.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/WindowDrawnDecorations.xaml
@@ -41,14 +41,14 @@
           <WindowDrawnDecorationsContent.Underlay>
             <Panel x:Name="PART_UnderlayWrapper">
               <Border x:Name="PART_WindowBorder"
-                      Background="{DynamicResource ThemeBackgroundBrush}"
+                      Background="Transparent"
                       BorderThickness="{TemplateBinding FrameThickness}"
                       BorderBrush="{DynamicResource ThemeBorderMidBrush}"
                       IsHitTestVisible="False" />
               <!-- Titlebar: background, title text, and drag area live in underlay -->
               <Panel x:Name="PART_TitleBar" VerticalAlignment="Top"
                      Height="{TemplateBinding TitleBarHeight}"
-                     Background="{DynamicResource ThemeBackgroundBrush}"
+                     Background="Transparent"
                      IsVisible="{TemplateBinding HasTitleBar}"
                      WindowDecorationProperties.ElementRole="TitleBar" />
             </Panel>


### PR DESCRIPTION
## What does the pull request do?
Fixes a [regression](https://github.com/AvaloniaUI/Avalonia/issues/21082) where `WindowDrawnDecorations` used an opaque background, blocking transparency effects (Mica/Acrylic/Blur) when `ExtendClientAreaToDecorationsHint` is enabled.

## What is the current behavior?
`WindowDrawnDecorations` renders a solid background, obscuring the window's transparency effects when `ExtendClientAreaToDecorationsHint="True"`.

## What is the updated/expected behavior with this PR?
`WindowDrawnDecorations` backgrounds are now transparent , allowing the window background to show through correctly.

**Proof (ExtendClientArea = True):**
| Theme | Before | After |
| :--- | :--- | :--- |
| **Fluent** |<img width="1026" height="832" alt="before-fluent-extend-true" src="https://github.com/user-attachments/assets/8655386c-c786-48dd-ac21-644ba00c29e0" />|<img width="1026" height="832" alt="after-fluent-extend-true" src="https://github.com/user-attachments/assets/306ca162-aed2-4012-b5c0-fae94cfc4345" />|
| **Simple** |<img width="1026" height="832" alt="before-simple-extend-true" src="https://github.com/user-attachments/assets/9fc55b51-7a26-4e59-b901-77fb5eba719b" />|<img width="1026" height="832" alt="after-simple-extend-true" src="https://github.com/user-attachments/assets/179f80ca-831e-4218-9648-f25ecb25e25c" />|

## How was the solution implemented?
- Set `WindowDrawnDecorationsContent.Underlay` backgrounds to `SystemControlTransparentBrush` in `Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml`.
- Set `WindowDrawnDecorationsContent.Underlay` backgrounds to `Transparent` in `Avalonia.Themes.Simple/Controls/WindowDrawnDecorations.xaml`.
- Verified that title bar hit-testing/dragging remains functional.

## Checklist
- [x] Added unit tests (if possible)? (Not feasible for this XAML-only theme fix; verified manually via Control Catalog)
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Fixes #21082