### PR TITLE
Respect IME preedit cursor position on Win32

### DIFF
--- a/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
+++ b/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
@@ -25,6 +25,7 @@ namespace Avalonia.Win32.Input
         private const int CaretMargin = 1;
 
         private bool _ignoreComposition;
+        private int? _compositionCursorPosition;
 
         public TextInputMethodClient? Client { get; private set; }
 
@@ -110,6 +111,7 @@ namespace Avalonia.Win32.Input
             _langId = 0;
 
             IsComposing = false;
+            _compositionCursorPosition = null;
         }
 
         //Dependant on CurrentThread. When Avalonia will support Multiple Dispatchers -
@@ -118,6 +120,8 @@ namespace Avalonia.Win32.Input
 
         public void Reset()
         {
+            _compositionCursorPosition = null;
+
             Dispatcher.UIThread.Post(() =>
             {
                 var himc = ImmGetContext(Hwnd);
@@ -141,6 +145,7 @@ namespace Avalonia.Win32.Input
                     IsComposing = false;
 
                     Composition = null;
+                    _compositionCursorPosition = null;
                 }
             });
         }
@@ -150,8 +155,9 @@ namespace Avalonia.Win32.Input
             if(Client != null)
             {
                 Composition = null;
+                _compositionCursorPosition = null;
 
-                Client.SetPreeditText(null);
+                Client.SetPreeditText(null, null);
             }
 
             Client = client;
@@ -266,16 +272,17 @@ namespace Avalonia.Win32.Input
             // we're skipping this. not usable on windows
         }
 
-        public void CompositionChanged(string? composition)
+        public void CompositionChanged(string? composition, int? cursorPosition)
         {
             Composition = composition;
+            _compositionCursorPosition = cursorPosition;
 
             if (!IsActive || !Client.SupportsPreedit)
             {
                 return;
             }
 
-            Client.SetPreeditText(composition);
+            Client.SetPreeditText(composition, cursorPosition);
         }
         
         public string? GetCompositionString(GCS flag)
@@ -290,13 +297,40 @@ namespace Avalonia.Win32.Input
             return ImmGetCompositionString(himc, flag);
         }
 
+        private int? GetCompositionCursorPosition()
+        {
+            if (!IsComposing)
+            {
+                return null;
+            }
+
+            var himc = ImmGetContext(Hwnd);
+
+            if (himc == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            try
+            {
+                var cursorPosition = ImmGetCompositionString(himc, GCS.GCS_CURSORPOS, IntPtr.Zero, 0);
+
+                return cursorPosition >= 0 ? cursorPosition : null;
+            }
+            finally
+            {
+                ImmReleaseContext(Hwnd, himc);
+            }
+        }
+
         public void HandleCompositionStart()
         {
             Composition = null;
+            _compositionCursorPosition = null;
 
             if (IsActive)
             {
-                Client.SetPreeditText(null);
+                Client.SetPreeditText(null, null);
 
                 if (Client.SupportsSurroundingText && Client.Selection.Start != Client.Selection.End)
                 {
@@ -325,10 +359,11 @@ namespace Avalonia.Win32.Input
             }
 
             Composition = null;
+            _compositionCursorPosition = null;
 
             if (IsActive)
             {
-                Client.SetPreeditText(null);
+                Client.SetPreeditText(null, null);
             }
         }
 
@@ -342,25 +377,27 @@ namespace Avalonia.Win32.Input
             }
 
             var flags = (GCS)ToInt32(lParam);
+            var resultChanged = (flags & GCS.GCS_RESULTSTR) != 0;
             
             if (flags == 0)
             {
-                CompositionChanged("");
+                CompositionChanged("", null);
             }
 
-            if ((flags & GCS.GCS_RESULTSTR) != 0)
+            if (resultChanged)
             {
                 var resultString = GetCompositionString(GCS.GCS_RESULTSTR);
 
+                Composition = null;
+                _compositionCursorPosition = null;
+
+                if (IsActive)
+                {
+                    Client.SetPreeditText(null, null);
+                }
+
                 if (_parent != null && !string.IsNullOrEmpty(resultString))
                 {
-                    Composition = null;
-
-                    if (IsActive)
-                    {
-                        Client.SetPreeditText(null);
-                    }
-
                     var e = new RawTextInputEventArgs(WindowsKeyboardDevice.Instance, timestamp, _parent.Owner, resultString);
 
                     if (_parent.Input != null)
@@ -372,11 +409,20 @@ namespace Avalonia.Win32.Input
                 }
             }
 
-            if ((flags & GCS.GCS_COMPSTR) != 0)
-            {
-                var compositionString = GetCompositionString(GCS.GCS_COMPSTR);
+            var compositionChanged = (flags & GCS.GCS_COMPSTR) != 0;
+            var cursorPositionChanged = (flags & GCS.GCS_CURSORPOS) != 0;
 
-                CompositionChanged(compositionString);
+            if (compositionChanged || (cursorPositionChanged && !resultChanged))
+            {
+                var compositionString = compositionChanged
+                    ? GetCompositionString(GCS.GCS_COMPSTR)
+                    : Composition;
+
+                var cursorPosition = cursorPositionChanged
+                    ? GetCompositionCursorPosition()
+                    : _compositionCursorPosition;
+
+                CompositionChanged(compositionString, cursorPosition);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

This PR fixes Win32 IME preedit caret handling in `Imm32InputMethod`.

When IMM32 reports `GCS_CURSORPOS`, Avalonia now forwards that caret position to `TextInputMethodClient.SetPreeditText`, so the visual caret in the preedit string stays in sync with the actual IME composition cursor.

The change is limited to the Win32 IMM32 path and does not modify the higher-level text input model or platform-independent preedit behavior.

## What is the current behavior?

On Windows, Avalonia updates the preedit text content, but it does not track the caret position inside the active composition string.

As a result, when editing an in-progress IME composition, the logical caret can move inside the composition string while the visual preedit caret remains stale, typically staying at the end.

## What is the updated/expected behavior with this PR?

Avalonia now updates the preedit caret position together with the preedit text on the Win32 IMM32 path.

This makes the caret follow IME cursor movement correctly when editing an active composition string, including cases where the user returns from conversion to composition editing and moves the caret within the preedit text.

Manual verification was done with Japanese IME on Windows 10/11 using `samples/ControlCatalog.Desktop` (`TextBox` page), including both Google IME and Microsoft IME.

| Before | After |
| ---- | ---- |
| <img width="250" height="155" alt="before" src="https://github.com/user-attachments/assets/47821002-9cf3-48a9-8724-6ccc9a1b8061" /> | <img width="250" height="155" alt="after" src="https://github.com/user-attachments/assets/45ff856f-3c3f-466f-b2e2-b51eea9e8493" /> |

## How was the solution implemented (if it's not obvious)?

- cached the current Win32 composition cursor position in `Imm32InputMethod`
- propagated `GCS_CURSORPOS` updates to `TextInputMethodClient.SetPreeditText`
- cleared cached cursor state on reset, composition start/end, result commit, and client changes
- avoided reapplying stale cursor state when `GCS_RESULTSTR` and `GCS_CURSORPOS` are reported together without a new `GCS_COMPSTR`

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #10933

Likely fixes #21618 as well, since the reported symptom matches this Win32 IMM32 caret synchronization issue. However, my manual verification for this PR was performed with Japanese IMEs (Google IME and Microsoft IME), not with a Chinese IME specifically.
