### PR TITLE
AT-SPI: Expose list item containers as accessible children

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/ItemsControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ItemsControlAutomationPeer.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Automation.Provider;
+﻿using System.Collections.Generic;
+using Avalonia.Automation.Provider;
 using Avalonia.Controls;
 
 namespace Avalonia.Automation.Peers
@@ -39,6 +40,25 @@ namespace Avalonia.Automation.Peers
         protected override AutomationControlType GetAutomationControlTypeCore()
         {
             return AutomationControlType.List;
+        }
+
+        protected override IReadOnlyList<AutomationPeer>? GetChildrenCore()
+        {
+            var owner = Owner;
+            if (owner.ItemCount == 0)
+                return null;
+
+            List<AutomationPeer>? result = null;
+            for (var i = 0; i < owner.ItemCount; i++)
+            {
+                if (owner.ContainerFromIndex(i) is Control container && container.IsVisible)
+                {
+                    result ??= new List<AutomationPeer>();
+                    result.Add(GetOrCreate(container));
+                }
+            }
+
+            return result;
         }
 
         public void Scroll(ScrollAmount horizontalAmount, ScrollAmount verticalAmount)

--- a/src/Avalonia.Controls/Automation/Peers/ItemsControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ItemsControlAutomationPeer.cs
@@ -42,25 +42,6 @@ namespace Avalonia.Automation.Peers
             return AutomationControlType.List;
         }
 
