### PR TITLE
Suppress culture flowing with ExecutionContext captured by DispatcherOperation

### DIFF
--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -227,6 +227,10 @@ partial class Build : NukeBuild
             {
                 tfm = "net8.0";
             }
+            if (tfm == "$(AvsCurrentWindowsTargetFramework)")
+            {
+                tfm = "net10.0-windows";
+            }
             
             if (tfm.StartsWith("net4")
                 && (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -279,6 +283,9 @@ partial class Build : NukeBuild
             RunCoreTest("Avalonia.Headless.NUnit.PerTest.UnitTests");
             RunCoreTest("Avalonia.Headless.XUnit.PerAssembly.UnitTests");
             RunCoreTest("Avalonia.Headless.XUnit.PerTest.UnitTests");
+
+            if (Parameters.IsRunningOnWindows)
+                RunCoreTest("Avalonia.UnitTests.WpfCompare");
         });
 
     Target RunRenderTests => _ => _

--- a/src/Avalonia.Base/Threading/CulturePreservingExecutionContext.cs
+++ b/src/Avalonia.Base/Threading/CulturePreservingExecutionContext.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Globalization;
+using System.Threading;
+
+namespace Avalonia.Threading;
+
+/// <summary>
+/// A wrapper around <see cref="ExecutionContext"/> for running dispatcher operations that deliberately
+/// opts OUT of the runtime flowing <see cref="CultureInfo.CurrentCulture"/> /
+/// <see cref="CultureInfo.CurrentUICulture"/> through the execution context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Since .NET Framework 4.6 the current culture and UI culture flow with the <see cref="ExecutionContext"/>,
+/// like any <see cref="AsyncLocal{T}"/>. For a UI toolkit this is the wrong model, and we explicitly do NOT
+/// want it. The culture is a property of the UI thread: the application sets it once (e.g. for localization)
+/// and every dispatcher operation - layout, rendering, input, user callbacks - must observe that single,
+/// live thread culture. With the built-in flow an operation instead runs under whatever culture happened to
+/// be current when it was <em>queued</em> (captured into its execution context), and any culture change the
+/// operation makes is silently discarded when the context is restored afterwards. The net effect is that a
+/// culture the user sets on the UI thread gets reverted by the next queued operation - see
+/// https://github.com/AvaloniaUI/Avalonia/issues/21451.
+/// </para>
+/// <para>
+/// This type restores the pre-4.6 semantics, which are the only ones that make sense for a UI application:
+/// culture is plain ambient state on the UI thread. It still runs the callback under the captured execution
+/// context, so impersonation and every other <see cref="AsyncLocal{T}"/> continue to flow normally; only the
+/// culture is special-cased. It:
+/// </para>
+/// <list type="number">
+///   <item>snapshots the executing (UI) thread's live culture immediately before running;</item>
+///   <item>re-applies that live culture <em>inside</em> the context, overriding whatever culture the captured
+///   context flows in, so the callback always runs under the current UI-thread culture; and</item>
+///   <item>reads the culture back after the callback and writes it onto the thread once the context has been
+///   restored, so any culture change the callback made persists instead of being thrown away.</item>
+/// </list>
+/// <para>
+/// This is a port of WPF's <c>CulturePreservingExecutionContext</c>, which exists for exactly the same reason.
+/// </para>
+/// </remarks>
+internal sealed class CulturePreservingExecutionContext
+{
+    private readonly ExecutionContext _context;
+    private CultureAndContext? _cultureAndContext;
+
+    private static readonly ContextCallback s_callbackWrapperDelegate = CallbackWrapper;
+
+    private CulturePreservingExecutionContext(ExecutionContext context)
+    {
+        _context = context;
+    }
+
+    public static CulturePreservingExecutionContext? Capture()
+    {
+        // Match ExecutionContext.Capture(): when the flow is suppressed it returns null and there is
+        // nothing to restore later, so we behave the same way.
+        if (ExecutionContext.IsFlowSuppressed())
+            return null;
+
+        var context = ExecutionContext.Capture();
+        if (context is null)
+            return null;
+
+        return new CulturePreservingExecutionContext(context);
+    }
+
+    public static void Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, object? state)
+    {
+        if (executionContext is null)
+            throw new InvalidOperationException("Cannot run on a null CulturePreservingExecutionContext.");
+
+        // Snapshot the live culture of the thread that is about to run the callback (the dispatcher thread).
+        // We need it to override the culture that ExecutionContext.Run flows in from the captured context.
+        executionContext._cultureAndContext = CultureAndContext.Initialize(callback, state);
+
+        try
+        {
+            ExecutionContext.Run(
+                executionContext._context,
+                s_callbackWrapperDelegate,
+                executionContext._cultureAndContext);
+        }
+        finally
+        {
+            // ExecutionContext.Run has reverted the context, discarding any culture change made inside it.
+            // Re-apply the culture we read back after the callback so the change persists on the thread.
+            executionContext._cultureAndContext.WriteCultureInfosToCurrentThread();
+        }
+    }
+
+    private static void CallbackWrapper(object? obj)
+    {
+        var cultureAndContext = (CultureAndContext)obj!;
+
+        // Override the culture flowed in by the captured context with the live UI-thread culture, run the
+        // callback, then capture whatever culture the callback leaves behind.
+        cultureAndContext.WriteCultureInfosToCurrentThread();
+        cultureAndContext.Callback(cultureAndContext.State);
+        cultureAndContext.ReadCultureInfosFromCurrentThread();
+    }
+
+    private sealed class CultureAndContext
+    {
+        private CultureInfo _culture;
+        private CultureInfo _uiCulture;
+
+        public ContextCallback Callback { get; }
+        public object? State { get; }
+
+        private CultureAndContext(ContextCallback callback, object? state)
+        {
+            Callback = callback;
+            State = state;
+            _culture = Thread.CurrentThread.CurrentCulture;
+            _uiCulture = Thread.CurrentThread.CurrentUICulture;
+        }
+
+        public static CultureAndContext Initialize(ContextCallback callback, object? state)
+            => new(callback, state);
+
+        public void ReadCultureInfosFromCurrentThread()
+        {
+            _culture = Thread.CurrentThread.CurrentCulture;
+            _uiCulture = Thread.CurrentThread.CurrentUICulture;
+        }
+
+        public void WriteCultureInfosToCurrentThread()
+        {
+            Thread.CurrentThread.CurrentCulture = _culture;
+            Thread.CurrentThread.CurrentUICulture = _uiCulture;
+        }
+    }
+}

