### PR TITLE
Map macOS ListItem accessibility peer to AXRow

### DIFF
--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -96,7 +96,7 @@
         case AutomationEdit: return NSAccessibilityTextFieldRole;
         case AutomationHyperlink: return NSAccessibilityLinkRole;
         case AutomationImage: return NSAccessibilityImageRole;
-        case AutomationListItem: return NSAccessibilityGroupRole;
+        case AutomationListItem: return NSAccessibilityRowRole;
         case AutomationList: return NSAccessibilityListRole;
         case AutomationMenu: return NSAccessibilityMenuBarRole;
         case AutomationMenuBar: return NSAccessibilityMenuBarRole;
@@ -141,6 +141,7 @@
     auto controlType = _peer->GetAutomationControlType();
     switch (controlType) {
         case AutomationList: return @"AXContentList";
+        case AutomationListItem: return NSAccessibilityTableRowSubrole;
     }
 
     auto landmarkType = _peer->GetLandmarkType();


### PR DESCRIPTION
## What does the pull request do?

Changes the macOS accessibility role reported for `ListItem` automation peers
(ListBoxItem and similar) from `AXGroup` to `AXRow`.

## What is the current behavior?

In `automation.mm`, `AutomationListItem` maps to `NSAccessibilityGroupRole`, so
every list item appears in the macOS accessibility tree as a plain `AXGroup`,
the same role used for generic panels and containers. VoiceOver and other
assistive clients cannot tell a list item apart from any other group.

## What is the updated/expected behavior with this PR?

`ListItem` peers now report `AXRow` with the `AXTableRow` subrole, matching how
AppKit exposes rows in list and table contexts, so list items are
distinguishable from generic containers in the accessibility tree.

## How was the solution implemented (if it's not obvious)?

Two lines in `native/Avalonia.Native/src/OSX/automation.mm`:
- `accessibilityRole`: `AutomationListItem` returns `NSAccessibilityRowRole`.
- `accessibilitySubrole`: `AutomationListItem` returns `NSAccessibilityTableRowSubrole`.

Verified with Xcode's Accessibility Inspector against the ListBox in
ControlCatalog: items previously reported as `AXGroup` now report `AXRow`.

## Breaking changes

None expected. The new role is more specific; clients that relied on list items
reporting `AXGroup` will need to adjust, but that was never the intended contract.