### PR TITLE
macOS: prune offscreen non-control elements from the accessibility tree

### DIFF
--- a/src/Avalonia.Native/AvnAutomationPeer.cs
+++ b/src/Avalonia.Native/AvnAutomationPeer.cs
@@ -48,7 +48,22 @@ namespace Avalonia.Native
         public AvnAutomationControlType AutomationControlType => (AvnAutomationControlType)_inner.GetAutomationControlType();
         public IAvnString? AutomationId => _inner.GetAutomationId().ToAvnString();
         public AvnRect BoundingRectangle => _inner.GetBoundingRectangle().ToAvnRect();
-        public IAvnAutomationPeerArray Children => new AvnAutomationPeerArray(_inner.GetChildren());
+        public IAvnAutomationPeerArray Children => new AvnAutomationPeerArray(GetControlViewChildren(_inner));
+
+        // Invisible content leaves the AX tree the way it leaves UIA's control
+        // view: offscreen non-control elements are pruned, descendants promoted.
+        private static List<AutomationPeer> GetControlViewChildren(AutomationPeer peer)
+        {
+            var result = new List<AutomationPeer>();
+            foreach (var child in peer.GetChildren())
+            {
+                if (child.IsControlElement() || !child.IsOffscreen())
+                    result.Add(child);
+                else
+                    result.AddRange(GetControlViewChildren(child));
+            }
+            return result;
+        }
         public IAvnString? ClassName => _inner.GetClassName().ToAvnString();
         public IAvnAutomationPeer? LabeledBy => Wrap(_inner.GetLabeledBy());
         public IAvnString? Name => _inner.GetName().ToAvnString();


### PR DESCRIPTION
## What does the pull request do?

Prunes offscreen non-control elements from the macOS accessibility tree, matching how invisible elements leave UIA's control view on Windows.

## What is the current behavior?

AXChildren comes straight from AutomationPeer.GetChildren(), and AppKit does not re-filter app-provided element arrays by isAccessibilityElement, so non-control peers stay reachable to AX clients. Peers that report collapsed content as non-control and offscreen (e.g. embedded-framework proxies like AvaloniaToXamlPeerProxy) keep exposing it to VoiceOver after it leaves the screen.

## What is the updated/expected behavior with this PR?

Children that are both non-control and offscreen are pruned from AXChildren, with their descendants promoted. All in-tree peers return IsOffscreenCore()=false, so this is a no-op for plain Avalonia apps; it only takes effect for peers that report offscreen content.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.