--- a/src/Avalonia.Base/Threading/DispatcherOperation.cs
+++ b/src/Avalonia.Base/Threading/DispatcherOperation.cs
@@ -5,8 +5,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-using ExecutionContext = System.Threading.ExecutionContext;
-
 namespace Avalonia.Threading;
 
 [DebuggerDisplay("{DebugDisplay}")]
@@ -42,7 +40,7 @@ public class DispatcherOperation
     private EventHandler? _aborted;
     private EventHandler? _completed;
     private DispatcherPriority _priority;
-    private readonly ExecutionContext? _executionContext;
+    private readonly CulturePreservingExecutionContext? _executionContext;
 
     internal DispatcherOperation(Dispatcher dispatcher, DispatcherPriority priority, Action callback, bool throwOnUiThread,
         bool captureExecutionContext = true) :
@@ -57,7 +55,7 @@ public class DispatcherOperation
         ThrowOnUiThread = throwOnUiThread;
         Priority = priority;
         Dispatcher = dispatcher;
-        _executionContext = captureExecutionContext ? ExecutionContext.Capture() : null;
+        _executionContext = captureExecutionContext ? CulturePreservingExecutionContext.Capture() : null;
     }
 
     internal string DebugDisplay
@@ -275,8 +273,8 @@ public class DispatcherOperation
             {
                 if (_executionContext is { } executionContext)
                 {
-                    ExecutionContext.Restore(executionContext);
-                    InvokeCore();
+                    CulturePreservingExecutionContext.Run(
+                        executionContext, static s => ((DispatcherOperation)s!).InvokeCore(), this);
                 }
                 else
                 {

--- a/tests/Avalonia.Base.UnitTests/DispatcherExecutionContextTests.cs
+++ b/tests/Avalonia.Base.UnitTests/DispatcherExecutionContextTests.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 // This file is compiled into BOTH:
@@ -31,6 +33,9 @@ public class DispatcherExecutionContextTests : global::Avalonia.UnitTests.Scoped
 {
     // Sumerian: extremely unlikely to be the machine default, so these tests don't depend on the environment.
     private const string CustomCultureName = "sux-Shaw-UM";
+
+    // A second, distinct culture used as the "calling thread" culture in the cross-thread test.
+    private const string CallSiteCultureName = "kk-KZ";
 
     // Regression test for https://github.com/AvaloniaUI/Avalonia/issues/21451. A dispatcher operation must
     // run under the UI thread's live culture - even one queued *before* the culture was set, whose execution
@@ -132,5 +137,57 @@ public class DispatcherExecutionContextTests : global::Avalonia.UnitTests.Scoped
         DispatcherTestServices.DrainQueue(dispatcher, DispatcherPriority.Background);
 
         Assert.Null(seen);
+    }
+
+    // A dispatcher operation runs under the UI thread's live culture, NOT under the culture of the thread
+    // that happened to queue it - even though that other thread's culture would flow into a plain Task.Run
+    // continuation. This is the cross-thread counterpart of the same-thread test above.
+    [CrossFact]
+    [SuppressMessage("Usage", "xUnit1031:Do not use blocking task operations in test method", Justification = "Tests the dispatcher itself")]
+    public void Dispatcher_Operations_Use_Live_UI_Thread_Culture_Not_Calling_Thread_Culture()
+    {
+        var dispatcher = Dispatcher.CurrentDispatcher;
+        var uiThreadCulture = CultureInfo.GetCultureInfo(CustomCultureName);
+        var callSiteCulture = CultureInfo.GetCultureInfo(CallSiteCultureName);
+        var oldCulture = Thread.CurrentThread.CurrentCulture;
+
+        // This (test) thread pumps the frame below, i.e. it is the UI thread. Give it a known culture.
+        Thread.CurrentThread.CurrentCulture = uiThreadCulture;
+        try
+        {
+            var frame = new DispatcherFrame();
+            string? taskRunSaw = null;
+            string? invokeSaw = null;
+            string? invokeAsyncSaw = null;
+
+            var callingThread = new Thread(() =>
+            {
+                // A DIFFERENT culture on this non-UI (calling) thread.
+                Thread.CurrentThread.CurrentCulture = callSiteCulture;
+
+                // Baseline: a plain Task.Run continuation DOES flow the calling-thread culture through the EC.
+                taskRunSaw = Task.Run(() => Thread.CurrentThread.CurrentCulture.Name).GetAwaiter().GetResult();
+
+                // Queue work onto the dispatcher from this non-UI thread, then stop the frame.
+                dispatcher.Invoke(() => invokeSaw = Thread.CurrentThread.CurrentCulture.Name);
+                dispatcher.InvokeAsync(() => invokeAsyncSaw = Thread.CurrentThread.CurrentCulture.Name, DispatcherPriority.Normal);
+                dispatcher.InvokeAsync(() => frame.Continue = false, DispatcherPriority.Normal);
+            });
+            callingThread.Start();
+
+            DispatcherTestServices.PushFrame(dispatcher, frame);
+            callingThread.Join();
+
+            // Baseline: Task.Run flows the calling-thread culture (guaranteed by the runtime).
+            Assert.Equal(CallSiteCultureName, taskRunSaw);
+            // Dispatcher operations run under the UI thread's live culture, not the calling thread's culture.
+            Assert.Equal(CustomCultureName, invokeSaw);
+            Assert.Equal(CustomCultureName, invokeAsyncSaw);
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = oldCulture;
+            Assert.NotEqual(CustomCultureName, oldCulture.Name);
+        }
     }
 }

--- a/tests/Avalonia.Base.UnitTests/DispatcherExecutionContextTests.cs
+++ b/tests/Avalonia.Base.UnitTests/DispatcherExecutionContextTests.cs
@@ -1,0 +1,136 @@
+using System.Globalization;
+using System.Threading;
+using Xunit;
+
+// This file is compiled into BOTH:
+//   * Avalonia.Base.UnitTests        - against Avalonia.Threading
+//   * Avalonia.UnitTests.WpfCompare  - against System.Windows.Threading (no Avalonia reference)
+// so that the exact same test bodies run against Avalonia's dispatcher and WPF's dispatcher,
+// proving that Avalonia's culture / ExecutionContext behaviour matches WPF. See issue #21451.
+//
+// The only per-framework differences are hidden behind two small helpers that each project
+// provides in its own namespace:
+//   * CrossFactAttribute     - [Fact] on Avalonia, [StaFact] on WPF (WPF dispatcher needs STA).
+//   * DispatcherTestServices - DrainQueue(), which differs only in static vs instance PushFrame.
+// Everything else (Dispatcher.CurrentDispatcher, InvokeAsync, DispatcherPriority, DispatcherFrame,
+// CultureInfo, Thread, AsyncLocal) is API-identical between the two frameworks.
+
+#if WPFCOMPARE
+using System.Windows.Threading;
+
+namespace Avalonia.UnitTests.WpfCompare;
+
+public class DispatcherExecutionContextTests
+#else
+using Avalonia.Threading;
+
+namespace Avalonia.Base.UnitTests;
+
+public class DispatcherExecutionContextTests : global::Avalonia.UnitTests.ScopedTestBase
+#endif
+{
+    // Sumerian: extremely unlikely to be the machine default, so these tests don't depend on the environment.
+    private const string CustomCultureName = "sux-Shaw-UM";
+
+    // Regression test for https://github.com/AvaloniaUI/Avalonia/issues/21451. A dispatcher operation must
+    // run under the UI thread's live culture - even one queued *before* the culture was set, whose execution
+    // context captured the old culture - and running operations must not reset the UI-thread culture.
+    [CrossFact]
+    public void Dispatcher_Operation_Runs_Under_Live_UI_Thread_Culture_And_Does_Not_Reset_It()
+    {
+        var dispatcher = Dispatcher.CurrentDispatcher;
+        var custom = CultureInfo.GetCultureInfo(CustomCultureName);
+        var oldCulture = Thread.CurrentThread.CurrentUICulture;
+        try
+        {
+            string? earlyOpSaw = null;
+            string? lateOpSaw = null;
+
+            // Queued BEFORE the culture is set: its execution context captures the current (default) culture.
+            dispatcher.InvokeAsync(() => earlyOpSaw = Thread.CurrentThread.CurrentUICulture.Name, DispatcherPriority.Normal);
+
+            // The application sets a custom UI culture on the UI thread.
+            Thread.CurrentThread.CurrentUICulture = custom;
+
+            dispatcher.InvokeAsync(() => lateOpSaw = Thread.CurrentThread.CurrentUICulture.Name, DispatcherPriority.Normal);
+
+            DispatcherTestServices.DrainQueue(dispatcher, DispatcherPriority.Background);
+
+            // The early operation runs under the LIVE UI-thread culture, not the default it captured...
+            Assert.Equal(CustomCultureName, earlyOpSaw);
+            Assert.Equal(CustomCultureName, lateOpSaw);
+            // ...and running operations must not have reset the UI-thread culture.
+            Assert.Equal(CustomCultureName, Thread.CurrentThread.CurrentUICulture.Name);
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentUICulture = oldCulture;
+            Assert.NotEqual(CustomCultureName, oldCulture.Name);
+        }
+    }
+
+    // A culture change made *inside* an operation persists on the UI thread (the outbound half of the
+    // pre-4.6 semantics). With the runtime's default ExecutionContext flow the change would be discarded.
+    [CrossFact]
+    public void Culture_Set_Inside_Dispatcher_Operation_Persists_To_UI_Thread()
+    {
+        var dispatcher = Dispatcher.CurrentDispatcher;
+        var custom = CultureInfo.GetCultureInfo(CustomCultureName);
+        var oldCulture = Thread.CurrentThread.CurrentUICulture;
+        try
+        {
+            string? nextOpSaw = null;
+
+            dispatcher.InvokeAsync(() => Thread.CurrentThread.CurrentUICulture = custom, DispatcherPriority.Normal);
+            dispatcher.InvokeAsync(() => nextOpSaw = Thread.CurrentThread.CurrentUICulture.Name, DispatcherPriority.Normal);
+
+            DispatcherTestServices.DrainQueue(dispatcher, DispatcherPriority.Background);
+
+            // The change made by the first operation is visible to the next one and stays on the thread.
+            Assert.Equal(CustomCultureName, nextOpSaw);
+            Assert.Equal(CustomCultureName, Thread.CurrentThread.CurrentUICulture.Name);
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentUICulture = oldCulture;
+            Assert.NotEqual(CustomCultureName, oldCulture.Name);
+        }
+    }
+
+    // Non-culture ExecutionContext state (an AsyncLocal) DOES flow into an operation from the context that
+    // was captured when it was queued - this is preserved, unlike culture which is special-cased.
+    [CrossFact]
+    public void ExecutionContext_Flows_Into_Dispatcher_Operation()
+    {
+        var dispatcher = Dispatcher.CurrentDispatcher;
+        var asyncLocal = new AsyncLocal<string?>();
+        string? seen = null;
+
+        asyncLocal.Value = "captured";
+        dispatcher.InvokeAsync(() => seen = asyncLocal.Value, DispatcherPriority.Normal);
+        // Change the ambient value AFTER the operation captured its context.
+        asyncLocal.Value = "ambient";
+
+        DispatcherTestServices.DrainQueue(dispatcher, DispatcherPriority.Background);
+
+        // The operation observes the value captured at post time, not the later ambient value.
+        Assert.Equal("captured", seen);
+    }
+
+    // An AsyncLocal set inside one operation must not leak into the next one (each operation restores its
+    // own captured context).
+    [CrossFact]
+    public void ExecutionContext_Does_Not_Flow_Between_Dispatcher_Operations()
+    {
+        var dispatcher = Dispatcher.CurrentDispatcher;
+        var asyncLocal = new AsyncLocal<string?>();
+        string? seen = "unset";
+
+        dispatcher.InvokeAsync(() => asyncLocal.Value = "set-by-first-op", DispatcherPriority.Normal);
+        dispatcher.InvokeAsync(() => seen = asyncLocal.Value, DispatcherPriority.Normal);
+
+        DispatcherTestServices.DrainQueue(dispatcher, DispatcherPriority.Background);
+
+        Assert.Null(seen);
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
+++ b/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
@@ -615,102 +615,9 @@ public partial class DispatcherTests
         }
     }
 
-    [Fact]
-    public async Task ExecutionContextIsPreservedInDispatcherInvokeAsync()
-    {
-        using var services = new DispatcherServices(new SimpleControlledDispatcherImpl());
-        var tokenSource = new CancellationTokenSource();
-        string? test1 = null;
-        string? test2 = null;
-        string? test3 = null;
-
-        // All test code must run inside Task.Run to avoid interfering with the test:
-        //  1. Prevent the execution context from being captured by MainLoop.
-        //  2. Prevent the execution context from remaining effective when set on the same thread.
-        var task = Task.Run(() =>
-        {
-            var testObject = new AsyncLocalTestClass();
-
-            // Test 1: Verify Task.Run preserves the execution context.
-            // First, test Task.Run to ensure that the preceding validation always passes, serving as a baseline for the subsequent Invoke/InvokeAsync tests.
-            // This way, if a later test fails, we have the .NET framework's baseline behavior for reference.
-            testObject.AsyncLocalField.Value = "Initial Value";
-            var task1 = Task.Run(() =>
-            {
-                test1 = testObject.AsyncLocalField.Value;
-            });
-
-            // Test 2: Verify Invoke preserves the execution context.
-            testObject.AsyncLocalField.Value = "Initial Value";
-            Dispatcher.UIThread.Invoke(() =>
-            {
-                test2 = testObject.AsyncLocalField.Value;
-            });
-
-            // Test 3: Verify InvokeAsync preserves the execution context.
-            testObject.AsyncLocalField.Value = "Initial Value";
-            _ = Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                test3 = testObject.AsyncLocalField.Value;
-            });
-
-            _ = Dispatcher.UIThread.InvokeAsync(async () =>
-            {
-                await Task.WhenAll(task1);
-                tokenSource.Cancel();
-            });
-
-        }, TestContext.Current.CancellationToken);
-
-        Dispatcher.UIThread.MainLoop(tokenSource.Token);
-        await Task.WhenAll(task);
-
-        // Assertions
-        // Task.Run: Always passes (guaranteed by the .NET runtime).
-        Assert.Equal("Initial Value", test1);
-        // Invoke: Always passes because the context is not changed.
-        Assert.Equal("Initial Value", test2);
-        // InvokeAsync: See https://github.com/AvaloniaUI/Avalonia/pull/19163
-        Assert.Equal("Initial Value", test3);
-    }
-
-    [Fact]
-    public async Task ExecutionContextIsNotPreservedAmongDispatcherInvokeAsync()
-    {
-        using var services = new DispatcherServices(new SimpleControlledDispatcherImpl());
-        var tokenSource = new CancellationTokenSource();
-        string? test = null;
-
-        // All test code must run inside Task.Run to avoid interfering with the test:
-        //  1. Prevent the execution context from being captured by MainLoop.
-        //  2. Prevent the execution context from remaining effective when set on the same thread.
-        var task = Task.Run(() =>
-        {
-            var testObject = new AsyncLocalTestClass();
-
-            // Test: Verify that InvokeAsync calls do not share execution context between each other.
-            _ = Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                testObject.AsyncLocalField.Value = "Initial Value";
-            });
-            _ = Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                test = testObject.AsyncLocalField.Value;
-            });
-
-            _ = Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                tokenSource.Cancel();
-            });
-        }, TestContext.Current.CancellationToken);
-
-        Dispatcher.UIThread.MainLoop(tokenSource.Token);
-        await Task.WhenAll(task);
-
-        // Assertions
-        // The value should NOT flow between different InvokeAsync execution contexts.
-        Assert.Null(test);
-    }
+    // NOTE: ExecutionContext / culture behaviour tests live in the shared DispatcherExecutionContextTests.cs,
+    // which is compiled into both this project and Avalonia.UnitTests.WpfCompare to verify the behaviour
+    // matches WPF.
 
     [Fact]
     public void MediaContextRenderSchedulingDoesNotCaptureAmbientExecutionContext()
