### PR TITLE
fix(controls): fix radio MenuItem grouping in MenuFlyout

### DIFF
--- a/samples/ControlCatalog/Pages/ContextFlyoutPage.xaml
+++ b/samples/ControlCatalog/Pages/ContextFlyoutPage.xaml
@@ -54,6 +54,15 @@
                           IsHitTestVisible="False" />
               </MenuItem.Icon>
             </MenuItem>
+            <MenuItem GroupName="Radio-ableMenuItem"
+                      Header="Menu Item with _RadioButton1"
+                      IsChecked="True"
+                      StaysOpenOnClick="True"
+                      ToggleType="Radio" />
+            <MenuItem GroupName="Radio-ableMenuItem"
+                      Header="Menu Item with _RadioButton2"
+                      StaysOpenOnClick="True"
+                      ToggleType="Radio" />
           </MenuFlyout>
         </Border.ContextFlyout>
         <TextBlock Text="Defined in XAML" />

--- a/samples/ControlCatalog/Pages/ContextMenuPage.xaml
+++ b/samples/ControlCatalog/Pages/ContextMenuPage.xaml
@@ -43,6 +43,15 @@
                           IsHitTestVisible="False" />
               </MenuItem.Icon>
             </MenuItem>
+            <MenuItem GroupName="Radio-ableMenuItem"
+                      Header="Menu Item with _RadioButton1"
+                      IsChecked="True"
+                      StaysOpenOnClick="True"
+                      ToggleType="Radio" />
+            <MenuItem GroupName="Radio-ableMenuItem"
+                      Header="Menu Item with _RadioButton2"
+                      StaysOpenOnClick="True"
+                      ToggleType="Radio" />
             <MenuItem Header="Menu Item that won't close on click" StaysOpenOnClick="True" />
           </ContextMenu>
         </Border.ContextMenu>

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -14,6 +14,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.Reactive;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
 {
@@ -387,7 +388,9 @@ namespace Avalonia.Controls
         /// <inheritdoc/>
         IEnumerable<IMenuItem> IMenuElement.SubItems => LogicalChildren.OfType<IMenuItem>();
 
-        private IMenuInteractionHandler? MenuInteractionHandler => this.FindLogicalAncestorOfType<MenuBase>()?.InteractionHandler;
+        private IMenuInteractionHandler? MenuInteractionHandler =>
+            this.FindLogicalAncestorOfType<MenuBase>()?.InteractionHandler ??
+            this.FindAncestorOfType<MenuBase>()?.InteractionHandler;
 
         /// <summary>
         /// Opens the submenu.
@@ -470,6 +473,7 @@ namespace Avalonia.Controls
             base.OnAttachedToVisualTree(e);
 
             TryUpdateCanExecute();
+            RegisterInMenuInteractionHandler();
         }
 
         protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
@@ -906,6 +910,16 @@ namespace Avalonia.Controls
         private void PopupClosed(object? sender, EventArgs e)
         {
             SelectedItem = null;
+        }
+
+        private void RegisterInMenuInteractionHandler()
+        {
+            if (ToggleType != MenuItemToggleType.Radio || MenuInteractionHandler is not DefaultMenuInteractionHandler handler)
+            {
+                return;
+            }
+
+            handler.OnGroupOrTypeChanged(this, null);
         }
 
         void ICommandSource.CanExecuteChanged(object sender, EventArgs e) => CanExecuteChangedHandler(sender, e);

--- a/src/Avalonia.Controls/RadioButtonGroupManager.cs
+++ b/src/Avalonia.Controls/RadioButtonGroupManager.cs
@@ -41,6 +41,23 @@ internal class RadioButtonGroupManager
                 _registeredGroups.Add(groupName, group);
             }
 
+            int i = 0;
+            while (i < group.Count)
+            {
+                if (!group[i].TryGetTarget(out var current))
+                {
+                    group.RemoveAt(i);
+                    continue;
+                }
+
+                if (current == radioButton)
+                {
+                    return;
+                }
+
+                i++;
+            }
+
             group.Add(new WeakReference<IRadioButton>(radioButton));
         }
     }

--- a/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
@@ -561,6 +561,47 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Radio_MenuItem_In_Same_Group_In_MenuFlyout_Is_Unchecked()
+        {
+            using var app = Application();
+
+            var menuItem1 = new MenuItem
+            {
+                GroupName = "A",
+                IsChecked = true,
+                StaysOpenOnClick = true,
+                ToggleType = MenuItemToggleType.Radio,
+            };
+            var menuItem2 = new MenuItem
+            {
+                GroupName = "A",
+                IsChecked = false,
+                StaysOpenOnClick = true,
+                ToggleType = MenuItemToggleType.Radio,
+            };
+
+            var flyout = new MenuFlyout
+            {
+                Items =
+                {
+                    menuItem1,
+                    menuItem2,
+                }
+            };
+            var button = new Button { ContextFlyout = flyout };
+            var window = new Window { Content = button };
+
+            window.Show();
+            flyout.ShowAt(button);
+            Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded, TestContext.Current.CancellationToken);
+
+            menuItem2.IsChecked = true;
+
+            Assert.False(menuItem1.IsChecked);
+            Assert.True(menuItem2.IsChecked);
+        }
+
+        [Fact]
         public void Radio_Menu_Group_Can_Be_Changed_In_Runtime()
         {
             using var app = Application();


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
fix https://github.com/AvaloniaUI/Avalonia/issues/21355


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
MenuFlyout radio MenuItems were not participating in radio group updates
the same way as ContextMenu items.

When MenuItems are hosted in a MenuFlyout, they may rely on the visual tree
to find their owning MenuBase/interaction handler after realization. As a
result, radio items could stay checked instead of unchecking other items in
the same group.

This change:
- adds a visual-tree fallback when resolving MenuItem interaction handlers
- registers radio MenuItems when they attach to the visual tree
- guards RadioButtonGroupManager against duplicate registrations
- adds a regression test covering MenuFlyout radio group behavior

This fixes the case where grouped radio MenuItems inside MenuFlyout do not
behave mutually exclusively, while the equivalent ContextMenu setup works.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
fix https://github.com/AvaloniaUI/Avalonia/issues/21355
