### PR TITLE
fix(iOS): drain UISceneConnectionOptions on cold launch (#21362)

### DIFF
--- a/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
@@ -15,6 +15,7 @@ namespace Avalonia.iOS
     internal interface IAvaloniaAppInternalDelegate
     {
         bool ContinueUserActivity(NSUserActivity userActivity);
+        bool OpenUrl(NSUrl url);
     }
 
     public class AvaloniaAppDelegate<TApp> : UIResponder, IUIApplicationDelegate, IAvaloniaAppDelegate, IAvaloniaAppInternalDelegate
@@ -87,6 +88,9 @@ namespace Avalonia.iOS
 
         [Export("application:openURL:options:")]
         public bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
+            => ((IAvaloniaAppInternalDelegate)this).OpenUrl(url);
+
+        bool IAvaloniaAppInternalDelegate.OpenUrl(NSUrl url)
         {
             if (Uri.TryCreate(url.ToString(), UriKind.Absolute, out var uri))
             {
@@ -98,7 +102,7 @@ namespace Avalonia.iOS
                 else
 #endif
                 {
-                    _onActivated?.Invoke(this, new ProtocolActivatedEventArgs(uri));   
+                    _onActivated?.Invoke(this, new ProtocolActivatedEventArgs(uri));
                 }
                 return true;
             }

--- a/src/iOS/Avalonia.iOS/AvaloniaSceneDelegate.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaSceneDelegate.cs
@@ -1,4 +1,6 @@
-﻿using Foundation;
+﻿using System;
+using Avalonia.Controls.ApplicationLifetimes;
+using Foundation;
 using UIKit;
 
 namespace Avalonia.iOS;
@@ -22,6 +24,18 @@ internal sealed class AvaloniaSceneDelegate : UIResponder, IUIWindowSceneDelegat
         InitWindow(Window, lifetime);
 
         Window.MakeKeyAndVisible();
+
+        // Cold-launch activation: when iOS launches the app to handle a
+        // Universal Link, a Handoff, or a custom-scheme URL, the
+        // payload is delivered via the connectionOptions parameter —
+        // NOT via the warm-path scene:continueUserActivity: or
+        // scene:openURLContexts: selectors. Without draining the
+        // options here, the URL is silently dropped and subscribers to
+        // IActivatableLifetime.Activated only see the base
+        // ActivatedEventArgs from the foreground transition. Fixes the
+        // cold path of #17600 that PR #18005 only addressed for the
+        // warm case.
+        DispatchConnectionOptions(connectionOptions);
     }
 
     [Export("scene:continueUserActivity:")]
@@ -29,6 +43,35 @@ internal sealed class AvaloniaSceneDelegate : UIResponder, IUIWindowSceneDelegat
     {
         var appDelegate = UIApplication.SharedApplication.Delegate as IAvaloniaAppInternalDelegate;
         appDelegate?.ContinueUserActivity(userActivity);
+    }
+
+    [Export("scene:openURLContexts:")]
+    public void OpenUrlContexts(UIScene scene, NSSet<UIOpenUrlContext> urlContexts)
+    {
+        var appDelegate = UIApplication.SharedApplication.Delegate as IAvaloniaAppInternalDelegate;
+        if (appDelegate is null || urlContexts is null)
+            return;
+        foreach (var ctx in urlContexts)
+            appDelegate.OpenUrl(ctx.Url);
+    }
+
+    private static void DispatchConnectionOptions(UISceneConnectionOptions connectionOptions)
+    {
+        var appDelegate = UIApplication.SharedApplication.Delegate as IAvaloniaAppInternalDelegate;
+        if (appDelegate is null)
+            return;
+
+        if (connectionOptions.UserActivities is { } activities)
+        {
+            foreach (NSUserActivity activity in activities)
+                appDelegate.ContinueUserActivity(activity);
+        }
+
+        if (connectionOptions.UrlContexts is { } urlContexts)
+        {
+            foreach (var ctx in urlContexts)
+                appDelegate.OpenUrl(ctx.Url);
+        }
     }
 
     internal static void InitWindow(UIWindow window, SingleViewLifetime lifetime)


### PR DESCRIPTION
## Summary

Fixes #21362 — the cold-launch path of [#17600](https://github.com/AvaloniaUI/Avalonia/issues/17600) ([#18005](https://github.com/AvaloniaUI/Avalonia/pull/18005) only addressed the warm path).

When the iOS app uses scene-based lifecycle (iOS 13+), Apple delivers cold-launch user activities and URL contexts via `UISceneConnectionOptions` on `scene:willConnectToSession:options:` — **not** via the warm-path selectors `scene:continueUserActivity:` or `scene:openURLContexts:`. `AvaloniaSceneDelegate` ignored `connectionOptions` entirely, so cold-launching the app from a Universal Link or custom-scheme URL dropped the URL on the floor.

The user's subscriber to `IActivatableLifetime.Activated` then only saw the base `ActivatedEventArgs` raised by the foreground transition (`OnLeavingBackground`), never a `ProtocolActivatedEventArgs` with the URL.

## Change

`AvaloniaSceneDelegate.WillConnect`, after creating the window, drains both `connectionOptions.UserActivities` and `connectionOptions.UrlContexts` through the existing `IAvaloniaAppInternalDelegate` paths.

Also adds `scene:openURLContexts:` so warm custom-scheme URLs work under scene lifecycle — previously these were silently dropped too because `application:openURL:` on the AppDelegate is not called when scenes are in use (a smaller pre-existing bug surfaced by this same investigation).

The `IAvaloniaAppInternalDelegate` interface gains an `OpenUrl(NSUrl)` method so the scene delegate can route URL contexts through the same code path the existing `application:openURL:options:` AppDelegate handler uses. The AppDelegate's public `OpenUrl` selector method is refactored to a one-liner delegating to the explicit interface impl — no behaviour change for the AppDelegate-only path.

## Test plan

The `Avalonia.iOS.UnitTests` / `Avalonia.IntegrationTests.iOS` paths in sparse-checkout return empty, so iOS scene-lifecycle test scaffolding doesn't currently exist in the repo to model from. Happy to add a test if maintainers can point at a fixture pattern.

Manual repro (from issue):
1. Avalonia 12.0.2 iOS app with `Associated Domains` entitlement (`applinks:<your-domain>`) + matching AASA served.
2. Subscribe to `IActivatableLifetime.Activated` in `App.Initialize`, log `ProtocolActivatedEventArgs.Kind` vs the bare type name.
3. Build signed dev IPA, install to physical device. **Force-quit** the app (this is critical — warm activations already work).
4. Tap a `https://<your-domain>/...` Universal Link from Messages / Mail.
5. **Before this fix:** `Activated` fires with base `ActivatedEventArgs`, no URL surfaces. Device console: `OnActivated fired: kind=ActivatedEventArgs`.
6. **After this fix:** `Activated` fires with `ProtocolActivatedEventArgs.Kind == OpenUri` carrying the URL.

For URL contexts (custom schemes via scene lifecycle): same flow, with a `myapp://...` URL instead of a Universal Link — before this PR these fall through entirely under scene lifecycle; after, they route to `ProtocolActivatedEventArgs` like the AppDelegate path.

## References

- #21362 — original bug report (this PR)
- #17600 — original Universal Link bug
- #18005 — earlier fix that only handled the warm path

🤖 PR drafted with assistance from Claude Code