@@ -782,64 +689,61 @@ public partial class DispatcherTests
         Assert.Null(test);
     }
 
+    // Avalonia deliberately opts OUT of the runtime's "culture flows with ExecutionContext" behaviour for
+    // dispatcher operations (see CulturePreservingExecutionContext and issue #21451): a dispatcher operation
+    // runs under the UI thread's live culture, NOT under whatever culture was current on the thread that
+    // happened to queue it. This is specific to culture - other ExecutionContext/AsyncLocal state still flows
+    // normally, see ExecutionContextIsPreservedInDispatcherInvokeAsync.
     [Fact]
-    public async Task ExecutionContextCultureInfoIsPreservedInDispatcherInvokeAsync()
+    [SuppressMessage("Usage", "xUnit1031:Do not use blocking task operations in test method", Justification = "Tests the dispatcher itself")]
+    public void DispatcherOperationsUseLiveUiThreadCultureInsteadOfCapturedCulture()
     {
         using var services = new DispatcherServices(new SimpleControlledDispatcherImpl());
         var tokenSource = new CancellationTokenSource();
-        string? test1 = null;
-        string? test2 = null;
-        string? test3 = null;
+
+        // "sux-Shaw-UM" (Sumerian) is extremely unlikely to be a machine default, so the test is not affected
+        // by the user's environment.
+        var uiThreadCulture = CultureInfo.GetCultureInfo("sux-Shaw-UM");
+        var callSiteCulture = CultureInfo.GetCultureInfo("kk-KZ");
+
         var oldCulture = Thread.CurrentThread.CurrentCulture;
 
-        // All test code must run inside Task.Run to avoid interfering with the test:
-        //  1. Prevent the execution context from being captured by MainLoop.
-        //  2. Prevent the execution context from remaining effective when set on the same thread.
-        var task = Task.Run(() =>
-        {
-            // This culture tag is Sumerian and is extremely unlikely to be set as the default on any device,
-            // ensuring that this test will not be affected by the user's environment.
-            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("sux-Shaw-UM");
+        // This thread runs the MainLoop below, i.e. it is the UI thread. Give it a known culture.
+        Thread.CurrentThread.CurrentCulture = uiThreadCulture;
 
-            // Test 1: Verify Task.Run preserves the culture in the execution context.
-            // First, test Task.Run to ensure that the preceding validation always passes, serving as a baseline for the subsequent Invoke/InvokeAsync tests.
-            // This way, if a later test fails, we have the .NET framework's baseline behavior for reference.
-            var task1 = Task.Run(() =>
-            {
-                test1 = Thread.CurrentThread.CurrentCulture.Name;
-            });
-
-            // Test 2: Verify Invoke preserves the execution context.
-            Dispatcher.UIThread.Invoke(() =>
-            {
-                test2 = Thread.CurrentThread.CurrentCulture.Name;
-            });
-
-            // Test 3: Verify InvokeAsync preserves the culture in the execution context.
-            _ = Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                test3 = Thread.CurrentThread.CurrentCulture.Name;
-            });
-
-            _ = Dispatcher.UIThread.InvokeAsync(async () =>
-            {
-                await Task.WhenAll(task1);
-                tokenSource.Cancel();
-            });
-        }, TestContext.Current.CancellationToken);
+        string? taskRunSaw = null;     // baseline: a plain Task.Run continuation DOES flow the call-site culture
+        string? invokeSaw = null;
+        string? invokeAsyncSaw = null;
 
         try
         {
-            Dispatcher.UIThread.MainLoop(tokenSource.Token);
-            await Task.WhenAll(task);
+            var task = Task.Run(() =>
+            {
+                // Set a DIFFERENT culture on this (non-UI) thread, then queue work onto the dispatcher.
+                Thread.CurrentThread.CurrentCulture = callSiteCulture;
 
-            // Assertions
-            // Task.Run: Always passes (guaranteed by the .NET runtime).
-            Assert.Equal("sux-Shaw-UM", test1);
-            // Invoke: Always passes because the context is not changed.
-            Assert.Equal("sux-Shaw-UM", test2);
-            // InvokeAsync: See https://github.com/AvaloniaUI/Avalonia/pull/19163
-            Assert.Equal("sux-Shaw-UM", test3);
+                // Baseline: confirms the runtime still flows culture through the ExecutionContext in general.
+                var baseline = Task.Run(() => taskRunSaw = Thread.CurrentThread.CurrentCulture.Name);
+
+                Dispatcher.UIThread.Invoke(() => invokeSaw = Thread.CurrentThread.CurrentCulture.Name);
+
+                _ = Dispatcher.UIThread.InvokeAsync(() => invokeAsyncSaw = Thread.CurrentThread.CurrentCulture.Name);
+
+                _ = Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await Task.WhenAll(baseline);
+                    tokenSource.Cancel();
+                });
+            }, TestContext.Current.CancellationToken);
+
+            Dispatcher.UIThread.MainLoop(tokenSource.Token);
+            task.GetAwaiter().GetResult();
+
+            // Baseline: Task.Run flows the call-site culture (guaranteed by the runtime).
+            Assert.Equal("kk-KZ", taskRunSaw);
+            // Dispatcher operations run under the UI thread's live culture, not the captured call-site culture.
+            Assert.Equal("sux-Shaw-UM", invokeSaw);
+            Assert.Equal("sux-Shaw-UM", invokeAsyncSaw);
         }
         finally
         {

--- a/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
+++ b/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
@@ -615,10 +615,6 @@ public partial class DispatcherTests
         }
     }
 
