### PR TITLE
fix(TextBox): avoid read-only editing side effects in keyboard handlers

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1040,6 +1040,10 @@ namespace Avalonia.Controls
                 UpdatePseudoclasses();
                 UpdateCommandStates();
             }
+            else if (change.Property == IsReadOnlyProperty || change.Property == PasswordCharProperty)
+            {
+                UpdateCommandStates();
+            }
             else if (change.Property == CaretIndexProperty)
             {
                 OnCaretIndexChanged(change);
@@ -1373,7 +1377,7 @@ namespace Avalonia.Controls
             }
             else if (Match(keymap.Copy))
             {
-                if (!IsPasswordBox)
+                if (CanCopy)
                 {
                     Copy();
                 }
@@ -1382,7 +1386,7 @@ namespace Avalonia.Controls
             }
             else if (Match(keymap.Cut))
             {
-                if (!IsPasswordBox)
+                if (CanCut)
                 {
                     Cut();
                 }
@@ -1391,18 +1395,28 @@ namespace Avalonia.Controls
             }
             else if (Match(keymap.Paste))
             {
-                Paste();
+                if (CanPaste)
+                {
+                    Paste();
+                }
+
                 handled = true;
             }
             else if (Match(keymap.Undo) && IsUndoEnabled)
             {
-                Undo();
+                if (!IsReadOnly)
+                {
+                    Undo();
+                }
 
                 handled = true;
             }
             else if (Match(keymap.Redo) && IsUndoEnabled)
             {
-                Redo();
+                if (!IsReadOnly)
+                {
+                    Redo();
+                }
 
                 handled = true;
             }
@@ -1546,6 +1560,7 @@ namespace Avalonia.Controls
                         break;
 
                     case Key.Back:
+                        if (!IsReadOnly)
                         {
                             SnapshotUndoRedo();
 
@@ -1591,38 +1606,42 @@ namespace Avalonia.Controls
                             }
 
                             SnapshotUndoRedo();
-
-                            handled = true;
-                            break;
                         }
+
+                        handled = true;
+                        break;
+
                     case Key.Delete:
-                        SnapshotUndoRedo();
-
-                        if (hasWholeWordModifiers && SelectionStart == SelectionEnd)
+                        if (!IsReadOnly)
                         {
-                            SetSelectionForControlDelete();
-                        }
+                            SnapshotUndoRedo();
 
-                        if (!DeleteSelection())
-                        {
-                            var characterHit = _presenter.GetNextCharacterHit();
-
-                            var nextPosition = characterHit.FirstCharacterIndex + characterHit.TrailingLength;
-
-                            if (nextPosition != caretIndex)
+                            if (hasWholeWordModifiers && SelectionStart == SelectionEnd)
                             {
-                                var start = Math.Min(nextPosition, caretIndex);
-                                var end = Math.Max(nextPosition, caretIndex);
-
-                                var sb = StringBuilderCache.Acquire(text.Length);
-                                sb.Append(text);
-                                sb.Remove(start, end - start);
-
-                                SetCurrentValue(TextProperty, StringBuilderCache.GetStringAndRelease(sb));
+                                SetSelectionForControlDelete();
                             }
-                        }
 
-                        SnapshotUndoRedo();
+                            if (!DeleteSelection())
+                            {
+                                var characterHit = _presenter.GetNextCharacterHit();
+
+                                var nextPosition = characterHit.FirstCharacterIndex + characterHit.TrailingLength;
+
+                                if (nextPosition != caretIndex)
+                                {
+                                    var start = Math.Min(nextPosition, caretIndex);
+                                    var end = Math.Max(nextPosition, caretIndex);
+
+                                    var sb = StringBuilderCache.Acquire(text.Length);
+                                    sb.Append(text);
+                                    sb.Remove(start, end - start);
+
+                                    SetCurrentValue(TextProperty, StringBuilderCache.GetStringAndRelease(sb));
+                                }
+                            }
+
+                            SnapshotUndoRedo();
+                        }
 
                         handled = true;
                         break;
@@ -1630,8 +1649,12 @@ namespace Avalonia.Controls
                     case Key.Enter:
                         if (AcceptsReturn)
                         {
-                            SnapshotUndoRedo();
-                            HandleTextInput(NewLine);
+                            if (!IsReadOnly)
+                            {
+                                SnapshotUndoRedo();
+                                HandleTextInput(NewLine);
+                            }
+
                             handled = true;
                         }
 
