### PR TITLE
Fix TimePicker selection style

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/TimePicker.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/TimePicker.xaml
@@ -203,6 +203,11 @@
                 MaxHeight="398">
           <Grid Name="ContentPanel" RowDefinitions="*,Auto">
             <Grid Name="PART_PickerContainer">
+              <Grid.Styles>
+                <Style Selector="DateTimePickerPanel > ListBoxItem">
+                  <Setter Property="Theme" Value="{StaticResource FluentDateTimePickerItem}" />
+                </Style>
+              </Grid.Styles>
               <!--Ignore col defs here, set in code-->
               <Panel Name="PART_HourHost" Grid.Column="0">
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled"

--- a/src/Avalonia.Themes.Simple/Controls/TimePicker.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/TimePicker.xaml
@@ -219,6 +219,11 @@
           <Grid Name="ContentPanel"
                 RowDefinitions="*,Auto">
             <Grid Name="PART_PickerContainer">
+              <Grid.Styles>
+                <Style Selector="DateTimePickerPanel > ListBoxItem">
+                  <Setter Property="Theme" Value="{StaticResource SimpleDateTimePickerItem}" />
+                </Style>
+              </Grid.Styles>
               <!--  Ignore col defs here, set in code  -->
               <Panel Name="PART_HourHost"
                      Grid.Column="0">


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix TimePicker selection style.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The TimePicker text is not centered and the selected item is highlighted multiple times.
<img width="431" height="699" alt="Snipaste_2026-06-22_21-37-16" src="https://github.com/user-attachments/assets/7294979e-ce63-43dc-a804-01ae353e4520" />

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
<img width="424" height="697" alt="Snipaste_2026-06-22_21-37-54" src="https://github.com/user-attachments/assets/c966ed4d-db7c-48a5-8060-0ea10aa3c061" />

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Change `DateTimePickerPanel > ListBoxItem` theme
This code exists in DatePicker but is missing in TimePicker.
```xaml
<Grid.Styles>
  <Style Selector="DateTimePickerPanel > ListBoxItem">
    <Setter Property="Theme" Value="{StaticResource FluentDateTimePickerItem}" />
  </Style>
</Grid.Styles>
```

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