-    // NOTE: ExecutionContext / culture behaviour tests live in the shared DispatcherExecutionContextTests.cs,
-    // which is compiled into both this project and Avalonia.UnitTests.WpfCompare to verify the behaviour
-    // matches WPF.
-
     [Fact]
     public void MediaContextRenderSchedulingDoesNotCaptureAmbientExecutionContext()
     {
@@ -687,70 +683,6 @@ public partial class DispatcherTests
 
         Assert.Null(schedulingException);
         Assert.Null(test);
-    }
-
-    // Avalonia deliberately opts OUT of the runtime's "culture flows with ExecutionContext" behaviour for
-    // dispatcher operations (see CulturePreservingExecutionContext and issue #21451): a dispatcher operation
-    // runs under the UI thread's live culture, NOT under whatever culture was current on the thread that
-    // happened to queue it. This is specific to culture - other ExecutionContext/AsyncLocal state still flows
-    // normally, see ExecutionContextIsPreservedInDispatcherInvokeAsync.
-    [Fact]
-    [SuppressMessage("Usage", "xUnit1031:Do not use blocking task operations in test method", Justification = "Tests the dispatcher itself")]
-    public void DispatcherOperationsUseLiveUiThreadCultureInsteadOfCapturedCulture()
-    {
-        using var services = new DispatcherServices(new SimpleControlledDispatcherImpl());
-        var tokenSource = new CancellationTokenSource();
-
-        // "sux-Shaw-UM" (Sumerian) is extremely unlikely to be a machine default, so the test is not affected
-        // by the user's environment.
-        var uiThreadCulture = CultureInfo.GetCultureInfo("sux-Shaw-UM");
-        var callSiteCulture = CultureInfo.GetCultureInfo("kk-KZ");
-
-        var oldCulture = Thread.CurrentThread.CurrentCulture;
-
-        // This thread runs the MainLoop below, i.e. it is the UI thread. Give it a known culture.
-        Thread.CurrentThread.CurrentCulture = uiThreadCulture;
-
-        string? taskRunSaw = null;     // baseline: a plain Task.Run continuation DOES flow the call-site culture
-        string? invokeSaw = null;
-        string? invokeAsyncSaw = null;
-
-        try
-        {
-            var task = Task.Run(() =>
-            {
-                // Set a DIFFERENT culture on this (non-UI) thread, then queue work onto the dispatcher.
-                Thread.CurrentThread.CurrentCulture = callSiteCulture;
-
-                // Baseline: confirms the runtime still flows culture through the ExecutionContext in general.
-                var baseline = Task.Run(() => taskRunSaw = Thread.CurrentThread.CurrentCulture.Name);
-
-                Dispatcher.UIThread.Invoke(() => invokeSaw = Thread.CurrentThread.CurrentCulture.Name);
-
-                _ = Dispatcher.UIThread.InvokeAsync(() => invokeAsyncSaw = Thread.CurrentThread.CurrentCulture.Name);
-
-                _ = Dispatcher.UIThread.InvokeAsync(async () =>
-                {
-                    await Task.WhenAll(baseline);
-                    tokenSource.Cancel();
-                });
-            }, TestContext.Current.CancellationToken);
-
-            Dispatcher.UIThread.MainLoop(tokenSource.Token);
-            task.GetAwaiter().GetResult();
-
-            // Baseline: Task.Run flows the call-site culture (guaranteed by the runtime).
-            Assert.Equal("kk-KZ", taskRunSaw);
-            // Dispatcher operations run under the UI thread's live culture, not the captured call-site culture.
-            Assert.Equal("sux-Shaw-UM", invokeSaw);
-            Assert.Equal("sux-Shaw-UM", invokeAsyncSaw);
-        }
-        finally
-        {
-            Thread.CurrentThread.CurrentCulture = oldCulture;
-            // Ensure that this test does not have a negative impact on other tests.
-            Assert.NotEqual("sux-Shaw-UM", oldCulture.Name);
-        }
     }
 
     [Fact]

