### PR TITLE
Fix caption button background in dark mode

### DIFF
--- a/src/Avalonia.Themes.Fluent/Accents/FluentControlResources.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentControlResources.xaml
@@ -1651,7 +1651,7 @@
 
       <!-- BaseResources for WindowDrawnDecorations.xaml -->
       <SolidColorBrush x:Key="CaptionButtonForeground" Color="White" />
-      <SolidColorBrush x:Key="CaptionButtonBackground" Color="#ffe5e5e5" />
+      <SolidColorBrush x:Key="CaptionButtonBackground" Color="#ff1d170f" />
       <SolidColorBrush x:Key="CaptionButtonBorderBrush" Color="#ffcacaca" />
       <StaticResource x:Key="TitleBarBackgroundBrush" ResourceKey="SystemControlBackgroundAltHighBrush" />
     </ResourceDictionary>

--- a/src/Avalonia.Themes.Simple/Accents/Base.xaml
+++ b/src/Avalonia.Themes.Simple/Accents/Base.xaml
@@ -90,7 +90,7 @@
 
       <!-- BaseResources for WindowDrawnDecorations.xaml -->
       <SolidColorBrush x:Key="CaptionButtonForeground" Color="White" />
-      <SolidColorBrush x:Key="CaptionButtonBackground" Color="#ffe5e5e5" />
+      <SolidColorBrush x:Key="CaptionButtonBackground" Color="#ff1d170f" />
       <SolidColorBrush x:Key="CaptionButtonBorderBrush" Color="#ffcacaca" />
       <StaticResource x:Key="TitleBarBackgroundBrush" ResourceKey="ThemeBackgroundBrush" />
     </ResourceDictionary>


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the background of caption buttons (when `ExtendClientAreaToDecorationsHint` is enabled) on pointer over, in dark mode.

## What is the current behavior?
<img width="216" height="61" alt="image" src="https://github.com/user-attachments/assets/fe6f4af5-38ee-48a8-85d7-aef02ff34557" />


## What is the updated/expected behavior with this PR?
<img width="207" height="58" alt="image" src="https://github.com/user-attachments/assets/a0d97592-fdb6-470d-9730-f31fcbc59039" />


