### PR TITLE
Update SkiaSharp to 3.119.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,9 +48,9 @@
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.22.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.22.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="2.1.12" />
-    <PackageVersion Include="SkiaSharp" Version="3.119.4-preview.1.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4-preview.1.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.4-preview.1.1" />
+    <PackageVersion Include="SkiaSharp" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.4" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="4.5.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.10" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />


### PR DESCRIPTION
## What does the pull request do?
This PR updates SkiaSharp from version 3.119.4-preview.1.1 to 3.119.4.
With this change, Avalonia is no longer dependent on pre-release packages.
