### PR TITLE
Fix `BclLauncher.Exec` throw exception instead of return false

### DIFF
--- a/src/Avalonia.Base/Platform/Storage/FileIO/BclLauncher.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/BclLauncher.cs
@@ -38,30 +38,37 @@ internal class BclLauncher : ILauncher
     
     private static bool Exec(string urlOrFile)
     {
-        if (OperatingSystem.IsLinux())
+        try
         {
-            // If no associated application/json MimeType is found xdg-open opens return error
-            // but it tries to open it anyway using the console editor (nano, vim, other..)
-            var args = EscapeForShell(urlOrFile);
-            ShellExecRaw($"xdg-open \\\"{args}\\\"", waitForExit: false);
-            return true;
-        }
-        else if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
-        {
-            var info = new ProcessStartInfo
+            if (OperatingSystem.IsLinux())
             {
-                FileName = OperatingSystem.IsWindows() ? urlOrFile : "open",
-                CreateNoWindow = true,
-                UseShellExecute = OperatingSystem.IsWindows()
-            };
-            // Using the argument list avoids having to escape spaces and other special 
-            // characters that are part of valid macos file and folder paths.
-            if (OperatingSystem.IsMacOS())
-                info.ArgumentList.Add(urlOrFile);
-            using var process = Process.Start(info);
-            return true;
+                // If no associated application/json MimeType is found xdg-open opens return error
+                // but it tries to open it anyway using the console editor (nano, vim, other..)
+                var args = EscapeForShell(urlOrFile);
+                ShellExecRaw($"xdg-open \\\"{args}\\\"", waitForExit: false);
+                return true;
+            }
+            else if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+            {
+                var info = new ProcessStartInfo
+                {
+                    FileName = OperatingSystem.IsWindows() ? urlOrFile : "open",
+                    CreateNoWindow = true,
+                    UseShellExecute = OperatingSystem.IsWindows()
+                };
+                // Using the argument list avoids having to escape spaces and other special 
+                // characters that are part of valid macos file and folder paths.
+                if (OperatingSystem.IsMacOS())
+                    info.ArgumentList.Add(urlOrFile);
+                using var process = Process.Start(info);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
-        else
+        catch
         {
             return false;
         }

--- a/src/Avalonia.Base/Platform/Storage/FileIO/BclLauncher.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/BclLauncher.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Avalonia.Logging;
 
 namespace Avalonia.Platform.Storage.FileIO;
 
@@ -68,8 +69,10 @@ internal class BclLauncher : ILauncher
                 return false;
             }
         }
-        catch
+        catch(Exception ex)
         {
+            Logger.TryGet(LogEventLevel.Error, nameof(BclLauncher))?
+                .Log(null, "Exception during BclLauncher.Exec: {Error}", ex);
             return false;
         }
     }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

This pull request add a try catch block to the `Avalonia.Platform.Storage.FileIO.BclLauncher.Exec` method.
Which will catch all the exception throw by `Process.Start()` and return `false` when it throw.

## What is the current behavior?

As #21673 described, if `Process.Start()` throw a exception, the `BclLauncher` will throw the exception instead of return `false`.
(In the case, if user try to launch a url, which url handler path is not exist, it will throw `Win32Exception`)

Since the API return a `bool`, developers may pretend this API will return is operation succussed instead of throw a exception. 

## What is the updated/expected behavior with this PR?

The `BclLauncher.Exec` should never throw exception, instead, it return `false` as user may excepted.

## How was the solution implemented (if it's not obvious)?

Add a `try catch` block to the `Avalonia.Platform.Storage.FileIO.BclLauncher.Exec` method.

***NOTE**: It will also hide all exception which maybe helpful for debugging, maybe debug logging or an API (not in this PR) throw exception will be better.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
  - It just make `BclLauncher` behavior match the `ILauncher` document described.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
  - Maybe we should add a warning about the this behavior changed, but i don't have a idea.

## Fixed issues

Fixes #21673 