--- a/tests/Avalonia.Base.UnitTests/WpfCompare.Support.cs
+++ b/tests/Avalonia.Base.UnitTests/WpfCompare.Support.cs
@@ -27,6 +27,10 @@ internal static class DispatcherTestServices
     {
         var frame = new DispatcherFrame();
         dispatcher.InvokeAsync(() => frame.Continue = false, priority);
-        dispatcher.PushFrame(frame);
+        PushFrame(dispatcher, frame);
     }
+
+    // Pumps the dispatcher until the frame is stopped. Avalonia's PushFrame is an instance method
+    // (WPF's is static) - that is the only difference from the WPF backend.
+    public static void PushFrame(Dispatcher dispatcher, DispatcherFrame frame) => dispatcher.PushFrame(frame);
 }

--- a/tests/Avalonia.Base.UnitTests/WpfCompare.Support.cs
+++ b/tests/Avalonia.Base.UnitTests/WpfCompare.Support.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.CompilerServices;
+using Avalonia.Threading;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests;
+
+// Avalonia backend for the shared DispatcherExecutionContextTests. The WPF project
+// (Avalonia.UnitTests.WpfCompare) provides its own version of these two types in its own namespace.
+
+public sealed class CrossFactAttribute : FactAttribute
+{
+    public CrossFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
+}
+
+internal static class DispatcherTestServices
+{
+    // Drains every dispatcher operation queued at or above <paramref name="priority"/> by pumping a frame
+    // until a sentinel posted at that priority runs. Replaces the Avalonia-only impl.ExecuteSignal() so the
+    // same body works against WPF too.
+    public static void DrainQueue(Dispatcher dispatcher, DispatcherPriority priority)
+    {
+        var frame = new DispatcherFrame();
+        dispatcher.InvokeAsync(() => frame.Continue = false, priority);
+        dispatcher.PushFrame(frame);
+    }
+}

