### PR TITLE
Pass shadow extents to the platform

### DIFF
--- a/src/Avalonia.Controls/Platform/IWindowImpl.cs
+++ b/src/Avalonia.Controls/Platform/IWindowImpl.cs
@@ -172,5 +172,13 @@ namespace Avalonia.Platform
         /// Gets or sets a callback invoked when <see cref="AllowedWindowActions"/> changes.
         /// </summary>
         Action<PlatformAllowedWindowActions>? AllowedWindowActionsChanged { get => null; set { } }
+        
+        /// <summary>
+        /// Informs the platform about the thickness of application-drawn shadow decorations
+        /// so that the platform can distinguish the window content area from shadows.
+        /// It's platform's responsibility to synchronize this with window resize and rendering of the next frame 
+        /// </summary>
+        /// <param name="extents">The shadow thickness on each side, in DIPs.</param>
+        void SetShadowExtents(Thickness extents) { }
     }
 }

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -805,6 +805,7 @@ namespace Avalonia.Controls
                 // Only use platform margins if drawn decorations are not active
                 WindowDecorationMargin = PlatformImpl?.ExtendedMargins ?? default;
                 TopLevelHost.DecorationInset = default;
+                PlatformImpl?.SetShadowExtents(default);
                 return;
             }
 
@@ -815,6 +816,9 @@ namespace Avalonia.Controls
                 ? decorations.FrameThickness : default;
             var shadow = parts.HasFlag(Chrome.DrawnWindowDecorationParts.Shadow)
                 ? decorations.ShadowThickness : default;
+            
+            PlatformImpl?.SetShadowExtents(shadow);
+            
             var margin = new Thickness(
                 frame.Left + shadow.Left,
                 titleBarHeight + frame.Top + shadow.Top,


### PR DESCRIPTION
API-only PR, since we didn't like the implementation in https://github.com/AvaloniaUI/Avalonia/pull/21036. So now it's exposed as a part of IWindowImpl.