### PR TITLE
AT-SPI: SelectChild should add to the selection instead of replacing it

### DIFF
--- a/src/Avalonia.FreeDesktop.AtSpi/Handlers/AtSpiSelectionHandler.cs
+++ b/src/Avalonia.FreeDesktop.AtSpi/Handlers/AtSpiSelectionHandler.cs
@@ -54,7 +54,7 @@ namespace Avalonia.FreeDesktop.AtSpi.Handlers
             if (childPeer.GetProvider<ISelectionItemProvider>() is not { } selectionItem)
                 return ValueTask.FromResult(false);
 
-            selectionItem.Select();
+            selectionItem.AddToSelection();
             return ValueTask.FromResult(true);
         }
 


### PR DESCRIPTION
AtSpiSelectionHandler.SelectChild called ISelectionItemProvider.Select(), which
replaces the selection, so additive multi-select was impossible over AT-SPI.
Switch to AddToSelection(): additive for multi-select containers, and still
replacing on single-select models. Matches the AT-SPI spec and the UIA backend.
