### PR TITLE
Android - Use BCL storage api for TryGet api

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageProvider.cs
+++ b/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageProvider.cs
@@ -65,7 +65,7 @@ internal class AndroidStorageProvider : IStorageProvider
         var javaFile = new JavaFile(androidUriPath);
         if (javaFile.Exists() && javaFile.IsFile)
         {
-            return new AndroidStorageFile(_activity, androidUri);
+            return new BclStorageFile(new System.IO.FileInfo(javaFile.AbsolutePath));
         }
 
         return null;
@@ -92,7 +92,7 @@ internal class AndroidStorageProvider : IStorageProvider
         var javaFile = new JavaFile(androidUriPath);
         if (javaFile.Exists() && javaFile.IsDirectory)
         {
-            return new AndroidStorageFolder(_activity, androidUri, false);
+            return new BclStorageFolder(new System.IO.DirectoryInfo(javaFile.AbsolutePath));
         }
 
         return null;
@@ -121,16 +121,9 @@ internal class AndroidStorageProvider : IStorageProvider
             return Task.FromResult<IStorageFolder?>(null);
         }
 
-        var uri = AndroidUri.FromFile(dir);
-        if (uri is null)
-        {
-            return Task.FromResult<IStorageFolder?>(null);
-        }
-
-        // To make TryGetWellKnownFolder API easier to use, we don't check for the permissions.
-        // It will work with file picker activities, but it will fail on any direct access to the folder, like getting list of children.
-        // We pass "needsExternalFilesPermission" parameter here, so folder itself can check for permissions on any FS access. 
-        return Task.FromResult<IStorageFolder?>(new WellKnownAndroidStorageFolder(_activity, dirCode, uri, true));
+        // From Android 10(API 29), WellKnownFolders points to the app's external files directories, rather than the system's.
+        // These paths can be access directly using File apis without need to go though the ContextResolver or requesting permissions.
+        return Task.FromResult<IStorageFolder?>(new BclStorageFolder(new System.IO.DirectoryInfo(dir.AbsolutePath)));
     }
 
     public Task<IStorageBookmarkFile?> OpenFileBookmarkAsync(string bookmark)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Changes `IStorageProvider.TryGetFileFromPathAsync`, `TryGetFolderFromPathAsync` and `TryGetWellKnownFolderAsync` to return `BCLStorageItem` for paths passed to them. 

From Android API 19, which is lower than our minimum supported API 24, apps access storage using the Storage Access Framework (SAF) and do not need permission for read and write access. File managers can still use Java File apis with the older permissions until API 29, from this point, they have to declare a special `MANAGE_EXTERNAL_STORAGE` permission. Arbitrary File access is no longer available to normal apps.
With these changes, it makes sense to treat direct file URIs as normal Java Files and require the dev to manage permissions and ensure the URI is valid. We return `BCLStorageItems` for these apis. 

## What is the current behavior?
`IStorageProvider.TryGetFileFromPathAsync`, `TryGetFolderFromPathAsync` and `TryGetWellKnownFolderAsync` returns `AndroidStorageItem` which will fail to be read, as these use invalid URIs.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/21629
