### PR TITLE
Register ITransformAnimator for ITransform properties (fixes #8640)

### DIFF
--- a/src/Avalonia.Base/Animation/Animation.AnimatorRegistry.cs
+++ b/src/Avalonia.Base/Animation/Animation.AnimatorRegistry.cs
@@ -37,6 +37,7 @@ partial class Animation
 
     static Animation()
     {
+        RegisterAnimator<ITransform?, ITransformAnimator>();
         RegisterAnimator<IEffect?, EffectAnimator>();
         RegisterAnimator<BoxShadow, BoxShadowAnimator>();
         RegisterAnimator<BoxShadows, BoxShadowsAnimator>();

--- a/src/Avalonia.Base/Animation/Animators/ITransformAnimator.cs
+++ b/src/Avalonia.Base/Animation/Animators/ITransformAnimator.cs
@@ -1,0 +1,23 @@
+using Avalonia.Media;
+using Avalonia.Media.Transformation;
+
+namespace Avalonia.Animation.Animators
+{
+    /// <summary>
+    /// Animator that handles <see cref="ITransform"/> properties such as
+    /// <see cref="Visual.RenderTransformProperty"/> by interpolating between
+    /// <see cref="TransformOperations"/> values.
+    /// </summary>
+    internal class ITransformAnimator : Animator<ITransform?>
+    {
+        public override ITransform? Interpolate(double progress, ITransform? oldValue, ITransform? newValue)
+        {
+            var from = EnsureOperations(oldValue);
+            var to = EnsureOperations(newValue);
+            return TransformOperations.Interpolate(from, to, progress);
+        }
+
+        private static TransformOperations EnsureOperations(ITransform? value)
+            => value as TransformOperations ?? TransformOperations.Identity;
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/Animation/RenderTransformAnimationTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Animation/RenderTransformAnimationTests.cs
@@ -1,0 +1,141 @@
+using System;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Media.Transformation;
+using Avalonia.Styling;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Animation;
+
+using Animation = global::Avalonia.Animation.Animation;
+
+public class RenderTransformAnimationTests
+{
+    /// <summary>
+    /// Regression test for https://github.com/AvaloniaUI/Avalonia/issues/8640.
+    /// Animating RenderTransform with TransformOperations keyframes must not throw
+    /// "No animator registered for the property RenderTransform".
+    /// </summary>
+    [Fact]
+    public void Animating_RenderTransform_Does_Not_Throw()
+    {
+        var from = TransformOperations.Parse("translateX(0px)");
+        var to = TransformOperations.Parse("translateX(100px)");
+
+        var animation = new Animation
+        {
+            Duration = TimeSpan.FromSeconds(1),
+            FillMode = FillMode.Both,
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0),
+                    Setters = { new Setter(Visual.RenderTransformProperty, (ITransform)from) }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1),
+                    Setters = { new Setter(Visual.RenderTransformProperty, (ITransform)to) }
+                },
+            }
+        };
+
+        var border = new Border();
+        var clock = new TestClock();
+
+        // Must not throw InvalidOperationException.
+        animation.RunAsync(border, clock, TestContext.Current.CancellationToken);
+
+        clock.Step(TimeSpan.Zero);
+        clock.Step(TimeSpan.FromSeconds(0.5));
+        clock.Step(TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public void Animating_RenderTransform_Interpolates_TranslateX()
+    {
+        var from = TransformOperations.Parse("translateX(0px)");
+        var to = TransformOperations.Parse("translateX(100px)");
+
+        var animation = new Animation
+        {
+            Duration = TimeSpan.FromSeconds(1),
+            FillMode = FillMode.Both,
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0),
+                    Setters = { new Setter(Visual.RenderTransformProperty, (ITransform)from) }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1),
+                    Setters = { new Setter(Visual.RenderTransformProperty, (ITransform)to) }
+                },
+            }
+        };
+
+        var border = new Border();
+        var clock = new TestClock();
+
+        animation.RunAsync(border, clock, TestContext.Current.CancellationToken);
+
+        clock.Step(TimeSpan.Zero);
+        var atStart = border.RenderTransform as TransformOperations;
+        Assert.NotNull(atStart);
+        Assert.Equal(from.Value, atStart.Value);
+
+        clock.Step(TimeSpan.FromSeconds(0.5));
+        var atMid = border.RenderTransform as TransformOperations;
+        Assert.NotNull(atMid);
+        // At 50% progress translateX should be 50px, i.e. M31 (translation X) ≈ 50.
+        Assert.Equal(50.0, atMid.Value.M31, precision: 5);
+
+        clock.Step(TimeSpan.FromSeconds(1));
+        var atEnd = border.RenderTransform as TransformOperations;
+        Assert.NotNull(atEnd);
+        Assert.Equal(to.Value, atEnd.Value);
+    }
+
+    [Fact]
+    public void Animating_RenderTransform_NonTransformOperations_Value_Treated_As_Identity()
+    {
+        // When one keyframe has a non-TransformOperations ITransform (e.g. TranslateTransform),
+        // it should be treated as identity and not throw.
+        var to = TransformOperations.Parse("translateX(100px)");
+
+        var animation = new Animation
+        {
+            Duration = TimeSpan.FromSeconds(1),
+            FillMode = FillMode.Both,
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0),
+                    Setters = { new Setter(Visual.RenderTransformProperty, (ITransform)TransformOperations.Identity) }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1),
+                    Setters = { new Setter(Visual.RenderTransformProperty, (ITransform)to) }
+                },
+            }
+        };
+
+        var border = new Border();
+        var clock = new TestClock();
+
+        animation.RunAsync(border, clock, TestContext.Current.CancellationToken);
+
+        clock.Step(TimeSpan.Zero);
+        clock.Step(TimeSpan.FromSeconds(0.5));
+
+        var atMid = border.RenderTransform as TransformOperations;
+        Assert.NotNull(atMid);
+        Assert.Equal(50.0, atMid.Value.M31, precision: 5);
+    }
+}


### PR DESCRIPTION
## Problem

Animating \RenderTransform\ via keyframe animations threw:

\\\
System.InvalidOperationException: No animator registered for the property RenderTransform.
Add an animator to the Animation.Animators collection that matches this property to animate it.
\\\

\TransformOperationsAnimator\ already existed and was used internally by \TransformOperationsTransition\, but was never registered in the \Animation.Animators\ collection. Since \RenderTransform\ is typed as \ITransform?\, no registered condition matched it.

## Fix

Add \ITransformAnimator : Animator<ITransform?>\ that interpolates between \TransformOperations\ values via \TransformOperations.Interpolate\. Non-\TransformOperations\ \ITransform\ values are treated as identity, matching the existing \TransformOperationsTransition\ behaviour.

Register it via \RegisterAnimator<ITransform?, ITransformAnimator>()\ in the static \Animation()\ constructor.

## Tests

- \Animating_RenderTransform_Does_Not_Throw\ — regression guard
- \Animating_RenderTransform_Interpolates_TranslateX\ — verifies correct midpoint interpolation (50px translateX at 50% progress)
- \Animating_RenderTransform_NonTransformOperations_Value_Treated_As_Identity\ — verifies non-\TransformOperations\ values fall back gracefully to identity

Fixes #8640