### PR TITLE
Correct nested `TreeViewItem` selection behaviour on pointer release

### DIFF
--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -6,9 +6,7 @@ using Avalonia.Automation;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Mixins;
-using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;
-using Avalonia.Controls.Selection;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -45,13 +43,13 @@ namespace Avalonia.Controls
         public static readonly DirectProperty<TreeViewItem, int> LevelProperty =
             AvaloniaProperty.RegisterDirect<TreeViewItem, int>(
                 nameof(Level), o => o.Level);
-        
+
         /// <summary>
         /// Defines the <see cref="Expanded"/> event.
         /// </summary>
         public static readonly RoutedEvent<RoutedEventArgs> ExpandedEvent =
             RoutedEvent.Register<TreeViewItem, RoutedEventArgs>(nameof(Expanded), RoutingStrategies.Bubble | RoutingStrategies.Tunnel);
-        
+
         /// <summary>
         /// Defines the <see cref="Collapsed"/> event.
         /// </summary>
@@ -67,6 +65,7 @@ namespace Avalonia.Controls
         private int _level;
         private bool _templateApplied;
         private bool _deferredBringIntoViewFlag;
+        private bool _itemsPanelPointerPressed;
 
         /// <summary>
         /// Initializes static members of the <see cref="TreeViewItem"/> class.
@@ -116,7 +115,7 @@ namespace Avalonia.Controls
             get => _level;
             private set => SetAndRaise(LevelProperty, ref _level, value);
         }
-        
+
         /// <summary>
         /// Occurs after the <see cref="TreeViewItem"/> has expanded to show its children.
         /// </summary>
@@ -125,7 +124,7 @@ namespace Avalonia.Controls
             add => AddHandler(ExpandedEvent, value);
             remove => RemoveHandler(ExpandedEvent, value);
         }
-        
+
         /// <summary>
         /// Occurs after the <see cref="TreeViewItem"/> has collapsed to hide its children.
         /// </summary>
