### PR TITLE
fix typo in key assignment for reference assembly

### DIFF
--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
@@ -89,7 +89,7 @@ namespace Avalonia.Build.Tasks
 
                 var refWriterParameters = new WriterParameters { WriteSymbols = false };
                 if (!string.IsNullOrWhiteSpace(strongNameKey))
-	                writerParameters.StrongNameKeyBlob = File.ReadAllBytes(strongNameKey);
+	                refWriterParameters.StrongNameKeyBlob = File.ReadAllBytes(strongNameKey);
                 refAsm?.Write(refOutput, refWriterParameters);
 
                 return new CompileResult(true, true);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
- fixes typo in `XamlCompilerTaskExecutor.cs`. since `refAsm.Write` uses `refWriterParameters`, this appears to be a copy-paste bug

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
