### PR TITLE
Fix crash when wrapping text containing an unbreakable trailing cluster

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
@@ -216,7 +216,13 @@ namespace Avalonia.Media.TextFormatting
 
             if (splitBuffer.Second == null)
             {
-                return new SplitResult<ShapedTextRun>(first, null);
+                // The requested split position falls inside an unbreakable cluster that extends
+                // to the end of the run (e.g. a ligature or grapheme shaped as a single glyph),
+                // so the run cannot be split any further. Return the whole run as a single part
+                // instead of throwing: the caller treats a null counterpart as "nothing left to split".
+                return isReversed
+                    ? new SplitResult<ShapedTextRun>(null, first)
+                    : new SplitResult<ShapedTextRun>(first, null);
             }
 
             var second = new ShapedTextRun(splitBuffer.Second, Properties);

--- a/src/Avalonia.Base/Media/TextFormatting/TextLeadingPrefixCharacterEllipsis.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLeadingPrefixCharacterEllipsis.cs
@@ -147,6 +147,8 @@ namespace Avalonia.Media.TextFormatting
                                                             var splitSuffix =
                                                                 endShapedRun.Split(run.Length - suffixCount);
 
+                                                            // Second is null when the run consists of a single
+                                                            // unbreakable cluster: keep the whole run in that case.
                                                             collapsedRuns.Add(splitSuffix.Second!);
                                                         }
                                                     }

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextShaperTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextShaperTests.cs
@@ -72,6 +72,29 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
         }
 
         [Fact]
+        public void Should_Return_Whole_Run_When_Split_Falls_Inside_Trailing_Cluster()
+        {
+            using (Start())
+            {
+                var typeface = new Typeface(FontFamily.Parse("resm:Avalonia.Skia.UnitTests.Fonts?assembly=Avalonia.Skia.UnitTests#Cascadia Code"));
+
+                // The text ends with a multi-char cluster ("๊) that is shaped as a single,
+                // unbreakable cluster reaching the end of the run.
+                var buffer = TextShaper.Current.ShapeText("a\"๊", new TextShaperOptions(typeface.GlyphTypeface));
+
+                var run = new ShapedTextRun(buffer, new GenericTextRunProperties(typeface));
+
+                // Splitting at index 2 lands inside the trailing cluster, which cannot be split.
+                // This must not throw: the whole run is returned as the first part instead.
+                var splitResult = run.Split(2);
+
+                Assert.NotNull(splitResult.First);
+                Assert.Equal(run.Length, splitResult.First.Length);
+                Assert.Null(splitResult.Second);
+            }
+        }
+
+        [Fact]
         public void Should_Split_RightToLeft()
         {
             var text = "أَبْجَدِيَّة عَرَبِيَّة";


### PR DESCRIPTION
## What does the pull request do?

Fixes an unhandled `System.InvalidOperationException` (`Cannot split: requested length N consumes entire run`) that crashes the process during text layout. The crash originates in `ShapedTextRun.Split` while wrapping or measuring text that contains a multi-character cluster shaped as a single, indivisible glyph cluster (e.g. a ligature, a base character with combining marks, or an emoji ZWJ sequence).

## What is the current behavior?

When `TextFormatterImpl.SplitTextRuns` needs to break a line inside a `ShapedTextRun`, it calls `ShapedTextRun.Split` at a character offset. If that offset falls inside an unbreakable cluster that extends to the end of the run, `ShapedBuffer.Split` correctly snaps to the cluster boundary and returns the whole run with a `null` second part. `ShapedTextRun.Split` then throws
```
InvalidOperationException, which is unhandled on the render/layout path and terminates the process:
System.InvalidOperationException: Cannot split: requested length 5 consumes entire run.
at Avalonia.Media.TextFormatting.ShapedTextRun.Split(Int32 length)
at Avalonia.Media.TextFormatting.TextFormatterImpl.SplitTextRuns(...)
at Avalonia.Media.TextFormatting.TextFormatterImpl.PerformTextWrapping(...)
...
at Avalonia.Controls.TextBlock.RenderCore(DrawingContext context)
```

The same path is reachable from both `TextBlock` rendering and `SelectableTextBlock` measuring.

## What is the updated/expected behavior with this PR?

Wrapping or measuring text that contains an unbreakable trailing cluster no longer crashes. The indivisible cluster is kept whole on the current line (overflow) and wrapping continues normally on the next line, the correct behavior for a cluster that genuinely cannot be split.

To test: render a `TextBlock`/`SelectableTextBlock` with `TextWrapping="Wrap"` and a narrow width, using text whose break candidate falls inside a single multi-character cluster (e.g. a base character followed by several combining marks). Before this PR the app crashes; after it, the text lays out and renders.

## How was the solution implemented (if it's not obvious)?

- `ShapedTextRun.Split`: instead of throwing when `ShapedBuffer.Split` returns a `null` second part, the run is returned whole as the first part with a `null` second part. This mirrors the existing reversed-text handling. The caller `SplitTextRuns` already null-checks both `split.First` and `split.Second`, so it simply absorbs the indivisible cluster and continues, progress is still guaranteed, so there is no risk of an infinite wrapping loop.
- `TextLeadingPrefixCharacterEllipsis`: the other caller of `ShapedTextRun.Split` dereferenced `splitSuffix.Second!`, which would now hit a `null`. It falls back to the whole run (`splitSuffix.Second ?? splitSuffix.First!`) when the run is a single unbreakable cluster.
- Added a regression test that shapes a run ending in a multi-character cluster and splits inside it, asserting that the whole run is returned without throwing.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21252
