### PR TITLE
Fix PART_OnContentPresenter name typo in ToggleSwitch

### DIFF
--- a/src/Avalonia.Controls/ToggleSwitch.cs
+++ b/src/Avalonia.Controls/ToggleSwitch.cs
@@ -169,7 +169,7 @@ namespace Avalonia.Controls
         {
             var result = base.RegisterContentPresenter(presenter);
 
-            if (presenter.Name == "Part_OnContentPresenter")
+            if (presenter.Name == "PART_OnContentPresenter")
             {
                 OnContentPresenter = presenter;
                 result = true;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes an incorrect PART_OnContentPresenter name comparison.

The code was checking for "Part_OnContentPresenter" instead of "PART_OnContentPresenter", causing the comparison to fail because template part names are case-sensitive.
