### PR TITLE
Show checkerboard background for transparent ColorView palette items

### DIFF
--- a/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorPicker.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorPicker.xaml
@@ -182,14 +182,18 @@
                              Margin="12">
                       <ListBox.ItemTemplate>
                         <DataTemplate DataType="{x:Type Color}">
-                          <Border AutomationProperties.Name="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
-                                  ToolTip.Tip="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
-                                  HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Stretch">
-                            <Border.Background>
-                              <SolidColorBrush Color="{Binding}" />
-                            </Border.Background>
-                          </Border>
+                          <Panel AutomationProperties.Name="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
+                                 ToolTip.Tip="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
+                                 HorizontalAlignment="Stretch"
+                                 VerticalAlignment="Stretch">
+                            <Border Background="{StaticResource ColorControlCheckeredBackgroundBrush}" />
+                            <Border HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch">
+                              <Border.Background>
+                                <SolidColorBrush Color="{Binding}" />
+                              </Border.Background>
+                            </Border>
+                          </Panel>
                         </DataTemplate>
                       </ListBox.ItemTemplate>
                       <ListBox.ItemsPanel>

--- a/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorView.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorView.xaml
@@ -426,14 +426,18 @@
                        Margin="12">
                 <ListBox.ItemTemplate>
                   <DataTemplate DataType="{x:Type Color}">
-                    <Border AutomationProperties.Name="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
-                            ToolTip.Tip="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Stretch">
-                      <Border.Background>
-                        <SolidColorBrush Color="{Binding}" />
-                      </Border.Background>
-                    </Border>
+                    <Panel AutomationProperties.Name="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
+                           ToolTip.Tip="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
+                           HorizontalAlignment="Stretch"
+                           VerticalAlignment="Stretch">
+                      <Border Background="{StaticResource ColorControlCheckeredBackgroundBrush}" />
+                      <Border HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch">
+                        <Border.Background>
+                          <SolidColorBrush Color="{Binding}" />
+                        </Border.Background>
+                      </Border>
+                    </Panel>
                   </DataTemplate>
                 </ListBox.ItemTemplate>
                 <ListBox.ItemsPanel>

--- a/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorPicker.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorPicker.xaml
@@ -184,14 +184,18 @@
                              Margin="12">
                       <ListBox.ItemTemplate>
                         <DataTemplate DataType="{x:Type Color}">
-                          <Border AutomationProperties.Name="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
-                                  ToolTip.Tip="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
-                                  HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Stretch">
-                            <Border.Background>
-                              <SolidColorBrush Color="{Binding}" />
-                            </Border.Background>
-                          </Border>
+                          <Panel AutomationProperties.Name="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
+                                 ToolTip.Tip="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
+                                 HorizontalAlignment="Stretch"
+                                 VerticalAlignment="Stretch">
+                            <Border Background="{StaticResource ColorControlCheckeredBackgroundBrush}" />
+                            <Border HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch">
+                              <Border.Background>
+                                <SolidColorBrush Color="{Binding}" />
+                              </Border.Background>
+                            </Border>
+                          </Panel>
                         </DataTemplate>
                       </ListBox.ItemTemplate>
                       <ListBox.ItemsPanel>

--- a/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorView.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorView.xaml
@@ -390,14 +390,18 @@
                        Margin="12">
                 <ListBox.ItemTemplate>
                   <DataTemplate DataType="{x:Type Color}">
-                    <Border AutomationProperties.Name="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
-                            ToolTip.Tip="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Stretch">
-                      <Border.Background>
-                        <SolidColorBrush Color="{Binding}" />
-                      </Border.Background>
-                    </Border>
+                    <Panel AutomationProperties.Name="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
+                           ToolTip.Tip="{Binding Converter={StaticResource ColorToDisplayNameConverter}}"
+                           HorizontalAlignment="Stretch"
+                           VerticalAlignment="Stretch">
+                      <Border Background="{StaticResource ColorControlCheckeredBackgroundBrush}" />
+                      <Border HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch">
+                        <Border.Background>
+                          <SolidColorBrush Color="{Binding}" />
+                        </Border.Background>
+                      </Border>
+                    </Panel>
                   </DataTemplate>
                 </ListBox.ItemTemplate>
                 <ListBox.ItemsPanel>


### PR DESCRIPTION
## Summary

Adds the existing ColorPicker checkerboard transparency background behind palette color swatches.

This makes palette entries with alpha below 255, including `Colors.Transparent`, visibly indicate transparency instead of appearing as empty or flat swatches.

**Before:**

<img width="360" height="410" alt="RIEGCxUXsXCQ" src="https://github.com/user-attachments/assets/b64bd71f-8222-459f-90a3-75e66a1988ea" />

**After:**

<img width="360" height="410" alt="TVn8KsycZtLe" src="https://github.com/user-attachments/assets/097769b2-7ea8-4f59-bd08-473cba6368eb" />

Fixes #20828

## Changes

- Updates `ColorView` palette item templates in Fluent and Simple themes.
- Updates `ColorPicker` dropdown palette item templates in Fluent and Simple themes for consistency.
- Reuses the existing `ColorControlCheckeredBackgroundBrush` already used by preview controls.

## Verification

- Built `Avalonia.Controls.ColorPicker` successfully.
- Confirmed the XAML changes compile with no warnings or errors.