### PR TITLE
Enhance Roslyn-compiler visible metadata

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -41,7 +41,7 @@
 
   <!-- Include AvaloniaXaml and AvaloniaResource as a Roslyn-visible additional files -->
   <!-- This is necessary to use these files in source generators and other Roslyn-based extension -->
-  <Target Name="_InjectAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
+  <Target Name="_InjectAvaloniaAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
     <ItemGroup>
       <AdditionalFiles Include="@(AvaloniaXaml)" SourceItemGroup="AvaloniaXaml" />
       <AdditionalFiles Include="@(AvaloniaResource)" SourceItemGroup="AvaloniaResource" />

--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -39,6 +39,12 @@
                       Condition="'$(ApplicationIcon)' != ''" />
   </ItemGroup>
 
+  <Target Name="_InjectAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
+    <ItemGroup>
+      <AdditionalFiles Include="@(AvaloniaXaml)" SourceItemGroup="AvaloniaXaml" />
+    </ItemGroup>
+  </Target>
+
   <UsingTask TaskName="GenerateAvaloniaResourcesTask"
              AssemblyFile="$(AvaloniaBuildTasksLocation)"
              />

--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -42,6 +42,7 @@
   <Target Name="_InjectAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
     <ItemGroup>
       <AdditionalFiles Include="@(AvaloniaXaml)" SourceItemGroup="AvaloniaXaml" />
+      <AdditionalFiles Include="@(AvaloniaResource)" SourceItemGroup="AvaloniaResource" />
     </ItemGroup>
   </Target>
 

--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -39,6 +39,8 @@
                       Condition="'$(ApplicationIcon)' != ''" />
   </ItemGroup>
 
+  <!-- Include AvaloniaXaml and AvaloniaResource as a Roslyn-visible additional files -->
+  <!-- This is necessary to use these files in source generators and other Roslyn-based extension -->
   <Target Name="_InjectAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
     <ItemGroup>
       <AdditionalFiles Include="@(AvaloniaXaml)" SourceItemGroup="AvaloniaXaml" />

--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -44,7 +44,9 @@
   <Target Name="_InjectAvaloniaAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
     <ItemGroup>
       <AdditionalFiles Include="@(AvaloniaXaml)" SourceItemGroup="AvaloniaXaml" />
-      <AdditionalFiles Include="@(AvaloniaResource)" SourceItemGroup="AvaloniaResource" />
+      <_AvaloniaResourceOnly Include="@(AvaloniaResource)"
+                             Exclude="@(AvaloniaXaml)" />
+      <AdditionalFiles Include="@(_AvaloniaResourceOnly)" SourceItemGroup="AvaloniaResource" />
     </ItemGroup>
   </Target>
 

--- a/src/tools/Avalonia.Generators/Avalonia.Generators.props
+++ b/src/tools/Avalonia.Generators/Avalonia.Generators.props
@@ -9,7 +9,9 @@
     <AvaloniaNameGeneratorAttachDevTools Condition="'$(AvaloniaNameGeneratorAttachDevTools)' == ''">true</AvaloniaNameGeneratorAttachDevTools>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Mark AvaloniaXaml/AvaloniaResource metadata visible for the Roslyn-compiler -->
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="SourceItemGroup"/>
+    <!-- Mark Avalonia.Generators config properties visible for the Roslyn-compiler  -->
     <CompilerVisibleProperty Include="AvaloniaNameGeneratorIsEnabled" />
     <CompilerVisibleProperty Include="AvaloniaNameGeneratorBehavior" />
     <CompilerVisibleProperty Include="AvaloniaNameGeneratorDefaultFieldModifier" />
@@ -17,5 +19,9 @@
     <CompilerVisibleProperty Include="AvaloniaNameGeneratorFilterByNamespace" />
     <CompilerVisibleProperty Include="AvaloniaNameGeneratorViewFileNamingStrategy" />
     <CompilerVisibleProperty Include="AvaloniaNameGeneratorAttachDevTools"/>
+    <!-- Mark additional Avalonia properties that might be useful for the Roslyn-compiler -->
+    <CompilerVisibleProperty Include="AvaloniaUseCompiledBindingsByDefault" />
+    <CompilerVisibleProperty Include="AvaloniaMainPackageVersion" />
+    <CompilerVisibleProperty Include="AvaloniaPreviewerNetCoreToolPath" />
   </ItemGroup>
 </Project>

--- a/src/tools/Avalonia.Generators/Avalonia.Generators.props
+++ b/src/tools/Avalonia.Generators/Avalonia.Generators.props
@@ -18,9 +18,4 @@
     <CompilerVisibleProperty Include="AvaloniaNameGeneratorViewFileNamingStrategy" />
     <CompilerVisibleProperty Include="AvaloniaNameGeneratorAttachDevTools"/>
   </ItemGroup>
-  <Target Name="_InjectAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
-    <ItemGroup>
-      <AdditionalFiles Include="@(AvaloniaXaml)" SourceItemGroup="AvaloniaXaml" />
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
## What does the pull request do?

Currently defined `CompilerVisibleProperty`/`AdditionalFiles` were added for the `Avalonia.Generator ` only.
But since then, we started using some of these properties in other Roslyn-based extensions (IDE plugins, for example).
And there are several missing pieces:

- `AvaloniaResource` is not defined as part of `AdditionalFiles`. This PR adds it, with its own `SourceItemGroup="AvaloniaResource"`
- Several extra properties like `AvaloniaUseCompiledBindingsByDefault` and `AvaloniaMainPackageVersion` were not exposed to the compiler, not it is. 
