### PR TITLE
Compiled Bindings: Fix unpredictable binding to method selection

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
@@ -210,9 +210,26 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                             {
                                 nodes.Add(new XamlIlClrPropertyPathElementNode(clrProperty, propName.AcceptsNull));
                             }
-                            else if (GetAllDefinedMethods(targetType).FirstOrDefault(m => m.Name == propName.PropertyName) is IXamlMethod method)
+                            else if (GetAllDefinedMethods(targetType)
+                                         .Where(p => p.Name == propName.PropertyName)
+                                         .OrderByDescending(m => m.Parameters.Count)
+                                         .ToArray()
+                                     is { Length: > 0 } methodCandidates)
                             {
-                                nodes.Add(new XamlIlClrMethodPathElementNode(method, context.Configuration.WellKnownTypes.Delegate, propName.AcceptsNull));
+                                var objType = context.Configuration.WellKnownTypes.Object;
+                                var candidate = methodCandidates
+                                    .FirstOrDefault(m => m.Parameters.Count == 0
+                                                         || (m.Parameters.Count == 1 &&
+                                                             m.Parameters[0].Equals(objType)));
+                                if (candidate is null)
+                                {
+                                    throw new XamlX.XamlTransformException(
+                                        $"Unable to resolve method of name '{propName.PropertyName}' on type '{targetType}'." +
+                                        $"Expected method with no parameters or a single object overload.",
+                                        lineInfo);
+                                }
+            
+                                nodes.Add(new XamlIlClrMethodPathElementNode(candidate, context.Configuration.WellKnownTypes.Delegate, propName.AcceptsNull));
                             }
                             else
                             {

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlTrampolineBuilder.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlTrampolineBuilder.cs
@@ -48,24 +48,9 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             }
             if (executeMethod.Parameters.Count != 0)
             {
-                Debug.Assert(executeMethod.Parameters.Count == 1);
-                if (executeMethod.Parameters[0] != context.Configuration.WellKnownTypes.Object)
-                {
-                    var convertedValue = gen.DefineLocal(context.Configuration.WellKnownTypes.Object);
-                    gen.Ldtype(executeMethod.Parameters[0])
-                        .Ldarg(1)
-                        .EmitCall(context.Configuration.WellKnownTypes.CultureInfo.GetMethod(m => m.Name == "get_CurrentCulture"))
-                        .Ldloca(convertedValue)
-                        .EmitCall(
-                            context.GetAvaloniaTypes().TypeUtilities.GetMethod(m => m.Name == "TryConvert"),
-                            swallowResult: true)
-                        .Ldloc(convertedValue)
-                        .Unbox_Any(executeMethod.Parameters[0]);
-                }
-                else
-                {
-                    gen.Ldarg(1);
-                }
+                Debug.Assert(executeMethod.Parameters.Count == 1
+                             && executeMethod.Parameters[0] == context.Configuration.WellKnownTypes.Object);
+                gen.Ldarg(1);
             }
             gen.EmitCall(executeMethod, swallowResult: true);
             gen.Ret();

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -1904,17 +1904,20 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             }
         }
 
-        [Fact]
-        public void Binding_Method_With_Parameter_To_Command_Works()
+        [Theory]
+        [InlineData("5")]
+        [InlineData("hello")]
+        [InlineData(null)]
+        public void Binding_Method_With_Parameter_To_Command_Works(string? parameter)
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
-                var xaml = @"
+                var xaml = $@"
 <Window xmlns='https://github.com/avaloniaui'
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
         x:DataType='local:MethodAsCommandDataContext'>
-    <Button Name='button' Command='{CompiledBinding Method1}' CommandParameter='5'/>
+    <Button Name='button' Command='{{CompiledBinding Method1}}' CommandParameter='{ parameter ?? "{x:Null}" }'/>
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
                 var button = window.GetControl<Button>("button");
@@ -1925,7 +1928,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
                 Assert.NotNull(button.Command);
                 PerformClick(button);
-                Assert.Equal("Called 5", vm.Value);
+                Assert.Equal("Called " + parameter, vm.Value);
             }
         }
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -1863,8 +1863,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
     <StackPanel>
         <ContentControl Content='{CompiledBinding Action}' Name='action' />
         <ContentControl Content='{CompiledBinding Func}' Name='func' />
-        <ContentControl Content='{CompiledBinding Action16}' Name='action16' />
-        <ContentControl Content='{CompiledBinding Func16}' Name='func16' />
+        <ContentControl Content='{CompiledBinding Func2}' Name='func2' />
         <ContentControl Content='{CompiledBinding CustomDelegateTypeVoid}' Name='customvoid' />
         <ContentControl Content='{CompiledBinding CustomDelegateTypeInt}' Name='customint' />
     </StackPanel>
