### PR TITLE
Preserve selection when selected source items move

### DIFF
--- a/src/Avalonia.Controls/Selection/SelectionModel.cs
+++ b/src/Avalonia.Controls/Selection/SelectionModel.cs
@@ -20,6 +20,7 @@ namespace Avalonia.Controls.Selection
         private EventHandler<SelectionModelSelectionChangedEventArgs>? _untypedSelectionChanged;
         private IList? _initSelectedItems;
         private bool _isSourceCollectionChanging;
+        private bool _selectionMoved;
 
         public SelectionModel()
         {
@@ -438,6 +439,45 @@ namespace Avalonia.Controls.Selection
             };
         }
 
+        private protected override CollectionChangeState OnItemsMoved(int oldIndex, int newIndex, IList items)
+        {
+            var count = items.Count;
+            var oldSelectedIndexes = RangesEnabled && Ranges.Count > 0 ?
+                IndexRange.EnumerateIndices(Ranges).ToList() :
+                null;
+            var shifted = false;
+
+            base.OnItemsMoved(oldIndex, newIndex, items);
+
+            var newSelectedIndex = MoveIndex(SelectedIndex, oldIndex, newIndex, count);
+            if (SelectedIndex != newSelectedIndex)
+            {
+                _selectedIndex = newSelectedIndex;
+                shifted = true;
+            }
+
+            var newAnchorIndex = MoveIndex(AnchorIndex, oldIndex, newIndex, count);
+            if (AnchorIndex != newAnchorIndex)
+            {
+                _anchorIndex = newAnchorIndex;
+                shifted = true;
+            }
+
+            if (oldSelectedIndexes is not null &&
+                !oldSelectedIndexes.SequenceEqual(IndexRange.EnumerateIndices(Ranges)))
+            {
+                shifted = true;
+            }
+
+            _selectionMoved = shifted;
+
+            return new CollectionChangeState
+            {
+                ShiftIndex = Math.Min(oldIndex, newIndex),
+                ShiftDelta = 0,
+            };
+        }
+
         protected override void OnSourceCollectionChanged(NotifyCollectionChangedEventArgs e)
         {
             if (_operation?.UpdateCount > 0)
@@ -457,7 +497,6 @@ namespace Avalonia.Controls.Selection
 
             if ((e.Action == NotifyCollectionChangedAction.Remove && e.OldStartingIndex <= oldSelectedIndex) ||
                 (e.Action == NotifyCollectionChangedAction.Replace && e.OldStartingIndex == oldSelectedIndex) ||
-                (e.Action == NotifyCollectionChangedAction.Move && e.OldStartingIndex == oldSelectedIndex) ||
                 e.Action == NotifyCollectionChangedAction.Reset)
             {
                 RaisePropertyChanged(nameof(SelectedItem));
@@ -467,6 +506,17 @@ namespace Avalonia.Controls.Selection
             {
                 RaisePropertyChanged(nameof(AnchorIndex));
             }
+
+            if (_selectionMoved)
+            {
+                RaisePropertyChanged(nameof(SelectedIndexes));
+                _selectedIndexes?.RaiseCollectionReset();
+
+                RaisePropertyChanged(nameof(SelectedItems));
+                _selectedItems?.RaiseCollectionReset();
+            }
+
+            _selectionMoved = false;
         }
 
         private protected void SetInitSelectedItems(IList items)

--- a/src/Avalonia.Controls/Selection/SelectionNodeBase.cs
+++ b/src/Avalonia.Controls/Selection/SelectionNodeBase.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 
 namespace Avalonia.Controls.Selection
 {
@@ -159,18 +160,9 @@ namespace Avalonia.Controls.Selection
                             goto case NotifyCollectionChangedAction.Reset;
                         }
 
-                        var removeChange = OnItemsRemoved(e.OldStartingIndex, e.OldItems!);
-                        var insertIndex = e.NewStartingIndex;
-
-                        if (e.NewStartingIndex > e.OldStartingIndex)
-                        {
-                            insertIndex -= e.OldItems!.Count - 1;
-                        }
-
-                        var addChange = OnItemsAdded(insertIndex, e.NewItems!);
-                        shiftIndex = removeChange.ShiftIndex;
-                        shiftDelta = removeChange.ShiftDelta + addChange.ShiftDelta;
-                        removed = removeChange.RemovedItems;
+                        var change = OnItemsMoved(e.OldStartingIndex, e.NewStartingIndex, e.OldItems!);
+                        shiftIndex = change.ShiftIndex;
+                        shiftDelta = change.ShiftDelta;
                     }
                     break;
                 case NotifyCollectionChangedAction.Reset:
@@ -375,6 +367,66 @@ namespace Avalonia.Controls.Selection
                 ShiftDelta = shifted ? -count : 0,
                 RemovedItems = removed,
             };
