### PR TITLE
Fix NotificationCard pseudo class state when NotificationType changes

### DIFF
--- a/src/Avalonia.Controls/Notifications/NotificationCard.cs
+++ b/src/Avalonia.Controls/Notifications/NotificationCard.cs
@@ -170,24 +170,10 @@ namespace Avalonia.Controls.Notifications
 
         private void UpdateNotificationType()
         {
-            switch (NotificationType)
-            {
-                case NotificationType.Error:
-                    PseudoClasses.Add(":error");
-                    break;
-
-                case NotificationType.Information:
-                    PseudoClasses.Add(":information");
-                    break;
-
-                case NotificationType.Success:
-                    PseudoClasses.Add(":success");
-                    break;
-
-                case NotificationType.Warning:
-                    PseudoClasses.Add(":warning");
-                    break;
-            }
+            PseudoClasses.Set(":error", NotificationType == NotificationType.Error);
+            PseudoClasses.Set(":information", NotificationType == NotificationType.Information);
+            PseudoClasses.Set(":success", NotificationType == NotificationType.Success);
+            PseudoClasses.Set(":warning", NotificationType == NotificationType.Warning);
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/NotificationsTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NotificationsTests.cs
@@ -113,4 +113,35 @@ namespace Avalonia.Controls.UnitTests
             Assert.True(!((WindowNotificationManager)manager).Notifications.Any(x => !x.IsClosing));
         }
     }
+
+    public class NotificationCardTests : ScopedTestBase
+    {
+        [Fact]
+        public void Should_Update_Pseudoclasses_When_NotificationType_Changes()
+        {
+            var target = new NotificationCard();
+
+            target.NotificationType = NotificationType.Error;
+            AssertPseudoClasses(target, ":error");
+
+            target.NotificationType = NotificationType.Information;
+            AssertPseudoClasses(target, ":information");
+
+            target.NotificationType = NotificationType.Success;
+            AssertPseudoClasses(target, ":success");
+
+            target.NotificationType = NotificationType.Warning;
+            AssertPseudoClasses(target, ":warning");
+ 
+            static void AssertPseudoClasses(NotificationCard target, string expected)
+            {
+                Assert.Contains(expected, target.Classes);
+
+                foreach (var pseudoclass in new[] { ":error", ":information", ":success", ":warning" }.Where(x => x != expected))
+                {
+                    Assert.DoesNotContain(pseudoclass, target.Classes);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
fix https://github.com/AvaloniaUI/Avalonia/issues/21489


## What is the current behavior?
Previous pseudo classes remain applied, causing stale visual states.


## What is the updated/expected behavior with this PR?
This change fixes NotificationCard pseudo class handling so that notification type visual states are updated correctly when NotificationType changes.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
fix https://github.com/AvaloniaUI/Avalonia/issues/21489
