### PR TITLE
Add support for hover events on android

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaView.Input.cs
+++ b/src/Android/Avalonia.Android/AvaloniaView.Input.cs
@@ -27,7 +27,13 @@ namespace Avalonia.Android
 
         protected override bool DispatchHoverEvent(MotionEvent? e)
         {
-            return _accessHelper.DispatchHoverEvent(e!) || base.DispatchHoverEvent(e);
+            var res = _view.PointerHelper.DispatchMotionEvent(e, out var callBase);
+            if (res == false)
+                callBase = !_accessHelper.DispatchHoverEvent(e!) && callBase;
+
+            var baseResult = callBase && base.DispatchHoverEvent(e);
+
+            return res ?? baseResult;
         }
 
         protected override bool DispatchGenericPointerEvent(MotionEvent? e)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds support for handling hover events for pointers on Android. This allows stylus/pen inputs that have hover states, like the S-Pen to trigger PointerMove events.


## What is the current behavior?
Hover events do not raise PointerMove events for pen input.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
