### PR TITLE
Fix working area changed on windows platform won't update screen

### DIFF
--- a/samples/IntegrationTestApp/Pages/ScreensPage.axaml
+++ b/samples/IntegrationTestApp/Pages/ScreensPage.axaml
@@ -3,7 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             AttachedToVisualTree="OnAttachedToVisualTree"
+             AttachedToVisualTree="OnAttachedToVisualTree" DetachedFromVisualTree="OnDetachedFromVisualTree"
              x:Class="IntegrationTestApp.Pages.ScreensPage">
   <StackPanel Spacing="4">
     <Button Name="ScreenRefresh"

--- a/samples/IntegrationTestApp/Pages/ScreensPage.axaml
+++ b/samples/IntegrationTestApp/Pages/ScreensPage.axaml
@@ -3,11 +3,15 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             AttachedToVisualTree="OnAttachedToVisualTree"
              x:Class="IntegrationTestApp.Pages.ScreensPage">
   <StackPanel Spacing="4">
     <Button Name="ScreenRefresh"
             Content="Refresh"
             Click="ScreenRefresh_Click"/>
+    <Button Name="UpdateViewOnly"
+            Content="Update View Only"
+            Click="UpdateViewOnly_OnClick"/>
     <TextBox Name="ScreenName" PlaceholderText="DisplayName" UseFloatingPlaceholder="true" />
     <TextBox Name="ScreenHandle" PlaceholderText="Handle" UseFloatingPlaceholder="true" />
     <TextBox Name="ScreenScaling" PlaceholderText="Scaling" UseFloatingPlaceholder="true" />
@@ -15,5 +19,6 @@
     <TextBox Name="ScreenWorkArea" PlaceholderText="WorkArea" UseFloatingPlaceholder="true" />
     <TextBox Name="ScreenOrientation" PlaceholderText="Orientation" UseFloatingPlaceholder="true" />
     <TextBox Name="ScreenSameReference" PlaceholderText="Is same reference" UseFloatingPlaceholder="true" />
+    <TextBox Name="ScreenOnChangedCounter" PlaceholderText="Screens.Changed Counter" UseFloatingPlaceholder="True" />
   </StackPanel>
 </UserControl>

--- a/samples/IntegrationTestApp/Pages/ScreensPage.axaml.cs
+++ b/samples/IntegrationTestApp/Pages/ScreensPage.axaml.cs
@@ -12,6 +12,8 @@ public partial class ScreensPage : UserControl
     private Screen? _lastScreen;
     private int _onScreenChangedCounter;
 
+    private Window? _lastWindow;
+
     public ScreensPage()
     {
         InitializeComponent();
@@ -19,12 +21,18 @@ public partial class ScreensPage : UserControl
 
     private void OnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
     {
-        var window = TopLevel.GetTopLevel(this) as Window ??
-                     throw new AvaloniaInternalException("ScreensPage is not attached to a Window.");
-        window.Screens.Changed += OnScreenChanged;
+        _lastWindow = TopLevel.GetTopLevel(this) as Window ??
+                      throw new AvaloniaInternalException("ScreensPage is not attached to a Window.");
+        _lastWindow.Screens.Changed += OnScreenChanged;
 
         _onScreenChangedCounter = 0;
         ScreenOnChangedCounter.Text = _onScreenChangedCounter.ToString();
+    }
+
+    private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        _lastWindow?.Screens.Changed -= OnScreenChanged;
+        _lastWindow = null;
     }
 
     private void OnScreenChanged(object? sender, EventArgs e)

--- a/samples/IntegrationTestApp/Pages/ScreensPage.axaml.cs
+++ b/samples/IntegrationTestApp/Pages/ScreensPage.axaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using Avalonia;
 using Avalonia.Controls;
@@ -9,10 +10,27 @@ namespace IntegrationTestApp.Pages;
 public partial class ScreensPage : UserControl
 {
     private Screen? _lastScreen;
+    private int _onScreenChangedCounter;
 
     public ScreensPage()
     {
         InitializeComponent();
+    }
+
+    private void OnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        var window = TopLevel.GetTopLevel(this) as Window ??
+                     throw new AvaloniaInternalException("ScreensPage is not attached to a Window.");
+        window.Screens.Changed += OnScreenChanged;
+
+        _onScreenChangedCounter = 0;
+        ScreenOnChangedCounter.Text = _onScreenChangedCounter.ToString();
+    }
+
+    private void OnScreenChanged(object? sender, EventArgs e)
+    {
+        _onScreenChangedCounter++;
+        ScreenOnChangedCounter.Text = _onScreenChangedCounter.ToString();
     }
 
     private void ScreenRefresh_Click(object? sender, RoutedEventArgs e)
@@ -28,5 +46,17 @@ public partial class ScreensPage : UserControl
         ScreenScaling.Text = screen?.Scaling.ToString(CultureInfo.InvariantCulture);
         ScreenOrientation.Text = screen?.CurrentOrientation.ToString();
         ScreenSameReference.Text = ReferenceEquals(lastScreen, screen).ToString();
