### PR TITLE
Enable stencil buffers by default + add configurable option

### DIFF
--- a/src/Skia/Avalonia.Skia/Gpu/Metal/SkiaMetalGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/Metal/SkiaMetalGpu.cs
@@ -15,11 +15,12 @@ internal class SkiaMetalGpu : ISkiaGpu
 
     internal GRContext GrContext => _context ?? throw new ObjectDisposedException(nameof(SkiaMetalGpu));
 
-    public SkiaMetalGpu(IMetalDevice device, long? maxResourceBytes)
+    public SkiaMetalGpu(IMetalDevice device, long? maxResourceBytes, bool? useStencilBuffers = null)
     {
+        var avoidStencilBuffers = useStencilBuffers == false;
         _context = GRContext.CreateMetal(
                        new GRMtlBackendContext { DeviceHandle = device.Device, QueueHandle = device.CommandQueue, },
-                       new GRContextOptions { AvoidStencilBuffers = true })
+                       new GRContextOptions { AvoidStencilBuffers = avoidStencilBuffers })
                    ?? throw new InvalidOperationException("Unable to create GRContext from Metal device.");
         _device = device;
         if (device.TryGetFeature<IMetalExternalObjectsFeature>() is { } externalObjects)

--- a/src/Skia/Avalonia.Skia/Gpu/OpenGl/GlSkiaGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/OpenGl/GlSkiaGpu.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Skia
         private bool? _canCreateSurfaces;
         private readonly IExternalObjectsRenderInterfaceContextFeature? _externalObjectsFeature;
 
-        public GlSkiaGpu(IGlContext context, long? maxResourceBytes)
+        public GlSkiaGpu(IGlContext context, long? maxResourceBytes, bool? useStencilBuffers)
         {
             _glContext = context;
             using (_glContext.EnsureCurrent())
@@ -40,7 +40,8 @@ namespace Avalonia.Skia
                 
                 using(iface)
                 {
-                    _grContext = GRContext.CreateGl(iface, new GRContextOptions { AvoidStencilBuffers = true });
+                    var avoidStencilBuffers = useStencilBuffers == false;
+                    _grContext = GRContext.CreateGl(iface, new GRContextOptions { AvoidStencilBuffers = avoidStencilBuffers });
                     if (maxResourceBytes.HasValue)
                     {
                         _grContext.SetResourceCacheLimit(maxResourceBytes.Value);

--- a/src/Skia/Avalonia.Skia/Gpu/Vulkan/VulkanSkiaGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/Vulkan/VulkanSkiaGpu.cs
@@ -13,7 +13,7 @@ internal class VulkanSkiaGpu : ISkiaGpu
     public IVulkanPlatformGraphicsContext Vulkan { get; private set; }
     public GRContext GrContext { get; private set; }
 
-    public VulkanSkiaGpu(IVulkanPlatformGraphicsContext vulkan, long? maxResourceBytes)
+    public VulkanSkiaGpu(IVulkanPlatformGraphicsContext vulkan, long? maxResourceBytes, bool? useStencilBuffers)
     {
         Vulkan = vulkan;
         var device = vulkan.Device;
@@ -48,7 +48,9 @@ internal class VulkanSkiaGpu : ISkiaGpu
                 GetProcedureAddress = GetProcAddressWrapper
             };
 
-            GrContext = GRContext.CreateVulkan(ctx) ??
+            var avoidStencilBuffers = useStencilBuffers == false;
+            
+            GrContext = GRContext.CreateVulkan(ctx, new GRContextOptions { AvoidStencilBuffers = avoidStencilBuffers }) ??
                          throw new VulkanException("Unable to create GrContext from IVulkanDevice");
             
             if (maxResourceBytes.HasValue)

--- a/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
+++ b/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
@@ -20,10 +20,12 @@ namespace Avalonia.Skia
     internal class PlatformRenderInterface : IPlatformRenderInterface
     {
         private readonly long? _maxResourceBytes;
+        private readonly bool? _useStencilBuffers;
 
-        public PlatformRenderInterface(long? maxResourceBytes = null)
+        public PlatformRenderInterface(long? maxResourceBytes = null, bool? useStencilBuffers = null)
         {
             _maxResourceBytes = maxResourceBytes;
+            _useStencilBuffers = useStencilBuffers;
             DefaultPixelFormat = SKImageInfo.PlatformColorType.ToPixelFormat();
         }
 
@@ -35,11 +37,11 @@ namespace Avalonia.Skia
             if (graphicsContext is ISkiaGpu skiaGpu)
                 return new SkiaContext(skiaGpu);
             if (graphicsContext is IGlContext gl)
-                return new SkiaContext(new GlSkiaGpu(gl, _maxResourceBytes));
+                return new SkiaContext(new GlSkiaGpu(gl, _maxResourceBytes, _useStencilBuffers));
             if (graphicsContext is IMetalDevice metal)
-                return new SkiaContext(new SkiaMetalGpu(metal, _maxResourceBytes));
+                return new SkiaContext(new SkiaMetalGpu(metal, _maxResourceBytes, _useStencilBuffers));
             if (graphicsContext is IVulkanPlatformGraphicsContext vulkanContext)
-                return new SkiaContext(new VulkanSkiaGpu(vulkanContext, _maxResourceBytes));
+                return new SkiaContext(new VulkanSkiaGpu(vulkanContext, _maxResourceBytes, _useStencilBuffers));
             throw new ArgumentException("Graphics context of type is not supported");
         }
 

--- a/src/Skia/Avalonia.Skia/SkiaOptions.cs
+++ b/src/Skia/Avalonia.Skia/SkiaOptions.cs
@@ -24,5 +24,11 @@ namespace Avalonia
         /// Enabling this might have performance implications.
         /// </remarks>
         public bool UseOpacitySaveLayer { get; set; } = false;
+        
+        /// <summary>
+        /// Gets whether stencil buffers can be used for various draw operations, improving performance.
+        /// If null (the default), Avalonia chooses whether to enable stencil buffers depending on the platform.
+        /// </summary>
+        public bool? UseStencilBuffers { get; set; }
     }
 }

--- a/src/Skia/Avalonia.Skia/SkiaPlatform.cs
+++ b/src/Skia/Avalonia.Skia/SkiaPlatform.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Skia
 
         public static void Initialize(SkiaOptions options)
         {
-            var renderInterface = new PlatformRenderInterface(options.MaxGpuResourceSizeBytes);
+            var renderInterface = new PlatformRenderInterface(options.MaxGpuResourceSizeBytes, options.UseStencilBuffers);
 
             AvaloniaLocator.CurrentMutable
                 .Bind<IPlatformRenderInterface>().ToConstant(renderInterface)


### PR DESCRIPTION
## What does the pull request do?
This PR introduces a new option `SkiaOptions.UseStencilBuffers` and enables it by default.

## What is the current behavior?
Stencil buffers were disabled on all platforms a long time ago, in #6896, due to issues on macOS.

## What is the updated/expected behavior with this PR?
Stencil buffers are enabled again. All platforms have been tested: Windows, macOS (both GL and Metal), X11, Android, iOS, and Browser. There is no visible clipping issue with Skia m119.

Clipping operations on GPUs should be faster, especially when `CompositionOptions.UseRegionDirtyRectClipping = true` (the sample in https://github.com/AvaloniaUI/Avalonia/issues/21538 goes from 70ms to 16ms render CPU time per frame).

This PR also adds a new option, `SkiaOptions.UseStencilBuffers`, so users can explicitly disable it without having to recompile Avalonia. The default is `null`, which means Avalonia chooses the best behavior depending on the platform (currently: enabled everywhere).