### PR TITLE
Generate a CycloneDX SBOM per published NuGet package

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,3 +2,15 @@
 When running code review, please refer to the following documents if they are relevant to the changed parts of the codebase:
 - `native/Avalonia.Native/**` -> `native/Avalonia.Native/README.md`
 - `src/Avalonia.Wayland/**` -> `src/Avalonia.Wayland/README.md`
+
+## SBOM (EU Cyber Resilience Act)
+
+We generate a CycloneDX SBOM per published NuGet package (`nukebuild/SbomGenerator.cs`, `CreateSbom` target) so that every shipped package carries an accurate bill of materials, as required for EU CRA compliance. When reviewing, flag the following:
+
+- **New shipped package:** if a change adds a new NuGet package that is published to end users (a new packable project, or a new final package in `nukebuild/numerge.json`), it must be covered by SBOM generation. Confirm `CreateSbom` produces an SBOM for it, and call it out if the package would ship without one.
+- **New kinds of shipped dependencies:** if a change alters what dependencies are delivered with a component in a way the existing scan doesn't already understand, `nukebuild/SbomGenerator.cs` must be updated so those dependencies appear in the SBOM. In particular:
+  - Adding npm/JS dependencies to a component that was previously .NET-only (e.g. a new `webapp` bundled into a package), or changing how existing bundled JS is built.
+  - Bundling third-party binaries directly into a package (copy-local/ILRepack/embedded assemblies) rather than referencing them as normal NuGet dependencies.
+  - New Numerge merge groups, or any other mechanism that folds a project's shipped output into a package other than via ordinary `PackageReference`/`ProjectReference`.
+
+  The scope is what is *delivered* with the package (BSI TR-03183-2 "scope of delivery"), not build/test-only tooling. Purely development-time dependencies that are never shipped do not need to be in the SBOM.

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -33,6 +33,7 @@
         "CompileNative",
         "CreateIntermediateNugetPackages",
         "CreateNugetPackages",
+        "CreateSbom",
         "DownloadApiBaselinePackages",
         "GenerateCppHeaders",
         "GenerateUnicodeData",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,6 +132,12 @@ jobs:
       artifactName: 'NuGetOSX'
     condition: succeeded()
 
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.SourcesDirectory)/artifacts/sbom'
+      artifactName: 'SBOMOSX'
+    condition: succeeded()
+
 - job: Windows
   pool:
     vmImage: 'windows-2025'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,3 +187,9 @@ jobs:
       artifactName: 'Samples'
     condition: succeeded()
 
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.SourcesDirectory)/artifacts/sbom'
+      artifactName: 'SBOM'
+    condition: succeeded()
+

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -43,6 +43,9 @@ partial class Build : NukeBuild
     [NuGetPackage("dotnet-ilrepack", "ILRepackTool.dll", Framework = "net8.0")]
     Tool IlRepackTool;
 