--- a/tests/Avalonia.UnitTests.WpfCompare/Avalonia.UnitTests.WpfCompare.csproj
+++ b/tests/Avalonia.UnitTests.WpfCompare/Avalonia.UnitTests.WpfCompare.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(AvsCurrentWindowsTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <Nullable>enable</Nullable>
+    <UseWpf>true</UseWpf>
+    <!-- WPFCOMPARE switches the shared test file to compile against System.Windows.Threading. -->
+    <DefineConstants>$(DefineConstants);WPFCOMPARE</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Avalonia.Base.UnitTests\DispatcherExecutionContextTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xunit.StaFact" />
+  </ItemGroup>
+  <Import Project="..\..\build\XUnit.props" />
+  <Import Project="..\..\build\SharedVersion.props" />
+</Project>

--- a/tests/Avalonia.UnitTests.WpfCompare/WpfCompare.Support.cs
+++ b/tests/Avalonia.UnitTests.WpfCompare/WpfCompare.Support.cs
@@ -29,6 +29,10 @@ internal static class DispatcherTestServices
     {
         var frame = new DispatcherFrame();
         dispatcher.InvokeAsync(() => frame.Continue = false, priority);
-        Dispatcher.PushFrame(frame);
+        PushFrame(dispatcher, frame);
     }
+
+    // Pumps the dispatcher until the frame is stopped. WPF's PushFrame is static (Avalonia's is an
+    // instance method) - that is the only difference from the Avalonia backend.
+    public static void PushFrame(Dispatcher dispatcher, DispatcherFrame frame) => Dispatcher.PushFrame(frame);
 }

