### PR TITLE
[WASM] Ensure sync context is set before running dispatcher messages

### DIFF
--- a/src/Avalonia.Base/Threading/Dispatcher.Invoke.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.Invoke.cs
@@ -649,7 +649,8 @@ public partial class Dispatcher
         {
             try
             {
-                action(arg);
+                using (AvaloniaSynchronizationContext.Ensure(this, (DispatcherPriority)priority))
+                    action(arg);
             }
             catch (Exception ex) when (ExceptionFilter(ex))
             {

--- a/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
+++ b/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
@@ -448,6 +448,7 @@ public partial class DispatcherTests
             }, DispatcherPriority.Background);
             disp.MainLoop(CancellationToken.None);
 
+            disp.Send(_ => DumpCurrentPriority(), DispatcherPriority.Send);
             disp.Invoke(DumpCurrentPriority, DispatcherPriority.Send, TestContext.Current.CancellationToken);
             disp.Invoke(() =>
             {
@@ -458,7 +459,7 @@ public partial class DispatcherTests
             Assert.Equal(
                 new[]
                 {
-                    DispatcherPriority.Normal, DispatcherPriority.Loaded, DispatcherPriority.Input, DispatcherPriority.Background,
+                    DispatcherPriority.Normal, DispatcherPriority.Loaded, DispatcherPriority.Input, DispatcherPriority.Background, DispatcherPriority.Send,
                     DispatcherPriority.Send, DispatcherPriority.Send,
                 },
                 priorities);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Ensures `AvaloniaSynchronizationContext.Current` is set before invoking messages on Dispatcher.


## What is the current behavior?
The dotnet wasm runtime sets `SynchronizationContext.Current` to null on wasm, most likely when moving from clr to browser context. This makes bindings not work if bound to a task on wasm.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/20627