@@ -1873,9 +1872,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 window.DataContext = new MethodDataContext();
 
                 Assert.IsAssignableFrom(typeof(Action), window.GetControl<ContentControl>("action").Content);
-                Assert.IsAssignableFrom(typeof(Func<int>), window.GetControl<ContentControl>("func").Content);
-                Assert.IsAssignableFrom(typeof(Action<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>), window.GetControl<ContentControl>("action16").Content);
-                Assert.IsAssignableFrom(typeof(Func<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>), window.GetControl<ContentControl>("func16").Content);
+                Assert.IsAssignableFrom(typeof(Func<object>), window.GetControl<ContentControl>("func").Content);
+                Assert.IsAssignableFrom(typeof(Func<object, object>), window.GetControl<ContentControl>("func2").Content);
                 Assert.True(typeof(Delegate).IsAssignableFrom(window.GetControl<ContentControl>("customvoid").Content!.GetType()));
                 Assert.True(typeof(Delegate).IsAssignableFrom(window.GetControl<ContentControl>("customint").Content!.GetType()));
             }
@@ -2533,12 +2531,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
     {
         public void Action() { }
 
-        public int Func() => 1;
+        public object Func() => 1;
+        public object Func2(object i) => i;
 
-        public void Action16(int i, int i2, int i3, int i4, int i5, int i6, int i7, int i8, int i9, int i10, int i11, int i12, int i13, int i14, int i15, int i16) { }
-        public int Func16(int i, int i2, int i3, int i4, int i5, int i6, int i7, int i8, int i9, int i10, int i11, int i12, int i13, int i14, int i15, int i16) => i;
-        public void CustomDelegateTypeVoid(int i, int i2, int i3, int i4, int i5, int i6, int i7, int i8, int i9, int i10, int i11, int i12, int i13, int i14, int i15, int i16, int i17) { }
-        public int CustomDelegateTypeInt(int i, int i2, int i3, int i4, int i5, int i6, int i7, int i8, int i9, int i10, int i11, int i12, int i13, int i14, int i15, int i16, int i17) => i;
+        public void CustomDelegateTypeVoid(object i) { }
+        public object CustomDelegateTypeInt(object i) => i;
     }
 
     public class MethodAsCommandDataContext : INotifyPropertyChanged
@@ -2546,7 +2543,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         public event PropertyChangedEventHandler? PropertyChanged;
 
         public string Method() => Value = "Called";
-        public string Method1(int i) => Value = $"Called {i}";
+        public string Method1() => Value = "Called";
+        public string Method1(int i) => throw new InvalidOperationException("Binding to method with typed parameters is not supported");
+        public string Method1(object i) => Value = $"Called {i}";
         public string Method2(int i, int j) => Value = $"Called {i},{j}";
         public string Value { get; private set; } = "Not called";
 


### PR DESCRIPTION
## What does the pull request do?

Let's say you have a binding to a method: `Command="{Binding #notification.Show}"`.
If `Show` method has multiple definitions:
```
public void Show();
public void Show(Notification arg);
public void Show(object arg);
```

Picked behavior will depend on the chosen bindings mechanism.
With `ReflectionBindings` `Show(object)` will be prioritized over `Show()`. `Show(Notification)` will be ignored as it's not a object override. This is the behavior we have [since 2022](https://github.com/AvaloniaUI/Avalonia/pull/8905).
With `CompiledBinding` `Show()` is prioritized, then `Show(Notification)`, and `Show(object)` is the last candidate.

## What is the current behavior?

`Command="{Binding #notification.Show}"` calls `Show(Notification)`. Inconsistent with `ReflectionBindings`.
Essentially, selected choice depends on the IL metadata order only.

This call also involves `TypeUtilities.TryConvert` call which triggers trimming/reflection warnings. 

## What is the updated/expected behavior with this PR?

`Command="{Binding #notification.Show}"` calls `Show(object)`. Consistent with `ReflectionBindings`.

If correct overload is not found, but there are methods with matching name, a new detailed exception is thrown.

## Alternative solution:

Technically, we can relax some rules here, compared to reflection bindings, and only do following:
- Prioritize 1 parameter over 0.
- Allow any typed method.
- But don't call `TypeUtilities.TryConvert`, instead use direct type casting.

The issue here, we can't always reliably pick typed method overload. Even in compiled binding context. `CommandParameter` might be set to an object value, or can be set outside of the same XAML files. Making compilation choose different overloads depending on the `CommandParameter` context might introduce more confusion that solve.

## Checklist

- [x] Added unit tests (if possible)?

## Breaking changes

Yes, it might app compilation that have bindings to typed methods. But otherwise, we previously had runtime errors, when incorrect method was chosen. 

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/5076#issuecomment-1238274606 (for the second time)