### PR TITLE
macOS: convert accessibility frames through the element's window

### DIFF
--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -530,7 +530,10 @@
 
 - (NSRect)rectToScreen:(AvnRect)rect
 {
-    id topLevel = [self accessibilityTopLevelUIElement];
+    // GetBoundingRectangle is measured in the element's own window, so convert through that window
+    // (accessibilityWindow) rather than the top-level UI element. The two differ when a peer's
+    // automation-root window is not its top-most UI-element ancestor.
+    id topLevel = [self accessibilityWindow];
 
     if (![topLevel isKindOfClass:[AvnWindow class]])
         return NSZeroRect;


### PR DESCRIPTION
## What does the pull request do?

`AvnAccessibilityElement.rectToScreen` converts a peer's bounding rectangle to a screen `NSRect` using `accessibilityTopLevelUIElement`. The rectangle is measured in the element's own window, so when that window differs from the element's top-most UI-element ancestor the conversion uses the wrong origin and the reported `accessibilityFrame` lands in the wrong place. Convert through `accessibilityWindow` instead, which is the window the rectangle was measured against.

## Breaking changes

None.
