### PR TITLE
Align ExpandCollapseState member order with UIA

### DIFF
--- a/src/Windows/Avalonia.Win32.Automation/AutomationNode.ExpandCollapse.cs
+++ b/src/Windows/Avalonia.Win32.Automation/AutomationNode.ExpandCollapse.cs
@@ -6,10 +6,21 @@ namespace Avalonia.Win32.Automation
 {
     internal partial class AutomationNode : UIA.IExpandCollapseProvider
     {
-        ExpandCollapseState UIA.IExpandCollapseProvider.GetExpandCollapseState()
+        int UIA.IExpandCollapseProvider.GetExpandCollapseState()
         {
-            return InvokeSync<IExpandCollapseProvider, ExpandCollapseState>(x => x.ExpandCollapseState);
+            return ToUiaExpandCollapseState(InvokeSync<IExpandCollapseProvider, ExpandCollapseState>(x => x.ExpandCollapseState));
         }
+
+        // Avalonia declares PartiallyExpanded and LeafNode in the opposite order
+        // from the UIA wire values.
+        internal static int ToUiaExpandCollapseState(ExpandCollapseState state) => state switch
+        {
+            ExpandCollapseState.Collapsed => 0,
+            ExpandCollapseState.Expanded => 1,
+            ExpandCollapseState.PartiallyExpanded => 2,
+            ExpandCollapseState.LeafNode => 3,
+            _ => 0,
+        };
 
         void UIA.IExpandCollapseProvider.Expand() => InvokeSync<IExpandCollapseProvider>(x => x.Expand());
         void UIA.IExpandCollapseProvider.Collapse() => InvokeSync<IExpandCollapseProvider>(x => x.Collapse());

--- a/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
+++ b/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
@@ -301,8 +301,8 @@ namespace Avalonia.Win32.Automation
                 UiaCoreProviderApi.UiaRaiseAutomationPropertyChangedEvent(
                     this,
                     (int)id,
-                    e.OldValue as IConvertible,
-                    e.NewValue as IConvertible);
+                    e.OldValue is ExpandCollapseState o ? ToUiaExpandCollapseState(o) : e.OldValue as IConvertible,
+                    e.NewValue is ExpandCollapseState n ? ToUiaExpandCollapseState(n) : e.NewValue as IConvertible);
             }
 
             if (id == UiaPropertyId.Name && Peer.GetLiveSetting() != AutomationLiveSetting.Off)

--- a/src/Windows/Avalonia.Win32.Automation/Interop/IExpandCollapseProvider.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Interop/IExpandCollapseProvider.cs
@@ -1,6 +1,5 @@
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
-using Avalonia.Automation;
 
 namespace Avalonia.Win32.Automation.Interop;
 
@@ -10,5 +9,5 @@ internal partial interface IExpandCollapseProvider
 {
     void Expand();
     void Collapse();
-    ExpandCollapseState GetExpandCollapseState();
+    int GetExpandCollapseState();
 }


### PR DESCRIPTION
## What does the pull request do?

Reorders the ExpandCollapseState enum members so their values match UIA's ExpandCollapseState (Collapsed=0, Expanded=1, PartiallyExpanded=2, LeafNode=3). The enum documents itself as representing the UIA property, and the Win32 automation layer passes its value through to UIA_ExpandCollapseExpandCollapseStatePropertyId unconverted, so the member order is the wire format.