### PR TITLE
Fix catastrophic TextLineImpl allocation when TextWrapping=Wrap and paragraphWidth<=0

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -878,13 +878,6 @@ namespace Avalonia.Media.TextFormatting
                 return CreateEmptyTextLine(firstTextSourceIndex, paragraphWidth, paragraphProperties);
             }
 
-            // A zero or negative paragraph width means there is no space to wrap into.
-            // Advancing one grapheme per call would create O(N) TextLineImpl instances for the
-            // entire text (one per character), causing catastrophic memory allocation.
-            // Treat it as unconstrained (infinite width) so all runs fit on one line.
-            if (paragraphWidth <= 0)
-                paragraphWidth = double.PositiveInfinity;
-
             var measuredLength = MeasureLength(textRuns, paragraphWidth);
 
             if(measuredLength == 0)

--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -878,6 +878,30 @@ namespace Avalonia.Media.TextFormatting
                 return CreateEmptyTextLine(firstTextSourceIndex, paragraphWidth, paragraphProperties);
             }
 
+            // A zero or negative paragraph width means there is no space to wrap into.
+            // Advancing one grapheme per call would create O(N) TextLineImpl instances for the
+            // entire text (one per character), causing catastrophic memory allocation.
+            // Treat it as unconstrained: put all runs on a single line without wrapping.
+            if (paragraphWidth <= 0)
+            {
+                var lineRuns = new TextRun[textRuns.Count];
+                var totalLength = 0;
+                for (var i = 0; i < textRuns.Count; i++)
+                {
+                    lineRuns[i] = textRuns[i];
+                    totalLength += textRuns[i].Length;
+                }
+
+                TextLineBreak? lineBreak = currentLineBreak?.TextEndOfLine is { } eol
+                    ? new TextLineBreak(eol, resolvedFlowDirection)
+                    : null;
+
+                var textLine = new TextLineImpl(lineRuns, firstTextSourceIndex, totalLength,
+                    paragraphWidth, paragraphProperties, resolvedFlowDirection, lineBreak);
+                textLine.FinalizeLine();
+                return textLine;
+            }
+
             var measuredLength = MeasureLength(textRuns, paragraphWidth);
 
             if(measuredLength == 0)

--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -881,26 +881,9 @@ namespace Avalonia.Media.TextFormatting
             // A zero or negative paragraph width means there is no space to wrap into.
             // Advancing one grapheme per call would create O(N) TextLineImpl instances for the
             // entire text (one per character), causing catastrophic memory allocation.
-            // Treat it as unconstrained: put all runs on a single line without wrapping.
+            // Treat it as unconstrained (infinite width) so all runs fit on one line.
             if (paragraphWidth <= 0)
-            {
-                var lineRuns = new TextRun[textRuns.Count];
-                var totalLength = 0;
-                for (var i = 0; i < textRuns.Count; i++)
-                {
-                    lineRuns[i] = textRuns[i];
-                    totalLength += textRuns[i].Length;
-                }
-
-                TextLineBreak? lineBreak = currentLineBreak?.TextEndOfLine is { } eol
-                    ? new TextLineBreak(eol, resolvedFlowDirection)
-                    : null;
-
-                var textLine = new TextLineImpl(lineRuns, firstTextSourceIndex, totalLength,
-                    paragraphWidth, paragraphProperties, resolvedFlowDirection, lineBreak);
-                textLine.FinalizeLine();
-                return textLine;
-            }
+                paragraphWidth = double.PositiveInfinity;
 
             var measuredLength = MeasureLength(textRuns, paragraphWidth);
 

--- a/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
@@ -560,7 +560,7 @@ namespace Avalonia.Media.TextFormatting
 
             var first = true;
 
-            if (MathUtilities.IsZero(MaxWidth) || MathUtilities.IsZero(MaxHeight))
+            if (MathUtilities.IsZero(MaxHeight))
             {
                 var textLine = TextFormatterImpl.CreateEmptyTextLine(0, double.PositiveInfinity, _paragraphProperties);
 
@@ -568,6 +568,11 @@ namespace Avalonia.Media.TextFormatting
 
                 return new TextLine[] { textLine };
             }
