### PR TITLE
macOS: fix accessibility read-only, selection, and expand/collapse actions

### DIFF
--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -267,7 +267,7 @@
         else if ([newValue isKindOfClass:[NSString class]])
             _peer->ValueProvider_SetValue([(NSString*)newValue UTF8String]);
     }
-    else if (_peer->IsRangeValueProvider())
+    else if (_peer->IsRangeValueProvider() && !_peer->RangeValueProvider_IsReadOnly())
     {
         if ([newValue isKindOfClass:[NSNumber class]])
             _peer->RangeValueProvider_SetValue([(NSNumber*)newValue doubleValue]);
@@ -281,7 +281,7 @@
         if (_peer->IsValueProvider())
             return !_peer->ValueProvider_IsReadOnly();
         if (_peer->IsRangeValueProvider())
-            return YES;
+            return !_peer->RangeValueProvider_IsReadOnly();
         return NO;
     }
 
@@ -422,7 +422,7 @@
 
 - (BOOL)accessibilityPerformIncrement
 {
-    if (!_peer->IsRangeValueProvider())
+    if (!_peer->IsRangeValueProvider() || _peer->RangeValueProvider_IsReadOnly())
         return NO;
     auto value = _peer->RangeValueProvider_GetValue();
     value += _peer->RangeValueProvider_GetSmallChange();
@@ -432,7 +432,7 @@
 
 - (BOOL)accessibilityPerformDecrement
 {
-    if (!_peer->IsRangeValueProvider())
+    if (!_peer->IsRangeValueProvider() || _peer->RangeValueProvider_IsReadOnly())
         return NO;
     auto value = _peer->RangeValueProvider_GetValue();
     value -= _peer->RangeValueProvider_GetSmallChange();
@@ -484,7 +484,8 @@
 {
     if (selector == @selector(setAccessibilityValue:))
     {
-        return (_peer->IsValueProvider() && !_peer->ValueProvider_IsReadOnly()) || _peer->IsRangeValueProvider();
+        return (_peer->IsValueProvider() && !_peer->ValueProvider_IsReadOnly()) ||
+               (_peer->IsRangeValueProvider() && !_peer->RangeValueProvider_IsReadOnly());
     }
     else if (selector == @selector(accessibilityPerformShowMenu))
     {
@@ -503,8 +504,11 @@
         return _peer->IsSelectionItemProvider();
     }
     else if (selector == @selector(accessibilityPerformIncrement) ||
-             selector == @selector(accessibilityPerformDecrement) ||
-             selector == @selector(accessibilityMinValue) ||
+             selector == @selector(accessibilityPerformDecrement))
+    {
+        return _peer->IsRangeValueProvider() && !_peer->RangeValueProvider_IsReadOnly();
+    }
+    else if (selector == @selector(accessibilityMinValue) ||
              selector == @selector(accessibilityMaxValue))
     {
         return _peer->IsRangeValueProvider();

--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -260,7 +260,9 @@
 
 - (void)setAccessibilityValue:(id)newValue
 {
-    if (_peer->IsValueProvider())
+    if (!_peer->IsEnabled())
+        return;
+    if (_peer->IsValueProvider() && !_peer->ValueProvider_IsReadOnly())
     {
         if (newValue == nil)
             _peer->ValueProvider_SetValue(nil);
@@ -395,7 +397,7 @@
 
 - (void)setAccessibilityExpanded:(BOOL)accessibilityExpanded
 {
-    if (!_peer->IsExpandCollapseProvider())
+    if (!_peer->IsExpandCollapseProvider() || !_peer->IsEnabled())
         return;
     if (accessibilityExpanded)
         _peer->ExpandCollapseProvider_Expand();
@@ -405,6 +407,8 @@
 
 - (BOOL)accessibilityPerformPress
 {
+    if (!_peer->IsEnabled())
+        return NO;
     if (_peer->IsInvokeProvider())
     {
         _peer->InvokeProvider_Invoke();
@@ -425,7 +429,7 @@
 
 - (BOOL)accessibilityPerformIncrement
 {
-    if (!_peer->IsRangeValueProvider() || _peer->RangeValueProvider_IsReadOnly())
+    if (!_peer->IsRangeValueProvider() || _peer->RangeValueProvider_IsReadOnly() || !_peer->IsEnabled())
         return NO;
     auto value = _peer->RangeValueProvider_GetValue();
     value += _peer->RangeValueProvider_GetSmallChange();
@@ -435,7 +439,7 @@
 
 - (BOOL)accessibilityPerformDecrement
 {
-    if (!_peer->IsRangeValueProvider() || _peer->RangeValueProvider_IsReadOnly())
+    if (!_peer->IsRangeValueProvider() || _peer->RangeValueProvider_IsReadOnly() || !_peer->IsEnabled())
         return NO;
     auto value = _peer->RangeValueProvider_GetValue();
     value -= _peer->RangeValueProvider_GetSmallChange();
@@ -445,7 +449,7 @@
 
 - (BOOL)accessibilityPerformShowMenu
 {
-    if (!_peer->IsExpandCollapseProvider())
+    if (!_peer->IsExpandCollapseProvider() || !_peer->IsEnabled())
         return NO;
     _peer->ExpandCollapseProvider_Expand();
     return YES;
@@ -479,10 +483,10 @@
 
 - (void)setAccessibilitySelected:(BOOL)accessibilitySelected
 {
-    if (!_peer->IsSelectionItemProvider())
+    if (!_peer->IsSelectionItemProvider() || !_peer->IsEnabled())
         return;
     if (accessibilitySelected)
-        _peer->SelectionItemProvider_Select();
+        _peer->SelectionItemProvider_AddToSelection();
     else
         _peer->SelectionItemProvider_RemoveFromSelection();
 }

--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -411,7 +411,10 @@
     }
     else if (_peer->IsExpandCollapseProvider())
     {
-        _peer->ExpandCollapseProvider_Expand();
+        if (_peer->ExpandCollapseProvider_GetIsExpanded())
+            _peer->ExpandCollapseProvider_Collapse();
+        else
+            _peer->ExpandCollapseProvider_Expand();
     }
     else if (_peer->IsToggleProvider())
     {
@@ -476,8 +479,12 @@
 
 - (void)setAccessibilitySelected:(BOOL)accessibilitySelected
 {
-    if (accessibilitySelected && _peer->IsSelectionItemProvider())
+    if (!_peer->IsSelectionItemProvider())
+        return;
+    if (accessibilitySelected)
         _peer->SelectionItemProvider_Select();
+    else
+        _peer->SelectionItemProvider_RemoveFromSelection();
 }
 
 - (BOOL)isAccessibilitySelectorAllowed:(SEL)selector

--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -484,7 +484,7 @@
 {
     if (selector == @selector(setAccessibilityValue:))
     {
-        return _peer->IsValueProvider() || _peer->IsRangeValueProvider();
+        return (_peer->IsValueProvider() && !_peer->ValueProvider_IsReadOnly()) || _peer->IsRangeValueProvider();
     }
     else if (selector == @selector(accessibilityPerformShowMenu))
     {

--- a/src/Avalonia.Native/AvnAutomationPeer.cs
+++ b/src/Avalonia.Native/AvnAutomationPeer.cs
@@ -184,6 +184,7 @@ namespace Avalonia.Native
         public double RangeValueProvider_GetSmallChange() => RangeValueProvider.SmallChange;
         public double RangeValueProvider_GetLargeChange() => RangeValueProvider.LargeChange;
         public void RangeValueProvider_SetValue(double value) => RangeValueProvider.SetValue(value);
+        public int RangeValueProvider_IsReadOnly() => RangeValueProvider.IsReadOnly.AsComBool();
 
         public int IsSelectionItemProvider() => IsProvider<ISelectionItemProvider>();
         public int SelectionItemProvider_IsSelected() => SelectionItemProvider.IsSelected.AsComBool();

--- a/src/Avalonia.Native/AvnAutomationPeer.cs
+++ b/src/Avalonia.Native/AvnAutomationPeer.cs
@@ -189,6 +189,7 @@ namespace Avalonia.Native
         public int IsSelectionItemProvider() => IsProvider<ISelectionItemProvider>();
         public int SelectionItemProvider_IsSelected() => SelectionItemProvider.IsSelected.AsComBool();
         public void SelectionItemProvider_Select() => SelectionItemProvider.Select();
+        public void SelectionItemProvider_RemoveFromSelection() => SelectionItemProvider.RemoveFromSelection();
 
         public IAvnAutomationPeer? ScrollProvider_GetHorizontalScrollBar()
             => _inner is ScrollViewerAutomationPeer scrollViewer ? Wrap(scrollViewer.GetHorizontalScrollBarPeer()) : null;

--- a/src/Avalonia.Native/AvnAutomationPeer.cs
+++ b/src/Avalonia.Native/AvnAutomationPeer.cs
@@ -189,6 +189,7 @@ namespace Avalonia.Native
         public int IsSelectionItemProvider() => IsProvider<ISelectionItemProvider>();
         public int SelectionItemProvider_IsSelected() => SelectionItemProvider.IsSelected.AsComBool();
         public void SelectionItemProvider_Select() => SelectionItemProvider.Select();
+        public void SelectionItemProvider_AddToSelection() => SelectionItemProvider.AddToSelection();
         public void SelectionItemProvider_RemoveFromSelection() => SelectionItemProvider.RemoveFromSelection();
 
         public IAvnAutomationPeer? ScrollProvider_GetHorizontalScrollBar()

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -1320,6 +1320,7 @@ interface IAvnAutomationPeer : IUnknown
      bool IsSelectionItemProvider();
      bool SelectionItemProvider_IsSelected();
      void SelectionItemProvider_Select();
+     void SelectionItemProvider_RemoveFromSelection();
 
      IAvnAutomationPeer* ScrollProvider_GetHorizontalScrollBar();
      IAvnAutomationPeer* ScrollProvider_GetVerticalScrollBar();

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -1315,7 +1315,8 @@ interface IAvnAutomationPeer : IUnknown
      double RangeValueProvider_GetSmallChange();
      double RangeValueProvider_GetLargeChange();
      void RangeValueProvider_SetValue(double value);
-     
+     bool RangeValueProvider_IsReadOnly();
+
      bool IsSelectionItemProvider();
      bool SelectionItemProvider_IsSelected();
      void SelectionItemProvider_Select();

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -1320,6 +1320,7 @@ interface IAvnAutomationPeer : IUnknown
      bool IsSelectionItemProvider();
      bool SelectionItemProvider_IsSelected();
      void SelectionItemProvider_Select();
+     void SelectionItemProvider_AddToSelection();
      void SelectionItemProvider_RemoveFromSelection();
 
      IAvnAutomationPeer* ScrollProvider_GetHorizontalScrollBar();


### PR DESCRIPTION
Follow-up to #21597 that grew to cover the rest of the macOS accessibility mutation surface. Stops the AX layer from advertising or performing mutations the underlying control does not support.

- Read-only value/range: a read-only `IValueProvider` (read-only TextBox) and `IRangeValueProvider` (ProgressBar, read-only NumericUpDown) report their value as not settable and no longer advertise `setAccessibilityValue` / increment / decrement. Gated on both the legacy `accessibilityIsAttributeSettable` and the modern `isAccessibilitySelectorAllowed` paths (#21597 added only the former, for `IValueProvider`).
- Selection: `setAccessibilitySelected:YES` adds to the selection instead of replacing it (multi-select was otherwise impossible), and `:NO` removes from the selection (was a no-op).
- Expand/collapse: `accessibilityPerformPress` toggles an expand/collapse provider instead of always expanding.
- Disabled controls: mutating actions are gated on `isAccessibilityEnabled`.

New `IAvnAutomationPeer` members: `RangeValueProvider_IsReadOnly`, `SelectionItemProvider_AddToSelection`, `SelectionItemProvider_RemoveFromSelection`.
