### PR TITLE
Add managed file chooser root class

### DIFF
--- a/src/Avalonia.Dialogs/ManagedStorageProvider.cs
+++ b/src/Avalonia.Dialogs/ManagedStorageProvider.cs
@@ -15,6 +15,8 @@ namespace Avalonia.Dialogs;
 
 internal class ManagedStorageProvider : BclStorageProvider
 {
+    private const string ManagedFileChooserRootName = "ManagedFileChooserRoot";
+
     private readonly TopLevel? _parent;
     private readonly ManagedFileDialogOptions _managedOptions;
 
@@ -75,11 +77,17 @@ internal class ManagedStorageProvider : BclStorageProvider
         {
             if (_parent is not null and not Window)
             {
-                root = new ContentControl();
+                root = new ContentControl
+                {
+                    Name = ManagedFileChooserRootName
+                };
             }
             else
             {
-                root = new Window();
+                root = new Window
+                {
+                    Name = ManagedFileChooserRootName
+                };
             }
         }
 


### PR DESCRIPTION
Fixes #19521.

Adds a stable managed-file-chooser-root class to internally-created managed file chooser roots while leaving custom ContentRootFactory roots under caller control.

Validation:
- git diff --check
- static search confirmed both internal root paths receive the class

Not run:
- full build; sparse checkout and one-file source change were checked statically