### PR TITLE
Make fullscreen reveal bar non-draggable

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
@@ -127,7 +127,7 @@
             <Panel Height="{TemplateBinding DefaultTitleBarHeight}"
                    VerticalAlignment="Top"
                    Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
-                   WindowDecorationProperties.ElementRole="TitleBar">
+                   WindowDecorationProperties.ElementRole="DecorationsElement">
               <TextBlock Text="{TemplateBinding Title}"
                          VerticalAlignment="Center"
                          Margin="12,0,0,0"


### PR DESCRIPTION
### What does the pull request do?

Marks the `FullscreenPopover` panel in `WindowDrawnDecorations` as `DecorationsElement` instead of `TitleBar`, so the fullscreen reveal bar is no longer registered as a window drag region.

### What is the current behavior?

In fullscreen, the normal title bar (`PART_TitleBar`) is collapsed, so the reveal bar is the only element with `ElementRole="TitleBar"`. Dragging its empty area starts `BeginMoveDrag` on the fullscreen window, moving it off the fullscreen rectangle and leaving the reveal bar / chrome in a broken state.

### What is the updated/expected behavior?

The reveal bar is part of the non-client chrome but is not a drag handle, so a fullscreen window can no longer be moved by dragging it. The caption buttons inside the popover keep their own roles (`FullScreenButton`, `CloseButton`) and remain fully functional.

### How was the solution implemented (if it's not obvious)?

One-line theme change in
`src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml`:

```diff
-                   WindowDecorationProperties.ElementRole="TitleBar">
+                   WindowDecorationProperties.ElementRole="DecorationsElement">
```

### Breaking changes

None. Behavioral change only: the fullscreen reveal bar is no longer a drag region (it should not have been one).

### Fixed issues

Fixes #21547