### PR TITLE
Support decimal in automation ComVariant (fixes NumericUpDown crash under UIA)

### DIFF
--- a/src/Windows/Avalonia.Win32.Automation/Marshalling/ComVariant.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Marshalling/ComVariant.cs
@@ -39,9 +39,17 @@ internal struct ComVariant : IDisposable
     // Most of the data types in the Variant are carried in _typeUnion
     [FieldOffset(0)] private TypeUnion _typeUnion;
 
+    // Decimal is the largest data type and it needs to use the space that is normally unused in
+    // TypeUnion._wReserved1, etc. Hence, it is declared to completely overlap with TypeUnion. A
+    // Decimal does not use the first two bytes, and so TypeUnion._vt can still be used to encode the
+    // type. (Win32 automation is Windows-only, i.e. always little-endian, so TypeUnion's field order
+    // already lines up with Decimal._flags and no big-endian special-casing is required.)
+    [FieldOffset(0)] private decimal _decimal;
+
     [StructLayout(LayoutKind.Sequential)]
     private struct TypeUnion
     {
+        // The layout of _wReserved1 and _vt fields needs to match Decimal._flags.
         public ushort _vt;
         public ushort _wReserved1;
         public ushort _wReserved2;
@@ -161,6 +169,15 @@ internal struct ComVariant : IDisposable
             variant.VarType = VarEnum.VT_R8;
             variant._typeUnion._unionTypes._r8 = (double)value;
         }
+        else if (value is decimal)
+        {
+            // Set the value first and then the type, as the decimal storage overlaps the whole
+            // variant (including the type discriminator, which lands in decimal's unused first two
+            // bytes). NumericUpDown.Value is a decimal?, so its automation property-changed events
+            // arrive here; without this branch they throw and crash the app (#21491).
+            variant._decimal = (decimal)value;
+            variant.VarType = VarEnum.VT_DECIMAL;
+        }
         else if (value is DateTime)
         {
             variant.VarType = VarEnum.VT_DATE;
@@ -260,6 +277,8 @@ internal struct ComVariant : IDisposable
             // floating
             VarEnum.VT_R4 => _typeUnion._unionTypes._r4,
             VarEnum.VT_R8 => _typeUnion._unionTypes._r8,
+            // decimal
+            VarEnum.VT_DECIMAL => GetDecimal(),
             // date
             VarEnum.VT_DATE => DateTime.FromOADate(_typeUnion._unionTypes._date),
             // string
@@ -294,6 +313,19 @@ internal struct ComVariant : IDisposable
             },
             _ => throw new ArgumentException($"Unknown variant type: {VarType}")
         };
+    }
+
+    /// <summary>
+    /// Read the <see cref="decimal"/> stored in a <see cref="VarEnum.VT_DECIMAL"/> variant. The
+    /// decimal storage overlaps the entire variant, so the type discriminator currently sits in the
+    /// decimal's otherwise-unused first two bytes; clear it on a copy (by setting the type to
+    /// <see cref="VarEnum.VT_EMPTY"/>) so the VT_DECIMAL flag doesn't leak into the returned value.
+    /// </summary>
+    private readonly decimal GetDecimal()
+    {
+        var copy = this;
+        copy.VarType = VarEnum.VT_EMPTY;
+        return copy._decimal;
     }
 
     /// <summary>


### PR DESCRIPTION
## What does the pull request do?

`ComVariant.Create` has no case for `decimal`, so it throws `ArgumentException` for any `decimal` automation value. `NumericUpDown.Value` is a `decimal?`, so changing it while a UI Automation client is connected crashes the app. This adds `VT_DECIMAL` support to `ComVariant`.

This is the root-cause `ComVariant` fix that @maxkatz6 identified in #21515 (which was closed with the CLA unsigned). I've scoped it to just `ComVariant`. There are  no `NumericUpDownAutomationPeer` changes.

Fixes #21491.

## What is the current behavior?
Setup: Windows, with any UI Automation client connected so Narrator, Magnifier, Voice Access, the touch keyboard (TabTip) that Steam opens, the "Show pointer location" setting, etc.  Then  spinning, typing, or setting a `NumericUpDown` value crashes the process:

```
System.ArgumentException: UnsupportedType (Parameter 'Decimal')
   at Avalonia.Win32.Automation.Marshalling.ComVariant.Create(Object value)
   at Avalonia.Win32.Automation.Marshalling.ComVariantMarshaller.ConvertToUnmanaged(Object managed)
   at Avalonia.Win32.Automation.Interop.UiaCoreProviderApi.UiaRaiseAutomationPropertyChangedEvent(...)
   at Avalonia.Win32.Automation.AutomationNode.OnPeerPropertyChanged(...)
   at Avalonia.Automation.Peers.NumericUpDownAutomationPeer.OwnerPropertyChanged(...)
   at Avalonia.Controls.NumericUpDown.set_Value(Nullable`1 value)
```

The event is only raised when a UIA client is listening, which is why it looks like it only happens on some machines.

## What is the updated/expected behavior with this PR?

`decimal` marshals to `VT_DECIMAL` and round-trips back, so the property-changed event is raised without throwing and the app keeps running.

To check: `dotnet new avalonia.app`, add a `<NumericUpDown/>`, run with Narrator on (`Ctrl`+`Win`+`Enter`), and change the value. It crashes on `master` and works with this change.

I've created a minimal demo Project to replicate and prove the issue. When running it, attach Narrator (or the included `trigger-uia.ps1`, which subscribes a programmatic UIA client so no screen reader is needed), then try to change the value.
[UiaDecimalCrashPoc.zip](https://github.com/user-attachments/files/29257349/UiaDecimalCrashPoc.zip)


## How was the solution implemented (if it's not obvious)?

Same approach as the BCL `System.Runtime.InteropServices.Marshalling.ComVariant`, which this type is based on:

- A `decimal` field that overlaps the whole variant. A `decimal` doesn't use its first two bytes, so `_vt` still encodes the type; the existing `TypeUnion` layout already lines up with `Decimal._flags`. Automation here is Windows-only (little-endian), so there's no big-endian case to handle.
- In `Create`, set the value before `VarType = VT_DECIMAL`, since the type discriminator overlaps the decimal's unused leading bytes.
- In `AsObject`, clear the discriminator on a copy (`VarType = VT_EMPTY`) before returning, so the `VT_DECIMAL` flag doesn't leak into the value.

## Checklist

- [x] Added unit tests (if possible)? `Avalonia.Win32.Automation` exposes its internals only to `Avalonia.Win32` and has no unit-test project yet
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to avalonia-docs: No. Internal n/a (internal marshalling).

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21491