@@ -1640,8 +1663,12 @@ namespace Avalonia.Controls
                     case Key.Tab:
                         if (AcceptsTab)
                         {
-                            SnapshotUndoRedo();
-                            HandleTextInput("\t");
+                            if (!IsReadOnly)
+                            {
+                                SnapshotUndoRedo();
+                                HandleTextInput("\t");
+                            }
+
                             handled = true;
                         }
                         else
@@ -1652,7 +1679,10 @@ namespace Avalonia.Controls
                         break;
 
                     case Key.Space:
-                        SnapshotUndoRedo(); // always snapshot in between words
+                        if (!IsReadOnly)
+                        {
+                            SnapshotUndoRedo(); // always snapshot in between words
+                        }
                         break;
 
                     default:

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -1483,6 +1483,117 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Command_States_Update_When_ReadOnly_And_PasswordChar_Change()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "1234",
+                    SelectionStart = 1,
+                    SelectionEnd = 3,
+                };
+
+                tb.Measure(Size.Infinity);
+
+                Assert.True(tb.CanCopy);
+                Assert.True(tb.CanCut);
+                Assert.True(tb.CanPaste);
+
+                tb.IsReadOnly = true;
+
+                Assert.True(tb.CanCopy);
+                Assert.False(tb.CanCut);
+                Assert.False(tb.CanPaste);
+
+                tb.PasswordChar = '*';
+
+                Assert.False(tb.CanCopy);
+                Assert.False(tb.CanCut);
+                Assert.False(tb.CanPaste);
+
+                tb.IsReadOnly = false;
+
+                Assert.False(tb.CanCopy);
+                Assert.False(tb.CanCut);
+                Assert.True(tb.CanPaste);
+
+                tb.PasswordChar = default;
+
+                Assert.True(tb.CanCopy);
+                Assert.True(tb.CanCut);
+                Assert.True(tb.CanPaste);
+            }
+        }
+
+        [Fact]
+        public void ReadOnly_Editing_Hotkeys_Do_Not_Modify_Text_Or_Undo_State()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    AcceptsReturn = true,
+                    AcceptsTab = true,
+                };
+
+                tb.Measure(Size.Infinity);
+
+                RaiseTextEvent(tb, "ABC");
+                RaiseKeyEvent(tb, Key.Space, KeyModifiers.None);
+                RaiseTextEvent(tb, "DEF");
+
+                Assert.Equal("ABCDEF", tb.Text);
+
+                tb.Undo();
+
+                Assert.Equal("ABC", tb.Text);
+                Assert.True(tb.CanUndo);
+                Assert.True(tb.CanRedo);
+
+                tb.IsReadOnly = true;
+                tb.CaretIndex = tb.Text!.Length;
+                tb.SelectionStart = 0;
+                tb.SelectionEnd = tb.Text.Length;
+
+                var originalText = tb.Text;
+                var originalCaretIndex = tb.CaretIndex;
+                var originalSelectionStart = tb.SelectionStart;
+                var originalSelectionEnd = tb.SelectionEnd;
+                var originalCanUndo = tb.CanUndo;
+                var originalCanRedo = tb.CanRedo;
+
+                var cutRaised = 0;
+                var pasteRaised = 0;
+                tb.CuttingToClipboard += (_, _) => cutRaised++;
+                tb.PastingFromClipboard += (_, _) => pasteRaised++;
+
+                AssertReadOnlyHotkeyLeavesStateUntouched(tb, Application.Current!.PlatformSettings!.HotkeyConfiguration.Cut, handled: true);
+                AssertReadOnlyHotkeyLeavesStateUntouched(tb, Application.Current.PlatformSettings.HotkeyConfiguration.Paste, handled: true);
+                AssertReadOnlyHotkeyLeavesStateUntouched(tb, Application.Current.PlatformSettings.HotkeyConfiguration.Undo, handled: true);
+                AssertReadOnlyHotkeyLeavesStateUntouched(tb, Application.Current.PlatformSettings.HotkeyConfiguration.Redo, handled: true);
+                AssertReadOnlyHotkeyLeavesStateUntouched(tb, Key.Back, KeyModifiers.None, handled: true);
+                AssertReadOnlyHotkeyLeavesStateUntouched(tb, Key.Back, KeyModifiers.Control, handled: true);
+                AssertReadOnlyHotkeyLeavesStateUntouched(tb, Key.Delete, KeyModifiers.None, handled: true);
+                AssertReadOnlyHotkeyLeavesStateUntouched(tb, Key.Delete, KeyModifiers.Control, handled: true);
+                AssertReadOnlyHotkeyLeavesStateUntouched(tb, Key.Enter, KeyModifiers.None, handled: true);
+                AssertReadOnlyHotkeyLeavesStateUntouched(tb, Key.Tab, KeyModifiers.None, handled: true);
+                AssertReadOnlyHotkeyLeavesStateUntouched(tb, Key.Space, KeyModifiers.None, handled: false);
+
+                Assert.Equal(originalText, tb.Text);
+                Assert.Equal(originalCaretIndex, tb.CaretIndex);
+                Assert.Equal(originalSelectionStart, tb.SelectionStart);
+                Assert.Equal(originalSelectionEnd, tb.SelectionEnd);
+                Assert.Equal(originalCanUndo, tb.CanUndo);
+                Assert.Equal(originalCanRedo, tb.CanRedo);
+                Assert.Equal(0, cutRaised);
+                Assert.Equal(0, pasteRaised);
+            }
+        }
+
+        [Fact]
         public void UndoLimit_Count_Is_Respected()
         {
             using (UnitTestApplication.Start(Services))
@@ -2247,14 +2358,52 @@ namespace Avalonia.Controls.UnitTests
             }.RegisterInNameScope(scope));
         }
 