+        }
+
+        /// <summary>
+        /// Called by <see cref="OnSourceCollectionChanged(NotifyCollectionChangedEventArgs)"/>
+        /// when items are moved within the source collection.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="CollectionChangeState"/> struct containing the details of the adjusted
+        /// selection.
+        /// </returns>
+        /// <remarks>
+        /// The implementation in <see cref="SelectionNodeBase{T}"/> adjusts the selected ranges,
+        /// preserving selection for moved items.
+        /// </remarks>
+        private protected virtual CollectionChangeState OnItemsMoved(int oldIndex, int newIndex, IList items)
+        {
+            var count = items.Count;
+
+            if (_ranges is not null && oldIndex != newIndex)
+            {
+                var selected = IndexRange.EnumerateIndices(_ranges)
+                    .ToList();
+                var moved = selected
+                    .Select(i => MoveIndex(i, oldIndex, newIndex, count))
+                    .OrderBy(i => i)
+                    .ToList();
+
+                if (!selected.SequenceEqual(moved))
+                {
+                    _ranges.Clear();
+
+                    foreach (var index in moved)
+                    {
+                        IndexRange.Add(_ranges, new IndexRange(index));
+                    }
+                }
+            }
+
+            return new CollectionChangeState
+            {
+                ShiftIndex = Math.Min(oldIndex, newIndex),
+                ShiftDelta = 0,
+            };
+        }
+
+        private protected static int MoveIndex(int index, int oldIndex, int newIndex, int count)
+        {
+            var oldEnd = oldIndex + count - 1;
+
+            if (index >= oldIndex && index <= oldEnd)
+            {
+                return newIndex + index - oldIndex;
+            }
+
+            if (newIndex > oldIndex)
+            {
+                return index > oldEnd && index <= newIndex ? index - count : index;
+            }
+
+            return index >= newIndex && index < oldIndex ? index + count : index;
         }
 
         private protected virtual bool IsValidCollectionChange(NotifyCollectionChangedEventArgs e)

--- a/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Multiple.cs
@@ -1290,23 +1290,61 @@ namespace Avalonia.Controls.UnitTests.Selection
 
                 target.SelectionChanged += (s, e) =>
                 {
-                    Assert.Empty(e.DeselectedIndexes);
-                    Assert.Equal(new[] { "bar" }, e.DeselectedItems);
-                    Assert.Empty(e.SelectedIndexes);
-                    Assert.Empty(e.SelectedItems);
                     ++selectionChangedRaised;
                 };
 
                 data.Move(1, 0);
 
-                Assert.Equal(2, target.SelectedIndex);
-                Assert.Equal(new[] { 2, 3, 4 }, target.SelectedIndexes);
-                Assert.Equal("baz", target.SelectedItem);
-                Assert.Equal(new[] { "baz", "qux", "quux" }, target.SelectedItems);
-                Assert.Equal(2, target.AnchorIndex);
-                Assert.Equal(1, selectionChangedRaised);
+                Assert.Equal(0, target.SelectedIndex);
+                Assert.Equal(new[] { 0, 2, 3, 4 }, target.SelectedIndexes);
+                Assert.Equal("bar", target.SelectedItem);
+                Assert.Equal(new[] { "bar", "baz", "qux", "quux" }, target.SelectedItems);
+                Assert.Equal(0, target.AnchorIndex);
+                Assert.Equal(0, selectionChangedRaised);
                 Assert.Equal(1, selectedIndexRaised);
-                Assert.Equal(1, selectedItemRaised);
+                Assert.Equal(0, selectedItemRaised);
+                Assert.Equal(0, indexesChangedRaised);
+            }
+
+            [Fact]
+            public void Moving_Selected_Item_Later_Updates_State()
+            {
+                var target = CreateTarget();
+                var data = (AvaloniaList<string>)target.Source!;
+                var selectionChangedRaised = 0;
+                var selectedIndexRaised = 0;
+                var selectedItemRaised = 0;
+                var indexesChangedRaised = 0;
+
+                target.Source = data;
+                target.SelectRange(1, 4);
+
+                target.PropertyChanged += (s, e) =>
+                {
+                    if (e.PropertyName == nameof(target.SelectedIndex))
+                    {
+                        ++selectedIndexRaised;
+                    }
+
+                    if (e.PropertyName == nameof(target.SelectedItem))
+                    {
+                        ++selectedItemRaised;
+                    }
+                };
+
+                target.IndexesChanged += (s, e) => ++indexesChangedRaised;
+                target.SelectionChanged += (s, e) => ++selectionChangedRaised;
+
+                data.Move(1, 5);
+
+                Assert.Equal(5, target.SelectedIndex);
+                Assert.Equal(new[] { 1, 2, 3, 5 }, target.SelectedIndexes);
+                Assert.Equal("bar", target.SelectedItem);
+                Assert.Equal(new[] { "baz", "qux", "quux", "bar" }, target.SelectedItems);
+                Assert.Equal(5, target.AnchorIndex);
+                Assert.Equal(0, selectionChangedRaised);
+                Assert.Equal(1, selectedIndexRaised);
+                Assert.Equal(0, selectedItemRaised);
                 Assert.Equal(0, indexesChangedRaised);
             }
 