+
+            // When MaxWidth is zero or negative, format as unconstrained (infinite width) so all
+            // text runs fit on a single line. Passing zero into the formatter would cause
+            // TextWrapping to advance one grapheme per line, creating O(N) TextLineImpl instances.
+            var formattingWidth = MaxWidth > 0 ? MaxWidth : double.PositiveInfinity;
 
             var textLines = objectPool.TextLines.Rent();
 
@@ -581,7 +586,7 @@ namespace Avalonia.Media.TextFormatting
 
                 while (true)
                 {
-                    var textLine = textFormatter.FormatLine(_textSource, _textSourceLength, MaxWidth,
+                    var textLine = textFormatter.FormatLine(_textSource, _textSourceLength, formattingWidth,
                         _paragraphProperties, previousLine?.TextLineBreak, _textRunCache) as TextLineImpl;
 
                     if (textLine is null)

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
@@ -1350,16 +1350,21 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
         /// <summary>
         /// Regression test for https://github.com/AvaloniaUI/Avalonia/issues/21685.
-        /// Wrapping with paragraphWidth=0 must not create O(N) TextLineImpl instances.
+        /// TextFormatterImpl.FormatLine with paragraphWidth=0 and TextWrapping.Wrap performs
+        /// emergency grapheme-level breaks (one per call). The catastrophic-allocation fix lives
+        /// in TextLayout, which redirects zero-width to infinity before calling the formatter.
+        /// With WrapWithOverflow a single word is allowed to overflow so the whole run is returned.
         /// </summary>
         [Theory]
-        [InlineData(TextWrapping.Wrap)]
-        [InlineData(TextWrapping.WrapWithOverflow)]
-        public void Should_Not_Create_O_N_Lines_When_ParagraphWidth_Is_Zero(TextWrapping wrapping)
+        [InlineData(TextWrapping.Wrap, true)]
+        [InlineData(TextWrapping.WrapWithOverflow, false)]
+        public void FormatLine_WithZeroWidth_PerformsEmergencyBreak(TextWrapping wrapping, bool expectsBreak)
         {
             using (Start())
             {
-                const string text = "Hello world this is a long string that would create millions of lines";
+                // "abc" is a single word — Wrap will emergency-break after the first grapheme,
+                // WrapWithOverflow allows the whole word to overflow onto one line.
+                const string text = "abc";
 
                 var defaultProperties =
                     new GenericTextRunProperties(Typeface.Default, 12, foregroundBrush: Brushes.Black);
@@ -1370,61 +1375,21 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 var formatter = new TextFormatterImpl();
 
-                // paragraphWidth=0 must not loop O(N) times — one line for all text is expected.
                 var textLine = formatter.FormatLine(textSource, 0, 0, paragraphProperties);
 
                 Assert.NotNull(textLine);
-                Assert.Equal(text.Length, textLine.Length);
-            }
-        }
+                Assert.True(textLine.Length > 0);
 
-        [Fact]
-        public void Should_Produce_Single_Line_For_Negative_ParagraphWidth_With_Wrap()
-        {
-            using (Start())
-            {
-                const string text = "abc def";
-
-                var defaultProperties =
-                    new GenericTextRunProperties(Typeface.Default, 12, foregroundBrush: Brushes.Black);
-
-                var paragraphProperties = new GenericTextParagraphProperties(defaultProperties, textWrapping: TextWrapping.Wrap);
-
-                var textSource = new SingleBufferTextSource(text, defaultProperties);
-
-                var formatter = new TextFormatterImpl();
-
-                var textLine = formatter.FormatLine(textSource, 0, -1, paragraphProperties);
-
-                Assert.NotNull(textLine);
-                Assert.Equal(text.Length, textLine.Length);
-            }
-        }
-
-        [Fact]
-        public void Should_Still_Wrap_Correctly_With_Positive_ParagraphWidth_After_Zero_Width_Format()
-        {
-            using (Start())
-            {
-                const string text = "Hello world";
-
-                var defaultProperties =
-                    new GenericTextRunProperties(Typeface.Default, 12, foregroundBrush: Brushes.Black);
-
-                var paragraphProperties = new GenericTextParagraphProperties(defaultProperties, textWrapping: TextWrapping.Wrap);
-
-                var textSource = new SingleBufferTextSource(text, defaultProperties);
-
-                var formatter = new TextFormatterImpl();
-
-                // First format with zero width — should not throw or hang
-                var zeroLine = formatter.FormatLine(textSource, 0, 0, paragraphProperties);
-                Assert.NotNull(zeroLine);
-
-                // Then format normally — should produce at least one line breaking normally
-                var normalLine = formatter.FormatLine(textSource, 0, 200, paragraphProperties);
-                Assert.NotNull(normalLine);
-                Assert.True(normalLine.Length > 0);
+                if (expectsBreak)
+                {
+                    // Wrap mode: emergency break advances exactly one grapheme, not the whole string.
+                    Assert.True(textLine.Length < text.Length);
+                }
+                else
+                {
+                    // WrapWithOverflow: single word overflows onto one line.
+                    Assert.Equal(text.Length, textLine.Length);
+                }
             }
         }
 

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
@@ -1348,6 +1348,86 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
             public override int Length { get; }
         }
 
+        /// <summary>
+        /// Regression test for https://github.com/AvaloniaUI/Avalonia/issues/21685.
+        /// Wrapping with paragraphWidth=0 must not create O(N) TextLineImpl instances.
+        /// </summary>
+        [Theory]
+        [InlineData(TextWrapping.Wrap)]
+        [InlineData(TextWrapping.WrapWithOverflow)]
+        public void Should_Not_Create_O_N_Lines_When_ParagraphWidth_Is_Zero(TextWrapping wrapping)
+        {
+            using (Start())
+            {
+                const string text = "Hello world this is a long string that would create millions of lines";
+
+                var defaultProperties =
+                    new GenericTextRunProperties(Typeface.Default, 12, foregroundBrush: Brushes.Black);
+
+                var paragraphProperties = new GenericTextParagraphProperties(defaultProperties, textWrapping: wrapping);
+
+                var textSource = new SingleBufferTextSource(text, defaultProperties);
+
+                var formatter = new TextFormatterImpl();
+
+                // paragraphWidth=0 must not loop O(N) times — one line for all text is expected.
+                var textLine = formatter.FormatLine(textSource, 0, 0, paragraphProperties);
+
+                Assert.NotNull(textLine);
+                Assert.Equal(text.Length, textLine.Length);
+            }
+        }
+
+        [Fact]
+        public void Should_Produce_Single_Line_For_Negative_ParagraphWidth_With_Wrap()
+        {
+            using (Start())
+            {
+                const string text = "abc def";
+
+                var defaultProperties =
+                    new GenericTextRunProperties(Typeface.Default, 12, foregroundBrush: Brushes.Black);
+
+                var paragraphProperties = new GenericTextParagraphProperties(defaultProperties, textWrapping: TextWrapping.Wrap);
+
+                var textSource = new SingleBufferTextSource(text, defaultProperties);
+
+                var formatter = new TextFormatterImpl();
+
+                var textLine = formatter.FormatLine(textSource, 0, -1, paragraphProperties);
+
+                Assert.NotNull(textLine);
+                Assert.Equal(text.Length, textLine.Length);
+            }
+        }
+
+        [Fact]
+        public void Should_Still_Wrap_Correctly_With_Positive_ParagraphWidth_After_Zero_Width_Format()
+        {
+            using (Start())
+            {
+                const string text = "Hello world";
+
+                var defaultProperties =
+                    new GenericTextRunProperties(Typeface.Default, 12, foregroundBrush: Brushes.Black);
+
+                var paragraphProperties = new GenericTextParagraphProperties(defaultProperties, textWrapping: TextWrapping.Wrap);
+
+                var textSource = new SingleBufferTextSource(text, defaultProperties);
+
+                var formatter = new TextFormatterImpl();
+
+                // First format with zero width — should not throw or hang
+                var zeroLine = formatter.FormatLine(textSource, 0, 0, paragraphProperties);
+                Assert.NotNull(zeroLine);
+
+                // Then format normally — should produce at least one line breaking normally
+                var normalLine = formatter.FormatLine(textSource, 0, 200, paragraphProperties);
+                Assert.NotNull(normalLine);
+                Assert.True(normalLine.Length > 0);
+            }
+        }
+
         public static IDisposable Start()
         {
             var disposable = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
@@ -1248,6 +1248,89 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
         
         private static void AssertGreaterThan(double x, double y, string message) => Assert.True(x > y, $"{message}. {x} is not > {y}");
 
+        /// <summary>
+        /// Regression tests for https://github.com/AvaloniaUI/Avalonia/issues/21685.
+        /// TextLayout with TextWrapping and maxWidth=0 must not create O(N) TextLineImpl instances.
+        /// The fix converts zero/negative maxWidth to infinity before calling the formatter so that
+        /// all text lands on a single line rather than triggering emergency grapheme-level breaks.
+        /// </summary>
+        [Theory]
+        [InlineData(TextWrapping.Wrap)]
+        [InlineData(TextWrapping.WrapWithOverflow)]
+        public void Should_Not_Create_O_N_Lines_When_MaxWidth_Is_Zero(TextWrapping wrapping)
+        {
+            using (Start())
+            {
+                const string text = "Hello world this is a long string that would create millions of lines";
+
+                var layout = new TextLayout(
+                    text,
+                    Typeface.Default,
+                    12.0f,
+                    Brushes.Black,
+                    textWrapping: wrapping,
+                    maxWidth: 0);
+
+                // All text should be on one line — not one line per grapheme.
+                Assert.Equal(1, layout.TextLines.Count);
+                Assert.True(layout.TextLines[0].Length >= text.Length);
+            }
+        }
+
+        [Theory]
+        [InlineData(TextWrapping.Wrap)]
+        [InlineData(TextWrapping.WrapWithOverflow)]
+        public void Should_Not_Create_O_N_Lines_When_MaxWidth_Is_Negative(TextWrapping wrapping)
+        {
+            using (Start())
+            {
+                const string text = "abc def ghi";
+
+                var layout = new TextLayout(
+                    text,
+                    Typeface.Default,
+                    12.0f,
+                    Brushes.Black,
+                    textWrapping: wrapping,
+                    maxWidth: -1);
+
+                Assert.Equal(1, layout.TextLines.Count);
+                Assert.True(layout.TextLines[0].Length >= text.Length);
+            }
+        }
+
+        [Fact]
+        public void Should_Wrap_Correctly_With_Positive_MaxWidth_After_Zero_MaxWidth()
+        {
+            using (Start())
+            {
+                const string text = "Hello world";
+
+                // Zero-width layout must not throw or hang.
+                var zeroLayout = new TextLayout(
+                    text,
+                    Typeface.Default,
+                    12.0f,
+                    Brushes.Black,
+                    textWrapping: TextWrapping.Wrap,
+                    maxWidth: 0);
+
+                Assert.Equal(1, zeroLayout.TextLines.Count);
+
+                // A wide-enough layout must still wrap at word boundaries.
+                var normalLayout = new TextLayout(
+                    text,
+                    Typeface.Default,
+                    12.0f,
+                    Brushes.Black,
+                    textWrapping: TextWrapping.Wrap,
+                    maxWidth: 200);
+
+                Assert.True(normalLayout.TextLines.Count >= 1);
+                Assert.True(normalLayout.Width <= 200);
+            }
+        }
+
         private static IDisposable Start()
         {
             var disposable = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface


### PR DESCRIPTION
Fixes #21685.

## Problem

When PerformTextWrapping was called with paragraphWidth = 0 (or negative), MeasureLength returned 