-        private static void RaiseKeyEvent(TextBox textBox, Key key, KeyModifiers inputModifiers)
+        private static void AssertReadOnlyHotkeyLeavesStateUntouched(
+            TextBox textBox,
+            IReadOnlyList<KeyGesture> gestures,
+            bool handled)
         {
-            textBox.RaiseEvent(new KeyEventArgs
+            Assert.NotEmpty(gestures);
+            var gesture = gestures[0];
+            AssertReadOnlyHotkeyLeavesStateUntouched(textBox, gesture.Key, gesture.KeyModifiers, handled);
+        }
+
+        private static void AssertReadOnlyHotkeyLeavesStateUntouched(
+            TextBox textBox,
+            Key key,
+            KeyModifiers inputModifiers,
+            bool handled)
+        {
+            var originalText = textBox.Text;
+            var originalCaretIndex = textBox.CaretIndex;
+            var originalSelectionStart = textBox.SelectionStart;
+            var originalSelectionEnd = textBox.SelectionEnd;
+            var originalCanUndo = textBox.CanUndo;
+            var originalCanRedo = textBox.CanRedo;
+
+            var args = RaiseKeyEvent(textBox, key, inputModifiers);
+
+            Assert.Equal(handled, args.Handled);
+            Assert.Equal(originalText, textBox.Text);
+            Assert.Equal(originalCaretIndex, textBox.CaretIndex);
+            Assert.Equal(originalSelectionStart, textBox.SelectionStart);
+            Assert.Equal(originalSelectionEnd, textBox.SelectionEnd);
+            Assert.Equal(originalCanUndo, textBox.CanUndo);
+            Assert.Equal(originalCanRedo, textBox.CanRedo);
+        }
+
+        private static KeyEventArgs RaiseKeyEvent(TextBox textBox, Key key, KeyModifiers inputModifiers)
+        {
+            var args = new KeyEventArgs
             {
                 RoutedEvent = InputElement.KeyDownEvent,
                 KeyModifiers = inputModifiers,
                 Key = key
-            });
+            };
+
+            textBox.RaiseEvent(args);
+
+            return args;
         }
 
         private static void RaiseTextEvent(TextBox textBox, string text)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adjust TextBox keyboard handling so read-only text boxes still consume editing hotkeys without triggering edit side effects.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
- use `CanCopy`, `CanCut`, and `CanPaste` in keyboard command handling
- refresh command states when `IsReadOnly` or `PasswordChar` changes
- prevent `Undo`, `Redo`, `Backspace`, `Delete`, `Enter`, `Tab`, and `Space` key handling from mutating undo/redo state in read-only mode
- keep read-only editing hotkeys handled by `TextBox` to avoid bubbling to parent/global handlers


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes #21583 
