### PR TITLE
Win32 - Support rendering at max refresh rate of current displays

### DIFF
--- a/src/Avalonia.Base/Rendering/RenderLoop.cs
+++ b/src/Avalonia.Base/Rendering/RenderLoop.cs
@@ -101,6 +101,8 @@ namespace Avalonia.Rendering
         /// <inheritdoc />
         public bool RunsInBackground => _timer.RunsInBackground;
 
+        internal IRenderTimer Timer => _timer;
+
         /// <inheritdoc />
         public void Wakeup()
         {

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -134,14 +134,7 @@ namespace Avalonia.Win32
             if (OleContext.Current != null)
                 AvaloniaLocator.CurrentMutable.Bind<IPlatformDragSource>().ToSingleton<DragSource>();
 
-            var maxDisplayFrequency = Instance.Screen?.AllScreens?.Max(s => (s as WinScreen)?.Frequency);
-
-            if (maxDisplayFrequency != null &&
-                maxDisplayFrequency != 0 &&
-                renderTimer is SleepLoopRenderTimer sleepLoopRenderTimer)
-            {
-                sleepLoopRenderTimer.DesiredFps = (int)maxDisplayFrequency;
-            }
+            UpdateTimerFps();
 
             s_compositor = new Compositor( platformGraphics);
             AvaloniaLocator.CurrentMutable.Bind<Compositor>().ToConstant(s_compositor);
@@ -203,6 +196,16 @@ namespace Avalonia.Win32
             TrayIconImpl.ProcWnd(hWnd, msg, wParam, lParam);
 
             return DefWindowProc(hWnd, msg, wParam, lParam);
+        }
+
+        internal static void UpdateTimerFps()
+        {
+            var maxDisplayFrequency = Math.Max(60, Instance.Screen?.AllScreens?.Max(s => (s as WinScreen)?.Frequency) ?? 0);
+            if (AvaloniaLocator.Current.GetService<IRenderLoop>() is DefaultRenderLoop defaultRenderLoop &&
+                defaultRenderLoop.Timer is SleepLoopRenderTimer sleepLoopRenderTimer)
+            {
+                sleepLoopRenderTimer.DesiredFps = maxDisplayFrequency;
+            }
         }
 
         private void CreateMessageWindow()

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -44,7 +44,7 @@ namespace Avalonia.Win32
         private static Win32PlatformOptions? s_options;
         private static Compositor? s_compositor;
         internal const int TIMERID_DISPATCHER = 1;
-
+        private const int DefaultFramesPerSecond = 60;
         private WndProc? _wndProcDelegate;
         private IntPtr _hwnd;
         private Win32DispatcherImpl _dispatcher;
@@ -87,7 +87,7 @@ namespace Avalonia.Win32
 
             Dispatcher.InitializeUIThreadDispatcher(s_instance._dispatcher);
             
-            var renderTimer = options.ShouldRenderOnUIThread ? new UiThreadRenderTimer(60) : new DefaultRenderTimer(60);
+            IRenderTimer renderTimer = options.ShouldRenderOnUIThread ? new UiThreadRenderTimer(DefaultFramesPerSecond) : new SleepLoopRenderTimer(DefaultFramesPerSecond);
             var clipboardImpl = new ClipboardImpl();
             var clipboard = new Clipboard(clipboardImpl);
 
@@ -133,7 +133,16 @@ namespace Avalonia.Win32
             
             if (OleContext.Current != null)
                 AvaloniaLocator.CurrentMutable.Bind<IPlatformDragSource>().ToSingleton<DragSource>();
