### PR TITLE
Handle platform clipboard exceptions in TextBox/SelectableTextBlock copy/cut/paste

### DIFF
--- a/src/Avalonia.Controls/SelectableTextBlock.cs
+++ b/src/Avalonia.Controls/SelectableTextBlock.cs
@@ -137,7 +137,17 @@ namespace Avalonia.Controls
                 var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
 
                 if (clipboard != null)
-                    await clipboard.SetTextAsync(text);
+                    {
+                     try
+                     {
+                         await clipboard.SetTextAsync(text);
+                     }
+                     catch (Exception ex) when (ex is COMException or TimeoutException or UnauthorizedAccessException)
+                     {
+                         Logger.TryGet(LogEventLevel.Warning, LogArea.Control)
+                             ?.Log(this, "Failed to write text to clipboard: {Error}", ex);
+                     }
+                 }
             }
         }
 

--- a/src/Avalonia.Controls/SelectableTextBlock.cs
+++ b/src/Avalonia.Controls/SelectableTextBlock.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls.Utils;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
+using Avalonia.Logging;
 using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
 using Avalonia.Platform;

--- a/src/Avalonia.Controls/SelectableTextBlock.cs
+++ b/src/Avalonia.Controls/SelectableTextBlock.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Avalonia.Controls.Documents;
 using Avalonia.Controls.Utils;
 using Avalonia.Input;

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1321,7 +1321,6 @@ namespace Avalonia.Controls
                 catch (Exception ex) when (ex is COMException or TimeoutException or UnauthorizedAccessException)
                 {
                     Logger.TryGet(LogEventLevel.Warning, LogArea.Control)
-                        ?.Log(this, "Failed to write text to clipboard: {Error}", uex);
                         ?.Log(this, "Failed to write text to clipboard: {Error}", ex);
                 }
             }

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1308,9 +1308,11 @@ namespace Avalonia.Controls
                     if (clipboard != null)
                         await clipboard.SetTextAsync(text);
                 }
-                catch (UnauthorizedAccessException uex)
+                catch (Exception ex) when (ex is COMException or TimeoutException or UnauthorizedAccessException)
                 {
-                    Logger.TryGet(LogEventLevel.Warning, LogArea.Control)?.Log(this, "Failed to write text to clipboard: {Error}", uex);
+                    Logger.TryGet(LogEventLevel.Warning, LogArea.Control)
+                        ?.Log(this, "Failed to write text to clipboard: {Error}", uex);
+                        ?.Log(this, "Failed to write text to clipboard: {Error}", ex);
                 }
             }
         }

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1280,8 +1280,17 @@ namespace Avalonia.Controls
                 if (clipboard == null)
                     return;
 
-                await clipboard.SetTextAsync(text);
-                DeleteSelection();
+               try
+               {
+                    await clipboard.SetTextAsync(text);
+               }
+               catch (Exception ex) when (ex is COMException or TimeoutException or UnauthorizedAccessException)
+               {
+                    Logger.TryGet(LogEventLevel.Warning, LogArea.Control)
+                        ?.Log(this, "Failed to write text to clipboard: {Error}", ex);
+                    return; // don't delete the selection if it never made it to the clipboard
+               }
+               DeleteSelection();
             }
         }
 

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1352,9 +1352,10 @@ namespace Avalonia.Controls
                 {
                     // Silently ignore.
                 }
-                catch (UnauthorizedAccessException uex)
+                catch (Exception ex) when (ex is COMException or UnauthorizedAccessException)
                 {
-                    Logger.TryGet(LogEventLevel.Warning, LogArea.Control)?.Log(this, "Failed to read text from clipboard: {Error}", uex);
+                    Logger.TryGet(LogEventLevel.Warning, LogArea.Control)
+                        ?.Log(this, "Failed to read text from clipboard: {Error}", ex);
                 }
             }
 

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.InteropServices; // COMException
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Platform;


### PR DESCRIPTION
## What does the pull request do?

Makes the clipboard command handlers on `TextBox` and `SelectableTextBlock` resilient to
platform clipboard failures. These handlers are `async void`, so any exception that escapes
them is posted to the dispatcher as an unhandled exception and crashes the application.

Related: #21296 (reported crash on paste).

## What is the current behavior?

When the OS clipboard is transiently locked by another process (clipboard managers,
password managers, `rdpclip` over RDP, Office, browsers), the Win32 backend throws a
`COMException` after exhausting its OLE retries (`Marshal.ThrowExceptionForHR`).

The four `async void` clipboard handlers do not handle this:

- `SelectableTextBlock.Copy` - no try/catch at all -> app crash.
- `TextBox.Cut` - no try/catch at all -> app crash.
- `TextBox.Copy` - only catches `UnauthorizedAccessException`; `COMException` escapes -> app crash.
- `TextBox.Paste` - only catches `TimeoutException`/`UnauthorizedAccessException`;
  `COMException` escapes -> app crash (#21296).

Because the throw happens on an `async void` continuation, callers cannot observe or catch
it, so it surfaces as an unhandled dispatcher exception (e.g.
`SendOrPostCallbackDispatcherOperation.InvokeCore`).

## What is the updated/expected behavior with this PR?

Copy / Cut / Paste fail gracefully instead of crashing: the failure is logged via `Logger`
(`LogArea.Control`, Warning) and the operation is abandoned. `Cut` additionally keeps the
selected text if the clipboard write failed, so no data is lost.

To test: hold the clipboard open with a clipboard manager / password manager (or run under
an RDP session) and trigger Ctrl+C, Ctrl+X, and Ctrl+V on a `TextBox`, and Ctrl+C on a
`SelectableTextBlock`. Before this PR the app crashes; after it, a warning is logged and the
UI stays alive.

## How was the solution implemented (if it's not obvious)?

- Broadened the existing catches in `TextBox.Copy` and `TextBox.Paste` to include
  `System.Runtime.InteropServices.COMException` (the type the Win32 backend actually throws),
  using exception filters (`catch (Exception ex) when (ex is COMException or ...)`).
- Added try/catch guards to `TextBox.Cut` and `SelectableTextBlock.Copy`, which had none.
- In `TextBox.Cut`, the catch returns before `DeleteSelection()` so the selection is not
  removed when it never reached the clipboard.

The retry/throw behavior in `ClipboardImpl.SetDataAsync` is intentionally left unchanged —
awaited clipboard APIs should still be able to surface failure to their callers. The defect
is only that these built-in `async void` command handlers don't observe that failure.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21296
