### PR TITLE
Fix xUnit headless tests losing TestContext on background thread

### DIFF
--- a/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
@@ -54,13 +54,13 @@ public sealed class HeadlessUnitTestSession : IDisposable, IAsyncDisposable
         {
             action();
             return Task.FromResult(0);
-        }, false ,cancellationToken);
+        }, true ,cancellationToken);
     }
 
     /// <inheritdoc cref="DispatchCore{TResult}"/>
     public Task<TResult> Dispatch<TResult>(Func<TResult> action, CancellationToken cancellationToken)
     {
-        return DispatchCore(() => Task.FromResult(action()), false, cancellationToken);
+        return DispatchCore(() => Task.FromResult(action()), true, cancellationToken);
     }
 
     /// <inheritdoc cref="DispatchCore{TResult}"/>

--- a/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
@@ -66,7 +66,7 @@ public sealed class HeadlessUnitTestSession : IDisposable, IAsyncDisposable
     /// <inheritdoc cref="DispatchCore{TResult}"/>
     public Task<TResult> Dispatch<TResult>(Func<Task<TResult>> action, CancellationToken cancellationToken)
     {
-        return DispatchCore(action, false, cancellationToken);
+        return DispatchCore(action, true, cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Attempts to mitigate the intermittant xUnit exception seen when running Headless tests. See #21332 for discussions.

## What is the current behavior?

Running headless tests in a single test assembly periodically results in an exception:

```
System.InvalidOperationException
  HResult=0x80131509
  Message=Cannot get KeyValueStorage on the idle test context
  Source=xunit.v3.core
  StackTrace:
   at Xunit.TestContext.get_KeyValueStorage() in /_/src/xunit.v3.core/TestContext.cs:line 111
   at Xunit.TestContext.SetForTest(ITest test, TestEngineStatus testStatus, CancellationToken cancellationToken, TestResultState testState, ITestOutputHelper testOutputHelper, Object testClassInstance) in /_/src/xunit.v3.core/TestContext.cs:line 360
```

## What is the updated/expected behavior with this PR?

The exception doesn't happen.

## Breaking changes

None I'm aware of.

## Fixed issues

Fixes #21332

