### PR TITLE
Win32 - Include border size in GetMinMax request

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -219,7 +219,7 @@ namespace Avalonia.Win32
         {
             get
             {
-                if (HasFullDecorations)
+                if (HasBorder)
                 {
                     var style = GetStyle();
                     var exStyle = GetExtendedStyle();
@@ -547,6 +547,7 @@ namespace Avalonia.Win32
         }
 
         private bool HasFullDecorations => _windowProperties.Decorations == WindowDecorations.Full;
+        private bool HasBorder => _windowProperties.Decorations != WindowDecorations.None;
 
 
         public void Move(PixelPoint point) => Position = point;

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -219,9 +219,9 @@ namespace Avalonia.Win32
         {
             get
             {
-                if (HasBorder)
+                var style = GetStyle();
+                if (style.HasFlag(WindowStyles.WS_BORDER))
                 {
-                    var style = GetStyle();
                     var exStyle = GetExtendedStyle();
 
                     var padding = new RECT();
@@ -431,7 +431,7 @@ namespace Avalonia.Win32
 
         private bool SetTransparencyTransparent()
         {
-            if (CompositionEffectsSurface is {} surface)
+            if (CompositionEffectsSurface is { } surface)
             {
                 surface.SetBlur(BlurEffect.None);
                 return true;
@@ -529,7 +529,7 @@ namespace Avalonia.Win32
                     0,
                     0,
                     SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOACTIVATE | SetWindowPosFlags.SWP_NOZORDER);
-                
+
                 if (ShCoreAvailable && Win32Platform.WindowsVersion >= PlatformConstants.Windows8_1)
                 {
                     var monitor = MonitorFromWindow(Handle.Handle, MONITOR.MONITOR_DEFAULTTONEAREST);
@@ -547,7 +547,6 @@ namespace Avalonia.Win32
         }
 
         private bool HasFullDecorations => _windowProperties.Decorations == WindowDecorations.Full;
-        private bool HasBorder => _windowProperties.Decorations != WindowDecorations.None;
 
 
         public void Move(PixelPoint point) => Position = point;
@@ -806,7 +805,7 @@ namespace Avalonia.Win32
             var hCursor = impl?.Handle ?? s_defaultCursor;
             SetClassLong(_hwnd, ClassLongIndex.GCLP_HCURSOR, hCursor);
 
-            UnmanagedMethods.SetCursor(hCursor);    
+            UnmanagedMethods.SetCursor(hCursor);
         }
 
         public void SetIcon(IWindowIconImpl? icon)
@@ -926,7 +925,7 @@ namespace Avalonia.Win32
 
         private void EnsureTopmost()
         {
-            if(_topmost)
+            if (_topmost)
             {
                 SetWindowPos(_hwnd,
                     WindowPosZOrder.HWND_TOPMOST,
@@ -1010,7 +1009,7 @@ namespace Avalonia.Win32
 
             Handle = new WindowImplPlatformHandle(this);
 
-                RegisterTouchWindow(_hwnd, 0);
+            RegisterTouchWindow(_hwnd, 0);
 
             if (ShCoreAvailable && Win32Platform.WindowsVersion >= PlatformConstants.Windows8_1)
             {
@@ -1207,7 +1206,8 @@ namespace Avalonia.Win32
 
                 // On Windows 11 21H2 and later, corners are configurable.
                 // When doing so, we need to make sure that DWM draws the non-client frame for that to work correctly.
-                if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000)) {
+                if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
+                {
                     SetWindowCornerPreference(DwmWindowCornerPreference.DWMWCP_ROUND);
                     SetNCRenderingPolicy(DwmNCRenderingPolicy.DWMNCRP_ENABLED);
                 }
@@ -1528,7 +1528,7 @@ namespace Avalonia.Win32
 
                 if (_shown || forceChanges)
                 {
-                    SetWindowPos(_hwnd, IntPtr.Zero, 0, 0, 0 ,0,
+                    SetWindowPos(_hwnd, IntPtr.Zero, 0, 0, 0, 0,
                         SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOACTIVATE |
                         SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOMOVE |
                         SetWindowPosFlags.SWP_FRAMECHANGED);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
BorderThickness now returns the current border thickness for BorderOnly windows.

## What is the current behavior?
When using a Border-Only window, the minimum size reported to Windows is always less than the actual minimum size the window wants. This is due to the GETMINMAXINFO message handler not including border size, even though we add border margins when setting the window decorations to BorderOnly.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/21235