### PR TITLE
Fix StreamGeometry Clone/Open with transforms

### DIFF
--- a/src/Avalonia.Base/Media/StreamGeometry.cs
+++ b/src/Avalonia.Base/Media/StreamGeometry.cs
@@ -47,7 +47,10 @@ namespace Avalonia.Media
         /// <inheritdoc/>
         public override Geometry Clone()
         {
-            return new StreamGeometry(((IStreamGeometryImpl)PlatformImpl!).Clone());
+            return new StreamGeometry(GetSourceGeometryImpl().Clone())
+            {
+                Transform = Transform
+            };
         }
 
         /// <summary>
@@ -58,7 +61,12 @@ namespace Avalonia.Media
         /// </returns>
         public StreamGeometryContext Open()
         {
-            return new StreamGeometryContext(((IStreamGeometryImpl)PlatformImpl!).Open());
+            return new StreamGeometryContext(GetSourceGeometryImpl().Open());
+        }
+
+        private IStreamGeometryImpl GetSourceGeometryImpl()
+        {
+            return _impl ?? (IStreamGeometryImpl)CreateDefiningGeometry()!;
         }
 
         /// <inheritdoc/>

--- a/tests/Avalonia.Base.UnitTests/Media/StreamGeometryTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/StreamGeometryTests.cs
@@ -1,0 +1,61 @@
+using Avalonia.Media;
+using Avalonia.Platform;
+using Avalonia.UnitTests;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Media;
+
+public class StreamGeometryTests
+{
+    [Fact]
+    public void Clone_With_Transform_Preserves_Transform()
+    {
+        using (UnitTestApplication.Start(GetServices()))
+        {
+            var target = new StreamGeometry();
+
+            using (target.Open())
+            {
+            }
+
+            var transform = new TranslateTransform(50, 50);
+            target.Transform = transform;
+
+            var clone = Assert.IsType<StreamGeometry>(target.Clone());
+
+            Assert.Same(transform, clone.Transform);
+        }
+    }
+
+    [Fact]
+    public void Open_With_Transform_Opens_Source_StreamGeometry()
+    {
+        using (UnitTestApplication.Start(GetServices()))
+        {
+            var target = new StreamGeometry();
+
+            using (target.Open())
+            {
+            }
+
+            target.Transform = new TranslateTransform(50, 50);
+
+            using (target.Open())
+            {
+            }
+        }
+    }
+
+    private static TestServices GetServices()
+    {
+        var context = Mock.Of<IStreamGeometryContextImpl>();
+        var transformedGeometry = Mock.Of<ITransformedGeometryImpl>();
+        var streamGeometry = Mock.Of<IStreamGeometryImpl>(x =>
+            x.Open() == context &&
+            x.WithTransform(It.IsAny<Matrix>()) == transformedGeometry);
+        var renderInterface = Mock.Of<IPlatformRenderInterface>(x =>
+            x.CreateStreamGeometry() == streamGeometry);
+        return new TestServices(renderInterface: renderInterface);
+    }
+}


### PR DESCRIPTION
Fixes #21494.

## What changed
- Make `StreamGeometry.Clone()` clone the source stream geometry instead of casting the possibly transformed `PlatformImpl`.
- Make `StreamGeometry.Open()` reopen the source stream geometry when `Transform` is set.
- Preserve `Transform` when cloning a `StreamGeometry`.
- Add regression coverage for `Clone()` and `Open()` with a transform applied.

## Verification
- `dotnet test tests\Avalonia.Base.UnitTests\Avalonia.Base.UnitTests.csproj -- --filter-class Avalonia.Base.UnitTests.Media.StreamGeometryTests`
- `dotnet test tests\Avalonia.Base.UnitTests\Avalonia.Base.UnitTests.csproj -- --filter-namespace Avalonia.Base.UnitTests.Media`
- `git diff --check origin/master...HEAD`