+    }
+
+    private void UpdateViewOnly_OnClick(object? sender, RoutedEventArgs e)
+    {
+        var screen = _lastScreen;
+        ScreenName.Text = screen?.DisplayName;
+        ScreenHandle.Text = screen?.TryGetPlatformHandle()?.ToString();
+        ScreenBounds.Text = screen?.Bounds.ToString();
+        ScreenWorkArea.Text = screen?.WorkingArea.ToString();
+        ScreenScaling.Text = screen?.Scaling.ToString(CultureInfo.InvariantCulture);
+        ScreenOrientation.Text = screen?.CurrentOrientation.ToString();
+        ScreenSameReference.Text = ReferenceEquals(_lastScreen, screen).ToString();
     }
 }

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -833,6 +833,11 @@ namespace Avalonia.Win32.Interop
             WM_DISPATCH_WORK_ITEM = WM_USER,
         }
 
+        public enum SystemParametersInfo
+        {
+            SPI_SETWORKAREA = 0x002F
+        }
+
         public enum DwmWindowAttribute : uint
         {
             DWMWA_NCRENDERING_ENABLED = 1,

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -185,6 +185,12 @@ namespace Avalonia.Win32
                 {
                     win32PlatformSettings.OnColorValuesChanged();   
                 }
+
+                // Notify WorkingArea changed to Screens
+                if ((SystemParametersInfo)wParam == SystemParametersInfo.SPI_SETWORKAREA)
+                {
+                    Screen?.OnChanged();
+                }
             }
 
             if (msg == (uint)WindowsMessage.WM_TIMER)

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -176,14 +176,16 @@ namespace Avalonia.Win32
                 }
             }
 
-            if (msg == (uint)WindowsMessage.WM_SETTINGCHANGE 
-                && PlatformSettings is Win32PlatformSettings win32PlatformSettings)
+            if (msg == (uint)WindowsMessage.WM_SETTINGCHANGE)
             {
-                var changedSetting = Marshal.PtrToStringAuto(lParam);
-                if (changedSetting == "ImmersiveColorSet" // dark/light mode
-                    || changedSetting == "WindowsThemeElement") // high contrast mode
+                if (PlatformSettings is Win32PlatformSettings win32PlatformSettings)
                 {
-                    win32PlatformSettings.OnColorValuesChanged();   
+                    var changedSetting = Marshal.PtrToStringAuto(lParam);
+                    if (changedSetting == "ImmersiveColorSet" // dark/light mode
+                        || changedSetting == "WindowsThemeElement") // high contrast mode
+                    {
+                        win32PlatformSettings.OnColorValuesChanged();
+                    }
                 }
 
                 // Notify WorkingArea changed to Screens

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -872,6 +872,15 @@ namespace Avalonia.Win32
                         break;
                     }
 
+                case WindowsMessage.WM_SETTINGCHANGE:
+                    //https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-systemparametersinfoa
+                    // SPI_SETWORKAREA
+                    if (wParam == 0x002F)
+                    {
+                        Screen?.OnChanged();
+                    }
+                    break;
+
                 case WindowsMessage.WM_DISPLAYCHANGE:
                     {
                         Screen?.OnChanged();

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -872,13 +872,6 @@ namespace Avalonia.Win32
                         break;
                     }
 
-                case WindowsMessage.WM_SETTINGCHANGE:
-                    if ((SystemParametersInfo)wParam == SystemParametersInfo.SPI_SETWORKAREA)
-                    {
-                        Screen?.OnChanged();
-                    }
-                    break;
-
                 case WindowsMessage.WM_DISPLAYCHANGE:
                     {
                         Screen?.OnChanged();

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -873,9 +873,7 @@ namespace Avalonia.Win32
                     }
 
                 case WindowsMessage.WM_SETTINGCHANGE:
-                    //https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-systemparametersinfoa
-                    // SPI_SETWORKAREA
-                    if (wParam == 0x002F)
+                    if ((SystemParametersInfo)wParam == SystemParametersInfo.SPI_SETWORKAREA)
                     {
                         Screen?.OnChanged();
                     }


### PR DESCRIPTION
## What does the pull request do?

This pull request will call `Screen?.OnChanged()` when received window message `WM_SETTINGCHANGE` with `wParam` `SPI_SETWORKAREA`.

## What is the current behavior?

`Screens.Changed` won't trigger and screen `WorkingArea` property won't updated if only working area changed.
(Change taskbar position or size will change the working area)

## What is the updated/expected behavior with this PR?

`Screens.Changed` will trigger and screen `WorkingArea` property will also update if working area changed.

## How was the solution implemented (if it's not obvious)?

This pull request add a `case` for `WM_SETTINGCHANGE` in `AppWndProc`, which will call `Screen?.OnChanged()`, update the screen working area property and trigger `Screens.Changed`.

## Test Video

See `WorkingArea` and `Screens.Changed Trigger Counter`

https://github.com/user-attachments/assets/ea076157-b94f-4d9a-8082-4d416a49419a

## Checklist

- [ ] Added unit tests (if possible)?
  - Currently no way to trigger working area changed without modify OS settings.
  - Update the IntergrationTestApp to test this patch. See above.
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues

Fixes #19006 