### PR TITLE
Support Value pattern on editable ComboBox automation peer

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/ComboBoxAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ComboBoxAutomationPeer.cs
@@ -22,19 +22,28 @@ namespace Avalonia.Automation.Peers
         public bool ShowsMenu => true;
         public void Collapse() => Owner.IsDropDownOpen = false;
         public void Expand() => Owner.IsDropDownOpen = true;
-        bool IValueProvider.IsReadOnly => true;
+        bool IValueProvider.IsReadOnly => !Owner.IsEditable;
 
         string? IValueProvider.Value
         {
             get
             {
+                if (Owner.IsEditable)
+                    return Owner.Text;
+
                 var selection = GetSelection();
                 return selection.Count == 1 ? selection[0].GetName() : null;
             }
         }
-        
-        void IValueProvider.SetValue(string? value) => throw new NotSupportedException();
-        
+
+        void IValueProvider.SetValue(string? value)
+        {
+            if (!Owner.IsEditable)
+                throw new InvalidOperationException("Cannot set the value of a non-editable ComboBox.");
+
+            Owner.SetCurrentValue(ComboBox.TextProperty, value);
+        }
+
         protected override AutomationControlType GetAutomationControlTypeCore()
         {
             return AutomationControlType.ComboBox;
@@ -68,6 +77,20 @@ namespace Avalonia.Automation.Peers
                     ExpandCollapsePatternIdentifiers.ExpandCollapseStateProperty,
                     ToState((bool)e.OldValue!),
                     ToState((bool)e.NewValue!));
+            }
+            else if (e.Property == ComboBox.TextProperty && Owner.IsEditable)
+            {
+                RaisePropertyChangedEvent(
+                    ValuePatternIdentifiers.ValueProperty,
+                    e.OldValue as string,
+                    e.NewValue as string);
+            }
+            else if (e.Property == ComboBox.IsEditableProperty)
+            {
+                RaisePropertyChangedEvent(
+                    ValuePatternIdentifiers.IsReadOnlyProperty,
+                    !(bool)e.OldValue!,
+                    !(bool)e.NewValue!);
             }
         }
 

--- a/src/Avalonia.Controls/Automation/Peers/ComboBoxAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ComboBoxAutomationPeer.cs
@@ -91,6 +91,9 @@ namespace Avalonia.Automation.Peers
                     ValuePatternIdentifiers.IsReadOnlyProperty,
                     !(bool)e.OldValue!,
                     !(bool)e.NewValue!);
+
+                // The Value pattern switches between SelectedItem name and Text when IsEditable changes.
+                RaisePropertyChangedEvent(ValuePatternIdentifiers.ValueProperty, null, null);
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/Automation/ComboBoxAutomationPeerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Automation/ComboBoxAutomationPeerTests.cs
@@ -1,0 +1,78 @@
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
+using Avalonia.Automation.Provider;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests.Automation;
+
+public class ComboBoxAutomationPeerTests : ScopedTestBase
+{
+    private static IValueProvider Value(ComboBox comboBox)
+        => Assert.IsAssignableFrom<IValueProvider>(ControlAutomationPeer.CreatePeerForElement(comboBox));
+
+    [Fact]
+    public void Non_Editable_ComboBox_Is_ReadOnly()
+    {
+        var provider = Value(new ComboBox());
+
+        Assert.True(provider.IsReadOnly);
+    }
+
+    [Fact]
+    public void Editable_ComboBox_Is_Not_ReadOnly()
+    {
+        var provider = Value(new ComboBox { IsEditable = true });
+
+        Assert.False(provider.IsReadOnly);
+    }
+
+    [Fact]
+    public void Value_Returns_Text_When_Editable()
+    {
+        var provider = Value(new ComboBox { IsEditable = true, Text = "hello" });
+
+        Assert.Equal("hello", provider.Value);
+    }
+
+    [Fact]
+    public void SetValue_Updates_Text_When_Editable()
+    {
+        var comboBox = new ComboBox { IsEditable = true };
+        var provider = Value(comboBox);
+
+        provider.SetValue("typed");
+
+        Assert.Equal("typed", comboBox.Text);
+        Assert.Equal("typed", provider.Value);
+    }
+
+    [Fact]
+    public void SetValue_Throws_When_Not_Editable()
+    {
+        var provider = Value(new ComboBox());
+
+        Assert.Throws<System.InvalidOperationException>(() => provider.SetValue("x"));
+    }
+
+    [Fact]
+    public void Text_Change_Raises_Value_PropertyChanged()
+    {
+        var comboBox = new ComboBox { IsEditable = true };
+        var peer = ControlAutomationPeer.CreatePeerForElement(comboBox);
+
+        var raised = 0;
+        peer.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == ValuePatternIdentifiers.ValueProperty)
+            {
+                Assert.Equal("abc", e.NewValue);
+                raised++;
+            }
+        };
+
+        comboBox.Text = "abc";
+
+        Assert.Equal(1, raised);
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Makes `ComboBoxAutomationPeer` expose the editable text through the Value pattern. Previously the peer hardcoded `IsReadOnly => true`, returned the selected item's name as `Value`, and threw from `SetValue`, so automation clients couldn't read or set the text of an editable ComboBox without reaching into the internal `PART_EditableTextBox` template part.

## What is the updated/expected behavior with this PR?

For an editable ComboBox (`IsEditable=true`): `IsReadOnly` is false, `Value` returns `Text`, and `SetValue` sets `Text`. Non-editable ComboBoxes are unchanged (read-only, value is the selected item name). `ValueProperty` change notifications fire when `Text` changes, and `IsReadOnlyProperty` when `IsEditable` changes. Verified on macOS through the AX bridge: `GetValue`/`SetValue` on the ComboBox element read and write the editable text, with no native change needed.

## How was the solution implemented (if it's not obvious)?

`IValueProvider` on the peer now branches on `Owner.IsEditable`, and `OwnerPropertyChanged` raises the value/read-only notifications. Six unit tests cover read-only state per editability, value get/set, the non-editable throw, and the change event.
