### PR TITLE
Listen to layout changes for ancestor visuals in text selection canvas

### DIFF
--- a/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
+++ b/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
@@ -5,9 +5,12 @@ using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives.PopupPositioning;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Layout;
 using Avalonia.Media.TextFormatting;
+using Avalonia.Reactive;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using static Avalonia.Reactive.Disposable;
 
 namespace Avalonia.Controls.Primitives
 {
@@ -98,8 +101,15 @@ namespace Avalonia.Controls.Primitives
 
         private void LayoutListener_Invalidated(object? sender, EventArgs e)
         {
+            InvalidateMeasure();
+        }
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
             if (ShowHandles)
                 MoveHandlesToSelection();
+
+            return base.MeasureOverride(availableSize);
         }
 
         private void Caret_ContextCanceled(object? sender, RoutedEventArgs e)
@@ -610,15 +620,48 @@ namespace Avalonia.Controls.Primitives
             private TextPresenter? _presenter;
 
             public event EventHandler? Invalidated;
+            
+            private CompositeDisposable? _disposables;
 
             public void Attach(TextPresenter presenter)
             {
                 if (_presenter != null)
                     throw new InvalidOperationException("Listener is already attached to a TextPresenter");
 
+                _disposables?.Dispose();
+                _disposables = new CompositeDisposable();
                 _presenter = presenter;
-                presenter.SizeChanged += Presenter_SizeChanged;
-                presenter.EffectiveViewportChanged += Visual_EffectiveViewportChanged;
+
+                Visual? current = presenter;
+                do
+                {
+                    AttachEvents(current);
+                    current = current?.VisualParent;
+                }
+                while (current != null);
+            }
+
+            private void AttachEvents(Visual? visual)
+            {
+                if (visual != null)
+                {
+                    if (visual is Layoutable layoutable)
+                    {
+                        layoutable.EffectiveViewportChanged += Visual_EffectiveViewportChanged;
+                        _disposables?.Add(new AnonymousDisposable(() =>
+                        {
+                            layoutable.EffectiveViewportChanged -= Visual_EffectiveViewportChanged;
+                        }));
+                    }
+                    if (visual is Control control)
+                    {
+                        control.SizeChanged += Visual_SizeChanged;
+                        _disposables?.Add(new AnonymousDisposable(() =>
+                        {
+                            control.SizeChanged -= Visual_SizeChanged;
+                        }));
+                    }
+                }
             }
 
             private void Visual_EffectiveViewportChanged(object? sender, Layout.EffectiveViewportChangedEventArgs e)
@@ -626,18 +669,15 @@ namespace Avalonia.Controls.Primitives
                 OnInvalidated();
             }
 
-            private void Presenter_SizeChanged(object? sender, SizeChangedEventArgs e)
+            private void Visual_SizeChanged(object? sender, SizeChangedEventArgs e)
             {
                 OnInvalidated();
             }
 
             public void Detach()
             {
-                if (_presenter is { } presenter)
-                {
-                    presenter.SizeChanged -= Presenter_SizeChanged;
-                    presenter.EffectiveViewportChanged -= Visual_EffectiveViewportChanged;
-                }
+                _disposables?.Dispose();
+                _disposables = null;
 
                 _presenter = null;
             }

