### PR TITLE
Avoid clipping immediate-rendered effects to visual bounds

### DIFF
--- a/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
@@ -50,6 +50,14 @@ internal class ImmediateRenderer
             transform = Matrix.CreateTranslation(bounds.Position);
         }
 
+        var totalTransform = transform * parentTransform;
+        var effectBounds = rect;
+
+        if (visual.Effect != null && totalTransform.TryInvert(out var invertedTransform))
+        {
+            effectBounds = clipRect.TransformToAABB(invertedTransform);
+        }
+
         using (visual.TextOptions != default ? context.PushTextOptions(visual.TextOptions) : default(DrawingContext.PushedState?))
         using (visual.RenderOptions != default ? context.PushRenderOptions(visual.RenderOptions) : default(DrawingContext.PushedState?))
         using (context.PushTransform(transform))
@@ -63,9 +71,8 @@ internal class ImmediateRenderer
         })
         using (visual.Clip is { } clip ? context.PushGeometryClip(clip) : default(DrawingContext.PushedState?))
         using (visual.OpacityMask is { } opctMask ? context.PushOpacityMask(opctMask, rect) : default(DrawingContext.PushedState?))
-        using (visual.Effect is { } effect ? context.PushEffect(effect, rect) : default(DrawingContext.PushedState?))
+        using (visual.Effect is { } effect ? context.PushEffect(effect, effectBounds) : default(DrawingContext.PushedState?))
         {
-            var totalTransform = transform * parentTransform;
             var effectRect = visual.Effect is { } e ? rect.Inflate(e.GetEffectOutputPadding()) : rect;
             var visualBounds = effectRect.TransformToAABB(totalTransform);
 

--- a/tests/Avalonia.Base.UnitTests/RenderTests_Culling.cs
+++ b/tests/Avalonia.Base.UnitTests/RenderTests_Culling.cs
@@ -210,9 +210,55 @@ namespace Avalonia.Base.UnitTests
             }
         }
 
+        [Fact]
+        public void Effect_Bounds_Should_Cover_Visible_Clip()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var effectImpl = new Mock<IDrawingContextImplWithEffects>();
+                effectImpl.SetupProperty(x => x.Transform, Matrix.Identity);
+
+                Rect? effectBounds = null;
+                effectImpl
+                    .Setup(x => x.PushEffect(It.IsAny<Rect?>(), It.IsAny<IEffect>()))
+                    .Callback<Rect?, IEffect>((bounds, _) => effectBounds = bounds);
+
+                var root = new Canvas
+                {
+                    Width = 300,
+                    Height = 300,
+                    Children =
+                    {
+                        new TestControl
+                        {
+                            Width = 250,
+                            Height = 250,
+                            Effect = new DropShadowEffect
+                            {
+                                Color = Colors.Black,
+                                BlurRadius = 3,
+                                OffsetX = 3,
+                                OffsetY = 3,
+                            }
+                        }
+                    }
+                };
+
+                Render(root, new PlatformDrawingContext(effectImpl.Object, ownsImpl: false));
+
+                Assert.NotNull(effectBounds);
+                Assert.True(effectBounds.Value.Width >= root.Bounds.Width);
+                Assert.True(effectBounds.Value.Height >= root.Bounds.Height);
+            }
+        }
+
         private void Render(Control control)
         {
-            var ctx = CreateDrawingContext();
+            Render(control, CreateDrawingContext());
+        }
+
+        private void Render(Control control, DrawingContext ctx)
+        {
             control.Measure(Size.Infinity);
             control.Arrange(new Rect(control.DesiredSize));
             ImmediateRenderer.Render(ctx, control);


### PR DESCRIPTION
Fixes #21497.

## What changed
- Make `ImmediateRenderer` use the current visible clip, transformed into the visual's local coordinates, as effect bounds for visuals with effects.
- This keeps effect layers bounded by the visible render area while avoiding a too-tight layer around the visual's layout rect.
- Add regression coverage proving immediate-rendered effects receive bounds that cover the visible clip rather than only the child visual bounds.

## Verification
- `dotnet build src\Avalonia.Base\Avalonia.Base.csproj --no-restore --framework net10.0 -maxcpucount:1 -p:BuildInParallel=false -p:UseSharedCompilation=false --disable-build-servers`
- `dotnet build tests\Avalonia.Base.UnitTests\Avalonia.Base.UnitTests.csproj --no-restore --framework net10.0 --no-dependencies -maxcpucount:1 -p:BuildInParallel=false -p:UseSharedCompilation=false --disable-build-servers`
- `dotnet test tests\Avalonia.Base.UnitTests\Avalonia.Base.UnitTests.csproj --no-build --framework net10.0 -- --filter-method Avalonia.Base.UnitTests.RenderTests_Culling.Effect_Bounds_Should_Cover_Visible_Clip`
- `dotnet test tests\Avalonia.Base.UnitTests\Avalonia.Base.UnitTests.csproj --no-build --framework net10.0 -- --filter-class Avalonia.Base.UnitTests.RenderTests_Culling`
- `git diff --check origin/master...HEAD`