### PR TITLE
Fix SelectableTextBlock selection offset with InlineUIContainer

### DIFF
--- a/src/Avalonia.Controls/Documents/InlineUIContainer.cs
+++ b/src/Avalonia.Controls/Documents/InlineUIContainer.cs
@@ -66,6 +66,10 @@ namespace Avalonia.Controls.Documents
 
         internal override void AppendText(StringBuilder stringBuilder)
         {
+            // EmbeddedControlRun occupies one position in TextLayout (TextRun.DefaultTextSourceLength = 1).
+            // Append the Unicode Object Replacement Character so that Inlines.Text stays in sync with
+            // the character offsets returned by TextLayout.HitTestPoint.
+            stringBuilder.Append('\uFFFC');
         }
 
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)

--- a/tests/Avalonia.Controls.UnitTests/SelectableTextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SelectableTextBlockTests.cs
@@ -10,6 +10,30 @@ namespace Avalonia.Controls.UnitTests
     public class SelectableTextBlockTests : ScopedTestBase
     {
         [Fact]
+        public void Selection_Spanning_InlineUIContainer_Returns_Correct_Text()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var target = new SelectableTextBlock();
+
+                target.Inlines!.Add(new Run("foo"));
+                target.Inlines!.Add(new InlineUIContainer(new Border()));
+                target.Inlines!.Add(new Run("bar"));
+
+                target.Measure(Size.Infinity);
+
+                // In TextLayout, EmbeddedControlRun (from InlineUIContainer) occupies 1 character
+                // position. After "foo" (3 chars) + InlineUIContainer (1 char), "bar" starts at
+                // position 4. SelectionStart/End come from TextLayout.HitTestPoint so they must
+                // align with the text returned by Inlines.Text.
+                target.SelectionStart = 4;
+                target.SelectionEnd = 7;
+
+                Assert.Equal("bar", target.SelectedText);
+            }
+        }
+
+        [Fact]
         public void SelectionForeground_Should_Not_Reset_Run_Typeface_And_Style()
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))

--- a/tests/Avalonia.Controls.UnitTests/SelectableTextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SelectableTextBlockTests.cs
@@ -9,8 +9,25 @@ namespace Avalonia.Controls.UnitTests
 {
     public class SelectableTextBlockTests : ScopedTestBase
     {
-        [Fact]
-        public void Selection_Spanning_InlineUIContainer_Returns_Correct_Text()
+        // Content: Run("foo") + InlineUIContainer + Run("bar")
+        // Inlines.Text after fix: "foo\uFFFCbar" (indices 0-6)
+        //   0='f', 1='o', 2='o', 3='\uFFFC' (embedded control), 4='b', 5='a', 6='r'
+        [Theory]
+        // Entirely before InlineUIContainer
+        [InlineData(0, 3, "foo")]
+        // Exactly the InlineUIContainer character
+        [InlineData(3, 4, "\uFFFC")]
+        // Up to and including InlineUIContainer (fencepost: last char before "bar")
+        [InlineData(0, 4, "foo\uFFFC")]
+        // Starting exactly after InlineUIContainer (fencepost: first char of "bar")
+        [InlineData(4, 7, "bar")]
+        // InlineUIContainer through end
+        [InlineData(3, 7, "\uFFFCbar")]
+        // Spanning InlineUIContainer (one char either side)
+        [InlineData(2, 5, "o\uFFFCb")]
+        // Entire content
+        [InlineData(0, 7, "foo\uFFFCbar")]
+        public void Selection_With_InlineUIContainer_Returns_Correct_Text(int start, int end, string expected)
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
@@ -22,14 +39,13 @@ namespace Avalonia.Controls.UnitTests
 
                 target.Measure(Size.Infinity);
 
-                // In TextLayout, EmbeddedControlRun (from InlineUIContainer) occupies 1 character
-                // position. After "foo" (3 chars) + InlineUIContainer (1 char), "bar" starts at
-                // position 4. SelectionStart/End come from TextLayout.HitTestPoint so they must
-                // align with the text returned by Inlines.Text.
-                target.SelectionStart = 4;
-                target.SelectionEnd = 7;
+                // SelectionStart/End values correspond to TextLayout character positions.
+                // EmbeddedControlRun occupies 1 position (TextRun.DefaultTextSourceLength),
+                // and Inlines.Text now has a matching U+FFFC placeholder, so they stay in sync.
+                target.SelectionStart = start;
+                target.SelectionEnd = end;
 
-                Assert.Equal("bar", target.SelectedText);
+                Assert.Equal(expected, target.SelectedText);
             }
         }
 


### PR DESCRIPTION
Fixes #15880

## Problem

EmbeddedControlRun (created by InlineUIContainer.BuildTextRun) inherits TextRun.DefaultTextSourceLength = 1, so each embedded control occupies one position in the TextLayout. However, InlineUIContainer.AppendText was a no-op, meaning Inlines.Text had zero characters for each embedded control.

This caused TextLayout.HitTestPoint to return positions that were ahead of Inlines.Text indices by one for every InlineUIContainer before the cursor, breaking SelectedText for any text after an embedded control.

## Fix

Append the Unicode Object Replacement Character (U+FFFC) in InlineUIContainer.AppendText — the standard placeholder for embedded objects (used by WPF for the same purpose) — so that Inlines.Text character offsets stay in sync with TextLayout positions.

## Testing

Added a unit test to SelectableTextBlockTests that verifies SelectedText returns the correct value when the selection range spans text after an InlineUIContainer.