--- a/tests/Avalonia.Controls.UnitTests/TextSelectionCanvasTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextSelectionCanvasTests.cs
@@ -1,0 +1,152 @@
+﻿using System.Linq;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Harfbuzz;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Platform;
+using Avalonia.UnitTests;
+using Avalonia.VisualTree;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests
+{
+    public class TextSelectionCanvasTests : ScopedTestBase
+    {
+        [Fact]
+        public void Text_Selection_Handle_Moves_With_Scrolling()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var touchHelper = new TouchTestHelper();
+                Border rootBorder = new Border()
+                {
+                    Width = 200,
+                    Height = 600
+                };
+                var visualLayerManager = new VisualLayerManager()
+                {
+                    Child = rootBorder,
+                    EnableTextSelectorLayer = true
+                };
+                var impl = CreateMockTopLevelImpl();
+                var topLevel = new TestTopLevel(impl.Object)
+                {
+                    Template = CreateTopLevelTemplate(),
+                    Content = visualLayerManager
+                };
+
+                var focusedTextBox = CreateTextBox();
+
+                var panel = new StackPanel()
+                {
+                    Orientation = Layout.Orientation.Vertical,
+                    Spacing = 20,
+                    Children =
+                    {
+                        focusedTextBox,
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                        CreateTextBox(),
+                    }
+                };
+
+                var scrollViewer = new ScrollViewer
+                {
+                    Template = new FuncControlTemplate<ScrollViewer>(ScrollViewerTests.CreateTemplate),
+                    Content = panel
+                };
+
+                rootBorder.Child = scrollViewer;
+
+                topLevel.LayoutManager.ExecuteInitialLayoutPass();
+
+                touchHelper.Tap(focusedTextBox);
+
+                topLevel.LayoutManager.ExecuteLayoutPass();
+
+                var presenter = focusedTextBox.FindDescendantOfType<TextPresenter>()!;
+                var canvas = presenter.TextSelectionHandleCanvas;
+
+                Assert.NotNull(canvas);
+
+                var handle = canvas.Children.FirstOrDefault() as TextSelectionHandle;
+
+                Assert.NotNull(handle);
+
+                Assert.Equal(new Point(25.5, 14.5), handle.GetTopLeft());
+
+                scrollViewer.Offset = new Vector(0, 50);
+
+                topLevel.LayoutManager.ExecuteLayoutPass();
+
+                Assert.Equal(new Point(25.5, -35.5), handle.GetTopLeft());
+            }
+
+            TextBox CreateTextBox()
+            {
+                return new TextBox
+                {
+                    Template = TextBoxTests.CreateTemplate(),
+                    Text = "Test",
+                    Width = 150
+                };
+            }
+        }
+
+        private class TestTopLevel(ITopLevelImpl impl) : TopLevel(impl)
+        {
+
+        }
+
+        static Mock<ITopLevelImpl> CreateMockTopLevelImpl()
+        {
+            var topLevel = new Mock<ITopLevelImpl>();
+            topLevel.Setup(x => x.RenderScaling).Returns(1);
+            topLevel.Setup(x => x.Compositor).Returns(RendererMocks.CreateDummyCompositor());
+            return topLevel;
+        }
+
+        private static FuncControlTemplate<TestTopLevel> CreateTopLevelTemplate()
+        {
+            return new FuncControlTemplate<TestTopLevel>((x, scope) =>
+                new ContentPresenter
+                {
+                    Name = "PART_ContentPresenter",
+                    [!ContentPresenter.ContentProperty] = x[!ContentControl.ContentProperty],
+                }.RegisterInNameScope(scope));
+        }
+
+        private static TestServices Services => TestServices.MockThreadingInterface.With(
+            standardCursorFactory: Mock.Of<ICursorFactory>(),
+            renderInterface: new HeadlessPlatformRenderInterface(),
+            textShaperImpl: new HarfBuzzTextShaper(),
+            fontManagerImpl: new TestFontManager(),
+            keyboardDevice: () => new KeyboardDevice(),
+            keyboardNavigation: () => new KeyboardNavigationHandler(),
+            inputManager: new InputManager(),
+            assetLoader: new StandardAssetLoader());
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Add event handlers for all visual ancestors of the `TextPresenter` that an active text selection canvas is attached to. This ensures that any layout changes, irrespective of the viewport, is sent to the canvas.


## What is the current behavior?
`TextSelectionCanvas` listens to the `EffectiveViewportChanged` event of the presenter its attached to.  The issue with this event is it only raises a change when the position in the closest viewport changes. With `TextBox` having a  scrollviewer in its template, the viewport becomes the scrollviewer for the presenter. In most cases where there's another scrollviewer hosting the textbox, the viewport changed event won't be raised. This is expected behavior to my knowledge, and thus just listening to the presenter's event won't be sufficient to ensure the canvas tracks the textbox in the visual root.

As such, we add listeners to each visual ancestor when attached and remove the listeners when detached.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
