### PR TITLE
Fix: Android TalkBack should still respond to all hover events

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaView.Input.cs
+++ b/src/Android/Avalonia.Android/AvaloniaView.Input.cs
@@ -28,8 +28,7 @@ namespace Avalonia.Android
         protected override bool DispatchHoverEvent(MotionEvent? e)
         {
             var res = _view.PointerHelper.DispatchMotionEvent(e, out var callBase);
-            if (res == false)
-                callBase = (_accessHelper?.DispatchHoverEvent(e!) == true) && callBase;
+            callBase = (_accessHelper?.DispatchHoverEvent(e!) == true) && callBase;
 
             var baseResult = callBase && base.DispatchHoverEvent(e);
 
@@ -50,7 +49,7 @@ namespace Avalonia.Android
             var result = _view.PointerHelper.DispatchMotionEvent(e, out var callBase);
             var baseResult = callBase && base.DispatchTouchEvent(e);
 
-            if(result == true)
+            if (result == true)
             {
                 // Request focus for this view
                 RequestFocus();


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR fixes a key accessibility issue for Android TalkBack users of Avalonia. A recent pull request (#21551) caused a regression in Avalonia's ability to respond to TalkBack touch exploration events and forward them to Android's accessibility framework. This PR fixes this issue by ensuring that `_accessHelper` is always notified of hover events. 


## What is the current behavior?
The current behavior allows users to use tab navigation for Android TalkBack, but not use touch exploration. In other words, touch exploration is completely disabled in the current revision. 


## What is the updated/expected behavior with this PR?
The new behavior ensures that the method of `_accessHelper` is called regardless of whether an existing pointer device is able to respond to a given event. 


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
