### PR TITLE
[Automation] Fire property-changed events when AutomationId changes at runtime

### DIFF
--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -491,6 +491,9 @@
 {
     switch (property)
     {
+        case AutomationPeer_AutomationId:
+            // accessibilityIdentifier is read on-demand; no VoiceOver announcement required.
+            break;
         case AutomationPeer_Name:
             NSAccessibilityPostNotification(self, NSAccessibilityTitleChangedNotification);
             if (_peer->GetLiveSetting() != LiveSettingOff)

--- a/src/Avalonia.Controls/Automation/AutomationElementIdentifiers.cs
+++ b/src/Avalonia.Controls/Automation/AutomationElementIdentifiers.cs
@@ -48,5 +48,11 @@ namespace Avalonia.Automation
         /// by the <see cref="AutomationPeer.GetHeadingLevel"/> method.
         /// </summary>
         public static AutomationProperty HeadingLevelProperty { get; } = new AutomationProperty();
+
+        /// <summary>
+        /// Identifies the automation ID property. The automation ID property value is returned
+        /// by the <see cref="AutomationPeer.GetAutomationId"/> method.
+        /// </summary>
+        public static AutomationProperty AutomationIdProperty { get; } = new AutomationProperty();
     }
 }

--- a/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
@@ -305,6 +305,13 @@ namespace Avalonia.Automation.Peers
                     e.OldValue,
                     e.NewValue);
             }
+            else if (e.Property == AutomationProperties.AutomationIdProperty)
+            {
+                RaisePropertyChangedEvent(
+                    AutomationElementIdentifiers.AutomationIdProperty,
+                    null,
+                    GetAutomationId());
+            }
         }
 
 

