### PR TITLE
fix duplicates in MacOS special character inputs

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -877,6 +877,19 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
             parent->InputMethod->Client->SelectInSurroundingText(start, end);
         }
     }
+    // If special character is selected with left/right arrow keys
+    // macOS reports NSNotFound instead of a replacement range.
+    // If there is a single marked character, select it so the committed
+    // character replaces the preview character.
+    // Only handle marked range of 1 character to avoid affecting IME.
+    if (replacementRange.location == NSNotFound &&
+    _markedRange.length == 1 &&
+    parent->InputMethod->IsActive())
+    {
+    int start = (int)_markedRange.location;
+    int end = start + 1;
+    parent->InputMethod->Client->SelectInSurroundingText(start, end);
+    }
 
     [self unmarkText];
         

--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -838,8 +838,9 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
         ![self hasMarkedText] &&
         parent->InputMethod->IsActive())
     {
-        int start;
-        int end;
+        int start = 0;
+        int end = 0;
+        bool shouldSelect = true;
 
         if (replacementRange.length > 0)
         {
@@ -857,7 +858,7 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
                 end = (int)(replacementRange.location + replacementRange.length) + 1;
             }
         }
-        
+
         // Special case for the first character. ReplacementRange for the first character
         // arrives as {0,0} instead of a replacement range, so explicitly
         // select it.
@@ -868,10 +869,13 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
         }
         else
         {
-            return;
+            shouldSelect = false;
         }
 
-        parent->InputMethod->Client->SelectInSurroundingText(start, end);
+        if (shouldSelect)
+        {
+            parent->InputMethod->Client->SelectInSurroundingText(start, end);
+        }
     }
 
     [self unmarkText];

--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -830,7 +830,50 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
     {
         text = (NSString*) string;
     }
-    
+
+    // If replacement range is provided for committed text input,
+    // select the corresponding surrounding text
+    // Skip this when marked text is active.
+    if (replacementRange.location != NSNotFound &&
+        ![self hasMarkedText] &&
+        parent->InputMethod->IsActive())
+    {
+        int start;
+        int end;
+
+        if (replacementRange.length > 0)
+        {
+            if (_selectedRange.length > 0)
+            {
+                start = (int)replacementRange.location;
+                end = (int)(replacementRange.location + replacementRange.length);
+            }
+
+            // ReplacementRange is reported one position behind,
+            // so adjust it.
+            else
+            {
+                start = (int)replacementRange.location + 1;
+                end = (int)(replacementRange.location + replacementRange.length) + 1;
+            }
+        }
+        
+        // Special case for the first character. ReplacementRange for the first character
+        // arrives as {0,0} instead of a replacement range, so explicitly
+        // select it.
+        else if (replacementRange.location == 0)
+        {
+            start = 0;
+            end = 1;
+        }
+        else
+        {
+            return;
+        }
+
+        parent->InputMethod->Client->SelectInSurroundingText(start, end);
+    }
+
     [self unmarkText];
         
     uint64_t timestamp = static_cast<uint64_t>([NSDate timeIntervalSinceReferenceDate] * 1000);


### PR DESCRIPTION
## What does the pull request do?
This pull request fixes a macOS-specific text input issue where selecting a letter and replacing it with a special character variant would insert the special character after the selection instead of replacing it.


## What is the current behavior?
When a letter is selected and replaced with a special character, the special character is inserted next to the selected letter instead of replacing it resulting in both characters appearing in the text.

<img width="457" height="186" alt="Screenshot 2026-06-12 at 13 41 19" src="https://github.com/user-attachments/assets/c7c23a47-b9c1-4464-9647-b9118409bf76" />
<img width="174" height="121" alt="Screenshot 2026-06-12 at 13 41 32" src="https://github.com/user-attachments/assets/20bf28a0-bc94-4b1b-b031-ee7d1e7cf275" />


## What is the updated/expected behavior with this PR?
Selected special character replaces the selected letter.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