+    [NuGetPackage("CycloneDX", "CycloneDX.dll", Framework = "net10.0")]
+    Tool CycloneDxTool;
+
     protected override void OnBuildInitialized()
     {
         Parameters = new BuildParameters(this, ScheduledTargets.Contains(BuildToNuGetCache));
@@ -352,6 +355,7 @@ partial class Build : NukeBuild
         .Executes(() =>
         {
             SbomGenerator.Generate(
+                CycloneDxTool,
                 RootDirectory,
                 Parameters.NugetRoot,
                 Parameters.NugetIntermediateRoot,

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -433,7 +433,8 @@ partial class Build : NukeBuild
 
     Target CiAzureOSX => _ => _
         .DependsOn(Package)
-        .DependsOn(ZipFiles);
+        .DependsOn(ZipFiles)
+        .DependsOn(CreateSbom);
 
     Target CiAzureWindows => _ => _
         .DependsOn(Package)

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -318,7 +318,9 @@ partial class Build : NukeBuild
         });
 
     Target ZipFiles => _ => _
-        .After(CreateNugetPackages, Compile, RunCoreLibsTests, Package)
+        // CreateSbom embeds the SBOM into each .nupkg in NugetRoot, so it must run before we zip
+        // that directory - otherwise the zipped NuGet artifacts would omit the embedded SBOM.
+        .After(CreateNugetPackages, Compile, RunCoreLibsTests, Package, CreateSbom)
         .Executes(() =>
         {
             var data = Parameters;

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -347,6 +347,19 @@ partial class Build : NukeBuild
                 Parameters.NugetRoot / $"Avalonia.{Parameters.Version}.snupkg");
         });
 
+    Target CreateSbom => _ => _
+        .DependsOn(CreateNugetPackages)
+        .Executes(() =>
+        {
+            SbomGenerator.Generate(
+                RootDirectory,
+                Parameters.NugetRoot,
+                Parameters.NugetIntermediateRoot,
+                RootDirectory / "nukebuild" / "numerge.json",
+                Parameters.SbomRoot,
+                Parameters.Version);
+        });
+
     Target DownloadApiBaselinePackages => _ => _
         .DependsOn(CreateNugetPackages)
         .Executes(async () =>
@@ -421,7 +434,8 @@ partial class Build : NukeBuild
     Target CiAzureWindows => _ => _
         .DependsOn(Package)
         .DependsOn(VerifyXamlCompilation)
-        .DependsOn(ZipFiles);
+        .DependsOn(ZipFiles)
+        .DependsOn(CreateSbom);
 
     Target BuildToNuGetCache => _ => _
         .DependsOn(CreateNugetPackages)

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -455,10 +455,7 @@ partial class Build : NukeBuild
             {
                 using var f = File.Open(path.ToString(), FileMode.Open, FileAccess.Read);
                 using var zip = new ZipArchive(f, ZipArchiveMode.Read);
-                var nuspecEntry = zip.Entries.First(e => e.FullName.EndsWith(".nuspec") && e.FullName == e.Name);
-                var packageId = XDocument.Load(nuspecEntry.Open()).Document.Root
-                    .Elements().First(x => x.Name.LocalName == "metadata")
-                    .Elements().First(x => x.Name.LocalName == "id").Value;
+                var packageId = SbomGenerator.ReadPackageId(path);
 
                 var packagePath = Path.Combine(
                     globalPackagesFolder,

--- a/nukebuild/BuildParameters.cs
+++ b/nukebuild/BuildParameters.cs
@@ -60,6 +60,7 @@ public partial class Build
         public AbsolutePath ArtifactsDir { get; }
         public AbsolutePath NugetIntermediateRoot { get; }
         public AbsolutePath NugetRoot { get; }
+        public AbsolutePath SbomRoot { get; }
         public AbsolutePath ZipRoot { get; }
         public AbsolutePath TestResultsRoot { get; }
         public string DirSuffix { get; }
@@ -139,6 +140,7 @@ public partial class Build
             ArtifactsDir = RootDirectory / "artifacts";
             NugetRoot = ArtifactsDir / "nuget";
             NugetIntermediateRoot = RootDirectory / "build-intermediate" / "nuget";
+            SbomRoot = ArtifactsDir / "sbom";
             ZipRoot = ArtifactsDir / "zip";
             TestResultsRoot = ArtifactsDir / "test-results";
             BuildDirs = RootDirectory.GlobDirectories("**/bin")

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -172,8 +172,44 @@ public static class SbomGenerator
             Warning($"SBOM: couldn't find the built .nupkg for '{finalId}' - root metadata and package-content verification were skipped.");
         }
 
+        // cyclonedx-dotnet leaves dependsOn edges pointing at packages it excluded as dev
+        // dependencies (e.g. analyzers stripped by -ed), which dangle once the component is gone.
+        // Drop those so the graph only references components actually present in the SBOM.
+        PruneDanglingDependencyEdges(merged);
+
         File.WriteAllText(outputDirectory / $"{finalId}.{version}.cdx.json",
             merged.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    static void PruneDanglingDependencyEdges(JsonObject merged)
+    {
+        var deps = merged["dependencies"]?.AsArray();
+        if (deps is null)
+            return;
+
+        var known = new HashSet<string>();
+        var rootRef = merged["metadata"]?["component"]?["bom-ref"]?.GetValue<string>();
+        if (rootRef is not null)
+            known.Add(rootRef);
+        foreach (var component in merged["components"]?.AsArray() ?? new JsonArray())
+        {
+            if (component?["bom-ref"]?.GetValue<string>() is { } bomRef)
+                known.Add(bomRef);
+            if (component?["purl"]?.GetValue<string>() is { } purl)
+                known.Add(purl);
+        }
+
+        foreach (var node in deps.OfType<JsonObject>())
+        {
+            var dependsOn = node["dependsOn"]?.AsArray();
+            if (dependsOn is null)
+                continue;
+            var kept = new JsonArray();
+            foreach (var edge in dependsOn)
+                if (known.Contains(edge!.GetValue<string>()))
+                    kept.Add(edge.GetValue<string>());
+            node["dependsOn"] = kept;
+        }
     }
 
     static void MergeDependencyGraph(JsonObject target, JsonArray incoming)

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -149,8 +149,9 @@ public static class SbomGenerator
         // Bun/npm-built webapp directly into their published package (e.g. Avalonia.Browser's
         // staticwebassets, Avalonia.DesignerSupport's embedded previewer) - scan those separately
         // so their shipped JS dependencies aren't silently absent from the SBOM.
+        var rootRef = merged["metadata"]?["component"]?["bom-ref"]?.GetValue<string>();
         foreach (var projectDir in scannedProjectDirs)
-            AddNpmComponents(merged, seenComponentKeys, projectDir);
+            AddNpmComponents(merged, seenComponentKeys, projectDir, rootRef);
 
         File.WriteAllText(outputDirectory / $"{finalId}.{version}.cdx.json",
             merged.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
@@ -182,10 +183,14 @@ public static class SbomGenerator
     }
 
     // Scans <projectDir>/**/webapp/package.json for production "dependencies" (deliberately
-    // ignoring devDependencies, which never ship) and adds them as components. Resolves each
-    // dependency's actually-installed version from node_modules where possible, same rationale
-    // as scanning project.assets.json instead of trusting floating NuGet version ranges.
-    static void AddNpmComponents(JsonObject merged, HashSet<string> seenComponentKeys, AbsolutePath projectDir)
+    // ignoring devDependencies, which never ship) and adds them - plus their transitive
+    // dependencies, walked through the installed node_modules - as fully-formed components:
+    // bom-ref, resolved version, license, and dependency-graph edges, matching the shape of the
+    // NuGet components cyclonedx-dotnet emits so npm packages aren't second-class SBOM entries.
+    // Versions come from the actually-installed node_modules (same rationale as reading
+    // project.assets.json rather than trusting floating ranges).
+    static void AddNpmComponents(JsonObject merged, HashSet<string> seenComponentKeys, AbsolutePath projectDir,
+        string? rootRef)
     {
         foreach (string packageJsonPath in projectDir.GlobFiles("**/webapp/package.json"))
         {
@@ -193,41 +198,127 @@ public static class SbomGenerator
             var nodeModules = ((AbsolutePath)packageJsonPath).Parent / "node_modules";
             var dependencies = packageJson["dependencies"]?.AsObject() ?? new JsonObject();
 
+            // The webapp is bundled into the shipped package, so its direct production
+            // dependencies are direct dependencies of the final NuGet package.
             foreach (var (name, rangeNode) in dependencies)
             {
-                var (purl, componentVersion) = ResolveNpmComponent(name, rangeNode!.GetValue<string>(), nodeModules);
-                if (!seenComponentKeys.Add(purl))
-                    continue;
-
-                var target = merged["components"]?.AsArray() ?? (JsonArray)(merged["components"] = new JsonArray());
-                target.Add(new JsonObject
-                {
-                    ["type"] = "library",
-                    ["name"] = name,
-                    ["version"] = componentVersion,
-                    ["purl"] = purl
-                });
+                var purl = AddNpmComponentTree(merged, seenComponentKeys, nodeModules, name,
+                    rangeNode!.GetValue<string>(), nodeModules);
+                if (rootRef is not null)
+                    AddDependsOn(merged, rootRef, purl);
             }
         }
     }
 
-    static (string Purl, string Version) ResolveNpmComponent(string name, string declaredRange, AbsolutePath nodeModules)
+    // Adds the component for (name, range) and, recursively, everything it depends on, returning
+    // its purl. The component/graph node/subtree are materialised only the first time a purl is
+    // seen (which also breaks any dependency cycles); repeat encounters just return the purl so
+    // the caller can still record its own edge to it.
+    static string AddNpmComponentTree(JsonObject merged, HashSet<string> seenComponentKeys,
+        AbsolutePath topLevelNodeModules, string name, string declaredRange, AbsolutePath parentNodeModules)
     {
+        var (purl, componentVersion, installedDir) =
+            ResolveNpmComponent(name, declaredRange, parentNodeModules, topLevelNodeModules);
+
+        if (!seenComponentKeys.Add(purl))
+            return purl;
+
+        var installed = installedDir is not null && File.Exists(installedDir / "package.json")
+            ? JsonNode.Parse(File.ReadAllText(installedDir / "package.json"))!.AsObject()
+            : null;
+
+        var component = new JsonObject
+        {
+            ["type"] = "library",
+            ["bom-ref"] = purl,
+            ["name"] = name,
+            ["version"] = componentVersion,
+            ["purl"] = purl
+        };
+        // No hashes: npm's verifiable hashes live in the (binary bun) lockfile, not the installed
+        // tree, and a hash of the unpacked directory wouldn't be checkable against a registry.
+        var licenses = installed is null ? null : BuildLicenses(installed);
+        if (licenses is not null)
+            component["licenses"] = licenses;
+
+        var target = merged["components"]?.AsArray() ?? (JsonArray)(merged["components"] = new JsonArray());
+        target.Add(component);
+
+        var node = new JsonObject { ["ref"] = purl, ["dependsOn"] = new JsonArray() };
+        (merged["dependencies"]?.AsArray() ?? (JsonArray)(merged["dependencies"] = new JsonArray())).Add(node);
+
+        var childDeps = installed?["dependencies"]?.AsObject() ?? new JsonObject();
+        var childNodeModules = installedDir is not null ? installedDir / "node_modules" : parentNodeModules;
+        var dependsOn = node["dependsOn"]!.AsArray();
+        foreach (var (childName, childRange) in childDeps)
+        {
+            var childPurl = AddNpmComponentTree(merged, seenComponentKeys, topLevelNodeModules, childName,
+                childRange!.GetValue<string>(), childNodeModules);
+            dependsOn.Add(childPurl);
+        }
+
+        return purl;
+    }
+
+    static void AddDependsOn(JsonObject merged, string fromRef, string toPurl)
+    {
+        var deps = merged["dependencies"]?.AsArray() ?? (JsonArray)(merged["dependencies"] = new JsonArray());
+        var node = deps.OfType<JsonObject>().FirstOrDefault(d => d["ref"]?.GetValue<string>() == fromRef);
+        if (node is null)
+        {
+            node = new JsonObject { ["ref"] = fromRef, ["dependsOn"] = new JsonArray() };
+            deps.Add(node);
+        }
+
+        var dependsOn = node["dependsOn"]?.AsArray() ?? (JsonArray)(node["dependsOn"] = new JsonArray());
+        if (!dependsOn.Any(x => x!.GetValue<string>() == toPurl))
+            dependsOn.Add(toPurl);
+    }
+
+    static JsonArray? BuildLicenses(JsonObject installedPackageJson)
+    {
+        // Modern npm: "license" is an SPDX id or expression. Legacy: "license"/"licenses" objects.
+        if (installedPackageJson["license"] is JsonValue licenseValue && licenseValue.TryGetValue(out string? spdx)
+            && !string.IsNullOrWhiteSpace(spdx))
+        {
+            var isExpression = spdx.IndexOf(" OR ", StringComparison.Ordinal) >= 0
+                || spdx.IndexOf(" AND ", StringComparison.Ordinal) >= 0
+                || spdx.IndexOf(" WITH ", StringComparison.Ordinal) >= 0;
+            return new JsonArray(isExpression
+                ? new JsonObject { ["expression"] = spdx }
+                : new JsonObject { ["license"] = new JsonObject { ["id"] = spdx } });
+        }
+
+        var legacy = (installedPackageJson["license"] as JsonObject)?["type"]?.GetValue<string>()
+            ?? (installedPackageJson["licenses"] as JsonArray)?.OfType<JsonObject>()
+                .FirstOrDefault()?["type"]?.GetValue<string>();
+        return legacy is null
+            ? null
+            : new JsonArray(new JsonObject { ["license"] = new JsonObject { ["name"] = legacy } });
+    }
+
+    static (string Purl, string Version, AbsolutePath? InstalledDir) ResolveNpmComponent(
+        string name, string declaredRange, AbsolutePath parentNodeModules, AbsolutePath topLevelNodeModules)
+    {
+        // npm/bun hoist most packages to the top level but may nest a conflicting version under
+        // the depending package, so prefer the nested copy and fall back to the hoisted one.
+        var installedDir = new[] { parentNodeModules / name, topLevelNodeModules / name }
+            .FirstOrDefault(d => File.Exists(d / "package.json"));
+
         if (declaredRange.StartsWith("github:") || declaredRange.StartsWith("git") || declaredRange.Contains("://"))
         {
             var (owner, repo, reference) = ParseGitDependency(declaredRange);
-            return ($"pkg:github/{owner}/{repo}@{reference}", reference);
+            return ($"pkg:github/{owner}/{repo}@{reference}", reference, installedDir);
         }
 
-        var installedPackageJson = nodeModules / name / "package.json";
-        if (!File.Exists(installedPackageJson))
+        if (installedDir is null)
         {
-            Warning($"SBOM: npm dependency '{name}' isn't installed under {nodeModules} - recording its declared range '{declaredRange}' instead of a resolved version.");
-            return ($"pkg:npm/{EncodeNpmName(name)}@{declaredRange}", declaredRange);
+            Warning($"SBOM: npm dependency '{name}' isn't installed near {parentNodeModules} - recording its declared range '{declaredRange}' instead of a resolved version.");
+            return ($"pkg:npm/{EncodeNpmName(name)}@{declaredRange}", declaredRange, null);
         }
 
-        var installedVersion = JsonNode.Parse(File.ReadAllText(installedPackageJson))!["version"]!.GetValue<string>();
-        return ($"pkg:npm/{EncodeNpmName(name)}@{installedVersion}", installedVersion);
+        var installedVersion = JsonNode.Parse(File.ReadAllText(installedDir / "package.json"))!["version"]!.GetValue<string>();
+        return ($"pkg:npm/{EncodeNpmName(name)}@{installedVersion}", installedVersion, installedDir);
     }
 
     static string EncodeNpmName(string name) => name.StartsWith("@") ? $"%40{name[1..]}" : name;

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -477,8 +477,15 @@ public static class SbomGenerator
         return true;
     }
 
+    // Prefer purl (or bom-ref) as the identity; both encode version. Fall back to name+version so
+    // distinct versions of the same package aren't collapsed into one, and to a fresh GUID when
+    // there's nothing identifiable to key on (treating it as unique rather than deduping blindly).
     static string ComponentKey(JsonNode? component) =>
-        component?["purl"]?.GetValue<string>() ?? component?["name"]?.GetValue<string>() ?? Guid.NewGuid().ToString();
+        component?["purl"]?.GetValue<string>()
+        ?? component?["bom-ref"]?.GetValue<string>()
+        ?? (component?["name"]?.GetValue<string>() is { } name
+            ? $"{name}@{component?["version"]?.GetValue<string>()}"
+            : Guid.NewGuid().ToString());
 
     // Fills in the root component with the publisher, licence, description and repository details
     // from the shipped .nuspec - cyclonedx-dotnet only emits type/name/version, which is far short
@@ -666,8 +673,9 @@ public static class SbomGenerator
     {
         using var file = File.Open(nupkgPath, FileMode.Open, FileAccess.Read);
         using var zip = new ZipArchive(file, ZipArchiveMode.Read);
-        var nuspecEntry = zip.Entries.First(e => e.FullName.EndsWith(".nuspec") && e.FullName == e.Name);
-        var metadata = XDocument.Load(nuspecEntry.Open()).Root!
+        var nuspecEntry = zip.Entries.First(e => e.FullName.EndsWith(".nuspec", StringComparison.Ordinal) && e.FullName == e.Name);
+        using var nuspecStream = nuspecEntry.Open();
+        var metadata = XDocument.Load(nuspecStream).Root!
             .Elements().First(x => x.Name.LocalName == "metadata");
 
         string? Value(string name) => metadata.Elements().FirstOrDefault(x => x.Name.LocalName == name)?.Value;

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -221,6 +221,8 @@ public static class SbomGenerator
             // dependencies are direct dependencies of the final NuGet package.
             foreach (var (name, rangeNode) in dependencies)
             {
+                if (IsTypeOnlyPackage(name))
+                    continue;
                 var purl = AddNpmComponentTree(merged, seenComponentKeys, nodeModules, name,
                     rangeNode!.GetValue<string>(), nodeModules);
                 if (rootRef is not null)
@@ -271,6 +273,8 @@ public static class SbomGenerator
         var dependsOn = node["dependsOn"]!.AsArray();
         foreach (var (childName, childRange) in childDeps)
         {
+            if (IsTypeOnlyPackage(childName))
+                continue;
             var childPurl = AddNpmComponentTree(merged, seenComponentKeys, topLevelNodeModules, childName,
                 childRange!.GetValue<string>(), childNodeModules);
             dependsOn.Add(childPurl);
@@ -278,6 +282,10 @@ public static class SbomGenerator
 
         return purl;
     }
+
+    // @types/* packages are TypeScript declaration stubs: esbuild strips them at build time, so
+    // they're never part of the shipped bytes and don't belong in a scope-of-delivery SBOM.
+    static bool IsTypeOnlyPackage(string name) => name.StartsWith("@types/", StringComparison.Ordinal);
 
     static void AddDependsOn(JsonObject merged, string fromRef, string toPurl)
     {

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -30,23 +30,6 @@ using static Serilog.Log;
 // project, and unions their components (de-duplicated by purl) into one BOM per final package.
 public static class SbomGenerator
 {
-    class NumergeConfigRoot
-    {
-        public List<NumergePackageGroup> Packages { get; set; } = new();
-    }
-
-    class NumergePackageGroup
-    {
-        public string Id { get; set; } = "";
-        public bool MergeAll { get; set; }
-        public List<NumergeMergeChild> Merge { get; set; } = new();
-    }
-
-    class NumergeMergeChild
-    {
-        public string Id { get; set; } = "";
-    }
-
     public static void Generate(
         Tool cycloneDx,
         AbsolutePath rootDirectory,
@@ -62,8 +45,7 @@ public static class SbomGenerator
         var intermediatePackageIds = nugetIntermediateRoot.GlobFiles("*.nupkg")
             .Select(p => ReadPackageId((string)p)).Distinct();
 
-        var numerge = JsonSerializer.Deserialize<NumergeConfigRoot>(File.ReadAllText(numergeConfigPath))
-            ?? new NumergeConfigRoot();
+        var numerge = Numerge.MergeConfiguration.LoadFile(numergeConfigPath);
         var explicitParentByChild = numerge.Packages
             .SelectMany(p => p.Merge.Select(c => (Parent: p.Id, Child: c.Id)))
             .ToDictionary(x => x.Child, x => x.Parent);
@@ -610,5 +592,5 @@ public static class SbomGenerator
         };
     }
 
-    static string ReadPackageId(string nupkgPath) => ReadNuspecMetadata(nupkgPath).Id;
+    public static string ReadPackageId(string nupkgPath) => ReadNuspecMetadata(nupkgPath).Id;
 }

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
@@ -84,11 +87,11 @@ public static class SbomGenerator
         }
 
         foreach (var (finalId, projectIds) in constituentProjectIdsByFinalId)
-            GenerateForPackage(rootDirectory, outputDirectory, version, finalId, projectIds);
+            GenerateForPackage(rootDirectory, nugetRoot, outputDirectory, version, finalId, projectIds);
     }
 
-    static void GenerateForPackage(AbsolutePath rootDirectory, AbsolutePath outputDirectory, string version,
-        string finalId, List<string> projectIds)
+    static void GenerateForPackage(AbsolutePath rootDirectory, AbsolutePath nugetRoot, AbsolutePath outputDirectory,
+        string version, string finalId, List<string> projectIds)
     {
         JsonObject? merged = null;
         var seenComponentKeys = new HashSet<string>();
@@ -152,6 +155,22 @@ public static class SbomGenerator
         var rootRef = merged["metadata"]?["component"]?["bom-ref"]?.GetValue<string>();
         foreach (var projectDir in scannedProjectDirs)
             AddNpmComponents(merged, seenComponentKeys, projectDir, rootRef);
+
+        // The final .nupkg carries the authoritative publisher/license/repository metadata and the
+        // actual shipped binaries; use it to flesh out the thin root component cyclonedx-dotnet
+        // emits and to verify nothing ships that the dependency scan didn't already account for.
+        var finalNupkg = nugetRoot.GlobFiles($"{finalId}.{version}.nupkg").FirstOrDefault()
+            ?? nugetRoot.GlobFiles("*.nupkg").FirstOrDefault(p => ReadPackageId((string)p) == finalId);
+        if (finalNupkg is not null)
+        {
+            var nuspec = ReadNuspecMetadata((string)finalNupkg);
+            EnrichRootComponent(merged, nuspec);
+            AddPackageContentComponents(merged, seenComponentKeys, (string)finalNupkg, finalId, projectIds, nuspec);
+        }
+        else
+        {
+            Warning($"SBOM: couldn't find the built .nupkg for '{finalId}' - root metadata and package-content verification were skipped.");
+        }
 
         File.WriteAllText(outputDirectory / $"{finalId}.{version}.cdx.json",
             merged.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
@@ -278,15 +297,11 @@ public static class SbomGenerator
     static JsonArray? BuildLicenses(JsonObject installedPackageJson)
     {
         // Modern npm: "license" is an SPDX id or expression. Legacy: "license"/"licenses" objects.
-        if (installedPackageJson["license"] is JsonValue licenseValue && licenseValue.TryGetValue(out string? spdx)
-            && !string.IsNullOrWhiteSpace(spdx))
+        if (installedPackageJson["license"] is JsonValue licenseValue && licenseValue.TryGetValue(out string? spdx))
         {
-            var isExpression = spdx.IndexOf(" OR ", StringComparison.Ordinal) >= 0
-                || spdx.IndexOf(" AND ", StringComparison.Ordinal) >= 0
-                || spdx.IndexOf(" WITH ", StringComparison.Ordinal) >= 0;
-            return new JsonArray(isExpression
-                ? new JsonObject { ["expression"] = spdx }
-                : new JsonObject { ["license"] = new JsonObject { ["id"] = spdx } });
+            var licenses = SpdxToLicenses(spdx);
+            if (licenses is not null)
+                return licenses;
         }
 
         var legacy = (installedPackageJson["license"] as JsonObject)?["type"]?.GetValue<string>()
@@ -295,6 +310,20 @@ public static class SbomGenerator
         return legacy is null
             ? null
             : new JsonArray(new JsonObject { ["license"] = new JsonObject { ["name"] = legacy } });
+    }
+
+    // Turns an SPDX string into a CycloneDX licenses array: a single license id becomes a
+    // {license:{id}} entry, a compound SPDX expression becomes an {expression} entry.
+    static JsonArray? SpdxToLicenses(string? spdx)
+    {
+        if (string.IsNullOrWhiteSpace(spdx))
+            return null;
+        var isExpression = spdx.IndexOf(" OR ", StringComparison.Ordinal) >= 0
+            || spdx.IndexOf(" AND ", StringComparison.Ordinal) >= 0
+            || spdx.IndexOf(" WITH ", StringComparison.Ordinal) >= 0;
+        return new JsonArray(isExpression
+            ? new JsonObject { ["expression"] = spdx }
+            : new JsonObject { ["license"] = new JsonObject { ["id"] = spdx } });
     }
 
     static (string Purl, string Version, AbsolutePath? InstalledDir) ResolveNpmComponent(
@@ -338,13 +367,200 @@ public static class SbomGenerator
     static string ComponentKey(JsonNode? component) =>
         component?["purl"]?.GetValue<string>() ?? component?["name"]?.GetValue<string>() ?? Guid.NewGuid().ToString();
 
-    static string ReadPackageId(string nupkgPath)
+    // Fills in the root component with the publisher, licence, description and repository details
+    // from the shipped .nuspec - cyclonedx-dotnet only emits type/name/version, which is far short
+    // of the manufacturer/provenance information a CRA-facing SBOM is expected to carry.
+    static void EnrichRootComponent(JsonObject merged, NuspecMetadata meta)
+    {
+        var component = merged["metadata"]?["component"]?.AsObject();
+        if (component is null)
+            return;
+
+        // These are shipped libraries, not applications (cyclonedx-dotnet's default type).
+        component["type"] = "library";
+        component["purl"] = $"pkg:nuget/{meta.Id}@{meta.Version}";
+        if (meta.Description is not null)
+            component["description"] = meta.Description;
+        if (meta.Copyright is not null)
+            component["copyright"] = meta.Copyright;
+
+        JsonObject? supplier = null;
+        if (meta.Authors is not null)
+        {
+            component["publisher"] = meta.Authors;
+            component["author"] = meta.Authors;
+            supplier = new JsonObject { ["name"] = meta.Authors };
+            if (meta.ProjectUrl is not null)
+                supplier["url"] = new JsonArray(meta.ProjectUrl);
+            component["supplier"] = supplier;
+        }
+
+        var licenses = SpdxToLicenses(meta.LicenseExpression ?? meta.LicenseId);
+        if (licenses is not null)
+            component["licenses"] = licenses;
+
+        var externalReferences = new JsonArray();
+        if (meta.ProjectUrl is not null)
+            externalReferences.Add(new JsonObject { ["url"] = meta.ProjectUrl, ["type"] = "website" });
+        if (meta.RepositoryUrl is not null)
+            externalReferences.Add(new JsonObject { ["url"] = meta.RepositoryUrl, ["type"] = "vcs" });
+        if (externalReferences.Count > 0)
+            component["externalReferences"] = externalReferences;
+
+        // Also record the manufacturer at the document level (the entity that supplied the BOM).
+        if (supplier is not null && merged["metadata"] is JsonObject metadata)
+            metadata["supplier"] = supplier.DeepClone();
+    }
+
+    // Cross-checks what the package actually ships against the components derived from the
+    // dependency graph. Avalonia's own merged modules (Numerge folds several projects' assemblies
+    // into one package) are recorded as manufacturer-supplied components with a verifiable SHA-512
+    // of the shipped bytes; any third-party binary that no restored dependency accounts for is
+    // added and flagged, so a future bundling regression can't silently escape the SBOM.
+    static void AddPackageContentComponents(JsonObject merged, HashSet<string> seenComponentKeys,
+        string nupkgPath, string finalId, List<string> constituentProjectIds, NuspecMetadata meta)
+    {
+        var productNames = new HashSet<string>(constituentProjectIds, StringComparer.OrdinalIgnoreCase) { finalId };
+        var representedNames = (merged["components"]?.AsArray() ?? new JsonArray())
+            .Select(c => c?["name"]?.GetValue<string>())
+            .Where(n => n is not null)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase)!;
+
+        var supplier = meta.Authors is null ? null : new JsonObject { ["name"] = meta.Authors };
+        var target = merged["components"]?.AsArray() ?? (JsonArray)(merged["components"] = new JsonArray());
+
+        using var file = File.Open(nupkgPath, FileMode.Open, FileAccess.Read);
+        using var zip = new ZipArchive(file, ZipArchiveMode.Read);
+        foreach (var entry in zip.Entries)
+        {
+            var path = entry.FullName;
+            // Reference assemblies under ref/ are compile-time surface, not shipped runtime code;
+            // the real implementation lives under lib/ and is scanned there.
+            if (!IsShippedBinary(path) || path.StartsWith("ref/", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var bytes = ReadEntry(entry);
+            var assemblyName = TryReadAssemblyName(bytes, out var assemblyVersion);
+            var simpleName = assemblyName ?? Path.GetFileNameWithoutExtension(path);
+
+            // Third-party binaries already represented by a NuGet/npm component need no duplicate.
+            if (assemblyName is not null && representedNames.Contains(simpleName))
+                continue;
+
+            var isProduct = productNames.Contains(simpleName)
+                || simpleName.StartsWith("Avalonia.", StringComparison.OrdinalIgnoreCase)
+                || simpleName.Equals("Avalonia", StringComparison.OrdinalIgnoreCase);
+
+            // The package's primary assembly is the root component itself - don't list it as its own subcomponent.
+            if (isProduct && simpleName.Equals(finalId, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var version = assemblyVersion ?? meta.Version;
+            var bomRef = $"binary:{simpleName}@{version}";
+            if (!seenComponentKeys.Add(bomRef))
+                continue;
+
+            if (!isProduct)
+                Warning($"SBOM: package '{finalId}' ships '{path}' ({simpleName}) which no restored dependency accounts for - added from package contents, please verify its provenance.");
+
+            var component = new JsonObject
+            {
+                ["type"] = "library",
+                ["bom-ref"] = bomRef,
+                ["name"] = simpleName,
+                ["version"] = version,
+                ["scope"] = "required",
+                ["hashes"] = new JsonArray(new JsonObject
+                {
+                    ["alg"] = "SHA-512",
+                    ["content"] = Convert.ToHexString(SHA512.HashData(bytes))
+                }),
+                ["properties"] = new JsonArray(new JsonObject
+                {
+                    ["name"] = "avalonia:packagePath",
+                    ["value"] = path
+                })
+            };
+            if (isProduct && supplier is not null)
+                component["supplier"] = supplier.DeepClone();
+            target.Add(component);
+        }
+    }
+
+    static bool IsShippedBinary(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return ext is ".dll" or ".so" or ".dylib" or ".wasm" or ".node" or ".a";
+    }
+
+    static byte[] ReadEntry(ZipArchiveEntry entry)
+    {
+        using var stream = entry.Open();
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return ms.ToArray();
+    }
+
+    // Returns the managed assembly's simple name (and version), or null for native / non-managed binaries.
+    static string? TryReadAssemblyName(byte[] bytes, out string? version)
+    {
+        version = null;
+        try
+        {
+            using var pe = new PEReader(new MemoryStream(bytes));
+            if (!pe.HasMetadata)
+                return null;
+            var reader = pe.GetMetadataReader();
+            if (!reader.IsAssembly)
+                return null;
+            var assembly = reader.GetAssemblyDefinition();
+            version = assembly.Version.ToString();
+            return reader.GetString(assembly.Name);
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+    }
+
+    class NuspecMetadata
+    {
+        public string Id = "";
+        public string Version = "";
+        public string? Authors;
+        public string? LicenseId;
+        public string? LicenseExpression;
+        public string? ProjectUrl;
+        public string? RepositoryUrl;
+        public string? Description;
+        public string? Copyright;
+    }
+
+    static NuspecMetadata ReadNuspecMetadata(string nupkgPath)
     {
         using var file = File.Open(nupkgPath, FileMode.Open, FileAccess.Read);
         using var zip = new ZipArchive(file, ZipArchiveMode.Read);
         var nuspecEntry = zip.Entries.First(e => e.FullName.EndsWith(".nuspec") && e.FullName == e.Name);
-        return XDocument.Load(nuspecEntry.Open()).Root!
-            .Elements().First(x => x.Name.LocalName == "metadata")
-            .Elements().First(x => x.Name.LocalName == "id").Value;
+        var metadata = XDocument.Load(nuspecEntry.Open()).Root!
+            .Elements().First(x => x.Name.LocalName == "metadata");
+
+        string? Value(string name) => metadata.Elements().FirstOrDefault(x => x.Name.LocalName == name)?.Value;
+        var license = metadata.Elements().FirstOrDefault(x => x.Name.LocalName == "license");
+        var repository = metadata.Elements().FirstOrDefault(x => x.Name.LocalName == "repository");
+
+        return new NuspecMetadata
+        {
+            Id = Value("id") ?? "",
+            Version = Value("version") ?? "",
+            Authors = Value("authors"),
+            LicenseExpression = license?.Attribute("type")?.Value == "expression" ? license.Value : null,
+            LicenseId = license?.Attribute("type")?.Value == "expression" ? null : license?.Value,
+            ProjectUrl = Value("projectUrl"),
+            RepositoryUrl = repository?.Attribute("url")?.Value,
+            Description = Value("description"),
+            Copyright = Value("copyright")
+        };
     }
+
+    static string ReadPackageId(string nupkgPath) => ReadNuspecMetadata(nupkgPath).Id;
 }

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -41,7 +41,13 @@ public static class SbomGenerator
     {
         outputDirectory.CreateOrCleanDirectory();
 
-        var finalPackageIds = nugetRoot.GlobFiles("*.nupkg").Select(p => ReadPackageId((string)p)).ToHashSet();
+        // Read each final package's id exactly once here (opening/unzipping a nupkg to parse its
+        // nuspec isn't free) and reuse the id->path map when locating each package's own nupkg
+        // below, rather than re-scanning every nupkg per final package.
+        var finalPackagePathsById = nugetRoot.GlobFiles("*.nupkg")
+            .GroupBy(p => ReadPackageId((string)p))
+            .ToDictionary(g => g.Key, g => g.First());
+        var finalPackageIds = finalPackagePathsById.Keys.ToHashSet();
         var intermediatePackageIds = nugetIntermediateRoot.GlobFiles("*.nupkg")
             .Select(p => ReadPackageId((string)p)).Distinct();
 
@@ -65,10 +71,11 @@ public static class SbomGenerator
         }
 
         foreach (var (finalId, projectIds) in constituentProjectIdsByFinalId)
-            GenerateForPackage(cycloneDx, rootDirectory, nugetRoot, outputDirectory, version, finalId, projectIds);
+            GenerateForPackage(cycloneDx, rootDirectory, finalPackagePathsById, outputDirectory, version, finalId, projectIds);
     }
 
-    static void GenerateForPackage(Tool cycloneDx, AbsolutePath rootDirectory, AbsolutePath nugetRoot,
+    static void GenerateForPackage(Tool cycloneDx, AbsolutePath rootDirectory,
+        IReadOnlyDictionary<string, AbsolutePath> finalPackagePathsById,
         AbsolutePath outputDirectory, string version, string finalId, List<string> projectIds)
     {
         JsonObject? merged = null;
@@ -136,8 +143,7 @@ public static class SbomGenerator
         // The final .nupkg carries the authoritative publisher/license/repository metadata and the
         // actual shipped binaries; use it to flesh out the thin root component cyclonedx-dotnet
         // emits and to verify nothing ships that the dependency scan didn't already account for.
-        var finalNupkg = nugetRoot.GlobFiles($"{finalId}.{version}.nupkg").FirstOrDefault()
-            ?? nugetRoot.GlobFiles("*.nupkg").FirstOrDefault(p => ReadPackageId((string)p) == finalId);
+        var finalNupkg = finalPackagePathsById.GetValueOrDefault(finalId);
         if (finalNupkg is not null)
         {
             var nuspec = ReadNuspecMetadata((string)finalNupkg);

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -541,6 +541,13 @@ public static class SbomGenerator
     // into one package) are recorded as manufacturer-supplied components with a verifiable SHA-512
     // of the shipped bytes; any third-party binary that no restored dependency accounts for is
     // added and flagged, so a future bundling regression can't silently escape the SBOM.
+    //
+    // These shipped binaries are *constituents* of the package, not dependencies of it: the package
+    // is made up of them (Component C bundles D and E, in CycloneDX's terms), so they're modelled as
+    // a CycloneDX "assembly" via a top-level `compositions` entry rather than with a dependsOn edge
+    // from the root - "contains" and "depends on" are different relationships, and an assembly does
+    // not imply a dependency. They stay flat top-level components (not nested subcomponents) so their
+    // per-assembly hashes remain visible to scanners that ignore nested components.
     static void AddPackageContentComponents(JsonObject merged, HashSet<string> seenComponentKeys,
         string nupkgPath, string finalId, List<string> constituentProjectIds, NuspecMetadata meta)
     {
@@ -553,6 +560,16 @@ public static class SbomGenerator
         var supplier = meta.Authors is null ? null : new JsonObject { ["name"] = meta.Authors };
         var target = merged["components"]?.AsArray() ?? (JsonArray)(merged["components"] = new JsonArray());
         var rootRef = merged["metadata"]?["component"]?["bom-ref"]?.GetValue<string>();
+
+        // The bundled first-party assemblies share the package's licence; cyclonedx-dotnet only puts
+        // it on the root component, so carry it onto them too (same derivation as EnrichRootComponent).
+        var productLicenses = SpdxToLicenses(meta.LicenseExpression ?? meta.LicenseId);
+        if (productLicenses is null && meta.LicenseFile is not null)
+            productLicenses = new JsonArray(new JsonObject
+                { ["license"] = new JsonObject { ["name"] = Path.GetFileName(meta.LicenseFile) } });
+
+        // bom-refs of every shipped binary added below; declared as a complete assembly at the end.
+        var assemblyRefs = new List<string>();
 
         using var file = File.Open(nupkgPath, FileMode.Open, FileAccess.Read);
         using var zip = new ZipArchive(file, ZipArchiveMode.Read);
@@ -606,16 +623,36 @@ public static class SbomGenerator
                     ["value"] = path
                 })
             };
-            if (isProduct && supplier is not null)
-                component["supplier"] = supplier.DeepClone();
+            if (isProduct)
+            {
+                if (supplier is not null)
+                    component["supplier"] = supplier.DeepClone();
+                if (productLicenses is not null)
+                    component["licenses"] = productLicenses.DeepClone();
+            }
             target.Add(component);
 
-            // Link the shipped binary into the dependency graph so consumers that traverse from
-            // the root component reach it: give it its own (leaf) node and an edge from the root.
-            (merged["dependencies"]?.AsArray() ?? (JsonArray)(merged["dependencies"] = new JsonArray()))
-                .Add(new JsonObject { ["ref"] = bomRef, ["dependsOn"] = new JsonArray() });
+            assemblyRefs.Add(bomRef);
+        }
+
+        // Declare the package's assembly: the root component consists of exactly these bundled
+        // binaries. We've read every shipped binary out of the .nupkg, so the enumeration is
+        // complete (third-party dependencies remain in the dependency graph, as they should).
+        if (assemblyRefs.Count > 0)
+        {
+            var assemblies = new JsonArray();
             if (rootRef is not null)
-                AddDependsOn(merged, rootRef, bomRef);
+                assemblies.Add(rootRef);
+            foreach (var bomRef in assemblyRefs)
+                assemblies.Add(bomRef);
+
+            var compositions = merged["compositions"]?.AsArray()
+                ?? (JsonArray)(merged["compositions"] = new JsonArray());
+            compositions.Add(new JsonObject
+            {
+                ["aggregate"] = "complete",
+                ["assemblies"] = assemblies
+            });
         }
     }
 

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -1,0 +1,155 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Xml.Linq;
+using Nuke.Common.IO;
+using Nuke.Common.Tooling;
+using static Nuke.Common.Tools.DotNet.DotNetTasks;
+using static Serilog.Log;
+
+// Generates one CycloneDX SBOM per published NuGet package, using the already-restored
+// solution (obj/project.assets.json) so component versions are the ones actually resolved
+// into the build, rather than the floating PackageReference ranges GitHub's own dependency
+// graph reports.
+//
+// Numerge (see numerge.json) merges several source projects' packed output into a handful of
+// the final NuGet packages (e.g. "Avalonia" absorbs Avalonia.Base, Avalonia.Controls, the
+// build tasks/analyzers, etc). That merge happens on the built .nupkg files, not via MSBuild
+// ProjectReferences, so it can't be discovered by pointing CycloneDX at a single project with
+// -rs/--recursive. Instead this compares the intermediate and final package sets to work out
+// which source projects were folded into which final package, generates a BOM per constituent
+// project, and unions their components (de-duplicated by purl) into one BOM per final package.
+public static class SbomGenerator
+{
+    const string CycloneDxToolVersion = "6.2.0";
+
+    class NumergeConfigRoot
+    {
+        public List<NumergePackageGroup> Packages { get; set; } = new();
+    }
+
+    class NumergePackageGroup
+    {
+        public string Id { get; set; } = "";
+        public bool MergeAll { get; set; }
+        public List<NumergeMergeChild> Merge { get; set; } = new();
+    }
+
+    class NumergeMergeChild
+    {
+        public string Id { get; set; } = "";
+    }
+
+    public static void Generate(
+        AbsolutePath rootDirectory,
+        AbsolutePath nugetRoot,
+        AbsolutePath nugetIntermediateRoot,
+        AbsolutePath numergeConfigPath,
+        AbsolutePath outputDirectory,
+        string version)
+    {
+        outputDirectory.CreateOrCleanDirectory();
+
+        DotNet($"tool update --global CycloneDX --version {CycloneDxToolVersion}");
+
+        var finalPackageIds = nugetRoot.GlobFiles("*.nupkg").Select(p => ReadPackageId((string)p)).ToHashSet();
+        var intermediatePackageIds = nugetIntermediateRoot.GlobFiles("*.nupkg")
+            .Select(p => ReadPackageId((string)p)).Distinct();
+
+        var numerge = JsonSerializer.Deserialize<NumergeConfigRoot>(File.ReadAllText(numergeConfigPath))
+            ?? new NumergeConfigRoot();
+        var explicitParentByChild = numerge.Packages
+            .SelectMany(p => p.Merge.Select(c => (Parent: p.Id, Child: c.Id)))
+            .ToDictionary(x => x.Child, x => x.Parent);
+        var mergeAllParent = numerge.Packages.FirstOrDefault(p => p.MergeAll)?.Id;
+
+        // Every final package starts out as its own sole constituent; leftover intermediate
+        // packages (ones that never shipped standalone) get assigned to whichever final
+        // package absorbed them, per numerge.json.
+        var constituentProjectIdsByFinalId = finalPackageIds.ToDictionary(id => id, id => new List<string> { id });
+        foreach (var id in intermediatePackageIds.Where(id => !finalPackageIds.Contains(id)))
+        {
+            var owner = explicitParentByChild.TryGetValue(id, out var explicitOwner) ? explicitOwner : mergeAllParent;
+            if (owner is not null && constituentProjectIdsByFinalId.TryGetValue(owner, out var siblings))
+                siblings.Add(id);
+            else
+                Warning($"SBOM: couldn't determine which published package absorbs intermediate package '{id}' - it will be missing from all generated SBOMs.");
+        }
+
+        foreach (var (finalId, projectIds) in constituentProjectIdsByFinalId)
+            GenerateForPackage(rootDirectory, outputDirectory, version, finalId, projectIds);
+    }
+
+    static void GenerateForPackage(AbsolutePath rootDirectory, AbsolutePath outputDirectory, string version,
+        string finalId, List<string> projectIds)
+    {
+        JsonObject? merged = null;
+        var seenComponentKeys = new HashSet<string>();
+
+        foreach (var projectId in projectIds)
+        {
+            var project = rootDirectory.GlobFiles($"src/**/{projectId}.csproj")
+                .Concat(rootDirectory.GlobFiles($"packages/**/{projectId}.csproj"))
+                .FirstOrDefault();
+            if (project is null)
+            {
+                Warning($"SBOM: couldn't locate source project for '{projectId}', skipping it in the SBOM for '{finalId}'.");
+                continue;
+            }
+
+            var tempBom = outputDirectory / $"_{projectId}.tmp.json";
+            ProcessTasks.StartProcess("dotnet-CycloneDX",
+                    $"\"{project}\" -o \"{outputDirectory}\" -fn \"{tempBom.Name}\" -F Json -dpr -ed -sn \"{finalId}\" -sv \"{version}\"",
+                    workingDirectory: rootDirectory)
+                .AssertZeroExitCode();
+
+            var doc = JsonNode.Parse(File.ReadAllText(tempBom))!.AsObject();
+            File.Delete(tempBom);
+
+            var components = doc["components"]?.AsArray() ?? new JsonArray();
+            if (merged is null)
+            {
+                merged = doc;
+                foreach (var component in components)
+                    seenComponentKeys.Add(ComponentKey(component));
+            }
+            else
+            {
+                var target = merged["components"]?.AsArray() ?? (JsonArray)(merged["components"] = new JsonArray());
+                foreach (var component in components)
+                {
+                    if (seenComponentKeys.Add(ComponentKey(component)))
+                        target.Add(component!.DeepClone());
+                }
+            }
+        }
+
+        if (merged is null)
+        {
+            Warning($"SBOM: no source projects could be scanned for '{finalId}', no SBOM was generated for it.");
+            return;
+        }
+
+        File.WriteAllText(outputDirectory / $"{finalId}.{version}.cdx.json",
+            merged.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    static string ComponentKey(JsonNode? component) =>
+        component?["purl"]?.GetValue<string>() ?? component?["name"]?.GetValue<string>() ?? Guid.NewGuid().ToString();
+
+    static string ReadPackageId(string nupkgPath)
+    {
+        using var file = File.Open(nupkgPath, FileMode.Open, FileAccess.Read);
+        using var zip = new ZipArchive(file, ZipArchiveMode.Read);
+        var nuspecEntry = zip.Entries.First(e => e.FullName.EndsWith(".nuspec") && e.FullName == e.Name);
+        return XDocument.Load(nuspecEntry.Open()).Root!
+            .Elements().First(x => x.Name.LocalName == "metadata")
+            .Elements().First(x => x.Name.LocalName == "id").Value;
+    }
+}

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -7,6 +7,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
@@ -91,6 +92,7 @@ public static class SbomGenerator
     {
         JsonObject? merged = null;
         var seenComponentKeys = new HashSet<string>();
+        var scannedProjectDirs = new List<AbsolutePath>();
 
         foreach (var projectId in projectIds)
         {
@@ -102,6 +104,7 @@ public static class SbomGenerator
                 Warning($"SBOM: couldn't locate source project for '{projectId}', skipping it in the SBOM for '{finalId}'.");
                 continue;
             }
+            scannedProjectDirs.Add(project.Parent);
 
             var tempBom = outputDirectory / $"_{projectId}.tmp.json";
             ProcessTasks.StartProcess("dotnet-CycloneDX",
@@ -127,6 +130,12 @@ public static class SbomGenerator
                     if (seenComponentKeys.Add(ComponentKey(component)))
                         target.Add(component!.DeepClone());
                 }
+
+                // Every constituent project's own -sn/-sv override makes its root component (and
+                // therefore its dependency-graph "ref") identical to the final package's, so merging
+                // by ref correctly unions all constituents' dependsOn edges onto that shared root
+                // instead of silently keeping only the first project's edges.
+                MergeDependencyGraph(merged, doc["dependencies"]?.AsArray() ?? new JsonArray());
             }
         }
 
@@ -136,8 +145,103 @@ public static class SbomGenerator
             return;
         }
 
+        // cyclonedx-dotnet only sees the MSBuild/NuGet graph. Some projects also bundle a
+        // Bun/npm-built webapp directly into their published package (e.g. Avalonia.Browser's
+        // staticwebassets, Avalonia.DesignerSupport's embedded previewer) - scan those separately
+        // so their shipped JS dependencies aren't silently absent from the SBOM.
+        foreach (var projectDir in scannedProjectDirs)
+            AddNpmComponents(merged, seenComponentKeys, projectDir);
+
         File.WriteAllText(outputDirectory / $"{finalId}.{version}.cdx.json",
             merged.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    static void MergeDependencyGraph(JsonObject target, JsonArray incoming)
+    {
+        var targetDeps = target["dependencies"]?.AsArray() ?? (JsonArray)(target["dependencies"] = new JsonArray());
+        var byRef = targetDeps.OfType<JsonObject>().ToDictionary(d => d["ref"]!.GetValue<string>());
+
+        foreach (var node in incoming.OfType<JsonObject>())
+        {
+            var nodeRef = node["ref"]!.GetValue<string>();
+            var dependsOn = node["dependsOn"]?.AsArray().Select(x => x!.GetValue<string>()) ?? Enumerable.Empty<string>();
+
+            if (!byRef.TryGetValue(nodeRef, out var existing))
+            {
+                existing = node.DeepClone().AsObject();
+                targetDeps.Add(existing);
+                byRef[nodeRef] = existing;
+            }
+
+            var existingDependsOn = existing["dependsOn"]?.AsArray() ?? (JsonArray)(existing["dependsOn"] = new JsonArray());
+            var seen = existingDependsOn.Select(x => x!.GetValue<string>()).ToHashSet();
+            foreach (var dep in dependsOn)
+                if (seen.Add(dep))
+                    existingDependsOn.Add(dep);
+        }
+    }
+
+    // Scans <projectDir>/**/webapp/package.json for production "dependencies" (deliberately
+    // ignoring devDependencies, which never ship) and adds them as components. Resolves each
+    // dependency's actually-installed version from node_modules where possible, same rationale
+    // as scanning project.assets.json instead of trusting floating NuGet version ranges.
+    static void AddNpmComponents(JsonObject merged, HashSet<string> seenComponentKeys, AbsolutePath projectDir)
+    {
+        foreach (string packageJsonPath in projectDir.GlobFiles("**/webapp/package.json"))
+        {
+            var packageJson = JsonNode.Parse(File.ReadAllText(packageJsonPath))!.AsObject();
+            var nodeModules = ((AbsolutePath)packageJsonPath).Parent / "node_modules";
+            var dependencies = packageJson["dependencies"]?.AsObject() ?? new JsonObject();
+
+            foreach (var (name, rangeNode) in dependencies)
+            {
+                var (purl, componentVersion) = ResolveNpmComponent(name, rangeNode!.GetValue<string>(), nodeModules);
+                if (!seenComponentKeys.Add(purl))
+                    continue;
+
+                var target = merged["components"]?.AsArray() ?? (JsonArray)(merged["components"] = new JsonArray());
+                target.Add(new JsonObject
+                {
+                    ["type"] = "library",
+                    ["name"] = name,
+                    ["version"] = componentVersion,
+                    ["purl"] = purl
+                });
+            }
+        }
+    }
+
+    static (string Purl, string Version) ResolveNpmComponent(string name, string declaredRange, AbsolutePath nodeModules)
+    {
+        if (declaredRange.StartsWith("github:") || declaredRange.StartsWith("git") || declaredRange.Contains("://"))
+        {
+            var (owner, repo, reference) = ParseGitDependency(declaredRange);
+            return ($"pkg:github/{owner}/{repo}@{reference}", reference);
+        }
+
+        var installedPackageJson = nodeModules / name / "package.json";
+        if (!File.Exists(installedPackageJson))
+        {
+            Warning($"SBOM: npm dependency '{name}' isn't installed under {nodeModules} - recording its declared range '{declaredRange}' instead of a resolved version.");
+            return ($"pkg:npm/{EncodeNpmName(name)}@{declaredRange}", declaredRange);
+        }
+
+        var installedVersion = JsonNode.Parse(File.ReadAllText(installedPackageJson))!["version"]!.GetValue<string>();
+        return ($"pkg:npm/{EncodeNpmName(name)}@{installedVersion}", installedVersion);
+    }
+
+    static string EncodeNpmName(string name) => name.StartsWith("@") ? $"%40{name[1..]}" : name;
+
+    static (string Owner, string Repo, string Reference) ParseGitDependency(string spec)
+    {
+        var hashIndex = spec.IndexOf('#');
+        var reference = hashIndex >= 0 ? spec[(hashIndex + 1)..] : "HEAD";
+        var withoutRef = hashIndex >= 0 ? spec[..hashIndex] : spec;
+
+        var match = Regex.Match(withoutRef, @"github(?:\.com)?[:/]+([^/]+)/([^/#]+?)(?:\.git)?$");
+        if (!match.Success)
+            throw new NotSupportedException($"SBOM: don't know how to parse git dependency specifier '{spec}'.");
+        return (match.Groups[1].Value, match.Groups[2].Value, reference);
     }
 
     static string ComponentKey(JsonNode? component) =>

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -385,7 +385,13 @@ public static class SbomGenerator
             return ($"pkg:npm/{EncodeNpmName(name)}@{declaredRange}", declaredRange, null);
         }
 
-        var installedVersion = JsonNode.Parse(File.ReadAllText(installedDir / "package.json"))!["version"]!.GetValue<string>();
+        var installedVersion = JsonNode.Parse(File.ReadAllText(installedDir / "package.json"))!["version"]?.GetValue<string>();
+        if (installedVersion is null)
+        {
+            // package.json without a "version" is valid for private packages; don't let it NRE.
+            Warning($"SBOM: npm dependency '{name}' installed at {installedDir} has no version in its package.json - recording its declared range '{declaredRange}' instead.");
+            installedVersion = declaredRange;
+        }
         return ($"pkg:npm/{EncodeNpmName(name)}@{installedVersion}", installedVersion, installedDir);
     }
 

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -161,8 +161,73 @@ public static class SbomGenerator
         // the graph only references components actually present in the SBOM.
         PruneDanglingDependencyEdges(merged);
 
-        File.WriteAllText(outputDirectory / $"{finalId}.{version}.cdx.json",
-            merged.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+        var sbomJson = merged.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(outputDirectory / $"{finalId}.{version}.cdx.json", sbomJson);
+
+        // Embed the SBOM inside the shipped .nupkg so it travels with the package, in addition to
+        // the standalone copy written above (which CI publishes as the SBOM artifact) - belt and
+        // suspenders: consumers who only ever see the package still get its bill of materials.
+        if (finalNupkg is not null)
+            EmbedSbomInPackage(finalNupkg, sbomJson);
+    }
+
+    // The path inside the .nupkg where the CycloneDX SBOM is embedded. Mirrors the _manifest/
+    // layout Microsoft.Sbom.Targets uses for its SPDX manifest, but keeps CycloneDX's recognised
+    // *.cdx.json filename so tools that scan for that pattern still find it once unpacked.
+    const string EmbeddedSbomEntryPath = "_manifest/cyclonedx/bom.cdx.json";
+
+    // Adds the generated SBOM as a new part inside the shipped package. Must run before the package
+    // is signed - a NuGet signature covers the whole archive, so adding a part afterwards would
+    // invalidate it. That holds here: these packages are signed server-side by nuget.org on push,
+    // which happens after this build step.
+    static void EmbedSbomInPackage(AbsolutePath nupkgPath, string sbomJson)
+    {
+        using var file = File.Open(nupkgPath, FileMode.Open, FileAccess.ReadWrite);
+        using var zip = new ZipArchive(file, ZipArchiveMode.Update);
+
+        if (zip.Entries.Any(e => e.FullName.EndsWith(".signature.p7s", StringComparison.OrdinalIgnoreCase)))
+        {
+            Warning($"SBOM: '{nupkgPath.Name}' is already signed - skipping embed so its signature stays valid.");
+            return;
+        }
+
+        // Re-embedding (e.g. a re-run over the same output) should replace, not stack duplicates.
+        zip.GetEntry(EmbeddedSbomEntryPath)?.Delete();
+        using (var entryStream = zip.CreateEntry(EmbeddedSbomEntryPath).Open())
+        using (var writer = new StreamWriter(entryStream))
+            writer.Write(sbomJson);
+
+        EnsureJsonContentTypeRegistered(zip);
+    }
+
+    // A .nupkg is an OPC package: every part's extension must be declared in [Content_Types].xml or
+    // strict OPC readers - including NuGet's own signature verification - reject the package. The
+    // SBOM is a .json part, so register that extension before (or as) we add it.
+    static void EnsureJsonContentTypeRegistered(ZipArchive zip)
+    {
+        const string contentTypesEntryName = "[Content_Types].xml";
+        XNamespace ns = "http://schemas.openxmlformats.org/package/2006/content-types";
+
+        var entry = zip.GetEntry(contentTypesEntryName);
+        if (entry is null)
+            return; // not a well-formed OPC package; don't fabricate one
+
+        XDocument doc;
+        using (var read = entry.Open())
+            doc = XDocument.Load(read);
+
+        var alreadyRegistered = doc.Root!.Elements(ns + "Default")
+            .Any(d => string.Equals((string?)d.Attribute("Extension"), "json", StringComparison.OrdinalIgnoreCase));
+        if (alreadyRegistered)
+            return;
+
+        doc.Root.Add(new XElement(ns + "Default",
+            new XAttribute("Extension", "json"),
+            new XAttribute("ContentType", "application/json")));
+
+        entry.Delete();
+        using var write = zip.CreateEntry(contentTypesEntryName).Open();
+        doc.Save(write);
     }
 
     static void PruneDanglingDependencyEdges(JsonObject merged)

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -444,6 +444,10 @@ public static class SbomGenerator
         }
 
         var licenses = SpdxToLicenses(meta.LicenseExpression ?? meta.LicenseId);
+        // A file license has no SPDX id; record it by name rather than emitting an invalid id.
+        if (licenses is null && meta.LicenseFile is not null)
+            licenses = new JsonArray(new JsonObject
+                { ["license"] = new JsonObject { ["name"] = Path.GetFileName(meta.LicenseFile) } });
         if (licenses is not null)
             component["licenses"] = licenses;
 
@@ -586,6 +590,7 @@ public static class SbomGenerator
         public string? Authors;
         public string? LicenseId;
         public string? LicenseExpression;
+        public string? LicenseFile;
         public string? ProjectUrl;
         public string? RepositoryUrl;
         public string? Description;
@@ -609,8 +614,11 @@ public static class SbomGenerator
             Id = Value("id") ?? "",
             Version = Value("version") ?? "",
             Authors = Value("authors"),
+            // A nuspec <license> is either type="expression" (an SPDX expression) or type="file"
+            // (a path to a bundled licence file); only the former is a valid SPDX id/expression.
             LicenseExpression = license?.Attribute("type")?.Value == "expression" ? license.Value : null,
-            LicenseId = license?.Attribute("type")?.Value == "expression" ? null : license?.Value,
+            LicenseFile = license?.Attribute("type")?.Value == "file" ? license.Value : null,
+            LicenseId = license?.Attribute("type")?.Value is "expression" or "file" ? null : license?.Value,
             ProjectUrl = Value("projectUrl"),
             RepositoryUrl = repository?.Attribute("url")?.Value,
             Description = Value("description"),

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -364,8 +364,19 @@ public static class SbomGenerator
 
         if (declaredRange.StartsWith("github:") || declaredRange.StartsWith("git") || declaredRange.Contains("://"))
         {
-            var (owner, repo, reference) = ParseGitDependency(declaredRange);
-            return ($"pkg:github/{owner}/{repo}@{reference}", reference, installedDir);
+            if (TryParseGitHubDependency(declaredRange, out var owner, out var repo, out var reference))
+                return ($"pkg:github/{owner}/{repo}@{reference}", reference, installedDir);
+
+            // A non-GitHub git/URL specifier (GitLab/Bitbucket, a raw tarball URL, ...). We have no
+            // provider-specific purl for it, so degrade to a generic component - preferring the
+            // version installed on disk - rather than throwing and failing the whole release over a
+            // single dependency we can't classify precisely.
+            var resolvedVersion = installedDir is not null
+                ? JsonNode.Parse(File.ReadAllText(installedDir / "package.json"))!["version"]?.GetValue<string>()
+                : null;
+            resolvedVersion ??= declaredRange;
+            Warning($"SBOM: npm dependency '{name}' uses an unrecognised git/URL specifier '{declaredRange}' - recording it as a generic component with version '{resolvedVersion}'.");
+            return ($"pkg:generic/{EncodeNpmName(name)}@{resolvedVersion}", resolvedVersion, installedDir);
         }
 
         if (installedDir is null)
@@ -380,16 +391,19 @@ public static class SbomGenerator
 
     static string EncodeNpmName(string name) => name.StartsWith("@") ? $"%40{name[1..]}" : name;
 
-    static (string Owner, string Repo, string Reference) ParseGitDependency(string spec)
+    static bool TryParseGitHubDependency(string spec, out string owner, out string repo, out string reference)
     {
+        owner = repo = "";
         var hashIndex = spec.IndexOf('#');
-        var reference = hashIndex >= 0 ? spec[(hashIndex + 1)..] : "HEAD";
+        reference = hashIndex >= 0 ? spec[(hashIndex + 1)..] : "HEAD";
         var withoutRef = hashIndex >= 0 ? spec[..hashIndex] : spec;
 
         var match = Regex.Match(withoutRef, @"github(?:\.com)?[:/]+([^/]+)/([^/#]+?)(?:\.git)?$");
         if (!match.Success)
-            throw new NotSupportedException($"SBOM: don't know how to parse git dependency specifier '{spec}'.");
-        return (match.Groups[1].Value, match.Groups[2].Value, reference);
+            return false;
+        owner = match.Groups[1].Value;
+        repo = match.Groups[2].Value;
+        return true;
     }
 
     static string ComponentKey(JsonNode? component) =>

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -436,6 +436,7 @@ public static class SbomGenerator
 
         var supplier = meta.Authors is null ? null : new JsonObject { ["name"] = meta.Authors };
         var target = merged["components"]?.AsArray() ?? (JsonArray)(merged["components"] = new JsonArray());
+        var rootRef = merged["metadata"]?["component"]?["bom-ref"]?.GetValue<string>();
 
         using var file = File.Open(nupkgPath, FileMode.Open, FileAccess.Read);
         using var zip = new ZipArchive(file, ZipArchiveMode.Read);
@@ -492,6 +493,13 @@ public static class SbomGenerator
             if (isProduct && supplier is not null)
                 component["supplier"] = supplier.DeepClone();
             target.Add(component);
+
+            // Link the shipped binary into the dependency graph so consumers that traverse from
+            // the root component reach it: give it its own (leaf) node and an edge from the root.
+            (merged["dependencies"]?.AsArray() ?? (JsonArray)(merged["dependencies"] = new JsonArray()))
+                .Add(new JsonObject { ["ref"] = bomRef, ["dependsOn"] = new JsonArray() });
+            if (rootRef is not null)
+                AddDependsOn(merged, rootRef, bomRef);
         }
     }
 

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -173,8 +173,9 @@ public static class SbomGenerator
         }
 
         // cyclonedx-dotnet leaves dependsOn edges pointing at packages it excluded as dev
-        // dependencies (e.g. analyzers stripped by -ed), which dangle once the component is gone.
-        // Drop those so the graph only references components actually present in the SBOM.
+        // dependencies (e.g. analyzers stripped by -ed), which dangle once the component is gone
+        // (upstream bug CycloneDX/cyclonedx-dotnet#761, still reproducing in 6.2.0). Drop those so
+        // the graph only references components actually present in the SBOM.
         PruneDanglingDependencyEdges(merged);
 
         File.WriteAllText(outputDirectory / $"{finalId}.{version}.cdx.json",

--- a/nukebuild/SbomGenerator.cs
+++ b/nukebuild/SbomGenerator.cs
@@ -14,7 +14,6 @@ using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
-using static Nuke.Common.Tools.DotNet.DotNetTasks;
 using static Serilog.Log;
 
 // Generates one CycloneDX SBOM per published NuGet package, using the already-restored
@@ -31,8 +30,6 @@ using static Serilog.Log;
 // project, and unions their components (de-duplicated by purl) into one BOM per final package.
 public static class SbomGenerator
 {
-    const string CycloneDxToolVersion = "6.2.0";
-
     class NumergeConfigRoot
     {
         public List<NumergePackageGroup> Packages { get; set; } = new();
@@ -51,6 +48,7 @@ public static class SbomGenerator
     }
 
     public static void Generate(
+        Tool cycloneDx,
         AbsolutePath rootDirectory,
         AbsolutePath nugetRoot,
         AbsolutePath nugetIntermediateRoot,
@@ -59,8 +57,6 @@ public static class SbomGenerator
         string version)
     {
         outputDirectory.CreateOrCleanDirectory();
-
-        DotNet($"tool update --global CycloneDX --version {CycloneDxToolVersion}");
 
         var finalPackageIds = nugetRoot.GlobFiles("*.nupkg").Select(p => ReadPackageId((string)p)).ToHashSet();
         var intermediatePackageIds = nugetIntermediateRoot.GlobFiles("*.nupkg")
@@ -87,11 +83,11 @@ public static class SbomGenerator
         }
 
         foreach (var (finalId, projectIds) in constituentProjectIdsByFinalId)
-            GenerateForPackage(rootDirectory, nugetRoot, outputDirectory, version, finalId, projectIds);
+            GenerateForPackage(cycloneDx, rootDirectory, nugetRoot, outputDirectory, version, finalId, projectIds);
     }
 
-    static void GenerateForPackage(AbsolutePath rootDirectory, AbsolutePath nugetRoot, AbsolutePath outputDirectory,
-        string version, string finalId, List<string> projectIds)
+    static void GenerateForPackage(Tool cycloneDx, AbsolutePath rootDirectory, AbsolutePath nugetRoot,
+        AbsolutePath outputDirectory, string version, string finalId, List<string> projectIds)
     {
         JsonObject? merged = null;
         var seenComponentKeys = new HashSet<string>();
@@ -110,10 +106,9 @@ public static class SbomGenerator
             scannedProjectDirs.Add(project.Parent);
 
             var tempBom = outputDirectory / $"_{projectId}.tmp.json";
-            ProcessTasks.StartProcess("dotnet-CycloneDX",
-                    $"\"{project}\" -o \"{outputDirectory}\" -fn \"{tempBom.Name}\" -F Json -dpr -ed -sn \"{finalId}\" -sv \"{version}\"",
-                    workingDirectory: rootDirectory)
-                .AssertZeroExitCode();
+            cycloneDx(
+                $"\"{project}\" -o \"{outputDirectory}\" -fn \"{tempBom.Name}\" -F Json -dpr -ed -sn \"{finalId}\" -sv \"{version}\"",
+                workingDirectory: rootDirectory);
 
             var doc = JsonNode.Parse(File.ReadAllText(tempBom))!.AsObject();
             File.Delete(tempBom);

--- a/nukebuild/_build.csproj
+++ b/nukebuild/_build.csproj
@@ -20,6 +20,7 @@
     <PackageDownload Include="Microsoft.DotNet.ApiCompat.Tool" Version="[10.0.100]" />
     <PackageDownload Include="Microsoft.DotNet.ApiDiff.Tool" Version="[10.0.100-rtm.25531.102]" />
     <PackageDownload Include="dotnet-ilrepack" Version="[2.0.44]" />
+    <PackageDownload Include="CycloneDX" Version="[6.2.0]" />
   </ItemGroup>
 
   <Import Project="..\build\MicroCOM.props" />


### PR DESCRIPTION
## Summary
Produces a per-package Software Bill of Materials so Avalonia can meet the **EU Cyber Resilience Act (CRA)** obligation (Annex I, Part II(1)) to identify and document the components contained in a product with digital elements, in a commonly used, machine-readable format. Output is CycloneDX JSON, scoped to what is actually *delivered* with each package (BSI TR-03183-2 "scope of delivery"), so it stands up as CRA technical-documentation evidence.

GitHub's dependency-graph SBOM export was insufficient for this: it reports unresolved version ranges for most packages (`>= 0` for NuGet, `^x.y.z` for npm) and can't see which source projects Numerge merges into which final package.

### What it does
- Adds a `CreateSbom` Nuke target that runs CycloneDX against each project's already-restored assets (exact resolved versions), reassembles the Numerge merge groups from `numerge.json`, and writes one SBOM per shipped NuGet package.
- **Dependency graph:** unions each merged constituent project's `dependsOn` edges onto the shared final-package root, rather than keeping only the first project's.
- **Bundled npm/JS coverage:** cyclonedx-dotnet only sees the NuGet graph, so shipped JS is scanned separately — `Avalonia.Browser`'s `staticwebassets` and `Avalonia.DesignerSupport`'s embedded previewer. npm packages are walked transitively and emitted with bom-ref, resolved version, license, and graph edges. Type-only `@types/*` packages (stripped by esbuild, never shipped) are excluded so the SBOM lists exactly what's delivered.
- **Root component enrichment:** fills the CRA-relevant manufacturer/provenance fields from the shipped `.nuspec` — purl, publisher/supplier, SPDX license, description, copyright, and website/vcs references.
- **Package-content verification:** scans the final `.nupkg`'s binaries; Avalonia's own Numerge-merged modules are recorded with a SHA-512 of the shipped bytes, and any third-party binary no restored dependency accounts for is added and flagged — a regression guard so bundled binaries can't silently escape the SBOM.
- **Delivery:** each SBOM is embedded inside its shipped `.nupkg` at `_manifest/cyclonedx/bom.cdx.json` so the bill of materials travels with the package, and is *also* published as a detached `SBOM` build artifact. Because a `.nupkg` is an OPC package, `[Content_Types].xml` gains a `json` default when embedding, otherwise strict OPC readers (including NuGet signature verification) would reject the modified package; already-signed packages are skipped so their signature stays valid.
- Wired into the `CiAzureWindows` and `CiAzureOSX` jobs; `azure-pipelines.yml` publishes `artifacts/sbom` as new `SBOM`/`SBOMOSX` build artifacts.

### Why not `Microsoft.Sbom.Targets`?
`Microsoft.Sbom.Targets` is the Microsoft-blessed route (it's what the .NET SDK/runtime and packages such as AutoMapper use) and would normally be the obvious choice. It hooks `dotnet pack` **per project** and embeds an SPDX manifest at `_manifest/spdx_2.2/` inside *that project's* `.nupkg`. That model assumes the shipped package **is** a project's pack output — which is exactly the assumption Numerge breaks here: the packages we actually ship (`Avalonia`, `Avalonia.Win32`, …) are assembled from several projects' packed output *after* packing, on the built `.nupkg` files.

So embedding at pack time would write manifests into the intermediate packages that get merged away, and leave each shipped package describing only one constituent project (or none). Reconstructing the Numerge merge groups — the hard part of this PR — is required regardless, which removes the pack-time convenience that is the tool's main advantage. Running the underlying `sbom-tool` CLI over the merged output *would* be viable, but it only swaps CycloneDX for SPDX while still needing this PR's Numerge-group reassembly and bundled-npm scanning, so there was no net simplification to gain — hence CycloneDX + cyclonedx-dotnet.

This PR still delivers the SBOM *inside* the package, the way `Microsoft.Sbom.Targets` would: it embeds the CycloneDX document at a well-known `_manifest/cyclonedx/bom.cdx.json` path in each shipped `.nupkg`, so the bill of materials travels with the package — just generated post-merge, once the final package contents actually exist and can be verified.

### Out of scope (follow-ups for full CRA evidence)
Long-term retention of the SBOM as technical documentation, an SBOM validation gate, signing/attestation, vulnerability scanning, and VEX artifacts are pipeline/process concerns not addressed here.

## Test plan
- [x] Verified `nukebuild/_build.csproj` compiles with the new code
- [x] Ran `dotnet-CycloneDX` manually against a real project to confirm CLI flags and JSON schema assumptions
- [x] Ran `--target CreateSbom` locally against real build output and confirmed all 24 published packages get an accurate SBOM, including the merged `Avalonia` and `Avalonia.Win32` groups
- [x] Confirmed npm transitives, licenses, bom-refs and graph edges are present; `@types/*` excluded; root component enriched; shipped modules hashed
- [x] Verified embedding: after embedding into a real `.nupkg`, a strict OPC reader opens the package cleanly with the SBOM part present at `_manifest/cyclonedx/bom.cdx.json` and typed `application/json`
- [x] Confirmed the target runs cleanly in a full CI build (Azure build 67065); verified the embedded SBOM is present at `_manifest/cyclonedx/bom.cdx.json` in the CI-published `Avalonia.12.1.999-cibuild0067065-alpha.nupkg` pulled from the nightly feed, and the modified package still opens as a valid OPC/NuGet package

🤖 Generated with [Claude Code](https://claude.com/claude-code)