@@ -167,9 +166,9 @@ namespace Avalonia.Controls
         protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
         {
             base.OnAttachedToLogicalTree(e);
-            
+
             _treeView = this.GetLogicalAncestors().OfType<TreeView>().FirstOrDefault();
-            
+
             Level = CalculateDistanceFromLogicalParent<TreeView>(this) - 1;
 
             if (ItemTemplate == null && _treeView?.ItemTemplate != null)
@@ -313,14 +312,34 @@ namespace Avalonia.Controls
         protected override void OnPointerPressed(PointerPressedEventArgs e)
         {
             base.OnPointerPressed(e);
-            TreeViewOwner?.UpdateSelectionFromEvent(this, e);
+
+            _itemsPanelPointerPressed = IsItemsPanelEvent(e);
+
+            // Don't select if the pointer was pressed over the items panel
+            if (!_itemsPanelPointerPressed)
+            {
+                TreeViewOwner?.UpdateSelectionFromEvent(this, e);
+            }
         }
 
         protected override void OnPointerReleased(PointerReleasedEventArgs e)
         {
             base.OnPointerReleased(e);
-            TreeViewOwner?.UpdateSelectionFromEvent(this, e);
+
+            // Don't select if the gesture either started on the items panel, or ended on it
+            if (!_itemsPanelPointerPressed && !IsItemsPanelEvent(e))
+            {
+                TreeViewOwner?.UpdateSelectionFromEvent(this, e);
+            }
+
+            _itemsPanelPointerPressed = false;
         }
+
+        /// <summary>
+        /// Due to Avalonia's implicit pointer capture, the items panel receives no events if swiped onto. So we need to 
+        /// perform our own hit test to reliably determine whether the mouse event occurred over it.
+        /// </summary>
+        private bool IsItemsPanelEvent(PointerEventArgs e) => ItemsPanelRoot?.InputHitTest(e.GetPosition(ItemsPanelRoot)) != null;
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {

--- a/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
@@ -4,18 +4,17 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using Avalonia.Collections;
+using Avalonia.Controls.Embedding;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
-using Avalonia.Data.Core;
 using Avalonia.Harfbuzz;
 using Avalonia.Headless;
 using Avalonia.Input;
-using Avalonia.Input.Platform;
-using Avalonia.Layout;
 using Avalonia.LogicalTree;
 using Avalonia.Markup.Xaml.Templates;
+using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Styling;
 using Avalonia.UnitTests;
@@ -292,6 +291,60 @@ namespace Avalonia.Controls.UnitTests
                 var container = Assert.IsType<TreeViewItem>(target.TreeContainerFromItem(child));
                 Assert.False(container.IsSelected);
             }
+        }
+
+        [Fact]
+        public void Swiping_Onto_Child_Should_Not_Select()
+        {
+            using (ConfigureHitTestTreeView(out var target, out var parent, out var child))
+            {
+                _mouse.Down(parent);
+
+                // The pointer is captured on mouse down, so we don't want to issue a mouse up event on child itself
+                // but on parent at a position ABOVE child, which is nested within the parent.
+                _mouse.Up(parent, position: child.GetTransformedBounds()!.Value.Bounds.Center);
+
+                Assert.Null(target.SelectedItem);
+            }
+        }
+
+        [Fact]
+        public void Swiping_Onto_Parent_Should_Not_Select()
+        {
+            using (ConfigureHitTestTreeView(out var target, out var parent, out var child))
+            {
+                _mouse.Down(child);
+
+                // When swiping from a child to a parent, behaviour is a little different: first there is a PointerReleased event
+                // on the child, then on the parent. This is because the PointerPressed event went unhandled and so was seen by the parent.
+                var mouseUpPosition = parent.HeaderPresenter!.GetTransformedBounds()!.Value.Bounds.Center;
+                _mouse.Up(child, position: mouseUpPosition);
+                _mouse.Up(parent, position: mouseUpPosition);
+
+                Assert.Null(target.SelectedItem);
+            }
+        }
+
+        private static CompositorTestServices ConfigureHitTestTreeView(out TreeView target, out TreeViewItem parent, out TreeViewItem child)
+        {
+            var services = new CompositorTestServices();
+            var data = CreateTestTreeData();
+            target = CreateTarget(data, expandAll: true,
+                embeddableRoot: services.TopLevel, styles: [new(x => x.OfType<TreeViewItem>())
+            {
+                Setters =
+                {
+                    new Setter(InputElement.IsHoldingEnabledProperty, true),
+                    new Setter(InputElement.IsHoldWithMouseEnabledProperty, true),
+                },
+            }]);
+
+            services.RunJobs();
+            target.SelectedItem = null;
+
+            parent = Assert.IsType<TreeViewItem>(target.TreeContainerFromItem(data[0]));
+            child = Assert.IsType<TreeViewItem>(target.TreeContainerFromItem(data[0].Children[0]));
+            return services;
         }
 
         [Fact]
@@ -1466,7 +1519,7 @@ namespace Avalonia.Controls.UnitTests
             var target = CreateTarget(
                 data: data,
                 expandAll: false,
-                itemContainerTheme: itemTheme, 
+                itemContainerTheme: itemTheme,
                 multiSelect: true);
 
             var rootContainer = Assert.IsType<TreeViewItem>(target.ContainerFromIndex(0));
@@ -1530,7 +1583,7 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(selected[0], target.SelectedItem);
             Assert.Equal(selected, target.SelectedItems);
         }
-        
+
         [Fact]
         public void CollapseEvent_Can_Be_Captured_By_TreeView_When_Collapsing_TreeViewItem()
         {
@@ -1551,7 +1604,7 @@ namespace Avalonia.Controls.UnitTests
             Assert.True(raised);
             Assert.Equal(container, source);
         }
