### PR TITLE
Allow attaching a platform-specific event cookie to platform events

### DIFF
--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -1,6 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Input.PointerEventArgs.#ctor(Avalonia.Interactivity.RoutedEvent,System.Object,Avalonia.Input.IPointer,Avalonia.Visual,Avalonia.Point,System.UInt64,Avalonia.Input.PointerPointProperties,Avalonia.Input.KeyModifiers,System.Lazy{System.Collections.Generic.IReadOnlyList{Avalonia.Input.Raw.RawPointerPoint}})</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Media.TextFormatting.ShapedBuffer.Reverse</Target>
@@ -12,6 +18,12 @@
     <Target>M:Avalonia.Media.TextFormatting.ShapedTextRun.get_IsReversed</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Input.PointerEventArgs.#ctor(Avalonia.Interactivity.RoutedEvent,System.Object,Avalonia.Input.IPointer,Avalonia.Visual,Avalonia.Point,System.UInt64,Avalonia.Input.PointerPointProperties,Avalonia.Input.KeyModifiers,System.Lazy{System.Collections.Generic.IReadOnlyList{Avalonia.Input.Raw.RawPointerPoint}})</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>

--- a/src/Avalonia.Base/Input/MouseDevice.cs
+++ b/src/Avalonia.Base/Input/MouseDevice.cs
@@ -89,7 +89,7 @@ namespace Avalonia.Input
                     if (ButtonCount(props) > 1)
                         e.Handled = MouseMove(mouse, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.IntermediatePoints, e.InputHitTestResult.firstEnabledAncestor);
                     else
-                        e.Handled = MouseDown(mouse, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult.firstEnabledAncestor);
+                        e.Handled = MouseDown(mouse, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult.firstEnabledAncestor, e.PlatformInputEventCookie);
                     break;
                 case RawPointerEventType.LeftButtonUp:
                 case RawPointerEventType.RightButtonUp:
@@ -134,7 +134,7 @@ namespace Avalonia.Input
 
         private bool MouseDown(IMouseDevice device, ulong timestamp, IInputRoot root, Point p,
             PointerPointProperties properties,
-            KeyModifiers inputModifiers, IInputElement? hitTest)
+            KeyModifiers inputModifiers, IInputElement? hitTest, object? platformInputEventCookie)
         {
             device = device ?? throw new ArgumentNullException(nameof(device));
             root = root ?? throw new ArgumentNullException(nameof(root));
@@ -163,7 +163,7 @@ namespace Avalonia.Input
                 }
 
                 _lastMouseDownButton = properties.PointerUpdateKind.GetMouseButton();
-                var e = new PointerPressedEventArgs(source, _pointer, root.RootElement, p, timestamp, properties, inputModifiers, _clickCount);
+                var e = new PointerPressedEventArgs(source, _pointer, root.RootElement, p, timestamp, properties, inputModifiers, _clickCount, platformInputEventCookie);
                 source.RaiseEvent(e);
                 return e.Handled;
             }

--- a/src/Avalonia.Base/Input/PenDevice.cs
+++ b/src/Avalonia.Base/Input/PenDevice.cs
@@ -68,7 +68,7 @@ namespace Avalonia.Input
                     case RawPointerEventType.MiddleButtonDown:
                     case RawPointerEventType.XButton1Down:
                     case RawPointerEventType.XButton2Down:
-                        e.Handled = PenDown(pointer, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult.firstEnabledAncestor);
+                        e.Handled = PenDown(pointer, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult.firstEnabledAncestor, e.PlatformInputEventCookie);
                         break;
                     case RawPointerEventType.LeftButtonUp:
                     case RawPointerEventType.RightButtonUp:
@@ -98,7 +98,7 @@ namespace Avalonia.Input
 
         private bool PenDown(Pointer pointer, ulong timestamp,
             IInputRoot root, Point p, PointerPointProperties properties,
-            KeyModifiers inputModifiers, IInputElement? hitTest)
+            KeyModifiers inputModifiers, IInputElement? hitTest, object? platformInputEventCookie)
         {
             var source = pointer.Captured ?? hitTest;
 
@@ -123,7 +123,7 @@ namespace Avalonia.Input
                 }
 
                 _lastMouseDownButton = properties.PointerUpdateKind.GetMouseButton();
