### PR TITLE
Fix Firefox drag-and-drop: handle effectAllowed = "uninitialized"

### DIFF
--- a/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
+++ b/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
@@ -208,7 +208,8 @@ internal class BrowserInputHandler
             effectAllowed |= DragDropEffects.Move;
         }
 
-        if (effectAllowedStr.Equals("all", StringComparison.OrdinalIgnoreCase))
+        if (effectAllowedStr.Equals("all", StringComparison.OrdinalIgnoreCase)
+            || effectAllowedStr.Equals("uninitialized", StringComparison.OrdinalIgnoreCase))
         {
             effectAllowed |= DragDropEffects.Move | DragDropEffects.Copy | DragDropEffects.Link;
         }


### PR DESCRIPTION
# Fix Firefox drag-and-drop: handle `effectAllowed = "uninitialized"`

## Summary

Drag and drop from external sources (e.g. files from the OS file manager) was broken in Firefox when targeting a browser-hosted Avalonia application.

## Root Cause

Firefox sends `effectAllowed = "uninitialized"` on `dragenter` and `dragover` events when the drag originates from outside the browser (e.g. a file drag from the OS). This is correct behaviour and [explicitly defined in the HTML Living Standard](https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-store):

> When a drag data store is created, it must be initialized such that [...] its drag data store allowed effects state is the string **"uninitialized"**.

The spec processing model table (§ 6.11.5) treats `"uninitialized"` identically to `"all"` for the purpose of determining which drop effects are permitted:

| `effectAllowed` | Permitted drop effects |
|---|---|
| `"uninitialized"`, `"copy"`, `"copyLink"`, `"copyMove"`, or `"all"` | copy |
| `"uninitialized"`, `"link"`, `"copyLink"`, `"linkMove"`, or `"all"` | link |
| `"uninitialized"`, `"move"`, `"copyMove"`, `"linkMove"`, or `"all"` | move |

Avalonia's `BrowserInputHandler.OnDragEvent` only checked for the literal string `"all"` when setting all three `DragDropEffects` flags. The `"uninitialized"` value fell through all checks, leaving `effectAllowed` as `DragDropEffects.None`, which caused the handler to return `false` immediately — silently rejecting every drag event in Firefox.

Chromium was unaffected because it sends `"all"` instead of `"uninitialized"` for the same scenario.

## Change

**`src/Browser/Avalonia.Browser/BrowserInputHandler.cs`**

Extended the `"all"` equality check to also match `"uninitialized"`:

```csharp
// Before
if (effectAllowedStr.Equals("all", StringComparison.OrdinalIgnoreCase))

// After
if (effectAllowedStr.Equals("all", StringComparison.OrdinalIgnoreCase)
    || effectAllowedStr.Equals("uninitialized", StringComparison.OrdinalIgnoreCase))
```

## How to Test

1. Run any browser-hosted Avalonia sample (e.g. `samples/ControlCatalog.Browser`) in **Firefox**.
2. Drag a file from the OS file manager and drop it onto the application.
3. **Before this fix:** the drop is silently rejected — no `DragEnter`/`DragOver`/`Drop` events reach Avalonia handlers.
4. **After this fix:** drag events are accepted and Avalonia's drag-and-drop pipeline fires normally.
5. Verify **Chromium** is unaffected (drag-and-drop must continue to work as before).

## References

- [HTML Living Standard § 6.11 Drag and drop — `effectAllowed`](https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-effectallowed)
- [HTML Living Standard § 6.11.2 — drag data store initialisation (`"uninitialized"` default)](https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-store)
- [HTML Living Standard § 6.11.5 — processing model table (`"uninitialized"` = all effects allowed)](https://html.spec.whatwg.org/multipage/dnd.html#drag-and-drop-processing-model)
- [MDN — DataTransfer.effectAllowed](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/effectAllowed)
