### PR TITLE
Fix ComboBox automation value for display member selections

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/ComboBoxAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ComboBoxAutomationPeer.cs
@@ -51,7 +51,7 @@ namespace Avalonia.Automation.Peers
             if (Owner.SelectedItem is object selection)
             {
                 _selection ??= new[] { new UnrealizedSelectionPeer(this) };
-                _selection[0].Item = selection;
+                _selection[0].Item = GetUnrealizedSelectionItem(selection);
                 return _selection;
             }
 
@@ -74,6 +74,11 @@ namespace Avalonia.Automation.Peers
         private static ExpandCollapseState ToState(bool value)
         {
             return value ? ExpandCollapseState.Expanded : ExpandCollapseState.Collapsed;
+        }
+
+        private object? GetUnrealizedSelectionItem(object selection)
+        {
+            return Owner.SelectionBoxItem is TextBlock ? Owner.SelectionBoxItem : selection;
         }
 
         private class UnrealizedSelectionPeer : UnrealizedElementAutomationPeer
@@ -116,6 +121,11 @@ namespace Avalonia.Automation.Peers
                 if (_item is Control c)
                 {
                     var result = AutomationProperties.GetName(c);
+
+                    if (result is null && c is TextBlock textBlock)
+                    {
+                        result = textBlock.Inlines?.Text ?? textBlock.Text;
+                    }
 
                     if (result is null && c is ContentControl cc && cc.Presenter?.Child is TextBlock text)
                     {

--- a/tests/Avalonia.Controls.UnitTests/Automation/ComplexControlAutomationPeerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Automation/ComplexControlAutomationPeerTests.cs
@@ -7,6 +7,7 @@ using Avalonia.Automation.Peers;
 using Avalonia.Automation.Provider;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Data;
 using Avalonia.UnitTests;
 using Xunit;
 
@@ -119,6 +120,31 @@ public class AutoCompleteBoxAutomationPeerTests : ScopedTestBase
         Assert.Equal(ValuePatternIdentifiers.ValueProperty, valueChanged!.Property);
         Assert.Equal(string.Empty, valueChanged.OldValue);
         Assert.Equal("query", valueChanged.NewValue);
+    }
+}
+
+public class ComboBoxAutomationPeerTests : ScopedTestBase
+{
+    [Fact]
+    public void Value_Uses_DisplayMemberBinding_For_Closed_Object_Selection()
+    {
+        var item = new ComboBoxDisplayItem("Displayed value");
+        var target = new ComboBox
+        {
+            DisplayMemberBinding = new Binding(nameof(ComboBoxDisplayItem.Display)),
+            ItemsSource = new[] { item },
+            SelectedItem = item,
+        };
+        var peer = (IValueProvider)ControlAutomationPeer.CreatePeerForElement(target);
+
+        Assert.Equal("Displayed value", peer.Value);
+    }
+
+    private sealed class ComboBoxDisplayItem(string display)
+    {
+        public string Display { get; } = display;
+
+        public override string ToString() => "Model type name";
     }
 }
 

--- a/tests/Avalonia.Controls.UnitTests/Automation/ComplexControlAutomationPeerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Automation/ComplexControlAutomationPeerTests.cs
@@ -143,7 +143,7 @@ public class ComboBoxAutomationPeerTests : ScopedTestBase
     [Fact]
     public void Value_Uses_Selected_Control_Text_When_SelectionBoxItem_Is_Proxy()
     {
-        using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+        using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
 
         var item = new TextBlock { Text = "Control text" };
         var target = new ComboBox

--- a/tests/Avalonia.Controls.UnitTests/Automation/ComplexControlAutomationPeerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Automation/ComplexControlAutomationPeerTests.cs
@@ -140,6 +140,24 @@ public class ComboBoxAutomationPeerTests : ScopedTestBase
         Assert.Equal("Displayed value", peer.Value);
     }
 
+    [Fact]
+    public void Value_Uses_Selected_Control_Text_When_SelectionBoxItem_Is_Proxy()
+    {
+        using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+        var item = new TextBlock { Text = "Control text" };
+        var target = new ComboBox
+        {
+            Items = { item },
+            SelectedIndex = 0,
+        };
+        var root = new TestRoot(target);
+        var peer = (IValueProvider)ControlAutomationPeer.CreatePeerForElement(target);
+
+        Assert.NotSame(item, target.SelectionBoxItem);
+        Assert.Equal("Control text", peer.Value);
+    }
+
     private sealed class ComboBoxDisplayItem(string display)
     {
         public string Display { get; } = display;


### PR DESCRIPTION
Fixes #17000.

## What changed
- When a closed `ComboBox` creates an unrealized automation peer for the selected item, use the displayed `SelectionBoxItem` text when the selection box item is a `TextBlock`.
- Preserve the existing selected-control behavior by not replacing control selections with the selection-box `Rectangle`/visual brush surrogate.
- Add regression coverage for object selections using `DisplayMemberBinding`, where `ToString()` does not match the displayed value.

## Why
For closed combo boxes, automation currently builds the unrealized selected item from `SelectedItem`. If the item is a view model object, `IValueProvider.Value` falls back to `SelectedItem.ToString()`, so Narrator reads the model type/class-style value instead of the text rendered by `DisplayMemberBinding`.

## Validation
- Red before fix: `ComboBoxAutomationPeerTests.Value_Uses_DisplayMemberBinding_For_Closed_Object_Selection` failed with actual `Model type name` instead of `Displayed value`.
- `dotnet build tests\Avalonia.Controls.UnitTests\Avalonia.Controls.UnitTests.csproj -m:1 --no-restore -v:minimal`
- `tests\Avalonia.Controls.UnitTests\bin\Debug\net10.0\Avalonia.Controls.UnitTests.exe --filter-class "Avalonia.Controls.UnitTests.Automation.ComboBoxAutomationPeerTests" --no-progress`
- `tests\Avalonia.Controls.UnitTests\bin\Debug\net10.0\Avalonia.Controls.UnitTests.exe --filter-class "Avalonia.Controls.UnitTests.Automation.AutoCompleteBoxAutomationPeerTests" "Avalonia.Controls.UnitTests.Automation.ComboBoxAutomationPeerTests" "Avalonia.Controls.UnitTests.Automation.CalendarAutomationPeerTests" --no-progress`
- `tests\Avalonia.Controls.UnitTests\bin\Debug\net10.0\Avalonia.Controls.UnitTests.exe --filter-namespace "Avalonia.Controls.UnitTests.Automation" --no-progress`
- `git diff --cached --check`