### PR TITLE
Fix borders and shadows on Windows 10 in extended mode

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1204,19 +1204,12 @@ namespace Avalonia.Win32
                 var margins = UpdateExtendMargins();
                 DwmExtendFrameIntoClientArea(_hwnd, ref margins);
 
+                // Make sure that Windows still paints the non-client area so we get native borders and shadows.
+                SetNCRenderingPolicy(DwmNCRenderingPolicy.DWMNCRP_ENABLED);
+
                 // On Windows 11 21H2 and later, corners are configurable.
-                // When doing so, we need to make sure that DWM draws the non-client frame for that to work correctly.
                 if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
-                {
                     SetWindowCornerPreference(DwmWindowCornerPreference.DWMWCP_ROUND);
-                    SetNCRenderingPolicy(DwmNCRenderingPolicy.DWMNCRP_ENABLED);
-                }
-                else
-                {
-                    // On older versions, we need to disable painting the non-client area to avoid issues
-                    // (alternatively, we could return 0 in WM_NCPAINT in this case).
-                    SetNCRenderingPolicy(DwmNCRenderingPolicy.DWMNCRP_DISABLED);
-                }
             }
             else
             {
@@ -1407,6 +1400,10 @@ namespace Avalonia.Win32
 
         private void UpdateWindowProperties(WindowProperties newProperties, bool forceChanges = false)
         {
+            // Implementation note: this method tries to keep the same styles for extended and non-extended modes.
+            // However, we had to make an exception for WS_CAPTION since it causes issues in Windows 10.
+            // See https://github.com/AvaloniaUI/Avalonia/issues/21328
+
             var oldProperties = _windowProperties;
 
             // Calling SetWindowPos will cause events to be sent and we need to respond
@@ -1474,7 +1471,15 @@ namespace Avalonia.Win32
                 switch (newProperties.Decorations)
                 {
                     case WindowDecorations.Full:
-                        style |= WindowStyles.WS_BORDER | WindowStyles.WS_CAPTION | WindowStyles.WS_SYSMENU;
+                        style |= WindowStyles.WS_BORDER | WindowStyles.WS_SYSMENU;
+
+                        // When WS_CAPTION is specified, Windows 10 always draws the caption even if we extend into it.
+                        // We can workaround that by setting DWMWA_NCRENDERING_POLICY to DISABLE, but that also removes
+                        // shadows and borders. Remove the style completely.
+                        // Windows 11 correctly handles this scenario.
+                        if (!_isClientAreaExtended)
+                            style |= WindowStyles.WS_CAPTION;
+
                         break;
 
                     case WindowDecorations.BorderOnly:
@@ -1597,6 +1602,9 @@ namespace Avalonia.Win32
         public void SetExtendClientAreaToDecorationsHint(bool hint)
         {
             _isClientAreaExtended = hint;
+
+            // We may need to toggle WS_CAPTION when extending, ensure the styles are up-to-date.
+            UpdateWindowProperties(_windowProperties);
 
             ExtendClientArea();
         }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes `ExtendClientAreaToDecorationsHint="True"` not displaying shadows and borders on Windows 10 correctly when `WindowDecorations` is `Full` or `BorderOnly`.

## What is the current behavior?
Borders and shadows, drawn by the OS, are missing when `ExtendClientAreaToDecorationsHint` is `true` on Windows 10 and Windows Server 2019/2022.

## What is the updated/expected behavior with this PR?
The borders and shadows are displayed.

## How was the solution implemented (if it's not obvious)?
In #20217, I made sure that extended and non-extended modes result in the exact same window styles, as it was very hard to reason about which styles were effectively applied before.

However, on Windows versions older than build 22000 (< Windows 11), DWM still draws the full caption when `WS_CAPTION` is specified, even if we reserved only a single pixel border for it. Windows 11 respects that correctly. To resolve this issue, the non-client rendering policy (`DWMWA_NCRENDERING_POLICY`) was set to `DWMNCRP_DISABLED` on these older versions. Doing so caused the shadows and borders not to be rendered, which was missed.

Plus, it turns out that the non-client rendering policy gets automatically reverted when WGL is used on Windows 10, so it wasn't really a good solution.

Rather than piling workarounds, this PR now removes the `WS_CAPTION` style in this case. The NC rendering policy is set to `DWMNCRP_ENABLED` in all cases, causing the borders and shadows to be displayed on all Windows versions.

All integration tests related to `ExtendClientAreaToDecorationsHint` are still passing.

## Fixed issues
- Fixes #21328