### PR TITLE
Disable region dirty rect clipping by default

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -62,7 +62,7 @@ namespace Avalonia.Rendering.Composition.Server
             _overlays = new CompositionTargetOverlays(this);
             var platformRender = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
 
-            if (platformRender?.SupportsRegions == true && compositor.Options.UseRegionDirtyRectClipping != false)
+            if (platformRender?.SupportsRegions == true && compositor.Options.UseRegionDirtyRectClipping == true)
             {
                 var maxRects = compositor.Options.MaxDirtyRects ?? 8;
                 DirtyRects = maxRects <= 0


### PR DESCRIPTION
## What does the pull request do?
This PR disables `CompositionOptions.UseRegionDirtyRectClipping` by default.

It's been found to cause slowdowns in various scenarios, read https://github.com/AvaloniaUI/Avalonia/issues/21538#issuecomment-4679543248 for details.

Users on embedded systems might still want to turn it on, but users with actual GPUs should benefit from the setting being off by default.

This will be the new default in Avalonia 12.1.

## Fixed issues
 - Fixes #21538