### PR TITLE
Fix ClipboardUriListHelper not flushing

### DIFF
--- a/src/Avalonia.X11/Clipboard/ClipboardUriListHelper.cs
+++ b/src/Avalonia.X11/Clipboard/ClipboardUriListHelper.cs
@@ -47,6 +47,8 @@ internal static class ClipboardUriListHelper
         foreach (var item in items)
             writer.WriteLine(item.Path.AbsoluteUri);
 
+        writer.Flush();
+
         return stream.ToArray();
     }
 }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes `ClipboardUriListHelper.FileUriListToUtf8Bytes`, which was missing a `Flush` call, resulting in an incomplete list.
(The fix is already present in #20926).