--- a/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Single.cs
+++ b/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Single.cs
@@ -1170,23 +1170,58 @@ namespace Avalonia.Controls.UnitTests.Selection
 
                 target.SelectionChanged += (s, e) =>
                 {
-                    Assert.Empty(e.DeselectedIndexes);
-                    Assert.Equal(new[] { "bar" }, e.DeselectedItems);
-                    Assert.Empty(e.SelectedIndexes);
-                    Assert.Empty(e.SelectedItems);
                     ++selectionChangedRaised;
                 };
 
                 data.Move(1, 0);
 
-                Assert.Equal(-1, target.SelectedIndex);
-                Assert.Empty(target.SelectedIndexes);
-                Assert.Null(target.SelectedItem);
-                Assert.Empty(target.SelectedItems);
-                Assert.Equal(-1, target.AnchorIndex);
-                Assert.Equal(1, selectionChangedRaised);
+                Assert.Equal(0, target.SelectedIndex);
+                Assert.Equal(new[] { 0 }, target.SelectedIndexes);
+                Assert.Equal("bar", target.SelectedItem);
+                Assert.Equal(new[] { "bar" }, target.SelectedItems);
+                Assert.Equal(0, target.AnchorIndex);
+                Assert.Equal(0, selectionChangedRaised);
                 Assert.Equal(1, selectedIndexRaised);
-                Assert.Equal(1, selectedItemRaised);
+                Assert.Equal(0, selectedItemRaised);
+            }
+
+            [Fact]
+            public void Moving_Selected_Item_Later_Updates_State()
+            {
+                var target = CreateTarget();
+                var data = (AvaloniaList<string>)target.Source!;
+                var selectionChangedRaised = 0;
+                var selectedIndexRaised = 0;
+                var selectedItemRaised = 0;
+
+                target.Source = data;
+                target.Select(1);
+
+                target.PropertyChanged += (s, e) =>
+                {
+                    if (e.PropertyName == nameof(target.SelectedIndex))
+                    {
+                        ++selectedIndexRaised;
+                    }
+
+                    if (e.PropertyName == nameof(target.SelectedItem))
+                    {
+                        ++selectedItemRaised;
+                    }
+                };
+
+                target.SelectionChanged += (s, e) => ++selectionChangedRaised;
+
+                data.Move(1, 2);
+
+                Assert.Equal(2, target.SelectedIndex);
+                Assert.Equal(new[] { 2 }, target.SelectedIndexes);
+                Assert.Equal("bar", target.SelectedItem);
+                Assert.Equal(new[] { "bar" }, target.SelectedItems);
+                Assert.Equal(2, target.AnchorIndex);
+                Assert.Equal(0, selectionChangedRaised);
+                Assert.Equal(1, selectedIndexRaised);
+                Assert.Equal(0, selectedItemRaised);
             }
 
             [Fact]


### PR DESCRIPTION
Fixes #17819.

## Summary
- Treat source collection `Move` notifications as index remaps instead of remove/add.
- Preserve selection, anchor, and selected item identity when a selected source item is moved.
- Avoid raising a false `SelectedItem` change when the selected item stays the same.

## Tests
- `dotnet build tests\Avalonia.Controls.UnitTests\Avalonia.Controls.UnitTests.csproj --no-restore`
- `tests\Avalonia.Controls.UnitTests\bin\Debug\net10.0\Avalonia.Controls.UnitTests.exe --filter-method Avalonia.Controls.UnitTests.Selection.SelectionModelTests_Single+CollectionChanges.Moving_Selected_Item_Updates_State --filter-method Avalonia.Controls.UnitTests.Selection.SelectionModelTests_Single+CollectionChanges.Moving_Selected_Item_Later_Updates_State --filter-method Avalonia.Controls.UnitTests.Selection.SelectionModelTests_Multiple+CollectionChanges.Moving_Selected_Item_Updates_State --filter-method Avalonia.Controls.UnitTests.Selection.SelectionModelTests_Multiple+CollectionChanges.Moving_Selected_Item_Later_Updates_State`
- `tests\Avalonia.Controls.UnitTests\bin\Debug\net10.0\Avalonia.Controls.UnitTests.exe --filter-namespace Avalonia.Controls.UnitTests.Selection`
- `dotnet build src\Avalonia.Controls\Avalonia.Controls.csproj --no-restore`
- `git diff --check`