### PR TITLE
Fix StackOverflow when a NaN offset is set on ScrollViewer

### DIFF
--- a/src/Avalonia.Controls/ScrollViewer.cs
+++ b/src/Avalonia.Controls/ScrollViewer.cs
@@ -696,6 +696,14 @@ namespace Avalonia.Controls
 
         private static double Clamp(double value, double min, double max)
         {
+            // A NaN offset must never survive. Offset is two-way coerced between the ScrollViewer and its
+            // ScrollContentPresenter; because NaN != NaN, a NaN offset never compares equal, so the
+            // coerce/raise cycle never converges and recurses until it overflows the stack (see #21444).
+            if (double.IsNaN(value))
+            {
+                return min;
+            }
+
             return (value < min) ? min : (value > max) ? max : value;
         }
 

--- a/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
@@ -45,6 +45,25 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Setting_Offset_To_NaN_Does_Not_Cause_Infinite_Coerce_Recursion()
+        {
+            var target = new ScrollViewer
+            {
+                Template = new FuncControlTemplate<ScrollViewer>(CreateTemplate),
+                Content = "Foo",
+                Extent = new Size(100, 100),
+                Viewport = new Size(10, 10),
+            };
+
+            InitializeScrollViewer(target);
+
+            target.Offset = new Vector(0, double.NaN);
+
+            Assert.False(double.IsNaN(target.Offset.X));
+            Assert.False(double.IsNaN(target.Offset.Y));
+        }
+
+        [Fact]
         public void Test_ScrollToHome()
         {
             var target = new ScrollViewer


### PR DESCRIPTION
## What does the pull request do?

Fixes a `StackOverflowException` (a hard, unrecoverable crash) that occurs when a `NaN` value reaches `ScrollViewer.Offset`. Related issue: #21444.

## What is the current behavior?

`ScrollViewer.Offset` and `ScrollContentPresenter.Offset` are a two-way *coerced* binding, and the property store decides whether a value "changed" using `EqualityComparer<Vector>.Default`. Because `NaN != NaN`, a `NaN` offset is reported as changed on every pass, so the coerce → raise → re-coerce cycle never converges and recurses until the stack overflows. `CoerceOffset`'s `Clamp` does not sanitize `NaN` (`NaN < min` and `NaN > max` are both `false`, so the `NaN` passes straight through).

This is unrecoverable, and on Mono/AOT targets (Android, iOS) it surfaces as a native `SIGSEGV` rather than a managed exception.

In practice the `NaN` originated from fast flinging: I originally reproduced it by scrolling the list **down quickly and then up quickly — two separate flick gestures performed in close succession**. That rapid direction reversal made the linear-velocity fallback in `VelocityTracker.GetVelocityEstimate()` divide by `duration.Milliseconds` (the 0–999 component, `0` on a quick flick) over a near-zero distance, i.e. `0 / 0 = NaN`, which then flowed into the scroll `Offset`. That fallback was removed in #20848. I verified on-device (Android) that the fast-flick no longer crashes current `master`, while the immediate pre-#20848 commit still crashes with the same native `SIGSEGV`/`SEGV_ACCERR` — so #20848 closed that particular trigger. However, the crash *mechanism* is unchanged on `master`: a `NaN` reaching `Offset` from any source (e.g. a programmatic `Offset` assignment) still never converges and overflows the stack, as the added test demonstrates.

## What is the updated/expected behavior with this PR?

A `NaN` offset component is coerced to the lower bound (0), so the two-way coerce always converges and the `ScrollViewer` no longer crashes.

To verify: run the added test `Setting_Offset_To_NaN_Does_Not_Cause_Infinite_Coerce_Recursion`. On `master` it crashes the test host with a stack overflow; with this change it passes.

## How was the solution implemented (if it's not obvious)?

Added a `double.IsNaN` guard at the start of `ScrollViewer.Clamp` (used by `CoerceOffset` for both axes) that returns the lower bound for a `NaN` input. This is the single choke point through which every offset value — programmatic, bound, or gesture-driven — must pass, so it closes the vulnerability at the source of truth.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21444
