### PR TITLE
Fix: UIA tree not visible for Avalonia content embedded via WinFormsAvaloniaControlHost

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/EmbeddableControlRootAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/EmbeddableControlRootAutomationPeer.cs
@@ -5,11 +5,12 @@ using Avalonia.Automation.Peers;
 using Avalonia.Automation.Provider;
 using Avalonia.Controls.Embedding;
 using Avalonia.Input;
+using Avalonia.Platform;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Automation.Peers
 {
-    public class EmbeddableControlRootAutomationPeer : ContentControlAutomationPeer, IEmbeddedRootProvider
+    public class EmbeddableControlRootAutomationPeer : ContentControlAutomationPeer, IEmbeddedRootProvider, IRootProvider
     {
         private Control? _focus;
 
@@ -23,6 +24,8 @@ namespace Avalonia.Controls.Automation.Peers
         }
 
         public new EmbeddableControlRoot Owner => (EmbeddableControlRoot)base.Owner;
+
+        ITopLevelImpl? IRootProvider.PlatformImpl => Owner.PlatformImpl;
 
         public event EventHandler? FocusChanged;
 

--- a/tests/Avalonia.Controls.UnitTests/Automation/EmbeddableControlRootAutomationPeerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Automation/EmbeddableControlRootAutomationPeerTests.cs
@@ -1,0 +1,47 @@
+using Avalonia.Automation.Peers;
+using Avalonia.Automation.Provider;
+using Avalonia.UnitTests;
+using Xunit;
+
+#nullable enable
+
+namespace Avalonia.Controls.UnitTests.Automation
+{
+    public class EmbeddableControlRootAutomationPeerTests : ScopedTestBase
+    {
+        [Fact]
+        public void Peer_Provides_IRootProvider()
+        {
+            using var services = new CompositorTestServices();
+            var peer = ControlAutomationPeer.CreatePeerForElement(services.TopLevel);
+
+            var rootProvider = peer.GetProvider<IRootProvider>();
+
+            Assert.NotNull(rootProvider);
+            Assert.Same(peer, rootProvider);
+        }
+
+        [Fact]
+        public void Peer_Still_Provides_IEmbeddedRootProvider()
+        {
+            using var services = new CompositorTestServices();
+            var peer = ControlAutomationPeer.CreatePeerForElement(services.TopLevel);
+
+            var embeddedRootProvider = peer.GetProvider<IEmbeddedRootProvider>();
+
+            Assert.NotNull(embeddedRootProvider);
+        }
+
+        [Fact]
+        public void IRootProvider_PlatformImpl_Returns_Owner_PlatformImpl()
+        {
+            using var services = new CompositorTestServices();
+            var peer = ControlAutomationPeer.CreatePeerForElement(services.TopLevel);
+
+            var rootProvider = peer.GetProvider<IRootProvider>();
+
+            Assert.NotNull(rootProvider);
+            Assert.Same(services.TopLevel.PlatformImpl, rootProvider!.PlatformImpl);
+        }
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes the UIA accessibility tree being invisible for Avalonia content hosted in WinForms/WPF via `WinFormsAvaloniaControlHost`. Tools like Inspect.exe, Accessibility Insights for Windows, Narrator and FlaUI see the embedded Avalonia HWND as an opaque `[pane]` with no children.

## What is the current behavior?
`EmbeddableControlRootAutomationPeer` implements `IEmbeddedRootProvider` but not `IRootProvider`. In the Win32 backend, `AutomationNode.Create` only checks for `IRootProvider` to instantiate `RootAutomationNode`:

```csharp
else if (peer.GetProvider<IRootProvider>() is not null)
    return new RootAutomationNode(peer);
else
    return new AutomationNode(peer);
```

Embedded roots fall into the last branch and get a plain `AutomationNode` that doesn't implement `IRawElementProviderFragmentRoot` and returns null from `GetHostRawElementProvider` (no `UiaHostProviderFromHwnd` call). `UiaReturnRawElementProvider` then responds to `WM_GETOBJECT` with `E_FAIL` (`0x80004005`) and the Avalonia subtree is missing from UIA.

## What is the updated/expected behavior with this PR?
`EmbeddableControlRootAutomationPeer` also implements `IRootProvider`. `AutomationNode.Create` picks the `RootAutomationNode` path, `UiaReturnRawElementProvider` succeeds, and the embedded Avalonia tree is fully exposed to UIA clients.

Verified by hosting an Avalonia control in a WPF window through `WindowsFormsHost` -> `WinFormsAvaloniaControlHost` and inspecting it with Inspect.exe and Accessibility Insights for Windows: the full control tree is now reachable instead of a single `[pane]`.

## How was the solution implemented (if it's not obvious)?
`IRootProvider` and `IEmbeddedRootProvider` share `GetFocus`, `GetPeerFromPoint` and `FocusChanged` with identical signatures, so the existing implementation satisfies both. The only extra `IRootProvider` member, `PlatformImpl`, is added as an explicit interface implementation forwarding to `Owner.PlatformImpl`.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