--- a/tests/Avalonia.UnitTests.WpfCompare/WpfCompare.Support.cs
+++ b/tests/Avalonia.UnitTests.WpfCompare/WpfCompare.Support.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Windows.Threading;
+using Xunit;
+
+namespace Avalonia.UnitTests.WpfCompare;
+
+// WPF backend for the shared DispatcherExecutionContextTests (compiled from
+// ..\Avalonia.Base.UnitTests\DispatcherExecutionContextTests.cs with WPFCOMPARE defined).
+// The Avalonia project provides equivalent types in the Avalonia.Base.UnitTests namespace.
+
+// The WPF dispatcher requires an STA thread, so the cross-framework [CrossFact] maps to [StaFact] here.
+public sealed class CrossFactAttribute : StaFactAttribute
+{
+    public CrossFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
+}
+
+internal static class DispatcherTestServices
+{
+    // Drains every dispatcher operation queued at or above <paramref name="priority"/> by pumping a frame
+    // until a sentinel posted at that priority runs. WPF's PushFrame is static (Avalonia's is an instance
+    // method) - that is the only difference from the Avalonia backend.
+    public static void DrainQueue(Dispatcher dispatcher, DispatcherPriority priority)
+    {
+        var frame = new DispatcherFrame();
+        dispatcher.InvokeAsync(() => frame.Continue = false, priority);
+        Dispatcher.PushFrame(frame);
+    }
+}


### PR DESCRIPTION
We want pre-4.6 behavior. WPF had CulturePreservingExecutionContext **specifically to suppress culture flowing with ExectionContext**. Post-4.6 behavior makes absolutely zero sense for any UI toolkit and should be suppressed.

Fix for #21451, also see #19163, https://github.com/dotnet/wpf/blob/511eaa44164372f174c6836cfd502fb4e38d90c0/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CulturePreservingExecutionContext.cs and https://github.com/dotnet/wpf/blob/511eaa44164372f174c6836cfd502fb4e38d90c0/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherOperation.cs.

This PR adds unit tests that run against **both** Avalonia and WPF to make sure that we **actually** do match the correct behavior.