-        protected override IReadOnlyList<AutomationPeer>? GetChildrenCore()
-        {
-            var owner = Owner;
-            if (owner.ItemCount == 0)
-                return null;
-
-            List<AutomationPeer>? result = null;
-            for (var i = 0; i < owner.ItemCount; i++)
-            {
-                if (owner.ContainerFromIndex(i) is Control container && container.IsVisible)
-                {
-                    result ??= new List<AutomationPeer>();
-                    result.Add(GetOrCreate(container));
-                }
-            }
-
-            return result;
-        }
-
         public void Scroll(ScrollAmount horizontalAmount, ScrollAmount verticalAmount)
         {
             _scroller?.Scroll(horizontalAmount, verticalAmount);

--- a/src/Avalonia.Controls/Automation/Peers/ListBoxAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ListBoxAutomationPeer.cs
@@ -1,12 +1,11 @@
 using Avalonia.Controls;
 
-namespace Avalonia.Automation.Peers
+namespace Avalonia.Automation.Peers;
+
+public class ListBoxAutomationPeer : SelectingItemsControlAutomationPeer
 {
-    public class ListBoxAutomationPeer : SelectingItemsControlAutomationPeer
+    public ListBoxAutomationPeer(ListBox owner)
+        : base(owner)
     {
-        public ListBoxAutomationPeer(ListBox owner)
-            : base(owner)
-        {
-        }
     }
 }

--- a/src/Avalonia.Controls/Automation/Peers/ListBoxAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ListBoxAutomationPeer.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Automation.Peers
+{
+    public class ListBoxAutomationPeer : SelectingItemsControlAutomationPeer
+    {
+        public ListBoxAutomationPeer(ListBox owner)
+            : base(owner)
+        {
+        }
+    }
+}

--- a/src/Avalonia.Controls/Automation/Peers/SelectingItemsControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/SelectingItemsControlAutomationPeer.cs
@@ -25,25 +25,6 @@ namespace Avalonia.Automation.Peers
         public bool IsSelectionRequired => GetSelectionModeCore().HasAllFlags(SelectionMode.AlwaysSelected);
         public IReadOnlyList<AutomationPeer> GetSelection() => GetSelectionCore() ?? Array.Empty<AutomationPeer>();
 
-        // Expose item containers as the accessible children so item indices line up with the child tree (AT-SPI selection, screen readers), skipping the intervening panel.
-        protected override IReadOnlyList<AutomationPeer>? GetChildrenCore()
-        {
-            if (Owner is not SelectingItemsControl owner || owner.ItemCount == 0)
-                return base.GetChildrenCore();
-
-            List<AutomationPeer>? result = null;
-            for (var i = 0; i < owner.ItemCount; i++)
-            {
-                if (owner.ContainerFromIndex(i) is Control container && container.IsVisible)
-                {
-                    result ??= new List<AutomationPeer>();
-                    result.Add(GetOrCreate(container));
-                }
-            }
-
-            return result ?? base.GetChildrenCore();
-        }
-
         protected virtual IReadOnlyList<AutomationPeer>? GetSelectionCore()
         {
             List<AutomationPeer>? result = null;

--- a/src/Avalonia.Controls/Automation/Peers/SelectingItemsControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/SelectingItemsControlAutomationPeer.cs
@@ -25,6 +25,25 @@ namespace Avalonia.Automation.Peers
         public bool IsSelectionRequired => GetSelectionModeCore().HasAllFlags(SelectionMode.AlwaysSelected);
         public IReadOnlyList<AutomationPeer> GetSelection() => GetSelectionCore() ?? Array.Empty<AutomationPeer>();
 
+        // Expose item containers as the accessible children so item indices line up with the child tree (AT-SPI selection, screen readers), skipping the intervening panel.
+        protected override IReadOnlyList<AutomationPeer>? GetChildrenCore()
+        {
+            if (Owner is not SelectingItemsControl owner || owner.ItemCount == 0)
+                return base.GetChildrenCore();
+
+            List<AutomationPeer>? result = null;
+            for (var i = 0; i < owner.ItemCount; i++)
+            {
+                if (owner.ContainerFromIndex(i) is Control container && container.IsVisible)
+                {
+                    result ??= new List<AutomationPeer>();
+                    result.Add(GetOrCreate(container));
+                }
+            }
+
+            return result ?? base.GetChildrenCore();
+        }
+
         protected virtual IReadOnlyList<AutomationPeer>? GetSelectionCore()
         {
             List<AutomationPeer>? result = null;

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using Avalonia.Automation.Peers;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Selection;
@@ -124,6 +125,11 @@ namespace Avalonia.Controls
         protected internal override bool NeedsContainerOverride(object? item, int index, out object? recycleKey)
         {
             return NeedsContainer<ListBoxItem>(item, out recycleKey);
+        }
+
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new ListBoxAutomationPeer(this);
         }
 
         protected override void OnKeyDown(KeyEventArgs e)

--- a/src/Avalonia.FreeDesktop.AtSpi/AtSpiNode.cs
+++ b/src/Avalonia.FreeDesktop.AtSpi/AtSpiNode.cs
@@ -164,6 +164,30 @@ namespace Avalonia.FreeDesktop.AtSpi
 
         internal bool RemoveAttachedChild(AtSpiNode child) => _attachedChildren.Remove(child);
 
+        // Present a selection container's realized item containers as its direct
+        // AT-SPI children so SelectChild-by-index and parent lookups work.
+        private IReadOnlyList<AutomationPeer> GetChildPeers()
+        {
+            if (Peer.GetProvider<ISelectionProvider>() is null)
+                return Peer.GetChildren();
+
+            var items = new List<AutomationPeer>();
+            CollectSelectionItemPeers(Peer.GetChildren(), items);
+            return items.Count > 0 ? items : Peer.GetChildren();
+        }
+
+        private static void CollectSelectionItemPeers(
+            IReadOnlyList<AutomationPeer> peers, List<AutomationPeer> result)
+        {
+            foreach (var peer in peers)
+            {
+                if (peer.GetProvider<ISelectionItemProvider>() is not null)
+                    result.Add(peer);
+                else
+                    CollectSelectionItemPeers(peer.GetChildren(), result);
+            }
+        }
+
         internal IReadOnlyList<AtSpiNode> EnsureChildren()
         {
             if (!IsAttached)
@@ -172,7 +196,7 @@ namespace Avalonia.FreeDesktop.AtSpi
             if (!_childrenDirty)
                 return _attachedChildren;
 
-            var childPeers = Peer.GetChildren();
+            var childPeers = GetChildPeers();
             var nextChildren = new List<AtSpiNode>(childPeers.Count);
             var nextChildrenSet = new HashSet<AtSpiNode>();
             foreach (var childPeer in childPeers)
@@ -275,7 +299,7 @@ namespace Avalonia.FreeDesktop.AtSpi
 
             _childrenDirty = true;
 
-            var childPeers = Peer.GetChildren();
+            var childPeers = GetChildPeers();
             if (_attachedChildren.Count > 0)
             {
                 var currentPeers = new HashSet<AutomationPeer>(childPeers);

--- a/src/Avalonia.FreeDesktop.AtSpi/Handlers/AtSpiSelectionHandler.cs
+++ b/src/Avalonia.FreeDesktop.AtSpi/Handlers/AtSpiSelectionHandler.cs
@@ -54,7 +54,7 @@ namespace Avalonia.FreeDesktop.AtSpi.Handlers
             if (childPeer.GetProvider<ISelectionItemProvider>() is not { } selectionItem)
                 return ValueTask.FromResult(false);
 
-            selectionItem.Select();
+            selectionItem.AddToSelection();
             return ValueTask.FromResult(true);
         }
 

--- a/src/Avalonia.FreeDesktop.AtSpi/Handlers/AtSpiSelectionHandler.cs
+++ b/src/Avalonia.FreeDesktop.AtSpi/Handlers/AtSpiSelectionHandler.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Avalonia.Automation.Peers;
 using Avalonia.Automation.Provider;
 using Avalonia.DBus;
 using Avalonia.FreeDesktop.AtSpi.DBusXml;
@@ -8,9 +8,6 @@ using static Avalonia.FreeDesktop.AtSpi.AtSpiConstants;
 
 namespace Avalonia.FreeDesktop.AtSpi.Handlers
 {
-    /// <summary>
-    /// Implements the AT-SPI Selection interface for list-like containers.
-    /// </summary>
     internal sealed class AtSpiSelectionHandler(AtSpiServer server, AtSpiNode node) : IOrgA11yAtspiSelection
     {
         public uint Version => SelectionVersion;
@@ -38,7 +35,7 @@ namespace Avalonia.FreeDesktop.AtSpi.Handlers
 
             var selectedPeer = selection[selectedChildIndex];
             var childNode = server.TryGetAttachedNode(selectedPeer);
-            if (childNode is null || !ReferenceEquals(childNode.Parent, node))
+            if (childNode is null)
                 return ValueTask.FromResult(server.GetNullReference());
 
             return ValueTask.FromResult(server.GetReference(childNode));
@@ -46,15 +43,11 @@ namespace Avalonia.FreeDesktop.AtSpi.Handlers
 
         public ValueTask<bool> SelectChildAsync(int childIndex)
         {
-            var children = node.Peer.GetChildren();
-            if (childIndex < 0 || childIndex >= children.Count)
+            var items = CollectSelectableItems(node.Peer);
+            if (childIndex < 0 || childIndex >= items.Count)
                 return ValueTask.FromResult(false);
 
-            var childPeer = children[childIndex];
-            if (childPeer.GetProvider<ISelectionItemProvider>() is not { } selectionItem)
-                return ValueTask.FromResult(false);
-
-            selectionItem.AddToSelection();
+            items[childIndex].AddToSelection();
             return ValueTask.FromResult(true);
         }
 
@@ -78,15 +71,11 @@ namespace Avalonia.FreeDesktop.AtSpi.Handlers
 
         public ValueTask<bool> IsChildSelectedAsync(int childIndex)
         {
-            var children = node.Peer.GetChildren();
-            if (childIndex < 0 || childIndex >= children.Count)
+            var items = CollectSelectableItems(node.Peer);
+            if (childIndex < 0 || childIndex >= items.Count)
                 return ValueTask.FromResult(false);
 
-            var childPeer = children[childIndex];
-            if (childPeer.GetProvider<ISelectionItemProvider>() is not { } selectionItem)
-                return ValueTask.FromResult(false);
-
-            return ValueTask.FromResult(selectionItem.IsSelected);
+            return ValueTask.FromResult(items[childIndex].IsSelected);
         }
 
         public ValueTask<bool> SelectAllAsync()
@@ -95,12 +84,8 @@ namespace Avalonia.FreeDesktop.AtSpi.Handlers
             if (provider is null || !provider.CanSelectMultiple)
                 return ValueTask.FromResult(false);
 
-            var children = node.Peer.GetChildren();
-            foreach (var child in children)
-            {
-                if (child.GetProvider<ISelectionItemProvider>() is { } selectionItem)
-                    selectionItem.AddToSelection();
-            }
+            foreach (var item in CollectSelectableItems(node.Peer))
+                item.AddToSelection();
 
             return ValueTask.FromResult(true);
         }
@@ -123,16 +108,32 @@ namespace Avalonia.FreeDesktop.AtSpi.Handlers
 
         public ValueTask<bool> DeselectChildAsync(int childIndex)
         {
-            var children = node.Peer.GetChildren();
-            if (childIndex < 0 || childIndex >= children.Count)
+            var items = CollectSelectableItems(node.Peer);
+            if (childIndex < 0 || childIndex >= items.Count)
                 return ValueTask.FromResult(false);
 
-            var childPeer = children[childIndex];
-            if (childPeer.GetProvider<ISelectionItemProvider>() is not { } selectionItem)
-                return ValueTask.FromResult(false);
-
-            selectionItem.RemoveFromSelection();
+            items[childIndex].RemoveFromSelection();
             return ValueTask.FromResult(true);
+        }
+
+        private static List<ISelectionItemProvider> CollectSelectableItems(AutomationPeer peer)
+        {
+            var result = new List<ISelectionItemProvider>();
+            CollectSelectableItemsCore(peer.GetChildren(), result);
+            return result;
+        }
+
+        private static void CollectSelectableItemsCore(
+            IReadOnlyList<AutomationPeer> children,
+            List<ISelectionItemProvider> result)
+        {
+            foreach (var child in children)
+            {
+                if (child.GetProvider<ISelectionItemProvider>() is { } item)
+                    result.Add(item);
+                else
+                    CollectSelectableItemsCore(child.GetChildren(), result);
+            }
         }
     }
 }


### PR DESCRIPTION
List automation peers exposed the items panel/scrollviewer as their accessible children, so the items were not direct children of the selection container. AT-SPI addresses selectable children by index on the container (SelectChild/DeselectChild), so item selection over AT-SPI could not reach the items.

Expose the realized item containers as the accessible children of SelectingItemsControl peers (ListBox, TreeView, ComboBox), matching how the selection model already resolves items via ContainerFromIndex.

Builds on #21602 (additive SelectChild). The first commit here is that change; it will drop out once #21602 merges.
