### PR TITLE
Avoid Android toggle accessibility checked-state crash

### DIFF
--- a/src/Android/Avalonia.Android/Automation/ToggleNodeInfoProvider.cs
+++ b/src/Android/Avalonia.Android/Automation/ToggleNodeInfoProvider.cs
@@ -1,4 +1,6 @@
-﻿using Android.OS;
+﻿using System;
+using Android.OS;
+using Android.Views.Accessibility;
 using AndroidX.Core.View.Accessibility;
 using AndroidX.CustomView.Widget;
 using Avalonia.Automation.Peers;
@@ -32,12 +34,36 @@ namespace Avalonia.Android.Automation
             nodeInfo.Clickable = true;
 
             IToggleProvider provider = GetProvider();
-            nodeInfo.Checked = provider.ToggleState switch
+            ToggleState toggleState = provider.ToggleState;
+
+            // Avoid the AndroidX.Core int Checked property here. Its generated
+            // setter maps setChecked(int), which can throw while accessibility
+            // services query ToggleButton/CheckBox nodes.
+            if (OperatingSystem.IsAndroidVersionAtLeast(36))
             {
-                ToggleState.On => 1,
-                ToggleState.Indeterminate => 2,
-                _ => 0
-            };
+                AccessibilityNodeInfo? nativeNodeInfo = nodeInfo.Unwrap();
+                if (nativeNodeInfo is not null)
+                {
+                    nativeNodeInfo.CheckedState = toggleState switch
+                    {
+                        ToggleState.On => CheckedState.True,
+                        ToggleState.Indeterminate => CheckedState.Partial,
+                        _ => CheckedState.False
+                    };
+                }
+            }
+            else
+            {
+#pragma warning disable CS0618 // Use the older bool overload to avoid the int setter crash.
+                nodeInfo.SetChecked(toggleState == ToggleState.On);
+#pragma warning restore CS0618
+
+                if (toggleState == ToggleState.Indeterminate)
+                {
+                    nodeInfo.StateDescription = "partially checked";
+                }
+            }
+
             nodeInfo.Checkable = true;
         }
     }


### PR DESCRIPTION
## What changed

Fixes #21504.

`ToggleNodeInfoProvider` no longer writes `AccessibilityNodeInfoCompat.Checked`, whose generated AndroidX.Core binding setter maps to `setChecked(int)` and can throw while Android accessibility services query `ToggleButton`/`CheckBox` nodes.

Instead:

- Android 36+ writes the native `AccessibilityNodeInfo.CheckedState`, preserving `true` / `false` / `partial` states.
- Older Android versions use the older bool `SetChecked(...)` overload to avoid the crashing int setter path.
- Older Android indeterminate toggles also get `StateDescription = "partially checked"` so the partial state is not silently exposed as just unchecked.

## Validation

- Baseline `dotnet build src\Android\Avalonia.Android\Avalonia.Android.csproj -m:1 --no-restore -v:minimal -p:JavaSdkDirectory="C:\Program Files\Unity\Hub\Editor\6000.4.10f1\Editor\Data\PlaybackEngines\AndroidPlayer\OpenJDK" -p:AndroidSdkDirectory="C:\Program Files\Unity\Hub\Editor\6000.4.10f1\Editor\Data\PlaybackEngines\AndroidPlayer\SDK"` passed before this change.
- Same Android build passed after this change with 0 warnings/errors.
- Inspected the compiled `ToggleNodeInfoProvider.PopulateNodeInfo` IL to confirm the AndroidX.Core `set_Checked(int)` path is no longer emitted; the method now calls guarded native `CheckedState`, bool `SetChecked`, and fallback `StateDescription`.
- `git diff --check` passed, with only the local Windows LF/CRLF warning for the touched file.