### PR TITLE
Fix WinUiCompositorConnection deadlock

### DIFF
--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositorConnection.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositorConnection.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Avalonia.Platform;
 using Avalonia.Platform.Surfaces;
 using Avalonia.Logging;
 using Avalonia.MicroCom;
@@ -20,6 +19,7 @@ internal class WinUiCompositorConnection : IRenderTimer, Win32.IWindowsSurfaceFa
     private readonly AutoResetEvent _wakeEvent = new(false);
     private volatile bool _stopped = true;
     private volatile Action<TimeSpan>? _tick;
+
     public bool RunsInBackground => true;
 
     public Action<TimeSpan>? Tick
@@ -40,7 +40,7 @@ internal class WinUiCompositorConnection : IRenderTimer, Win32.IWindowsSurfaceFa
             }
         }
     }
-    
+
     public WinUiCompositorConnection()
     {
         using var compositor = NativeWinRTMethods.CreateInstance<ICompositor>("Windows.UI.Composition.Compositor");
@@ -59,7 +59,7 @@ internal class WinUiCompositorConnection : IRenderTimer, Win32.IWindowsSurfaceFa
         void* texture = null;
         surfInterop.BeginDraw(null, &IID_ID3D11Texture2D, &texture);
         */
-        
+
         _shared = new WinUiCompositionShared(compositor);
     }
 
@@ -106,26 +106,45 @@ internal class WinUiCompositorConnection : IRenderTimer, Win32.IWindowsSurfaceFa
         private readonly Stopwatch _st = Stopwatch.StartNew();
         private TimeSpan? _commitDueAt;
         private IAsyncAction? _currentCommit;
+        private bool _commitCompleted;
+
         public RunLoopHandler(WinUiCompositorConnection parent)
         {
             _parent = parent;
         }
 
         public void Invoke(IAsyncAction? asyncInfo, AsyncStatus asyncStatus)
-        { 
-            if (_currentCommit == null ||
-              _currentCommit.GetNativeIntPtr() != asyncInfo.GetNativeIntPtr())
-                return;
-            OnCommitCompleted();
+        {
+            lock (_parent._shared.SyncRoot)
+            {
+                if (_currentCommit == null || _currentCommit.GetNativeIntPtr() != asyncInfo.GetNativeIntPtr())
+                    return;
+                OnCommitCompleted();
+            }
         }
-        
+
         private void OnCommitCompleted()
         {
+            Debug.Assert(Monitor.IsEntered(_parent._shared.SyncRoot), "Lock should be held");
+
             _currentCommit?.Dispose();
             _currentCommit = null;
             _parent._tick?.Invoke(_st.Elapsed);
             // Always schedule a commit so the current frame's work reaches DWM.
             ScheduleNextCommit();
+            _commitCompleted = true;
+        }
+
+        // This method should be called outside the shared lock, as it might wait for a long time.
+        public void OnAfterMessageWithoutLock()
+        {
+            Debug.Assert(!Monitor.IsEntered(_parent._shared.SyncRoot), "Lock should NOT be held");
+
+            if (!_commitCompleted)
+                return;
+
+            _commitCompleted = false;
+
             if (_parent._stopped)
             {
                 _parent._wakeEvent.WaitOne();
@@ -137,40 +156,47 @@ internal class WinUiCompositorConnection : IRenderTimer, Win32.IWindowsSurfaceFa
 
         private void ScheduleNextCommit()
         {
-            lock (_parent._shared.SyncRoot)
-            {
-                _commitDueAt = _st.Elapsed + TimeSpan.FromSeconds(1);
-                _currentCommit = _parent._shared.Compositor5.RequestCommitAsync();
-                _currentCommit.SetCompleted(this);
-            }
+            Debug.Assert(Monitor.IsEntered(_parent._shared.SyncRoot), "Lock should be held");
+
+            _commitDueAt = _st.Elapsed + TimeSpan.FromSeconds(1);
+            _currentCommit = _parent._shared.Compositor5.RequestCommitAsync();
+            _currentCommit.SetCompleted(this);
         }
 
         public void WatchDog()
         {
-            // This is a workaround for a nasty WinUI composition API bug that prevents
-            // RequestCommitAsync to ever complete after D3D device loss event with some systems
-            // (A notable example is after pause/resume in Parallels Desktop)
-            // We check if we haven't got a commit completion callback for a second
-            // And forcefully trigger the next one, which makes the entire thing to unstuck
-            
-            if (_st.Elapsed > _commitDueAt && _currentCommit != null)
+            lock (_parent._shared.SyncRoot)
             {
-                Logger.TryGet(LogEventLevel.Error, LogArea.Visual)?.Log(this,
-                    "windows::UI::Composition::ICompositor5.RequestCommitAsync timed out, force-triggering next tick");
-                try
-                {
-                    _currentCommit?.GetResults();
-                }
-                catch (Exception e)
+                // This is a workaround for a nasty WinUI composition API bug that prevents
+                // RequestCommitAsync to ever complete after D3D device loss event with some systems
+                // (A notable example is after pause/resume in Parallels Desktop)
+                // We check if we haven't got a commit completion callback for a second
+                // And forcefully trigger the next one, which makes the entire thing to unstuck
+
+                if (_st.Elapsed > _commitDueAt && _currentCommit != null)
                 {
                     Logger.TryGet(LogEventLevel.Error, LogArea.Visual)?.Log(this,
-                        "ICompositor5::RequestCommitAsync failed: {HR}, {ERR}", e.HResult, e.ToString());
+                        "windows::UI::Composition::ICompositor5.RequestCommitAsync timed out, force-triggering next tick");
+                    try
+                    {
+                        _currentCommit?.GetResults();
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.TryGet(LogEventLevel.Error, LogArea.Visual)?.Log(this,
+                            "ICompositor5::RequestCommitAsync failed: {HR}, {ERR}", e.HResult, e.ToString());
+                    }
+
+                    OnCommitCompleted();
                 }
-                OnCommitCompleted();
             }
         }
 
-        public void Start() => ScheduleNextCommit();
+        public void Start()
+        {
+            lock (_parent._shared.SyncRoot)
+                ScheduleNextCommit();
+        }
     }
 
     private void RunLoop()
@@ -187,18 +213,22 @@ internal class WinUiCompositorConnection : IRenderTimer, Win32.IWindowsSurfaceFa
             if (msg == (uint)UnmanagedMethods.WindowsMessage.WM_TIMER)
             {
                 handler.WatchDog();
-                UnmanagedMethods.SetTimer(hwnd, IntPtr.Zero, 1000, null);
+                UnmanagedMethods.SetTimer(hwnd, IntPtr.Zero, 10, null);
             }
             return UnmanagedMethods.DefWindowProc(hwnd, msg, w, l);
         });
