### PR TITLE
Win32: Fix window animations in extended mode

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -93,11 +93,9 @@ namespace Avalonia.Win32
                                 }
                                 else
                                 {
+                                    // There's no extra border on top with WS_CAPTION: it's part of the caption.
                                     adjuster.Adjust(ref borderThickness, style, 0);
-
-                                    var thinBorderThickness = new RECT();
-                                    adjuster.Adjust(ref thinBorderThickness, style & ~(WindowStyles.WS_CAPTION | WindowStyles.WS_THICKFRAME) | WindowStyles.WS_BORDER, 0);
-                                    borderThickness.top = thinBorderThickness.top;
+                                    borderThickness.top = 0;
                                 }
                             }
                             else if (style.HasAllFlags(WindowStyles.WS_BORDER))

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -596,12 +596,18 @@ namespace Avalonia.Win32
 
             if (_isClientAreaExtended)
             {
-                // We told Windows we have a caption, but since we're actually extending into it,
+                // We told Windows we have a border, but since we're actually extending into it,
                 // it should be excluded from the final window bounds.
-                if (_windowProperties.Decorations != WindowDecorations.None)
+                var style = GetStyle();
+                if ((style & WindowStyles.WS_BORDER) != 0)
                 {
                     var borderOnlyRect = ClientRectToWindowRect(requestedClientRect, WindowStyles.WS_BORDER);
+
                     requestedWindowRect.top = borderOnlyRect.top;
+
+                    // If we're supposed to have a caption, the top border is actually collapsed into it.
+                    if ((style & WindowStyles.WS_CAPTION) == WindowStyles.WS_CAPTION)
+                        requestedWindowRect.top += 1;
                 }
             }
 
@@ -1400,10 +1406,6 @@ namespace Avalonia.Win32
 
         private void UpdateWindowProperties(WindowProperties newProperties, bool forceChanges = false)
         {
-            // Implementation note: this method tries to keep the same styles for extended and non-extended modes.
-            // However, we had to make an exception for WS_CAPTION since it causes issues in Windows 10.
-            // See https://github.com/AvaloniaUI/Avalonia/issues/21328
-
             var oldProperties = _windowProperties;
 
             // Calling SetWindowPos will cause events to be sent and we need to respond
@@ -1471,15 +1473,7 @@ namespace Avalonia.Win32
                 switch (newProperties.Decorations)
                 {
                     case WindowDecorations.Full:
-                        style |= WindowStyles.WS_BORDER | WindowStyles.WS_SYSMENU;
-
-                        // When WS_CAPTION is specified, Windows 10 always draws the caption even if we extend into it.
-                        // We can workaround that by setting DWMWA_NCRENDERING_POLICY to DISABLE, but that also removes
-                        // shadows and borders. Remove the style completely.
-                        // Windows 11 correctly handles this scenario.
-                        if (!_isClientAreaExtended)
-                            style |= WindowStyles.WS_CAPTION;
-
+                        style |= WindowStyles.WS_BORDER | WindowStyles.WS_SYSMENU | WindowStyles.WS_CAPTION;
                         break;
 
                     case WindowDecorations.BorderOnly:
@@ -1602,9 +1596,6 @@ namespace Avalonia.Win32
         public void SetExtendClientAreaToDecorationsHint(bool hint)
         {
             _isClientAreaExtended = hint;
-
-            // We may need to toggle WS_CAPTION when extending, ensure the styles are up-to-date.
-            UpdateWindowProperties(_windowProperties);
 
             ExtendClientArea();
         }


### PR DESCRIPTION
## What does the pull request do?
This PR restores the window animations on Windows when `WindowDecorations = Full` and `ExtendClientAreaToDecorationsHint = True` in both Windows 10 and 11.

## Notes
The animations were broken by #21412. The changes from this PR are partially reverted here. `WS_CAPTION` is now enforced again in `Full` decorations mode, as it's the style Windows uses to trigger animations.

The comment in #21412 is still valid: as soon as we reserve a single pixel for the caption (to use as the top border), Windows 10 draws the full height caption (Windows 11 handles that scenario correctly). To prevent that, the solution seems obvious: do not reserve any height for that top border.

I spent hours looking at how Chromium and various modern applications with custom chrome (Calculator, Windows Explorer, Windows Settings...) do things, by analyzing styles and messages.

The result is always the same: the caption / top border is 0 as specified in [Chromium's source code](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/frame/browser_frame_view_win.cc;l=746-750) to avoid the duplicated caption described above. The top border is then drawn manually. Interestingly, this is also the case in Windows Settings or Calculator: a bug exists in Windows 10 where changing the frame color isn't always updated, and it's noticeable that the top border isn't the same color as the rest of the frame.

Note that this PR does not try to draw that extra top border on Windows 10 (Windows 11 does not need it).

Tested against Windows 10 22H2 (19045) and Windows 11 25H2 (26200).

## Fixed issues
 - Fixes #21456