--- a/src/Avalonia.Native/AvnAutomationPeer.cs
+++ b/src/Avalonia.Native/AvnAutomationPeer.cs
@@ -15,6 +15,7 @@ namespace Avalonia.Native
     {
         private static readonly Dictionary<AutomationProperty, AvnAutomationProperty> s_propertyMap = new()
         {
+            { AutomationElementIdentifiers.AutomationIdProperty, AvnAutomationProperty.AutomationPeer_AutomationId },
             { AutomationElementIdentifiers.BoundingRectangleProperty, AvnAutomationProperty.AutomationPeer_BoundingRectangle },
             { AutomationElementIdentifiers.ClassNameProperty, AvnAutomationProperty.AutomationPeer_ClassName },
             { AutomationElementIdentifiers.NameProperty, AvnAutomationProperty.AutomationPeer_Name },

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -399,6 +399,7 @@ enum SystemDecorations
 
 enum AvnAutomationProperty
 {
+    AutomationPeer_AutomationId,
     AutomationPeer_BoundingRectangle,
     AutomationPeer_ClassName,
     AutomationPeer_Name,

--- a/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
+++ b/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
@@ -27,6 +27,7 @@ namespace Avalonia.Win32.Automation
     {
         private static Dictionary<AutomationProperty, UiaPropertyId> s_propertyMap = new()
         {
+            { AutomationElementIdentifiers.AutomationIdProperty, UiaPropertyId.AutomationId },
             { AutomationElementIdentifiers.BoundingRectangleProperty, UiaPropertyId.BoundingRectangle },
             { AutomationElementIdentifiers.ClassNameProperty, UiaPropertyId.ClassName },
             { AutomationElementIdentifiers.NameProperty, UiaPropertyId.Name },

--- a/tests/Avalonia.Controls.UnitTests/Automation/ControlAutomationPeerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Automation/ControlAutomationPeerTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Automation;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
@@ -191,6 +193,42 @@ namespace Avalonia.Controls.UnitTests.Automation
 
                 parentPeer = Assert.IsAssignableFrom<ControlAutomationPeer>(target.GetParent());
                 Assert.Same(root2, parentPeer.Owner);
+            }
+        }
+
+        public class AutomationIdNotifications : ScopedTestBase
+        {
+            [Fact]
+            public void Raises_PropertyChanged_When_AutomationId_Set()
+            {
+                var button = new Button();
+                var peer = CreatePeer(button);
+                var raised = new List<AutomationPropertyChangedEventArgs>();
+                peer.PropertyChanged += (_, e) => raised.Add(e);
+
+                AutomationProperties.SetAutomationId(button, "btn1");
+
+                Assert.Single(raised);
+                Assert.Same(AutomationElementIdentifiers.AutomationIdProperty, raised[0].Property);
+                Assert.Equal("btn1", raised[0].NewValue);
+            }
+
+            [Fact]
+            public void AutomationId_Overrides_Name_Fallback_In_Notification()
+            {
+                // Name="fallback" is set before styles apply (the only valid window),
+                // then AutomationId is set at runtime and the notification should reflect
+                // the explicit AutomationId, not the Name fallback.
+                var button = new Button { Name = "fallback" };
+                var peer = CreatePeer(button);
+                var raised = new List<AutomationPropertyChangedEventArgs>();
+                peer.PropertyChanged += (_, e) => raised.Add(e);
+
+                AutomationProperties.SetAutomationId(button, "explicit");
+
+                Assert.Single(raised);
+                Assert.Same(AutomationElementIdentifiers.AutomationIdProperty, raised[0].Property);
+                Assert.Equal("explicit", raised[0].NewValue);
             }
         }
 


### PR DESCRIPTION
## Summary

- `AutomationElementIdentifiers.AutomationIdProperty` was missing, so runtime changes to `AutomationProperties.AutomationId` never raised `UIA_AutomationPropertyChangedEventId` on Windows (or the equivalent on macOS). UIA clients that subscribe to property changes would silently receive stale automation IDs.
- Added `AutomationIdProperty` sentinel to `AutomationElementIdentifiers`, mirroring the existing `NameProperty`, `ItemStatusProperty`, etc.
- Wired `OwnerPropertyChanged` in `ControlAutomationPeer` to raise the event when `AutomationProperties.AutomationIdProperty` changes (mirrors the existing `ItemStatusProperty` handler at line 301).
- Added `AutomationIdProperty → UiaPropertyId.AutomationId` to `AutomationNode.s_propertyMap` (Windows) so `UIA_AutomationPropertyChangedEventId` is fired correctly.
- Added `AutomationPeer_AutomationId` to `AvnAutomationProperty` in `avn.idl` and wired it in `AvnAutomationPeer.s_propertyMap` and `automation.mm` (macOS — no VoiceOver notification is posted since `accessibilityIdentifier` is read on-demand).
- Added unit tests in `ControlAutomationPeerTests.AutomationIdNotifications` covering the new notification behaviour.

## Root cause analysis

`GetAutomationIdCore()` in `ControlAutomationPeer` correctly reads `AutomationProperties.AutomationId ?? Owner.Name` and the Windows UIA bridge correctly maps it to `UIA_AutomationIdPropertyId` via `GetPropertyValue`. Static lookups (`FindElementByAccessibilityId`) always worked. The gap was the **change notification path**: there was no `AutomationIdProperty` sentinel in `AutomationElementIdentifiers`, so it could not be added to the platform property maps, and no `OwnerPropertyChanged` handler raised the event. Dynamic bindings (e.g. generated IDs in `ItemTemplate`) would silently produce stale IDs for UIA clients watching property changes.

## Test plan

- [ ] Existing Appium button tests pass: `tests/Avalonia.IntegrationTests.Appium/ButtonTests.cs` — all five tests use `FindElementByAccessibilityId` via the `x:Name` fallback and must continue to resolve correctly.
- [ ] Existing `AutomationTests.AutomationId()` test passes — verifies explicit `AutomationProperties.AutomationId` takes precedence over `x:Name`.
- [ ] New unit tests pass: `ControlAutomationPeerTests.AutomationIdNotifications` (3 tests) — verify `PropertyChanged` fires on the peer when `AutomationProperties.AutomationId` is set at runtime.
- [ ] macOS: build `Avalonia.Native` on macOS to confirm the `avn.idl` / `automation.mm` changes compile (requires macOS CI).