### PR TITLE
Fix SplitView stealing BackRequested when its pane is closed (#21740)

### DIFF
--- a/src/Avalonia.Controls/SplitView/SplitView.cs
+++ b/src/Avalonia.Controls/SplitView/SplitView.cs
@@ -598,6 +598,9 @@ namespace Avalonia.Controls
             if (!IsInOverlayMode())
                 return;
 
+            if (!IsPaneOpen)
+                return;
+
             SetCurrentValue(IsPaneOpenProperty, false);
             e.Handled = true;
         }

--- a/tests/Avalonia.Controls.UnitTests/SplitViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SplitViewTests.cs
@@ -284,6 +284,43 @@ namespace Avalonia.Controls.UnitTests
             Assert.True(splitView.IsPaneOpen);
         }
 
+        [Theory]
+        [InlineData(SplitViewDisplayMode.Overlay)]
+        [InlineData(SplitViewDisplayMode.CompactOverlay)]
+        public void Top_Level_Back_Requested_Should_Not_Be_Handled_When_Pane_Is_Closed(SplitViewDisplayMode displayMode)
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow
+                .With(globalClock: new MockGlobalClock()));
+            var wnd = new Window
+            {
+                Width = 1280,
+                Height = 720
+            };
+            var splitView = new SplitView
+            {
+                DisplayMode = displayMode
+            };
+            wnd.Content = splitView;
+            wnd.Show();
+
+            // Pane is closed: the SplitView must ignore the event so back navigation can proceed.
+            Assert.False(splitView.IsPaneOpen);
+
+            var closedArgs = new Interactivity.RoutedEventArgs(TopLevel.BackRequestedEvent);
+            wnd.RaiseEvent(closedArgs);
+
+            Assert.False(closedArgs.Handled);
+
+            // Pane is open: the SplitView should close it and handle the event.
+            splitView.IsPaneOpen = true;
+
+            var openArgs = new Interactivity.RoutedEventArgs(TopLevel.BackRequestedEvent);
+            wnd.RaiseEvent(openArgs);
+
+            Assert.True(openArgs.Handled);
+            Assert.False(splitView.IsPaneOpen);
+        }
+
         [Fact]
         public void With_Default_IsPaneOpen_Value_Should_Have_Closed_Pseudo_Class_Set()
         {


### PR DESCRIPTION
Fixes #21740

So while messing around with a mobile app I ran into this: on some pages the Android back button / back gesture just did… nothing 🤔

Took me a while, but the culprit turned out to be the `SplitView`. When it's in `Overlay` or `CompactOverlay` mode it hooks into `TopLevel.BackRequested` so it can close its pane on back. Makes sense - except it swallowed the event (`e.Handled = true`) **even when the pane wasn't open at all**. So the back navigation never got a chance to run.

The fix is tiny: if the pane is already closed, just bail out early and leave the event alone so it can bubble on to whoever actually wants to navigate back.

Behaviour now:
- pane open (overlay/compact overlay) → close the pane + mark handled ✅
- pane closed → don't touch it, `Handled` stays false → back navigation works again 🎉

Also threw in a couple of unit tests (both overlay modes) so we don't accidentally start stealing the event again when the pane is closed.
