### PR TITLE
Fix AndroidStorage.TryGetFile/FolderFromPathAsync returning null or throwing

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageItem.cs
+++ b/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageItem.cs
@@ -118,7 +118,8 @@ internal abstract class AndroidStorageItem : IStorageBookmarkItem
 
     protected async Task<bool> EnsureExternalFilesPermission(bool write)
     {
-        if (!_needsExternalFilesPermission)
+        // Starting in API level 33, this permission has no effect.
+        if (!_needsExternalFilesPermission || OperatingSystem.IsAndroidVersionAtLeast(33))
         {
             return true;
         }

--- a/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageProvider.cs
+++ b/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageProvider.cs
@@ -55,15 +55,20 @@ internal class AndroidStorageProvider : IStorageProvider
             return null;
         }
 
-        await EnsureUriReadPermission(androidUri);
+        // About the READ_EXTERNAL_STORAGE permission:
+        // https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE
+        //  - "Starting in API level 33, this permission has no effect."
+        //  - "Also starting in API level 19, this permission is not required
+        //     to read or write files in your application-specific directories [...]"
+        // Consequently, we don't try to check for that permission here anymore.
 
         var javaFile = new JavaFile(androidUriPath);
         if (javaFile.Exists() && javaFile.IsFile)
         {
-            return null;
+            return new AndroidStorageFile(_activity, androidUri);
         }
 
-        return new AndroidStorageFile(_activity, androidUri);
+        return null;
     }
 
     public async Task<IStorageFolder?> TryGetFolderFromPathAsync(Uri folderPath)
@@ -84,15 +89,13 @@ internal class AndroidStorageProvider : IStorageProvider
             return null;
         }
 
-        await EnsureUriReadPermission(androidUri);
-
         var javaFile = new JavaFile(androidUriPath);
         if (javaFile.Exists() && javaFile.IsDirectory)
         {
-            return null;
+            return new AndroidStorageFolder(_activity, androidUri, false);
         }
 
-        return new AndroidStorageFolder(_activity, androidUri, false);
+        return null;
     }
 
     public Task<IStorageFolder?> TryGetWellKnownFolderAsync(WellKnownFolder wellKnownFolder)
@@ -283,31 +286,5 @@ internal class AndroidStorageProvider : IStorageProvider
         }
 
         return intent;
-    }
-
-    private async Task EnsureUriReadPermission(AndroidUri androidUri)
-    {
-        bool hasPerms = false;
-        Exception? innerEx = null;
-        try
-        {
-            hasPerms = _activity.CheckUriPermission(androidUri,
-                global::Android.OS.Process.MyPid(),
-                global::Android.OS.Process.MyUid(),
-                ActivityFlags.GrantReadUriPermission)
-                == global::Android.Content.PM.Permission.Granted;
-
-            // TODO: call RequestPermission or add proper permissions API, something like in Browser File API.
-            hasPerms = hasPerms || await _activity.CheckPermission(Manifest.Permission.ReadExternalStorage);
-        }
-        catch (Exception ex)
-        {
-            innerEx = ex;
-        }
-
-        if (!hasPerms)
-        {
-            throw new InvalidOperationException("Application doesn't have READ_EXTERNAL_STORAGE permission. Make sure android manifest has this permission defined and user allowed it.", innerEx);
-        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes `AndroidStorage.TryGetFileFromPathAsync` and `TryGetFolderFromPathAsync` not returning results for several reasons.

First, the `READ_EXTERNAL_STORAGE` permission is always denied since Android API 33, which means the call always failed on such platforms. This PR no longer checks for that permission, as it might not be required at all (e.g., files in the app's folder since API 19, well below our minimum supported level, 24) or might always be denied (API ≥ 33). This is a bit similar to what https://github.com/AvaloniaUI/Avalonia/pull/18637 was doing.

Second, some code logic was inverted, meaning that existing files and folders would always return `null`.

## Notes

On Android, the objects we return from `TryGetFileFromPathAsync`, `TryGetFolderFromPathAsync` and `TryGetWellKnownFolderAsync` are pretty useless. See #21629.