### PR TITLE
Add a resource for title bar background

### DIFF
--- a/src/Avalonia.Themes.Fluent/Accents/FluentControlResources.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentControlResources.xaml
@@ -825,6 +825,7 @@
       <SolidColorBrush x:Key="CaptionButtonForeground" Color="Black" />
       <SolidColorBrush x:Key="CaptionButtonBackground" Color="#ffe5e5e5" />
       <SolidColorBrush x:Key="CaptionButtonBorderBrush" Color="#ffcacaca" />
+      <StaticResource x:Key="TitleBarBackgroundBrush" ResourceKey="SystemControlBackgroundAltHighBrush" />
     </ResourceDictionary>
     <ResourceDictionary x:Key="Dark">
       <!-- Resources for Button.xaml -->
@@ -1652,6 +1653,7 @@
       <SolidColorBrush x:Key="CaptionButtonForeground" Color="White" />
       <SolidColorBrush x:Key="CaptionButtonBackground" Color="#ffe5e5e5" />
       <SolidColorBrush x:Key="CaptionButtonBorderBrush" Color="#ffcacaca" />
+      <StaticResource x:Key="TitleBarBackgroundBrush" ResourceKey="SystemControlBackgroundAltHighBrush" />
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
@@ -48,7 +48,7 @@
               <!-- Titlebar: background, title text, and drag area live in underlay -->
               <Panel x:Name="PART_TitleBar" VerticalAlignment="Top"
                      Height="{TemplateBinding TitleBarHeight}"
-                     Background="{DynamicResource SystemControlTransparentBrush}"
+                     Background="{DynamicResource TitleBarBackgroundBrush}"
                      IsVisible="{TemplateBinding HasTitleBar}"
                      WindowDecorationProperties.ElementRole="TitleBar" />
 

--- a/src/Avalonia.Themes.Simple/Accents/Base.xaml
+++ b/src/Avalonia.Themes.Simple/Accents/Base.xaml
@@ -46,6 +46,7 @@
       <SolidColorBrush x:Key="CaptionButtonForeground" Color="Black" />
       <SolidColorBrush x:Key="CaptionButtonBackground" Color="#ffe5e5e5" />
       <SolidColorBrush x:Key="CaptionButtonBorderBrush" Color="#ffcacaca" />
+      <StaticResource x:Key="TitleBarBackgroundBrush" ResourceKey="ThemeBackgroundBrush" />
       
     </ResourceDictionary>
     <ResourceDictionary x:Key="Dark">
@@ -91,6 +92,7 @@
       <SolidColorBrush x:Key="CaptionButtonForeground" Color="White" />
       <SolidColorBrush x:Key="CaptionButtonBackground" Color="#ffe5e5e5" />
       <SolidColorBrush x:Key="CaptionButtonBorderBrush" Color="#ffcacaca" />
+      <StaticResource x:Key="TitleBarBackgroundBrush" ResourceKey="ThemeBackgroundBrush" />
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
   <FontFamily x:Key="ContentControlThemeFontFamily">fonts:Inter#Inter, $Default</FontFamily>

--- a/src/Avalonia.Themes.Simple/Controls/WindowDrawnDecorations.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/WindowDrawnDecorations.xaml
@@ -48,7 +48,7 @@
               <!-- Titlebar: background, title text, and drag area live in underlay -->
               <Panel x:Name="PART_TitleBar" VerticalAlignment="Top"
                      Height="{TemplateBinding TitleBarHeight}"
-                     Background="Transparent"
+                     Background="{DynamicResource TitleBarBackgroundBrush}"
                      IsVisible="{TemplateBinding HasTitleBar}"
                      WindowDecorationProperties.ElementRole="TitleBar" />
             </Panel>


### PR DESCRIPTION
## What does the pull request do?
This PR partly reverts #21354 by re-introducing an opaque brush for the title bar by default. The window's background stays transparent, though.

To make it easy to alter the title bar's background, a new resource `TitleBarBackgroundBrush` is introduced in the fluent theme.

## What is the current behavior?
On X11, with `ForceDrawnDecorations = true` enabled and `ExtendClientAreaToDecorationsHint = false`, the title bar is incorrectly transparent.

## What is the updated/expected behavior with this PR?
The title bar has a proper color.
