### PR TITLE
Fix NumericUpDown automation range value events

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/NumericUpDownAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/NumericUpDownAutomationPeer.cs
@@ -44,22 +44,22 @@ namespace Avalonia.Automation.Peers
             {
                 RaisePropertyChangedEvent(
                     RangeValuePatternIdentifiers.MinimumProperty,
-                    e.OldValue,
-                    e.NewValue);
+                    ToRangeValue(e.OldValue),
+                    ToRangeValue(e.NewValue));
             }
             else if (e.Property == NumericUpDown.MaximumProperty)
             {
                 RaisePropertyChangedEvent(
                     RangeValuePatternIdentifiers.MaximumProperty,
-                    e.OldValue,
-                    e.NewValue);
+                    ToRangeValue(e.OldValue),
+                    ToRangeValue(e.NewValue));
             }
             else if (e.Property == NumericUpDown.ValueProperty)
             {
                 RaisePropertyChangedEvent(
                     RangeValuePatternIdentifiers.ValueProperty,
-                    e.OldValue,
-                    e.NewValue);
+                    ToRangeValue(e.OldValue),
+                    ToRangeValue(e.NewValue));
             }
             else if (e.Property == NumericUpDown.IsReadOnlyProperty)
             {
@@ -68,6 +68,11 @@ namespace Avalonia.Automation.Peers
                     e.OldValue,
                     e.NewValue);
             }
+        }
+
+        private static object? ToRangeValue(object? value)
+        {
+            return value is decimal decimalValue ? (double)decimalValue : value;
         }
     }
 }

--- a/src/Windows/Avalonia.Win32.Automation/Marshalling/ComVariant.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Marshalling/ComVariant.cs
@@ -39,6 +39,9 @@ internal struct ComVariant : IDisposable
     // Most of the data types in the Variant are carried in _typeUnion
     [FieldOffset(0)] private TypeUnion _typeUnion;
 
+    // DECIMAL overlaps the VARIANT type discriminator and reserved fields.
+    [FieldOffset(0)] private decimal _decimal;
+
     [StructLayout(LayoutKind.Sequential)]
     private struct TypeUnion
     {
@@ -161,6 +164,11 @@ internal struct ComVariant : IDisposable
             variant.VarType = VarEnum.VT_R8;
             variant._typeUnion._unionTypes._r8 = (double)value;
         }
+        else if (value is decimal)
+        {
+            variant._decimal = (decimal)value;
+            variant.VarType = VarEnum.VT_DECIMAL;
+        }
         else if (value is DateTime)
         {
             variant.VarType = VarEnum.VT_DATE;
@@ -260,6 +268,7 @@ internal struct ComVariant : IDisposable
             // floating
             VarEnum.VT_R4 => _typeUnion._unionTypes._r4,
             VarEnum.VT_R8 => _typeUnion._unionTypes._r8,
+            VarEnum.VT_DECIMAL => DecimalValue,
             // date
             VarEnum.VT_DATE => DateTime.FromOADate(_typeUnion._unionTypes._date),
             // string
@@ -294,6 +303,16 @@ internal struct ComVariant : IDisposable
             },
             _ => throw new ArgumentException($"Unknown variant type: {VarType}")
         };
+    }
+
+    private readonly decimal DecimalValue
+    {
+        get
+        {
+            var variant = this;
+            variant.VarType = VarEnum.VT_EMPTY;
+            return variant._decimal;
+        }
     }
 
     /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/Automation/FoundationAutomationPeerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Automation/FoundationAutomationPeerTests.cs
@@ -243,9 +243,9 @@ public class FoundationAutomationPeerTests
         }
 
         [Fact]
-        public void PropertyChanged_Raises_Range_When_Value_Changes()
+        public void PropertyChanged_Raises_Range_Value_As_Double_When_Value_Changes()
         {
-            var control = new NumericUpDown();
+            var control = new NumericUpDown { Value = 1.25m };
             var peer = (NumericUpDownAutomationPeer)ControlAutomationPeer.CreatePeerForElement(control);
             AutomationPropertyChangedEventArgs? changed = null;
 
@@ -259,8 +259,42 @@ public class FoundationAutomationPeerTests
 
             Assert.NotNull(changed);
             Assert.Equal(RangeValuePatternIdentifiers.ValueProperty, changed!.Property);
-            Assert.Null(changed.OldValue);
-            Assert.Equal(7.5m, changed.NewValue);
+            Assert.Equal(1.25d, changed.OldValue);
+            Assert.Equal(7.5d, changed.NewValue);
+        }
+
+        [Fact]
+        public void PropertyChanged_Raises_Range_Minimum_And_Maximum_As_Double()
+        {
+            var control = new NumericUpDown
+            {
+                Minimum = 0m,
+                Maximum = 10m,
+            };
+            var peer = (NumericUpDownAutomationPeer)ControlAutomationPeer.CreatePeerForElement(control);
+            AutomationPropertyChangedEventArgs? minimumChanged = null;
+            AutomationPropertyChangedEventArgs? maximumChanged = null;
+
+            peer.PropertyChanged += (_, e) =>
+            {
+                if (e.Property == RangeValuePatternIdentifiers.MinimumProperty)
+                    minimumChanged = e;
+                else if (e.Property == RangeValuePatternIdentifiers.MaximumProperty)
+                    maximumChanged = e;
+            };
+
+            control.Minimum = 1.5m;
+            control.Maximum = 9.5m;
+
+            Assert.NotNull(minimumChanged);
+            Assert.Equal(RangeValuePatternIdentifiers.MinimumProperty, minimumChanged!.Property);
+            Assert.Equal(0d, minimumChanged.OldValue);
+            Assert.Equal(1.5d, minimumChanged.NewValue);
+
+            Assert.NotNull(maximumChanged);
+            Assert.Equal(RangeValuePatternIdentifiers.MaximumProperty, maximumChanged!.Property);
+            Assert.Equal(10d, maximumChanged.OldValue);
+            Assert.Equal(9.5d, maximumChanged.NewValue);
         }
     }
 }


### PR DESCRIPTION
Fixes #21491.

## What changed
- Convert `NumericUpDownAutomationPeer` range property change payloads from `decimal` to `double` before raising UI Automation `RangeValue` events.
- Keep the provider/event value types aligned with `IRangeValueProvider`, whose `Value`, `Minimum`, and `Maximum` members are already exposed as `double`.
- Add regression coverage for `Value`, `Minimum`, and `Maximum` automation events so they no longer forward raw `decimal` values into the Win32 COM variant marshaller.

## Why
`NumericUpDown.Value`, `Minimum`, and `Maximum` are stored as `decimal`, but Win32 UI Automation `RangeValue` properties are `VT_R8`/double values. Forwarding raw decimal values into `UiaRaiseAutomationPropertyChangedEvent` reaches `ComVariant.Create`, which has no decimal case and throws before Narrator can consume the event.

## Validation
- `dotnet build tests\Avalonia.Controls.UnitTests\Avalonia.Controls.UnitTests.csproj -m:1 --no-restore -v:minimal`
- `tests\Avalonia.Controls.UnitTests\bin\Debug\net10.0\Avalonia.Controls.UnitTests.exe --filter-class "Avalonia.Controls.UnitTests.Automation.FoundationAutomationPeerTests+NumericUpDownPeer" --no-progress`
- `dotnet build src\Windows\Avalonia.Win32.Automation\Avalonia.Win32.Automation.csproj -m:1 --no-restore -v:minimal`
- `git diff --cached --check`