### PR TITLE
Fix empty automation bounds for custom root providers

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
@@ -421,6 +421,14 @@ namespace Avalonia.Automation.Peers
         public AutomationPeer? GetAutomationRoot() => GetAutomationRootCore();
 
         /// <summary>
+        /// Converts a rectangle in the peer's coordinate space, as returned by
+        /// <see cref="GetBoundingRectangle"/>, to screen coordinates; returns null if the peer is
+        /// not currently hosted in a rendered visual tree.
+        /// </summary>
+        [PrivateApi]
+        public Rect? ToScreen(Rect rect) => ToScreenCore(rect);
+
+        /// <summary>
         /// Gets a value that indicates whether the element that is associated with this automation
         /// peer currently has keyboard focus.
         /// </summary>
@@ -668,6 +676,8 @@ namespace Avalonia.Automation.Peers
         }
 
         private protected virtual AutomationPeer? GetVisualRootCore() => GetAutomationRootCore();
+
+        private protected virtual Rect? ToScreenCore(Rect rect) => null;
 
 
         protected virtual bool IsContentElementOverrideCore()

--- a/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
@@ -425,6 +425,10 @@ namespace Avalonia.Automation.Peers
         /// <see cref="GetBoundingRectangle"/>, to screen coordinates; returns null if the peer is
         /// not currently hosted in a rendered visual tree.
         /// </summary>
+        /// <param name="rect">
+        /// A rectangle in the peer's own coordinate space, as returned by
+        /// <see cref="GetBoundingRectangle"/>.
+        /// </param>
         public Rect? ToScreen(Rect rect) => ToScreenCore(rect);
 
         /// <summary>

--- a/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
@@ -425,7 +425,6 @@ namespace Avalonia.Automation.Peers
         /// <see cref="GetBoundingRectangle"/>, to screen coordinates; returns null if the peer is
         /// not currently hosted in a rendered visual tree.
         /// </summary>
-        [PrivateApi]
         public Rect? ToScreen(Rect rect) => ToScreenCore(rect);
 
         /// <summary>

--- a/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
@@ -155,6 +155,13 @@ namespace Avalonia.Automation.Peers
             return null;
         }
 
+        private protected override Rect? ToScreenCore(Rect rect)
+        {
+            if (Owner?.PresentationSource?.RootVisual is not { } root)
+                return null;
+            return new PixelRect(root.PointToScreen(rect.TopLeft), root.PointToScreen(rect.BottomRight)).ToRect(1);
+        }
+
         /// <summary>
         /// Invalidates the peer's children and causes a re-read from <see cref="GetChildrenCore"/>.
         /// </summary>

--- a/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
+++ b/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
@@ -11,7 +11,6 @@ using Avalonia.Automation;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Automation.Peers;
 using Avalonia.Threading;
-using Avalonia.VisualTree;
 using Avalonia.Win32.Automation.Interop;
 using AAP = Avalonia.Automation.Provider;
 using UIA = Avalonia.Win32.Automation.Interop;
@@ -76,18 +75,7 @@ namespace Avalonia.Win32.Automation
 
         public virtual Rect GetBoundingRectangle()
         {
-            return InvokeSync(() =>
-            {
-                if (Peer.GetVisualRoot() is ControlAutomationPeer root &&
-                    root.Owner.GetPresentationSource() is not null)
-                {
-                    var originalRect = Peer.GetBoundingRectangle();
-                    return new PixelRect(root.Owner.PointToScreen(originalRect.TopLeft),
-                        root.Owner.PointToScreen(originalRect.BottomRight)).ToRect(1);
-                }
-
-                return default;
-            });
+            return InvokeSync(() => Peer.ToScreen(Peer.GetBoundingRectangle()) ?? default);
         }
 
         public virtual IRawElementProviderFragmentRoot? GetFragmentRoot()

--- a/tests/Avalonia.Controls.UnitTests/Automation/ControlAutomationPeerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Automation/ControlAutomationPeerTests.cs
@@ -232,6 +232,31 @@ namespace Avalonia.Controls.UnitTests.Automation
             }
         }
 
+        public class ToScreen : ScopedTestBase
+        {
+            [Fact]
+            public void Converts_Rect_When_Attached_To_Rooted_Tree()
+            {
+                var border = new Border();
+                var root = new TestRoot(border);
+                var peer = CreatePeer(border);
+
+                Assert.Equal(new Rect(10, 20, 30, 40), peer.ToScreen(new Rect(10, 20, 30, 40)));
+            }
+
+            [Fact]
+            public void Returns_Null_When_Detached()
+            {
+                var border = new Border();
+                var root = new TestRoot(border);
+                var peer = CreatePeer(border);
+
+                root.Child = null;
+
+                Assert.Null(peer.ToScreen(new Rect(10, 20, 30, 40)));
+            }
+        }
+
         private static AutomationPeer CreatePeer(Control control)
         {
             return ControlAutomationPeer.CreatePeerForElement(control);


### PR DESCRIPTION
## What does the pull request do?

Adds `AutomationPeer.ToScreen(Rect)` so each peer converts its own bounding rectangle to screen coordinates, and uses it from the Win32 UIA backend.

## What is the current behavior?

`AutomationNode.GetBoundingRectangle` only produces bounds when the visual root peer is a `ControlAutomationPeer` with a live `Control` owner:

```csharp
if (Peer.GetVisualRoot() is ControlAutomationPeer root &&
    root.Owner.GetPresentationSource() is not null)
    ...
```

Any custom `IRootProvider` that is not a `ControlAutomationPeer` (embedded/hosted trees) fails that check and every element reports an empty rectangle. The conversion also goes through `root.Owner` (the FocusRoot), while `GetBoundingRectangle` returns rects relative to the visual root, so the two disagree whenever FocusRoot is offset from the root.

## What is the updated/expected behavior with this PR?

Bounds are correct for any root provider. The peer converts its own rectangle in the coordinate space it was measured in, so there is no root-peer type requirement and no FocusRoot offset.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None. `ToScreen` is additive and `[PrivateApi]`.
