### PR TITLE
Fix RequestedThemeVariant default value

### DIFF
--- a/src/Avalonia.Base/Styling/ThemeVariant.cs
+++ b/src/Avalonia.Base/Styling/ThemeVariant.cs
@@ -16,6 +16,22 @@ namespace Avalonia.Styling;
 public sealed record ThemeVariant
 {
     /// <summary>
+    /// Inherit theme variant from the parent. If set on Application, system theme is inherited.
+    /// Using Default as the ResourceDictionary.Key marks this dictionary as a fallback in case the theme variant or resource key is not found in other theme dictionaries.
+    /// </summary>
+    public static ThemeVariant Default { get; } = new(nameof(Default));
+
+    /// <summary>
+    /// Use the Light theme variant.
+    /// </summary>
+    public static ThemeVariant Light { get; } = new(nameof(Light));
+
+    /// <summary>
+    /// Use the Dark theme variant.
+    /// </summary>
+    public static ThemeVariant Dark { get; } = new(nameof(Dark));
+
+    /// <summary>
     /// Defines the ActualThemeVariant property.
     /// </summary>
     internal static readonly StyledProperty<ThemeVariant> ActualThemeVariantProperty =
@@ -62,22 +78,6 @@ public sealed record ThemeVariant
     /// Reference to a theme variant which should be used, if resource wasn't found for the requested variant.
     /// </summary>
     public ThemeVariant? InheritVariant { get; }
-
-    /// <summary>
-    /// Inherit theme variant from the parent. If set on Application, system theme is inherited.
-    /// Using Default as the ResourceDictionary.Key marks this dictionary as a fallback in case the theme variant or resource key is not found in other theme dictionaries.
-    /// </summary>
-    public static ThemeVariant Default { get; } = new(nameof(Default));
-
-    /// <summary>
-    /// Use the Light theme variant.
-    /// </summary>
-    public static ThemeVariant Light { get; } = new(nameof(Light));
-
-    /// <summary>
-    /// Use the Dark theme variant.
-    /// </summary>
-    public static ThemeVariant Dark { get; } = new(nameof(Dark));
 
     public override string ToString()
     {


### PR DESCRIPTION
## What does the pull request do?
This PR fixes `ThemeVariant.RequestedThemeVariant`'s default value, which was `null` instead of `ThemeVariant.Default`.
This was caused by `Default` being defined after `RequestedThemeVariant`, messing up the static initialization order (note: Rider/ReSharper properly flags this issue).

This property is internal, and `null` and `Default` were treated the same currently, but caused issues in other PRs such as https://github.com/AvaloniaUI/Avalonia/pull/16340.
