### PR TITLE
[EGL] Use eglGetProcAddress instead of NativeLibrary.TryGetExport

### DIFF
--- a/src/Avalonia.OpenGL/Egl/EglInterface.cs
+++ b/src/Avalonia.OpenGL/Egl/EglInterface.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Text;
 using Avalonia.SourceGenerator;
 
 namespace Avalonia.OpenGL.Egl
@@ -33,7 +34,16 @@ namespace Avalonia.OpenGL.Egl
         static Func<string, IntPtr> Load(string library)
         {
             var lib = NativeLibrary.Load(library);
-            return (s) => NativeLibrary.TryGetExport(lib, s, out var address) ? address : default;
+            NativeLibrary.TryGetExport(lib, "eglGetProcAddress", out var getProcAddress);
+            if (getProcAddress == IntPtr.Zero)
+                throw new OpenGlException($"{library} doesn't expose eglGetProcAddress");
+            return s =>
+            {
+                var bytes = new byte[Encoding.UTF8.GetByteCount(s) + 1];
+                Encoding.UTF8.GetBytes(s, bytes.AsSpan().Slice(0, bytes.Length - 1));
+                fixed (byte* ptr = bytes)
+                    return ((delegate* unmanaged[Stdcall]<byte*, IntPtr>)getProcAddress)(ptr);
+            };
         }
 
         // ReSharper disable UnassignedGetOnlyAutoProperty


### PR DESCRIPTION
According to the spec, "For functions that are queryable with eglGetProcAddress, implementations _**MAY**_ choose to also export those functions statically from the object libraries implementing those functions. However, portable clients cannot rely on this behavior. ".

We've been relying on that "may". It's not a guarantee especially for extension functions