-            
+
+            var maxDisplayFrequency = Instance.Screen?.AllScreens?.Max(s => (s as WinScreen)?.Frequency);
+
+            if (maxDisplayFrequency != null &&
+                maxDisplayFrequency != 0 &&
+                renderTimer is SleepLoopRenderTimer sleepLoopRenderTimer)
+            {
+                sleepLoopRenderTimer.DesiredFps = (int)maxDisplayFrequency;
+            }
+
             s_compositor = new Compositor( platformGraphics);
             AvaloniaLocator.CurrentMutable.Bind<Compositor>().ToConstant(s_compositor);
         }

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -876,14 +876,8 @@ namespace Avalonia.Win32
                     {
                         Screen?.OnChanged();
 
-                        var maxDisplayFrequency = Screen?.AllScreens?.Max(s => (s as WinScreen)?.Frequency);
-                        if (maxDisplayFrequency != null &&
-                            maxDisplayFrequency != 0 &&
-                            AvaloniaLocator.Current.GetService<IRenderLoop>() is DefaultRenderLoop defaultRenderLoop &&
-                            defaultRenderLoop.Timer is SleepLoopRenderTimer sleepLoopRenderTimer)
-                        {
-                            sleepLoopRenderTimer.DesiredFps = (int)maxDisplayFrequency;
-                        }
+                        Win32Platform.UpdateTimerFps();
+
                         return IntPtr.Zero;
                     }
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
+using Avalonia.Rendering;
 using Avalonia.Threading;
 using Avalonia.Win32.Automation;
 using Avalonia.Win32.Automation.Interop;
@@ -873,6 +875,15 @@ namespace Avalonia.Win32
                 case WindowsMessage.WM_DISPLAYCHANGE:
                     {
                         Screen?.OnChanged();
+
+                        var maxDisplayFrequency = Screen?.AllScreens?.Max(s => (s as WinScreen)?.Frequency);
+                        if (maxDisplayFrequency != null &&
+                            maxDisplayFrequency != 0 &&
+                            AvaloniaLocator.Current.GetService<IRenderLoop>() is DefaultRenderLoop defaultRenderLoop &&
+                            defaultRenderLoop.Timer is SleepLoopRenderTimer sleepLoopRenderTimer)
+                        {
+                            sleepLoopRenderTimer.DesiredFps = (int)maxDisplayFrequency;
+                        }
                         return IntPtr.Zero;
                     }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Updates `SleepRenderTimer` with the max refresh rate reported for the displays available on Windows. This allows Vulkan and WGL to render at the highest refresh rate available, though there are some inconsistencies due to the lack of hardware timing.
This doesn't affect AngleGL because that backend uses the DWM Composition as timer.

WGL and Vulkan behave differently based on display and driver settings.
WGL: On a Nvidia GPU
 - Using default driver settings, render rate will be locked to the lowest refresh rate currently being used among all displays. 2 monitors rendering at 60hz and 120hz will result in Avalonia rendering at 60fps on both monitors.
 - Setting VSync driver setting to `Fast`, render rate will be locked to the refresh rate of the last display the window was resized on. 2 monitors with 60hz and 120hz will result in Avalonia rendering at 120fps if initially moved from the second monitor to the first, and 60fps if initially moved from the first monitor to the second. Resizing will reset the frame rate to the current monitor.

Vulkan: 
 - We use MAILBOX present mode by default, which allows render as fast as we can without tearing, though the driver decides how fast we render. In this mode, Avalonia renders at the highest frame rate available when the window is first created and shown, and will reset to the current display's refresh rate when resized. It will then onwards adapt to the display it's moved to. This behavior was only observed when the window is resized on a slower refresh rate display and moved to a higher one and back. When resized on a higher refresh rate display, it will favor the high frame rate even when moved to a slower one, until it's resized again.
 - When FIFO present mode in forced internally, It will lock to the lowest refresh rate of the displays available when driver settings are default. If VSync is set to `Fast` or equivalent, it will adapt to the current display's refresh rate, dynamically switching with no need to resize. This would have been the more favored present mode, if it didn't rely on the driver settings.

## What is the current behavior?
Rendering is locked to 60fps, regardless of the display's refresh rate.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
