### PR TITLE
Draft: Prototype clause-aware Win32 IME preedit rendering

### DIFF
--- a/src/Avalonia.Base/Input/TextInput/TextInputMethodClient.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextInputMethodClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Avalonia.Input.TextInput
 {
@@ -81,6 +82,17 @@ namespace Avalonia.Input.TextInput
         public virtual void SetPreeditText(string? preeditText, int? cursorPos)
         {
             SetPreeditText(preeditText);
+        }
+
+        /// <summary>
+        /// Sets the non-committed input string, cursor offset, and optional segment styles.
+        /// </summary>
+        public virtual void SetPreeditText(
+            string? preeditText,
+            int? cursorPos,
+            IReadOnlyList<TextInputMethodPreeditSegment>? segments)
+        {
+            SetPreeditText(preeditText, cursorPos);
         }
         
         protected virtual void RaiseTextViewVisualChanged()

--- a/src/Avalonia.Base/Input/TextInput/TextInputMethodPreeditSegment.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextInputMethodPreeditSegment.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Avalonia.Input.TextInput
+{
+    public enum TextInputMethodPreeditSegmentKind
+    {
+        ActiveClause,
+        InactiveClause
+    }
+
+    public readonly record struct TextInputMethodPreeditSegment(
+        int Start,
+        int Length,
+        TextInputMethodPreeditSegmentKind Kind)
+    {
+        public int End => Start + Length;
+    }
+}

--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using Avalonia.Collections;
 using Avalonia.Controls.Documents;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Input.TextInput;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
@@ -66,6 +68,12 @@ namespace Avalonia.Controls.Presenters
             AvaloniaProperty.Register<TextPresenter, int?>(nameof(PreeditTextCursorPosition));
 
         /// <summary>
+        /// Defines the <see cref="PreeditTextSegments"/> property.
+        /// </summary>
+        public static readonly StyledProperty<IReadOnlyList<TextInputMethodPreeditSegment>?> PreeditTextSegmentsProperty =
+            AvaloniaProperty.Register<TextPresenter, IReadOnlyList<TextInputMethodPreeditSegment>?>(nameof(PreeditTextSegments));
+
+        /// <summary>
         /// Defines the <see cref="TextAlignment"/> property.
         /// </summary>
         public static readonly StyledProperty<TextAlignment> TextAlignmentProperty =
@@ -106,6 +114,8 @@ namespace Avalonia.Controls.Presenters
         private Point _navigationPosition;
         private Point? _previousOffset;
         private TextSelectorLayer? _layer;
+        private static readonly TextDecorationCollection s_activePreeditTextDecorations = CreatePreeditTextDecorations(2, null);
+        private static readonly TextDecorationCollection s_inactivePreeditTextDecorations = CreatePreeditTextDecorations(1, new AvaloniaList<double> { 1, 2 });
 
         static TextPresenter()
         {
@@ -154,6 +164,12 @@ namespace Avalonia.Controls.Presenters
         {
             get => GetValue(PreeditTextCursorPositionProperty);
             set => SetValue(PreeditTextCursorPositionProperty, value);
+        }
+
+        public IReadOnlyList<TextInputMethodPreeditSegment>? PreeditTextSegments
+        {
+            get => GetValue(PreeditTextSegmentsProperty);
+            set => SetValue(PreeditTextSegmentsProperty, value);
         }
 
         /// <summary>
@@ -567,18 +583,7 @@ namespace Avalonia.Controls.Presenters
 
             if (!string.IsNullOrEmpty(preeditText))
             {
-                var preeditHighlight = new ValueSpan<TextRunProperties>(caretIndex, preeditText.Length,
-                        new GenericTextRunProperties(
-                            typeface,
-                            FontSize,
-                            TextDecorations.Underline,
-                            foreground,
-                            fontFeatures: FontFeatures));
-
-                textStyleOverrides = new[]
-                {
-                    preeditHighlight
-                };
+                textStyleOverrides = CreatePreeditTextStyleOverrides(caretIndex, preeditText, typeface, foreground);
             }
             else
             {
@@ -628,6 +633,76 @@ namespace Avalonia.Controls.Presenters
             sb.Append(text.Substring(caretIndex));
 
             return StringBuilderCache.GetStringAndRelease(sb);
+        }
+
+        private IReadOnlyList<ValueSpan<TextRunProperties>> CreatePreeditTextStyleOverrides(
+            int caretIndex,
+            string preeditText,
+            Typeface typeface,
+            IBrush? foreground)
+        {
+            var segments = PreeditTextSegments;
+
+            if (segments is { Count: > 0 })
+            {
+                var valueSpans = new List<ValueSpan<TextRunProperties>>(segments.Count);
+
+                foreach (var segment in segments)
+                {
+                    var start = Math.Max(0, segment.Start);
+                    var end = Math.Min(preeditText.Length, segment.End);
+
+                    if (end <= start)
+                    {
+                        continue;
+                    }
+
+                    valueSpans.Add(new ValueSpan<TextRunProperties>(
+                        caretIndex + start,
+                        end - start,
+                        new GenericTextRunProperties(
+                            typeface,
+                            FontSize,
+                            GetPreeditTextDecorations(segment.Kind),
+                            foreground,
+                            fontFeatures: FontFeatures)));
+                }
+
+                if (valueSpans.Count > 0)
+                {
+                    return valueSpans;
+                }
+            }
+
+            return new[]
+            {
+                new ValueSpan<TextRunProperties>(caretIndex, preeditText.Length,
+                    new GenericTextRunProperties(
+                        typeface,
+                        FontSize,
+                        TextDecorations.Underline,
+                        foreground,
+                        fontFeatures: FontFeatures))
+            };
+        }
+
+        private static TextDecorationCollection GetPreeditTextDecorations(TextInputMethodPreeditSegmentKind kind) =>
+            kind == TextInputMethodPreeditSegmentKind.ActiveClause ?
+                s_activePreeditTextDecorations :
+                s_inactivePreeditTextDecorations;
+
+        private static TextDecorationCollection CreatePreeditTextDecorations(double strokeThickness, AvaloniaList<double>? strokeDashArray)
+        {
+            return new TextDecorationCollection
+            {
+                new TextDecoration
+                {
+                    Location = TextDecorationLocation.Underline,
+                    StrokeThicknessUnit = TextDecorationUnit.Pixel,
+                    StrokeThickness = strokeThickness,
+                    StrokeDashArray = strokeDashArray
+                }
+            };
         }
 
         protected virtual void InvalidateTextLayout()
@@ -1052,6 +1127,7 @@ namespace Avalonia.Controls.Presenters
             {
                 // Properties that affect shaping: invalidate the run cache + layout.
                 case nameof(PreeditText):
+                case nameof(PreeditTextSegments):
                 case nameof(Foreground):
                 case nameof(FontSize):
                 case nameof(FontStyle):

--- a/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
+++ b/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Avalonia.Controls.Presenters;
 using Avalonia.Input.TextInput;
 using Avalonia.Media.TextFormatting;
@@ -135,6 +136,8 @@ namespace Avalonia.Controls
             {
                 oldPresenter.CurrentImClient = null;
                 oldPresenter.ClearValue(TextPresenter.PreeditTextProperty);
+                oldPresenter.ClearValue(TextPresenter.PreeditTextCursorPositionProperty);
+                oldPresenter.ClearValue(TextPresenter.PreeditTextSegmentsProperty);
 
                 oldPresenter.CaretBoundsChanged -= (s, e) => RaiseCursorRectangleChanged();
             }
@@ -161,6 +164,12 @@ namespace Avalonia.Controls
         public override void SetPreeditText(string? preeditText) => SetPreeditText(preeditText, null);
 
         public override void SetPreeditText(string? preeditText, int? cursorPos)
+            => SetPreeditText(preeditText, cursorPos, null);
+
+        public override void SetPreeditText(
+            string? preeditText,
+            int? cursorPos,
+            IReadOnlyList<TextInputMethodPreeditSegment>? segments)
         {
             if (_presenter == null || _parent == null)
             {
@@ -169,6 +178,7 @@ namespace Avalonia.Controls
 
             _presenter.SetCurrentValue(TextPresenter.PreeditTextProperty, preeditText);
             _presenter.SetCurrentValue(TextPresenter.PreeditTextCursorPositionProperty, cursorPos);
+            _presenter.SetCurrentValue(TextPresenter.PreeditTextSegmentsProperty, segments);
         }
 
         private static string GetTextLineText(TextLine textLine)

--- a/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
+++ b/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Avalonia.Win32.Interoperability, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.WinUI, PublicKey=$(AvaloniaPublicKey)" />
+    <InternalsVisibleTo Include="Avalonia.IntegrationTests.Win32, PublicKey=$(AvaloniaPublicKey)" />
   </ItemGroup>
   <ItemGroup>
     <!-- By default, any projects supports Windows, Linux, MacOS platforms. -->

--- a/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
+++ b/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
 using Avalonia.Input.TextInput;
@@ -26,6 +28,7 @@ namespace Avalonia.Win32.Input
 
         private bool _ignoreComposition;
         private int? _compositionCursorPosition;
+        private IReadOnlyList<TextInputMethodPreeditSegment>? _compositionSegments;
 
         public TextInputMethodClient? Client { get; private set; }
 
@@ -112,6 +115,7 @@ namespace Avalonia.Win32.Input
 
             IsComposing = false;
             _compositionCursorPosition = null;
+            _compositionSegments = null;
         }
 
         //Dependant on CurrentThread. When Avalonia will support Multiple Dispatchers -
@@ -121,6 +125,7 @@ namespace Avalonia.Win32.Input
         public void Reset()
         {
             _compositionCursorPosition = null;
+            _compositionSegments = null;
 
             Dispatcher.UIThread.Post(() =>
             {
@@ -146,6 +151,7 @@ namespace Avalonia.Win32.Input
 
                     Composition = null;
                     _compositionCursorPosition = null;
+                    _compositionSegments = null;
                 }
             });
         }
@@ -156,8 +162,9 @@ namespace Avalonia.Win32.Input
             {
                 Composition = null;
                 _compositionCursorPosition = null;
+                _compositionSegments = null;
 
-                Client.SetPreeditText(null, null);
+                Client.SetPreeditText(null, null, null);
             }
 
             Client = client;
@@ -272,17 +279,21 @@ namespace Avalonia.Win32.Input
             // we're skipping this. not usable on windows
         }
 
-        public void CompositionChanged(string? composition, int? cursorPosition)
+        public void CompositionChanged(
+            string? composition,
+            int? cursorPosition,
+            IReadOnlyList<TextInputMethodPreeditSegment>? segments)
         {
             Composition = composition;
             _compositionCursorPosition = cursorPosition;
+            _compositionSegments = segments;
 
             if (!IsActive || !Client.SupportsPreedit)
             {
                 return;
             }
 
-            Client.SetPreeditText(composition, cursorPosition);
+            Client.SetPreeditText(composition, cursorPosition, segments);
         }
         
         public string? GetCompositionString(GCS flag)
@@ -323,14 +334,273 @@ namespace Avalonia.Win32.Input
             }
         }
 