-        
+
         [Fact]
         public void CollapseEvent_Should_Be_Raised_When_Collapsing_TreeViewItem()
         {
@@ -1578,7 +1631,8 @@ namespace Avalonia.Controls.UnitTests
             ControlTheme? itemContainerTheme = null,
             IDataTemplate? itemTemplate = null,
             bool multiSelect = false,
-            IEnumerable<Style>? styles = null)
+            IEnumerable<Style>? styles = null,
+            EmbeddableControlRoot? embeddableRoot = null)
         {
             var target = new TreeView
             {
@@ -1588,12 +1642,22 @@ namespace Avalonia.Controls.UnitTests
                 SelectionMode = multiSelect ? SelectionMode.Multiple : SelectionMode.Single,
             };
 
-            var root = CreateRoot(target);
+            if (embeddableRoot == null)
+            {
+                var root = CreateRoot(target);
 
-            if (styles is not null)
-                root.Styles.AddRange(styles);
+                if (styles is not null)
+                    root.Styles.AddRange(styles);
 
-            root.LayoutManager.ExecuteInitialLayoutPass();
+                root.LayoutManager.ExecuteInitialLayoutPass();
+            }
+            else
+            {
+                ConfigureRoot(embeddableRoot);
+                embeddableRoot.Styles.AddRange(styles ?? []);
+                embeddableRoot.Content = target;
+                embeddableRoot.LayoutManager.ExecuteInitialLayoutPass();
+            }
 
             if (expandAll)
             {
@@ -1605,29 +1669,27 @@ namespace Avalonia.Controls.UnitTests
 
         private static TestRoot CreateRoot(Control child)
         {
-            return new TestRoot
+            var root = new TestRoot();
+            ConfigureRoot(root);
+            root.Child = child;
+            return root;
+        }
+
+        private static void ConfigureRoot(Control root)
+        {
+            root.Resources.Add(typeof(TreeView), CreateTreeViewControlTheme());
+            root.Resources.Add(typeof(TreeViewItem), CreateTreeViewItemControlTheme());
+            root.DataTemplates.Add(new TreeDataTemplate
             {
-                Resources =
-                {
-                    { typeof(TreeView), CreateTreeViewControlTheme() },
-                    { typeof(TreeViewItem), CreateTreeViewItemControlTheme() },
-                },
-                DataTemplates =
-                {
-                    new TreeDataTemplate
+                DataType = typeof(Node),
+                ItemsSource = new Binding(nameof(Node.Children)),
+                Content = (IServiceProvider? _) => new TemplateResult<Control>(
+                    new TextBlock
                     {
-                        DataType = typeof(Node),
-                        ItemsSource = new Binding(nameof(Node.Children)),
-                        Content = (IServiceProvider? _) => new TemplateResult<Control>(
-                            new TextBlock
-                            {
-                                [!TextBlock.TextProperty] = new Binding(nameof(Node.Value)),
-                            },
-                            new NameScope())
+                        [!TextBlock.TextProperty] = new Binding(nameof(Node.Value)),
                     },
-                },
-                Child = child,
-            };
+                    new NameScope())
+            });
         }
 
         private static AvaloniaList<Node> CreateTestTreeData()
@@ -1702,6 +1764,7 @@ namespace Avalonia.Controls.UnitTests
                     new Border
                     {
                         Name = "PART_Header",
+                        Background = Brushes.Transparent,
                         Child = new ContentPresenter
                         {
                             Name = "PART_HeaderPresenter",


### PR DESCRIPTION
This fixes #21427, in which swiping over nested `TreeViewItem` containers incorrectly selects items. I found that there are actually two scenarios:

1. Swiping from a parent to a nested item selects the parent
2. Swiping from a nested item to a parent selects the nested item

Both a resolved. The changes can be tested with a mouse by applying this style:

```xaml
<Style Selector="TreeViewItem">
  <Setter Property="InputElement.IsHoldWithMouseEnabled" Value="True"/>  
</Style>
```

I tried to write a unit test but found that hit testing isn't supported in the headless unit test application used by other `TreeView` tests.

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #21427
