### PR TITLE
Fix: correct usage of `PointToScreen` for Android TalkBack

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
+++ b/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
@@ -8,6 +8,7 @@ using Avalonia.Android.Automation;
 using Avalonia.Automation;
 using Avalonia.Automation.Peers;
 using Avalonia.Automation.Provider;
+using Avalonia.Controls;
 using Java.Lang;
 
 namespace Avalonia.Android
@@ -208,8 +209,8 @@ namespace Avalonia.Android
             // On-screen bounds
             Rect bounds = peer.GetBoundingRectangle();
             PixelRect screenRect = new PixelRect(
-                _view.TopLevelImpl.PointToScreen(bounds.TopLeft),
-                _view.TopLevelImpl.PointToScreen(bounds.BottomRight)
+                _view.TopLevelImpl.InputRoot?.RootElement.PointToScreen(bounds.TopLeft) ?? default,
+                _view.TopLevelImpl.InputRoot?.RootElement.PointToScreen(bounds.BottomRight) ?? default
                 );
             nodeInfo.SetBoundsInScreen(new(
                 screenRect.X, screenRect.Y,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR patches the Android TalkBack plugin for Avalonia (previously implemented in #17704) to update its usage of the `Visual.PointToScreen` extension method such that correct screen coordinates are reported to the TalkBack API. 


## What is the current behavior?
The current behavior is broken due to updates provided in #20624 which switch the preferred method for gathering screen-space coordinates from `TopLevel.PointToScreen` to `IInputRoot.RootElement.PointToScreen`. Now, Android TalkBack uses the correct internal API per this change. 


## What is the updated/expected behavior with this PR?
Before this PR, Avalonia 12 on Android devices would show strangely offset outlines while using Android TalkBack. Now, the correct bounds are reported to the OS and the outlines show as expected. 


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