-        UnmanagedMethods.SetTimer(dw.Handle, IntPtr.Zero, 1000, null);
+        UnmanagedMethods.SetTimer(dw.Handle, IntPtr.Zero, 10, null);
+
+        // Warning: the completion callback (RunLoopHandler.Invoke) from ICompositor5.RequestCommitAsync()
+        // is called in DispatchMessage() on Windows 10, but in GetMessage() on Windows 11!
+        // Be careful when changing the scope of the shared lock.
 
         var result = 0;
         while (!cts.IsCancellationRequested
                && (result = UnmanagedMethods.GetMessage(out var msg, IntPtr.Zero, 0, 0)) > 0)
         {
-            lock (_shared.SyncRoot)
-                UnmanagedMethods.DispatchMessage(ref msg);
+            UnmanagedMethods.DispatchMessage(ref msg);
+            handler.OnAfterMessageWithoutLock();
         }
 
         if (result < 0)
@@ -212,7 +242,7 @@ internal class WinUiCompositorConnection : IRenderTimer, Win32.IWindowsSurfaceFa
     {
         return Win32Platform.WindowsVersion >= WinUiCompositionShared.MinWinCompositionVersion;
     }
-    
+
     public static bool TryCreateAndRegister()
     {
         if (IsSupported())

--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositorConnection.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositorConnection.cs
@@ -208,16 +208,18 @@ internal class WinUiCompositorConnection : IRenderTimer, Win32.IWindowsSurfaceFa
         var handler = new RunLoopHandler(this);
         handler.Start();
 
+        const int watchDogIntervalInMs = 1000;
+
         using var dw = new SimpleWindow((hwnd, msg, w, l) =>
         {
             if (msg == (uint)UnmanagedMethods.WindowsMessage.WM_TIMER)
             {
                 handler.WatchDog();
-                UnmanagedMethods.SetTimer(hwnd, IntPtr.Zero, 10, null);
+                UnmanagedMethods.SetTimer(hwnd, IntPtr.Zero, watchDogIntervalInMs, null);
             }
             return UnmanagedMethods.DefWindowProc(hwnd, msg, w, l);
         });
-        UnmanagedMethods.SetTimer(dw.Handle, IntPtr.Zero, 10, null);
+        UnmanagedMethods.SetTimer(dw.Handle, IntPtr.Zero, watchDogIntervalInMs, null);
 
         // Warning: the completion callback (RunLoopHandler.Invoke) from ICompositor5.RequestCommitAsync()
         // is called in DispatchMessage() on Windows 10, but in GetMessage() on Windows 11!


### PR DESCRIPTION
## What does the pull request do?

This PR fixes two compositor deadlocks on Win32.

The root cause is the same for both: when the app is idle, `_wakeEvent.WaitOne()` is called on the render thread while holding a lock on `WinUiCompositionShared.SyncRoot`, preventing it from being released:

https://github.com/AvaloniaUI/Avalonia/blob/f99be63eff3a654f6d171fab78fc0556776a404e/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositorConnection.cs#L131

When `WinUiCompositedWindow` gets disposed, it waits for that lock forever on the main thread:

https://github.com/AvaloniaUI/Avalonia/blob/55c03069b1e9cf681cde74a476038118296c340f/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositedWindow.cs#L23-L25

Causing a deadlock.

There are two different ways this can be triggered:

### Watchdog (all Windows versions)

The current composition commit takes a long time, triggering the watchdog, which holds the lock and calls `_wakeEvent.WaitOne()`. At the exact same time, a window is being disposed of.

This is very, very unlikely to happen in normal situations.

### Slow close (Windows 10 only)

If a window takes a long time to close, the render thread gets idle, and the deadlock mentioned above occurs "naturally".

Why does that happen on Windows 10 only? It turns out that the completion callback (`RunLoopHandler.Invoke`) from `ICompositor5.RequestCommitAsync()` is called from different places depending on the Windows version!

On Windows 10 22H2, it's called from `DispatchMessage()`.
On Windows 11 25H2, it's called from `GetMessage()`.

That subtle, undocumented implementation difference changes everything. Avalonia was holding a lock during `DispatchMessage`, triggering the problem. It also means that on Windows 11, the lock wasn't really held as expected.

## Solution

This PR changes the lock to be held during commit operations, regardless of whether it comes from `GetMessage` or `DispatchMessage`. The call to `_wakeEvent.WaitOne()` is moved outside the lock to prevent any issue.

## Fixed issues
 - Fixes #21531