### PR TITLE
Fix text selection brush not applying when text selection changes

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -58,7 +58,7 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         public static readonly StyledProperty<string?> PreeditTextProperty =
             AvaloniaProperty.Register<TextPresenter, string?>(nameof(PreeditText));
-        
+
         /// <summary>
         /// Defines the <see cref="PreeditText"/> property.
         /// </summary>
@@ -149,7 +149,7 @@ namespace Avalonia.Controls.Presenters
             get => GetValue(PreeditTextProperty);
             set => SetValue(PreeditTextProperty, value);
         }
-        
+
         public int? PreeditTextCursorPosition
         {
             get => GetValue(PreeditTextCursorPositionProperty);
@@ -427,11 +427,11 @@ namespace Avalonia.Controls.Presenters
                 }
             }
 
-            if(VisualRoot is Visual root)
+            if (VisualRoot is Visual root)
             {
                 var offset = this.TranslatePoint(Bounds.Position, root);
 
-                if(_previousOffset != offset)
+                if (_previousOffset != offset)
                 {
                     _previousOffset = offset;
                 }
@@ -778,7 +778,7 @@ namespace Avalonia.Controls.Presenters
 
             CaretChanged();
         }
-        
+
         private void EnsureCaretTimer()
         {
             if (_caretTimer == null)
@@ -804,7 +804,7 @@ namespace Avalonia.Controls.Presenters
                 _caretTimer = null;
             }
 
-            if (CaretBlinkInterval.TotalMilliseconds > 0) 
+            if (CaretBlinkInterval.TotalMilliseconds > 0)
             {
                 _caretTimer = new DispatcherTimer { Interval = CaretBlinkInterval };
                 _caretTimer.Tick += CaretTimerTick;
@@ -977,7 +977,7 @@ namespace Avalonia.Controls.Presenters
 
         internal void RemoveTextSelectionCanvas()
         {
-            if(_layer != null && TextSelectionHandleCanvas is { } canvas)
+            if (_layer != null && TextSelectionHandleCanvas is { } canvas)
             {
                 canvas.SetPresenter(null);
                 _layer.Remove(canvas);
@@ -998,7 +998,7 @@ namespace Avalonia.Controls.Presenters
                 _caretTimer.Tick -= CaretTimerTick;
             }
         }
-        
+
         private void OnPreeditChanged(string? preeditText, int? cursorPosition)
         {
             if (string.IsNullOrEmpty(preeditText))
@@ -1025,17 +1025,17 @@ namespace Avalonia.Controls.Presenters
                 MoveCaretToTextPosition(change.GetNewValue<int>());
             }
 
-            if(change.Property == PreeditTextProperty)
+            if (change.Property == PreeditTextProperty)
             {
                 OnPreeditChanged(change.NewValue as string, PreeditTextCursorPosition);
             }
-            
-            if(change.Property == PreeditTextCursorPositionProperty)
+
+            if (change.Property == PreeditTextCursorPositionProperty)
             {
                 OnPreeditChanged(PreeditText, PreeditTextCursorPosition);
             }
 
-            if(change.Property == TextProperty || change.Property == CaretIndexProperty)
+            if (change.Property == TextProperty || change.Property == CaretIndexProperty)
             {
                 if (!string.IsNullOrEmpty(PreeditText))
                 {
@@ -1063,8 +1063,6 @@ namespace Avalonia.Controls.Presenters
                 case nameof(PasswordChar):
                 case nameof(RevealPassword):
                 case nameof(FlowDirection):
-                case nameof(SelectionStart):
-                case nameof(SelectionEnd):
                 case nameof(SelectionForegroundBrush):
                 case nameof(ShowSelectionHighlight):
                     {
@@ -1077,6 +1075,19 @@ namespace Avalonia.Controls.Presenters
                 case nameof(LineHeight):
                     {
                         InvalidateTextLayoutKeepCache();
+                        break;
+                    }
+                case nameof(SelectionStart):
+                case nameof(SelectionEnd):
+                    {
+                        if (SelectionForegroundBrush != null)
+                        {
+                            InvalidateTextLayout();
+                        }
+                        else
+                        {
+                            InvalidateTextLayoutKeepCache();
+                        }
                         break;
                     }
             }

--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -1063,6 +1063,10 @@ namespace Avalonia.Controls.Presenters
                 case nameof(PasswordChar):
                 case nameof(RevealPassword):
                 case nameof(FlowDirection):
+                case nameof(SelectionStart):
+                case nameof(SelectionEnd):
+                case nameof(SelectionForegroundBrush):
+                case nameof(ShowSelectionHighlight):
                     {
                         InvalidateTextLayout();
                         break;
@@ -1071,10 +1075,6 @@ namespace Avalonia.Controls.Presenters
                 case nameof(TextAlignment):
                 case nameof(TextWrapping):
                 case nameof(LineHeight):
-                case nameof(SelectionStart):
-                case nameof(SelectionEnd):
-                case nameof(SelectionForegroundBrush):
-                case nameof(ShowSelectionHighlight):
                     {
                         InvalidateTextLayoutKeepCache();
                         break;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This pr invalidates the text run cache in TextLayout when selection changes. This changes the behavior from only invalidating the text layout while keeping the cache. This ensures that selection styles are applied to the text run when selection changes.


## What is the current behavior?
When selection changes and `SelectionForegroundBrush` is set, changing the selection doesn't apply the brush to the new selection until the textbox is invalidated, like from losing focus. This stems from the textformatter using cached textruns while selection changes, and only resets the text cache when the textbox runs its measure pass. Because the textStyleOverride are baked into the textrun, the selection foreground never changed in the text


## What is the updated/expected behavior with this PR?


## How was the solution implemented (if it's not obvious)?
`SelectionStart`, `SelectionEnd`, `SelectionForegroundBrush`, `ShowSelectionHighlight` property changes call `InvalidateTextLayout`. `TextRunCache.InvalidateFrom` is ineffective here due to selection indexes not always marching the source index of the text run in the cache. In most case, it will not reset the cache from the selection region, so `InvalidateTextLayout` is called instead.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/21460