### PR TITLE
Dispatcher.ReplaceImplementation bugfix

### DIFF
--- a/src/Avalonia.Base/Threading/Dispatcher.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.cs
@@ -162,6 +162,9 @@ public partial class Dispatcher : IDispatcher
             _backgroundProcessingImpl.ReadyForBackgroundProcessing += OnReadyForExplicitBackgroundProcessing;
         if (_signaled)
             _impl.Signal();
+        if (_explicitBackgroundProcessingRequested) 
+            _backgroundProcessingImpl?.RequestBackgroundProcessing();
+            
         _osTimerSetTo = null;
         UpdateOSTimer();
     }

--- a/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
+++ b/tests/Avalonia.Base.UnitTests/DispatcherTests.cs
@@ -152,6 +152,38 @@ public partial class DispatcherTests
     }
 
     [Fact]
+    public void DispatcherRepeatsBackgroundProcessingRequestToTheNewImplementation()
+    {
+        var actions = new List<string>();
+
+        // Requests background processing from the pre-initialization implementation
+        _uiThread.Post(() => actions.Add("Background"), DispatcherPriority.Background);
+
+        var impl = new SimpleDispatcherWithBackgroundProcessingImpl();
+        Dispatcher.InitializeUIThreadDispatcher(impl);
+
+        Assert.True(impl.AskedForBackgroundProcessing);
+        impl.FireBackgroundProcessing();
+        Assert.Equal(new[] { "Background" }, actions);
+    }
+
+    [Fact]
+    public void DispatcherRepeatsSignalToTheNewImplementation()
+    {
+        var actions = new List<string>();
+
+        // Signals the pre-initialization implementation
+        _uiThread.Post(() => actions.Add("Render"), DispatcherPriority.Render);
+
+        var impl = new SimpleDispatcherWithBackgroundProcessingImpl();
+        Dispatcher.InitializeUIThreadDispatcher(impl);
+
+        Assert.True(impl.AskedForSignal);
+        impl.ExecuteSignal();
+        Assert.Equal(new[] { "Render" }, actions);
+    }
+
+    [Fact]
     public void DispatcherStopsItemProcessingWhenInteractivityDeadlineIsReached()
     {
         var impl = new SimpleDispatcherImpl();


### PR DESCRIPTION
I've missed a call to RequestBackgroundProcessing to a new implementation previously, this caused dispatcher to think that it has already requested processing.