### PR TITLE
Fix LayoutTransformControl zoom-out centering

### DIFF
--- a/src/Avalonia.Controls/LayoutTransformControl.cs
+++ b/src/Avalonia.Controls/LayoutTransformControl.cs
@@ -76,19 +76,18 @@ namespace Avalonia.Controls
                 finalSizeTransformed = TransformRoot.DesiredSize;
             }
 
-            // Transform the working size to find its width/height
-            Rect transformedRect = new Rect(0, 0, finalSizeTransformed.Width, finalSizeTransformed.Height).TransformToAABB(_transformation);
-            // Create the Arrange rect to center the transformed content
-            Rect finalRect = new Rect(
-                -transformedRect.X + ((finalSize.Width - transformedRect.Width) / 2),
-                -transformedRect.Y + ((finalSize.Height - transformedRect.Height) / 2),
-                finalSizeTransformed.Width,
-                finalSizeTransformed.Height);
+            var finalRect = CreateTransformRootArrangeRect(finalSize, finalSizeTransformed);
 
             // Perform an Arrange on TransformRoot (containing Child)
-            Size arrangedsize;
             TransformRoot.Arrange(finalRect);
-            arrangedsize = TransformRoot.Bounds.Size;
+            var arrangedsize = TransformRoot.Bounds.Size;
+
+            if (IsSizeSmaller(arrangedsize, finalSizeTransformed))
+            {
+                var actualFinalRect = CreateTransformRootArrangeRect(finalSize, arrangedsize);
+                TransformRoot.Arrange(actualFinalRect);
+                arrangedsize = TransformRoot.Bounds.Size;
+            }
 
             // This is the first opportunity under Silverlight to find out the Child's true DesiredSize
             if (IsSizeSmaller(finalSizeTransformed, arrangedsize) && _childActualSize == default)
@@ -247,6 +246,23 @@ namespace Avalonia.Controls
         private static bool IsSizeSmaller(Size a, Size b)
         {
             return (a.Width + AcceptableDelta < b.Width) || (a.Height + AcceptableDelta < b.Height);
+        }
+
+        private Rect CreateTransformRootArrangeRect(Size finalSize, Size transformRootSize)
+        {
+            // Transform the working size to find its width/height
+            Rect transformedRect = new Rect(
+                0,
+                0,
+                transformRootSize.Width,
+                transformRootSize.Height).TransformToAABB(_transformation);
+
+            // Create the Arrange rect to center the transformed content
+            return new Rect(
+                -transformedRect.X + ((finalSize.Width - transformedRect.Width) / 2),
+                -transformedRect.Y + ((finalSize.Height - transformedRect.Height) / 2),
+                transformRootSize.Width,
+                transformRootSize.Height);
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/LayoutTransformControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/LayoutTransformControlTests.cs
@@ -134,6 +134,29 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Stretch_Scale_Down_Centers_Actual_Transformed_Child_When_Final_Size_Exceeds_Desired_Size()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var child = new Rectangle { Width = 300, Height = 300 };
+            var target = new LayoutTransformControl
+            {
+                Child = child,
+                LayoutTransform = new ScaleTransform { ScaleX = 0.4, ScaleY = 0.4 }
+            };
+
+            target.Measure(new Size(200, 200));
+            target.Arrange(new Rect(0, 0, 200, 200));
+
+            Assert.Equal(new Size(120, 120), target.DesiredSize);
+            Assert.Equal(new Rect(40, 40, 300, 300), child.Bounds);
+            Assert.Equal(
+                new Rect(40, 40, 120, 120),
+                new Rect(child.Bounds.Size).TransformToAABB(child.RenderTransform!.Value)
+                    .Translate((Vector)child.Bounds.Position));
+        }
+
+        [Fact]
         public void Bounds_On_Rotate_180_degrees_Are_correct()
         {
             TransformRootBoundsTest(


### PR DESCRIPTION
## What changed
- Re-center `LayoutTransformControl` using the child size actually produced by arrange when it is smaller than the inverse-transformed working size.
- Keeps the existing transformed-content centering behavior, but avoids double-centering empty layout space when a stretched `LayoutTransformControl` scales fixed-size content down.
- Adds regression coverage for the `ScaleTransform`/Stretch zoom-out case from #13407.

Fixes #13407.

## Validation
- `git submodule update --init --recursive`
- `dotnet test --project tests\Avalonia.Controls.UnitTests\Avalonia.Controls.UnitTests.csproj --no-build --no-restore -- --filter-method Avalonia.Controls.UnitTests.LayoutTransformControlTests.Stretch_Scale_Down_Centers_Actual_Transformed_Child_When_Final_Size_Exceeds_Desired_Size --output Detailed`
- `dotnet test --project tests\Avalonia.Controls.UnitTests\Avalonia.Controls.UnitTests.csproj --no-build --no-restore -- --filter-class Avalonia.Controls.UnitTests.LayoutTransformControlTests --output Normal`
- `git diff --check`

Note: the first local build attempt failed before submodules were initialized because `external/XamlX` was missing. After `git submodule update --init --recursive`, the focused LayoutTransformControl test artifacts built and the focused tests above passed.