+        private IReadOnlyList<TextInputMethodPreeditSegment>? GetCompositionSegments(string? composition, int? cursorPosition)
+        {
+            if (!IsComposing || string.IsNullOrEmpty(composition) || composition.Length <= 1)
+            {
+                return null;
+            }
+
+            var himc = ImmGetContext(Hwnd);
+
+            if (himc == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            try
+            {
+                var clauses = GetCompositionClauseOffsets(himc, composition.Length);
+
+                if (clauses is null || clauses.Count <= 2)
+                {
+                    return null;
+                }
+
+                var attributes = GetCompositionAttributes(himc, composition.Length);
+
+                return BuildCompositionSegments(clauses, attributes, composition.Length, cursorPosition);
+            }
+            finally
+            {
+                ImmReleaseContext(Hwnd, himc);
+            }
+        }
+
+        private static byte[]? GetCompositionAttributes(IntPtr himc, int compositionLength)
+        {
+            var bytes = GetCompositionBytes(himc, GCS.GCS_COMPATTR);
+
+            if (bytes is null || bytes.Length == 0)
+            {
+                return null;
+            }
+
+            return bytes.Length > compositionLength ? bytes.Take(compositionLength).ToArray() : bytes;
+        }
+
+        private static IReadOnlyList<int>? GetCompositionClauseOffsets(IntPtr himc, int compositionLength)
+        {
+            var bytes = GetCompositionBytes(himc, GCS.GCS_COMPCLAUSE);
+
+            if (bytes is null || bytes.Length < sizeof(int) * 2 || bytes.Length % sizeof(int) != 0)
+            {
+                return null;
+            }
+
+            var rawOffsets = new int[bytes.Length / sizeof(int)];
+            Buffer.BlockCopy(bytes, 0, rawOffsets, 0, bytes.Length);
+
+            return NormalizeClauseOffsets(rawOffsets, compositionLength);
+        }
+
+        private static byte[]? GetCompositionBytes(IntPtr himc, GCS flag)
+        {
+            var bufferLength = ImmGetCompositionString(himc, flag, IntPtr.Zero, 0);
+
+            if (bufferLength <= 0)
+            {
+                return null;
+            }
+
+            var buffer = new byte[bufferLength];
+
+            unsafe
+            {
+                fixed (byte* bufferPtr = buffer)
+                {
+                    var result = ImmGetCompositionString(himc, flag, (IntPtr)bufferPtr, (uint)bufferLength);
+
+                    if (result <= 0)
+                    {
+                        return null;
+                    }
+                }
+            }
+
+            return buffer;
+        }
+
+        internal static IReadOnlyList<int>? NormalizeClauseOffsets(IReadOnlyList<int> rawOffsets, int compositionLength)
+        {
+            if (rawOffsets.Count < 2 || compositionLength <= 0)
+            {
+                return null;
+            }
+
+            var lastOffset = rawOffsets[rawOffsets.Count - 1];
+            var scale = lastOffset switch
+            {
+                var value when value == compositionLength => 1,
+                var value when value == compositionLength * sizeof(char) => sizeof(char),
+                _ => 0
+            };
+
+            if (scale == 0)
+            {
+                return null;
+            }
+
+            var normalized = new List<int>(rawOffsets.Count);
+            var previous = -1;
+
+            foreach (var rawOffset in rawOffsets)
+            {
+                if (rawOffset < 0 || rawOffset % scale != 0)
+                {
+                    return null;
+                }
+
+                var normalizedOffset = rawOffset / scale;
+
+                if (normalizedOffset < previous || normalizedOffset > compositionLength)
+                {
+                    return null;
+                }
+
+                normalized.Add(normalizedOffset);
+                previous = normalizedOffset;
+            }
+
+            if (normalized[0] != 0 || normalized[normalized.Count - 1] != compositionLength)
+            {
+                return null;
+            }
+
+            return normalized;
+        }
+
+        internal static IReadOnlyList<TextInputMethodPreeditSegment>? BuildCompositionSegments(
+            IReadOnlyList<int> clauses,
+            IReadOnlyList<byte>? attributes,
+            int compositionLength,
+            int? cursorPosition)
+        {
+            if (clauses.Count <= 2 || compositionLength <= 1)
+            {
+                return null;
+            }
+
+            var clampedCursorPosition = cursorPosition is >= 0 && cursorPosition <= compositionLength
+                ? cursorPosition.Value
+                : compositionLength;
+
+            var targetClauseIndices = new List<int>();
+
+            for (var i = 0; i < clauses.Count - 1; i++)
+            {
+                var start = clauses[i];
+                var end = clauses[i + 1];
+
+                if (end <= start)
+                {
+                    continue;
+                }
+
+                if (ContainsTargetAttribute(attributes, start, end))
+                {
+                    targetClauseIndices.Add(i);
+                }
+            }
+
+            var activeClauseIndex = targetClauseIndices.Count switch
+            {
+                0 => FindClauseIndex(clauses, clampedCursorPosition),
+                1 => targetClauseIndices[0],
+                _ => FindClauseIndex(clauses, clampedCursorPosition, targetClauseIndices) ?? targetClauseIndices[0]
+            };
+
+            if (activeClauseIndex < 0)
+            {
+                return null;
+            }
+
+            var segments = new List<TextInputMethodPreeditSegment>(clauses.Count - 1);
+
+            for (var i = 0; i < clauses.Count - 1; i++)
+            {
+                var start = clauses[i];
+                var end = clauses[i + 1];
+
+                if (start < 0 || end > compositionLength || end <= start)
+                {
+                    continue;
+                }
+
+                segments.Add(new TextInputMethodPreeditSegment(
+                    start,
+                    end - start,
+                    i == activeClauseIndex ?
+                        TextInputMethodPreeditSegmentKind.ActiveClause :
+                        TextInputMethodPreeditSegmentKind.InactiveClause));
+            }
+
+            return segments.Count > 1 ? segments : null;
+        }
+
+        private static bool ContainsTargetAttribute(IReadOnlyList<byte>? attributes, int start, int end)
+        {
+            if (attributes is null || attributes.Count == 0)
+            {
+                return false;
+            }
+
+            var upperBound = Math.Min(end, attributes.Count);
+
+            for (var i = Math.Max(0, start); i < upperBound; i++)
+            {
+                if (attributes[i] is 0x01 or 0x03)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static int FindClauseIndex(IReadOnlyList<int> clauses, int cursorPosition)
+        {
+            for (var i = 0; i < clauses.Count - 1; i++)
+            {
+                var start = clauses[i];
+                var end = clauses[i + 1];
+
+                if (cursorPosition >= start && cursorPosition < end)
+                {
+                    return i;
+                }
+            }
+
+            return clauses.Count - 2;
+        }
+
+        private static int? FindClauseIndex(IReadOnlyList<int> clauses, int cursorPosition, IReadOnlyList<int> candidates)
+        {
+            foreach (var clauseIndex in candidates)
+            {
+                if (clauseIndex < 0 || clauseIndex >= clauses.Count - 1)
+                {
+                    continue;
+                }
+
+                if (cursorPosition >= clauses[clauseIndex] && cursorPosition < clauses[clauseIndex + 1])
+                {
+                    return clauseIndex;
+                }
+            }
+
+            return null;
+        }
+
         public void HandleCompositionStart()
         {
             Composition = null;
             _compositionCursorPosition = null;
+            _compositionSegments = null;
 
             if (IsActive)
             {
-                Client.SetPreeditText(null, null);
+                Client.SetPreeditText(null, null, null);
 
                 if (Client.SupportsSurroundingText && Client.Selection.Start != Client.Selection.End)
                 {
@@ -360,10 +630,11 @@ namespace Avalonia.Win32.Input
 
             Composition = null;
             _compositionCursorPosition = null;
+            _compositionSegments = null;
 
             if (IsActive)
             {
-                Client.SetPreeditText(null, null);
+                Client.SetPreeditText(null, null, null);
             }
         }
 
@@ -381,7 +652,7 @@ namespace Avalonia.Win32.Input
             
             if (flags == 0)
             {
-                CompositionChanged("", null);
+                CompositionChanged("", null, null);
             }
 
             if (resultChanged)
@@ -390,10 +661,11 @@ namespace Avalonia.Win32.Input
 
                 Composition = null;
                 _compositionCursorPosition = null;
+                _compositionSegments = null;
 
                 if (IsActive)
                 {
-                    Client.SetPreeditText(null, null);
+                    Client.SetPreeditText(null, null, null);
                 }
 
                 if (_parent != null && !string.IsNullOrEmpty(resultString))
@@ -411,8 +683,9 @@ namespace Avalonia.Win32.Input
 
             var compositionChanged = (flags & GCS.GCS_COMPSTR) != 0;
             var cursorPositionChanged = (flags & GCS.GCS_CURSORPOS) != 0;
+            var segmentChanged = (flags & GCS.GCS_COMPATTR) != 0 || (flags & GCS.GCS_COMPCLAUSE) != 0;
 
-            if (compositionChanged || (cursorPositionChanged && !resultChanged))
+            if (compositionChanged || (cursorPositionChanged && !resultChanged) || segmentChanged)
             {
                 var compositionString = compositionChanged
                     ? GetCompositionString(GCS.GCS_COMPSTR)
@@ -422,7 +695,11 @@ namespace Avalonia.Win32.Input
                     ? GetCompositionCursorPosition()
                     : _compositionCursorPosition;
 
-                CompositionChanged(compositionString, cursorPosition);
+                var segments = (compositionChanged || segmentChanged)
+                    ? GetCompositionSegments(compositionString, cursorPosition)
+                    : _compositionSegments;
+
+                CompositionChanged(compositionString, cursorPosition, segments);
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
@@ -1,5 +1,6 @@
-﻿using System.Linq;
+using System.Linq;
 using Avalonia.Controls.Presenters;
+using Avalonia.Input.TextInput;
 using Avalonia.Media;
 using Avalonia.UnitTests;
 using Xunit;
@@ -98,6 +99,99 @@ namespace Avalonia.Controls.UnitTests.Presenters
                 presenter.Arrange(new Rect(default, presenter.DesiredSize));
 
                 Assert.Equal(new Rect(default, expectedSize), presenter.Bounds);
+            }
+        }
+
+        [Fact]
+        public void TextPresenter_Should_Use_Preedit_Segment_Decorations()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var presenter = new TextPresenter
+                {
+                    PreeditText = "abcdef",
+                    PreeditTextSegments =
+                    [
+                        new TextInputMethodPreeditSegment(0, 2, TextInputMethodPreeditSegmentKind.InactiveClause),
+                        new TextInputMethodPreeditSegment(2, 2, TextInputMethodPreeditSegmentKind.ActiveClause),
+                        new TextInputMethodPreeditSegment(4, 2, TextInputMethodPreeditSegmentKind.InactiveClause)
+                    ]
+                };
+
+                presenter.Measure(Size.Infinity);
+
+                var runs = presenter.TextLayout.TextLines
+                    .SelectMany(x => x.TextRuns)
+                    .Where(x => x.Length > 0)
+                    .ToArray();
+
+                Assert.Equal(3, runs.Length);
+                AssertPreeditDecoration(runs[0].Properties!.TextDecorations, 1, true);
+                AssertPreeditDecoration(runs[1].Properties!.TextDecorations, 2, false);
+                AssertPreeditDecoration(runs[2].Properties!.TextDecorations, 1, true);
+            }
+        }
+
+        [Fact]
+        public void TextPresenter_Should_Fall_Back_To_Default_Preedit_Underline_When_Segments_Are_Missing()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var presenter = new TextPresenter
+                {
+                    PreeditText = "abcdef"
+                };
+
+                presenter.Measure(Size.Infinity);
+
+                var run = presenter.TextLayout.TextLines
+                    .SelectMany(x => x.TextRuns)
+                    .Single(x => x.Length > 0);
+
+                var decoration = Assert.Single(run.Properties!.TextDecorations!);
+                Assert.Equal(1, decoration.StrokeThickness);
+                Assert.Null(decoration.StrokeDashArray);
+            }
+        }
+
+        [Fact]
+        public void TextPresenter_Should_Move_Caret_Within_Preedit_Text()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var presenter = new TextPresenter
+                {
+                    Text = "zz",
+                    CaretIndex = 1,
+                    PreeditText = "abcdef",
+                    PreeditTextCursorPosition = 1
+                };
+
+                presenter.Measure(Size.Infinity);
+
+                var firstCursorX = presenter.GetCursorRectangle().X;
+
+                presenter.PreeditTextCursorPosition = 4;
+
+                var secondCursorX = presenter.GetCursorRectangle().X;
+
+                Assert.True(secondCursorX > firstCursorX);
+            }
+        }
+
+        private static void AssertPreeditDecoration(TextDecorationCollection? decorations, double strokeThickness, bool dotted)
+        {
+            var decoration = Assert.Single(decorations!);
+
+            Assert.Equal(strokeThickness, decoration.StrokeThickness);
+
+            if (dotted)
+            {
+                Assert.Equal(new[] { 1d, 2d }, decoration.StrokeDashArray!);
+            }
+            else
+            {
+                Assert.Null(decoration.StrokeDashArray);
             }
         }
     }

