### PR TITLE
AutoCompleteBox does not close DropDown when using Tab-Navigation

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
@@ -746,6 +746,18 @@ namespace Avalonia.Controls
                     }
                     break;
 
+                case Key.Tab:
+                    // When the dropdown is open, treat Tab like Enter to commit the
+                    // current selection and close the dropdown, but DO NOT mark the
+                    // event as handled so that focus traversal with Tab still occurs.
+                    if (IsDropDownOpen)
+                    {
+                        OnAdapterSelectionComplete(this, new RoutedEventArgs());
+                        // Intentionally not setting e.Handled = true here to allow
+                        // normal Tab focus navigation to proceed after committing.
+                    }
+                    break;
+
                 default:
                     break;
             }

--- a/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
@@ -747,14 +747,11 @@ namespace Avalonia.Controls
                     break;
 
                 case Key.Tab:
-                    // When the dropdown is open, treat Tab like Enter to commit the
-                    // current selection and close the dropdown, but DO NOT mark the
-                    // event as handled so that focus traversal with Tab still occurs.
+                    // When the dropdown is open, close it but let Tab focus navigation proceed.
                     if (IsDropDownOpen)
                     {
-                        OnAdapterSelectionComplete(this, new RoutedEventArgs());
-                        // Intentionally not setting e.Handled = true here to allow
-                        // normal Tab focus navigation to proceed after committing.
+                        SetCurrentValue(IsDropDownOpenProperty, false);
+                        ClearTextBoxSelection();
                     }
                     break;
 

--- a/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
@@ -1373,7 +1373,7 @@ namespace Avalonia.Controls.UnitTests
                 Assert.True(control.IsDropDownOpen);
 
                 // Move selection to the first item in the suggestion list
-                control.RaiseEvent(new KeyEventArgs
+                textbox.RaiseEvent(new KeyEventArgs
                 {
                     RoutedEvent = InputElement.KeyDownEvent,
                     Key = Key.Down
@@ -1384,11 +1384,13 @@ namespace Avalonia.Controls.UnitTests
                 Assert.NotNull(selectedBefore);
 
                 // Press Tab to commit selection and close the dropdown
-                control.RaiseEvent(new KeyEventArgs
+                var tabArgs = new KeyEventArgs
                 {
                     RoutedEvent = InputElement.KeyDownEvent,
                     Key = Key.Tab
-                });
+                };
+                textbox.RaiseEvent(tabArgs);
+                Assert.False(tabArgs.Handled);
 
                 Dispatcher.UIThread.RunJobs();
 

--- a/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
@@ -1359,6 +1359,43 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(2, textChangedCount);
             }
         }
+
+        [Fact]
+        public void Tab_Commits_Selection_And_Closes_Dropdown()
+        {
+            RunTest((control, textbox) =>
+            {
+                // Ensure dropdown opens with suggestions
+                control.MinimumPrefixLength = 0;
+                textbox.Text = "cu"; // matches items like "cucumber", "cup", etc.
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(control.IsDropDownOpen);
+
+                // Move selection to the first item in the suggestion list
+                control.RaiseEvent(new KeyEventArgs
+                {
+                    RoutedEvent = InputElement.KeyDownEvent,
+                    Key = Key.Down
+                });
+                Dispatcher.UIThread.RunJobs();
+
+                var selectedBefore = control.SelectedItem;
+                Assert.NotNull(selectedBefore);
+
+                // Press Tab to commit selection and close the dropdown
+                control.RaiseEvent(new KeyEventArgs
+                {
+                    RoutedEvent = InputElement.KeyDownEvent,
+                    Key = Key.Tab
+                });
+
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.False(control.IsDropDownOpen);
+                Assert.Equal(selectedBefore!.ToString(), control.Text);
+            });
+        }
     }
 
     public class AutoCompleteBoxViewModel : INotifyPropertyChanged


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
fixes an issue where AutoCompleteBox will not close the DropDown when naviating via Tab-key

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
DropDown stays open which is confusing for the user since it may hide content below

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
I think the current behavior is wrong, so the change is just correcting it. Technically still a breaking behavior change if anyone relied on it. 

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