-                var e = new PointerPressedEventArgs(source, pointer, root.RootElement, p, timestamp, properties, inputModifiers, _clickCount);
+                var e = new PointerPressedEventArgs(source, pointer, root.RootElement, p, timestamp, properties, inputModifiers, _clickCount, platformInputEventCookie);
                 source.RaiseEvent(e);
                 return e.Handled;
             }

--- a/src/Avalonia.Base/Input/PointerEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerEventArgs.cs
@@ -40,10 +40,12 @@ namespace Avalonia.Input
             ulong timestamp,
             PointerPointProperties properties,
             KeyModifiers modifiers,
-            Lazy<IReadOnlyList<RawPointerPoint>?>? previousPoints)
+            Lazy<IReadOnlyList<RawPointerPoint>?>? previousPoints,
+            object? platformInputEventCookie = null)
             : this(routedEvent, source, pointer, rootVisual, rootVisualPosition, timestamp, properties, modifiers)
         {
             _previousPoints = previousPoints;
+            PlatformInputEventCookie = platformInputEventCookie;
         }
 
         /// <summary>
@@ -55,6 +57,13 @@ namespace Avalonia.Input
         /// Gets the time when the input occurred.
         /// </summary>
         public ulong Timestamp { get; }
+
+        /// <summary>
+        /// An opaque platform-specific cookie associated with this event.
+        /// Used by backends to pass platform data through the input pipeline.
+        /// </summary>
+        [PrivateApi]
+        public object? PlatformInputEventCookie { get; }
 
         internal bool IsGestureRecognitionSkipped
         {
@@ -170,6 +179,22 @@ namespace Avalonia.Input
             int clickCount = 1)
             : base(InputElement.PointerPressedEvent, source, pointer, rootVisual, rootVisualPosition,
                 timestamp, properties, modifiers)
+        {
+            ClickCount = clickCount;
+        }
+
+        [PrivateApi]
+        public PointerPressedEventArgs(
+            object? source,
+            IPointer pointer,
+            Visual rootVisual, Point rootVisualPosition,
+            ulong timestamp,
+            PointerPointProperties properties,
+            KeyModifiers modifiers,
+            int clickCount,
+            object? platformInputEventCookie)
+            : base(InputElement.PointerPressedEvent, source, pointer, rootVisual, rootVisualPosition,
+                timestamp, properties, modifiers, null, platformInputEventCookie)
         {
             ClickCount = clickCount;
         }

--- a/src/Avalonia.Base/Input/Raw/RawPointerEventArgs.cs
+++ b/src/Avalonia.Base/Input/Raw/RawPointerEventArgs.cs
@@ -124,6 +124,13 @@ namespace Avalonia.Input.Raw
         /// </summary>
         public Lazy<IReadOnlyList<RawPointerPoint>?>? IntermediatePoints { get; set; }
 
+        /// <summary>
+        /// An opaque platform-specific cookie associated with this event.
+        /// Used by backends to pass platform data (e.g. Wayland serial + seat) through
+        /// the input pipeline to platform-consuming code like BeginMoveDrag.
+        /// </summary>
+        public object? PlatformInputEventCookie { get; set; }
+
         internal (IInputElement? element, IInputElement? firstEnabledAncestor) InputHitTestResult { get; set; }
     }
 

--- a/src/Avalonia.Base/Input/TouchDevice.cs
+++ b/src/Avalonia.Base/Input/TouchDevice.cs
@@ -88,7 +88,7 @@ namespace Avalonia.Input
                 target.RaiseEvent(new PointerPressedEventArgs(target, pointer,
                     args.Root.RootElement, args.Position, ev.Timestamp,
                     new PointerPointProperties(GetModifiers(args.InputModifiers, true), updateKind, args.Point),
-                    keyModifier, _clickCount));
+                    keyModifier, _clickCount, args.PlatformInputEventCookie));
             }
 
             if (args.Type == RawPointerEventType.TouchEnd)


### PR DESCRIPTION
Needed for platform-specific handling of window drag and drag-n-drop where just timestamp is not enough.