--- a/tests/Avalonia.IntegrationTests.Win32/Imm32InputMethodTests.cs
+++ b/tests/Avalonia.IntegrationTests.Win32/Imm32InputMethodTests.cs
@@ -1,0 +1,54 @@
+using Avalonia.Input.TextInput;
+using Avalonia.Win32.Input;
+using Xunit;
+
+namespace Avalonia.IntegrationTests.Win32;
+
+public class Imm32InputMethodTests
+{
+    [Fact]
+    public void NormalizeClauseOffsets_Should_Support_Character_Offsets()
+    {
+        var actual = Imm32InputMethod.NormalizeClauseOffsets([0, 2, 5], 5);
+
+        Assert.Equal([0, 2, 5], actual);
+    }
+
+    [Fact]
+    public void NormalizeClauseOffsets_Should_Support_Byte_Offsets()
+    {
+        var actual = Imm32InputMethod.NormalizeClauseOffsets([0, 4, 10], 5);
+
+        Assert.Equal([0, 2, 5], actual);
+    }
+
+    [Fact]
+    public void BuildCompositionSegments_Should_Use_Target_Clause_When_Present()
+    {
+        var actual = Imm32InputMethod.BuildCompositionSegments(
+            [0, 2, 4, 6],
+            [0x02, 0x02, 0x01, 0x01, 0x02, 0x02],
+            6,
+            1);
+
+        Assert.Collection(actual!,
+            segment => Assert.Equal(new TextInputMethodPreeditSegment(0, 2, TextInputMethodPreeditSegmentKind.InactiveClause), segment),
+            segment => Assert.Equal(new TextInputMethodPreeditSegment(2, 2, TextInputMethodPreeditSegmentKind.ActiveClause), segment),
+            segment => Assert.Equal(new TextInputMethodPreeditSegment(4, 2, TextInputMethodPreeditSegmentKind.InactiveClause), segment));
+    }
+
+    [Fact]
+    public void BuildCompositionSegments_Should_Fall_Back_To_Cursor_Clause_When_Target_Is_Missing()
+    {
+        var actual = Imm32InputMethod.BuildCompositionSegments(
+            [0, 2, 4, 6],
+            [0x02, 0x02, 0x02, 0x02, 0x02, 0x02],
+            6,
+            3);
+
+        Assert.Collection(actual!,
+            segment => Assert.Equal(TextInputMethodPreeditSegmentKind.InactiveClause, segment.Kind),
+            segment => Assert.Equal(TextInputMethodPreeditSegmentKind.ActiveClause, segment.Kind),
+            segment => Assert.Equal(TextInputMethodPreeditSegmentKind.InactiveClause, segment.Kind));
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This draft PR demonstrates one way to render Win32 IME conversion clauses during preedit. (see #21647)

A recent fix propagated the caret position inside the composition string. That improved caret movement, but it did not solve clause visibility during conversion mode. (#21632)

This PR focuses on the remaining problem: Avalonia currently renders the whole preedit text with one underline, so the active conversion clause is not visually distinguishable.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When using Google Japanese Input on Windows:

- press `Space` to enter conversion mode
- move between clauses
- Avalonia keeps the same underline for the whole preedit text

This makes it difficult to tell which clause is currently active.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
This prototype renders the active clause differently from the surrounding clauses, so clause navigation becomes visible during conversion.

Expected outcome:

- active clause is visually highlighted
- surrounding clauses remain distinguishable
- behavior is closer to standard Win32 controls such as Notepad

| original | improved |
|----|----|
| <img width="250" height="155" alt="Image" src="https://github.com/user-attachments/assets/1487f799-f5f5-41b1-a8d8-7d545c4d68f9" /> | <img width="250" height="155" alt="Image" src="https://github.com/user-attachments/assets/224001e5-c82a-4701-81bf-e6f0e7b57f47" /> |

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

The prototype reads Win32 composition attribute data, converts it into preedit segment information, and passes that through the preedit pipeline so `TextPresenter` can apply different underline styles per segment.

The exact API shape in this PR is only a proposal. The main goal is to make the missing information visible and get feedback on the right abstraction.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

This prototype touches a public input method API in order to carry preedit segment metadata.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

None proposed.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Related to #21647.
Not intended as a final fix yet. This draft PR is for design discussion.

