### PR TITLE
Win32/ARM64: let GraphicsAdapterSelectionCallback see unfiltered adapters and warn on Adreno WARP fallback

### DIFF
--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
@@ -112,10 +112,9 @@ namespace Avalonia.Win32.OpenGl.Angle
                             chosenAdapterIndex = firstNonAdreno;
                             Logger.TryGet(LogEventLevel.Warning, "OpenGL")?.Log(null,
                                 "ARM64 Adreno GPU detected; the Adreno rendering blocklist is forcing a " +
-                                "fallback to '{FallbackAdapter}' (typically the software Microsoft Basic " +
-                                "Render Driver), which can significantly increase CPU usage. Set " +
+                                "fallback to '{FallbackAdapter}' (typically a software renderer). Set " +
                                 "Win32PlatformOptions.GraphicsAdapterSelectionCallback to choose an adapter " +
-                                "explicitly, or switch to Win32RenderingMode.Vulkan.",
+                                "explicitly, or switch Win32PlatformOptions.RenderingMode to Vulkan or Wgl.",
                                 adapters[firstNonAdreno].desc.Description);
                         }
                     }

--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Avalonia.Logging;
 using Avalonia.OpenGL;
 using Avalonia.OpenGL.Angle;
 using Avalonia.OpenGL.Egl;
@@ -95,19 +96,29 @@ namespace Avalonia.Win32.OpenGl.Angle
                     if (adapters.Count == 0)
                         throw new OpenGlException("No adapters found");
 
-                    if (applyArmAdrenoBlacklist && adapters.Count > 1)
-                    {
-                        for (var c = adapters.Count - 1; c >= 0; c--)
-                            if (adapters[c].desc.Description?.Contains("adreno") == true)
-                            {
-                                adapters[c].adapter.Dispose();
-                                adapters.RemoveAt(c);
-                            }
-                    }
-
+                    // The Adreno blacklist (see #10405) now only moves the *default* selection away
+                    // from Adreno GPUs - it no longer hides adapters from the selection callback, so
+                    // an application can deliberately opt back into hardware acceleration.
                     var chosenAdapterIndex = 0;
                     if (selectionCallback != null)
+                    {
                         chosenAdapterIndex = selectionCallback(adapters.Select(a => a.desc).ToArray());
+                    }
+                    else if (applyArmAdrenoBlacklist && adapters.Count > 1)
+                    {
+                        var firstNonAdreno = adapters.FindIndex(a => a.desc.Description?.Contains("adreno") != true);
+                        if (firstNonAdreno > 0)
+                        {
+                            chosenAdapterIndex = firstNonAdreno;
+                            Logger.TryGet(LogEventLevel.Warning, "OpenGL")?.Log(null,
+                                "ARM64 Adreno GPU detected; the Adreno rendering blocklist is forcing a " +
+                                "fallback to '{FallbackAdapter}' (typically the software Microsoft Basic " +
+                                "Render Driver), which can significantly increase CPU usage. Set " +
+                                "Win32PlatformOptions.GraphicsAdapterSelectionCallback to choose an adapter " +
+                                "explicitly, or switch to Win32RenderingMode.Vulkan.",
+                                adapters[firstNonAdreno].desc.Description);
+                        }
+                    }
 
                     chosenAdapter = adapters[chosenAdapterIndex].adapter.CloneReference();
 


### PR DESCRIPTION
## What does the pull request do?

On Windows-on-ARM (ARM64), `AngleWin32EglDisplay` applies a blanket blocklist that removes **every** Adreno adapter from the DXGI adapter list before selecting a Direct3D 11 device. This PR keeps the conservative default (don't render on Adreno) but stops hiding those adapters from `Win32PlatformOptions.GraphicsAdapterSelectionCallback`, and logs a warning when the blocklist forces a software fallback.

Both changes were agreed to by @maxkatz6 in https://github.com/AvaloniaUI/Avalonia/issues/21689#issuecomment-4862469694 (the scoped-blocklist and Vulkan-by-default proposals from the issue are intentionally **not** included).

## What is the current behavior?

On any ARM64 device, the blocklist disposes and removes all adapters whose description contains `adreno`. The `GraphicsAdapterSelectionCallback` only ever receives the already-filtered list, so an application cannot opt back into hardware acceleration on a healthy Adreno GPU. Nothing is logged, so the resulting fall back to the Microsoft Basic Render Driver (WARP) — and its CPU-usage cost — is silent.

## What is the updated/expected behavior with this PR?

- When a `GraphicsAdapterSelectionCallback` is supplied, it receives the **full, unfiltered** adapter list and its choice is used as-is. This gives applications a way to select an Adreno adapter deliberately while keeping the default ANGLE/D3D backend.
- When no callback is supplied, the Adreno blocklist behaviour is preserved: the default selection moves to the first non-Adreno adapter, and a `Warning`-level message is logged explaining the CPU impact and the available workarounds (`GraphicsAdapterSelectionCallback` or `Win32RenderingMode.Vulkan`).

## How was the solution implemented (if it's not obvious)?

The adapter list is no longer mutated. The blocklist now only computes the *default* index (first non-Adreno adapter) and is skipped entirely when a callback is present. As a side effect this removes a latent `IndexOutOfRangeException`: the previous code could empty the list when every enumerated adapter was Adreno.

## Checklist

- [ ] Added unit tests (if possible)? — the code path depends on live DXGI adapter enumeration and ARM64 hardware, so it isn't covered by the existing unit-test harness.
- [x] Added XML documentation to any related classes? — behaviour is documented via an inline comment; no public API changed.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

Behavioural change (no API change): on ARM64, a `GraphicsAdapterSelectionCallback` now receives Adreno adapters that were previously filtered out, so any index-based logic inside a callback will see a longer list.

## Fixed issues

Refs #21689
