### PR TITLE
Allow copying and cutting revealed TextBox passwords

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1041,7 +1041,9 @@ namespace Avalonia.Controls
                 UpdatePseudoclasses();
                 UpdateCommandStates();
             }
-            else if (change.Property == IsReadOnlyProperty || change.Property == PasswordCharProperty)
+            else if (change.Property == IsReadOnlyProperty ||
+                change.Property == PasswordCharProperty ||
+                change.Property == RevealPasswordProperty)
             {
                 UpdateCommandStates();
             }
@@ -1746,7 +1748,7 @@ namespace Avalonia.Controls
                 else
                 {
                     // We select the current held word, or the whole hidden content
-                    if (IsPasswordBox && !RevealPassword)
+                    if (IsPasswordBox)
                     {
                         _wordSelectionStart = -1;
 
@@ -1881,7 +1883,7 @@ namespace Avalonia.Controls
 
         private void SelectWord(string text, int caretIndex, int selectionStart, int selectionEnd)
         {
-            if (IsPasswordBox && !RevealPassword)
+            if (IsPasswordBox)
             {
                 // double-clicking in a cloaked single-line password box selects all text
                 // see https://github.com/AvaloniaUI/Avalonia/issues/14956
@@ -2530,7 +2532,7 @@ namespace Avalonia.Controls
             PseudoClasses.Set(":touch-mode", _isInTouchMode);
         }
 
-        private bool IsPasswordBox => PasswordChar != default(char);
+        private bool IsPasswordBox => PasswordChar != default(char) && !RevealPassword;
 
         UndoRedoState UndoRedoHelper<UndoRedoState>.IUndoRedoHost.UndoRedoState
         {

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -1528,6 +1528,40 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Command_States_Update_When_RevealPassword_Changes()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "1234",
+                    PasswordChar = '*',
+                    SelectionStart = 1,
+                    SelectionEnd = 3,
+                };
+
+                tb.Measure(Size.Infinity);
+
+                Assert.False(tb.CanCopy);
+                Assert.False(tb.CanCut);
+                Assert.True(tb.CanPaste);
+
+                tb.RevealPassword = true;
+
+                Assert.True(tb.CanCopy);
+                Assert.True(tb.CanCut);
+                Assert.True(tb.CanPaste);
+
+                tb.RevealPassword = false;
+
+                Assert.False(tb.CanCopy);
+                Assert.False(tb.CanCut);
+                Assert.True(tb.CanPaste);
+            }
+        }
+
+        [Fact]
         public void ReadOnly_Editing_Hotkeys_Do_Not_Modify_Text_Or_Undo_State()
         {
             using (UnitTestApplication.Start(Services))


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Allow copying and cutting revealed TextBox passwords


## What is the current behavior?
<img width="1297" height="1045" alt="99bde4e7123e2d8c58497d67b7f67e2" src="https://github.com/user-attachments/assets/74c06369-aaa3-4472-90d8-6cd14327c580" />



## What is the updated/expected behavior with this PR?
<img width="1297" height="1044" alt="23e8a43363472fd34d8c357cb8c0f5e" src="https://github.com/user-attachments/assets/a74ce4ff-dd79-4ad1-abd7-a760accde907" />


## How was the solution implemented (if it's not obvious)?
- Treats a password `TextBox` as protected only while `PasswordChar` is set and `RevealPassword` is `false`.
- Updates command states when `RevealPassword` changes.
- Adds regression coverage for toggling `RevealPassword`:
  - hidden password text disables `CanCopy` / `CanCut`
  - revealed password text enables `CanCopy` / `CanCut`
  - hiding again disables them again


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes #21709

