### PR TITLE
Platform event to toggle drawn decorations state

### DIFF
--- a/src/Avalonia.Controls/Platform/IWindowImpl.cs
+++ b/src/Avalonia.Controls/Platform/IWindowImpl.cs
@@ -112,6 +112,18 @@ namespace Avalonia.Platform
         PlatformRequestedDrawnDecoration RequestedDrawnDecorations { get; }
 
         /// <summary>
+        /// Triggered when decorations request from platform got changed
+        /// </summary>
+        Action? DrawnDecorationsRequestChanged
+        {
+            get => null;
+            set
+            {
+
+            }
+        }
+
+        /// <summary>
         /// Gets a thickness that describes the amount each side of the non-client area extends into the client area.
         /// It includes the titlebar.
         /// </summary>

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -255,6 +255,7 @@ namespace Avalonia.Controls
             impl.Closing = HandleClosing;
             impl.GotInputWhenDisabled = OnGotInputWhenDisabled;
             impl.WindowStateChanged = HandleWindowStateChanged;
+            impl.DrawnDecorationsRequestChanged = UpdateDrawnDecorations;
             _maxPlatformClientSize = PlatformImpl?.MaxAutoSizeHint ?? default(Size);
             impl.ExtendClientAreaToDecorationsChanged = ExtendClientAreaToDecorationsChanged;
             impl.AllowedWindowActionsChanged = OnAllowedWindowActionsChanged;


### PR DESCRIPTION
A way for IWindowImpl to change its preference about drawn decorations after the initial negotiation