### PR TITLE
Fix CommandBar secondary visibility during overflow open

### DIFF
--- a/src/Avalonia.Controls/CommandBar/CommandBar.cs
+++ b/src/Avalonia.Controls/CommandBar/CommandBar.cs
@@ -140,6 +140,8 @@ namespace Avalonia.Controls
         private readonly CommandBarSeparator _overflowPrimarySecondarySeparator = new();
         private readonly CompositeDisposable _secondaryCommandVisibilitySubscriptions = new();
         private bool _isDynamicUpdateInProgress;
+        private bool _isOpeningOverflowPopup;
+        private bool _hasDeferredDynamicOverflowUpdate;
         private double _constraintWidth = double.PositiveInfinity;
         private bool _openedViaKeyboard;
 
@@ -387,7 +389,7 @@ namespace Avalonia.Controls
             ApplyLabelPositionToChildren();
             UpdateOverflowButtonVisibility();
             UpdateStickyBehavior();
-            UpdateDynamicOverflow();
+            RequestDynamicOverflowUpdate();
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -413,7 +415,19 @@ namespace Avalonia.Controls
                 {
                     RaiseEvent(new RoutedEventArgs(OpeningEvent));
                     if (_overflowPopup != null)
-                        _overflowPopup.IsOpen = true;
+                    {
+                        try
+                        {
+                            _isOpeningOverflowPopup = true;
+                            _overflowPopup.IsOpen = true;
+                        }
+                        finally
+                        {
+                            _isOpeningOverflowPopup = false;
+                        }
+
+                        ApplyDeferredDynamicOverflowUpdate();
+                    }
                     RaiseEvent(new RoutedEventArgs(OpenedEvent));
                 }
                 else
@@ -428,7 +442,7 @@ namespace Avalonia.Controls
             {
                 ApplyLabelPositionToChildren();
                 if (IsDynamicOverflowEnabled)
-                    UpdateDynamicOverflow();
+                    RequestDynamicOverflowUpdate();
             }
             else if (change.Property == OverflowButtonVisibilityProperty)
             {
@@ -440,7 +454,7 @@ namespace Avalonia.Controls
             }
             else if (change.Property == IsDynamicOverflowEnabledProperty)
             {
-                UpdateDynamicOverflow();
+                RequestDynamicOverflowUpdate();
             }
             else if (change.Property == PrimaryCommandsProperty)
             {
@@ -449,7 +463,7 @@ namespace Avalonia.Controls
                 if (change.NewValue is INotifyCollectionChanged newPrimary)
                     newPrimary.CollectionChanged += OnPrimaryCommandsChanged;
                 ApplyLabelPositionToChildren();
-                UpdateDynamicOverflow();
+                RequestDynamicOverflowUpdate();
             }
             else if (change.Property == SecondaryCommandsProperty)
             {
@@ -458,7 +472,7 @@ namespace Avalonia.Controls
                 if (change.NewValue is INotifyCollectionChanged newSecondary)
                     newSecondary.CollectionChanged += OnSecondaryCommandsChanged;
                 RebuildSecondaryCommandVisibilitySubscriptions();
-                UpdateDynamicOverflow();
+                RequestDynamicOverflowUpdate();
             }
         }
 
@@ -472,7 +486,7 @@ namespace Avalonia.Controls
             if (newConstraint != _constraintWidth)
             {
                 _constraintWidth = newConstraint;
-                UpdateDynamicOverflow();
+                RequestDynamicOverflowUpdate();
             }
 
             return base.MeasureOverride(availableSize);
@@ -480,7 +494,7 @@ namespace Avalonia.Controls
 
         private void CommandBar_SizeChanged(object? sender, SizeChangedEventArgs e)
         {
-            UpdateDynamicOverflow();
+            RequestDynamicOverflowUpdate();
         }
 
         private void OnOverflowButtonClick(object? sender, Interactivity.RoutedEventArgs e)
@@ -597,12 +611,32 @@ namespace Avalonia.Controls
                         ApplyLabelPositionToElement(element);
                 }
             }
-            UpdateDynamicOverflow();
+            RequestDynamicOverflowUpdate();
         }
 
         private void OnSecondaryCommandsChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             RebuildSecondaryCommandVisibilitySubscriptions();
+            RequestDynamicOverflowUpdate();
+        }
+
+        private void RequestDynamicOverflowUpdate()
+        {
+            if (_isOpeningOverflowPopup)
+            {
+                _hasDeferredDynamicOverflowUpdate = true;
+                return;
+            }
+
+            UpdateDynamicOverflow();
+        }
+
+        private void ApplyDeferredDynamicOverflowUpdate()
+        {
+            if (!_hasDeferredDynamicOverflowUpdate)
+                return;
+
+            _hasDeferredDynamicOverflowUpdate = false;
             UpdateDynamicOverflow();
         }
 
@@ -829,7 +863,7 @@ namespace Avalonia.Controls
                                 return;
                             }
 
-                            UpdateDynamicOverflow();
+                            RequestDynamicOverflowUpdate();
                         })
                         .DisposeWith(_secondaryCommandVisibilitySubscriptions);
                 }

--- a/tests/Avalonia.Controls.UnitTests/CommandBarTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CommandBarTests.cs
@@ -1364,6 +1364,20 @@ public class CommandBarOverflowKeyboardTests : ScopedTestBase
         Assert.True(first.Classes.Contains(":focus-visible"));
     }
 
+    [Fact]
+    public void Open_DoesNotThrow_WhenSecondaryCommandVisibilityChangesDuringOverflowRealization()
+    {
+        var secondary = new VisibilityChangingCommandBarButton { Label = "Bound" };
+        var cb = new CommandBar();
+        cb.SecondaryCommands.Add(secondary);
+        var window = CreateWindow(cb);
+
+        cb.IsOpen = true;
+
+        Assert.True(cb.IsOpen);
+        Assert.False(secondary.IsVisible);
+    }
+
     private static ItemsControl GetOverflowPresenter(CommandBar cb)
     {
         var popup = cb.GetVisualDescendants()
@@ -1411,6 +1425,24 @@ public class CommandBarOverflowKeyboardTests : ScopedTestBase
             timestamp: 1,
             new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed),
             KeyModifiers.None));
+    }
+
+    private class VisibilityChangingCommandBarButton : CommandBarButton
+    {
+        private bool _hasUpdatedVisibility;
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (!_hasUpdatedVisibility &&
+                change.Property == ParentProperty &&
+                change.NewValue is not null)
+            {
+                _hasUpdatedVisibility = true;
+                SetCurrentValue(IsVisibleProperty, false);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## What does the pull request do?
Fixes a `CommandBar` overflow crash when a secondary command changes `IsVisible` while the overflow popup is realizing its items.

The scenario is reported in #21694: a `CommandBarButton` in `CommandBar.SecondaryCommands` can update `IsVisible` from a binding as it is added to the popup's `ItemsControl`, which re-enters the command bar overflow rebuild.

## What is the current behavior?
Opening the overflow popup can throw:

`InvalidOperationException: The control CommandBarButton already has a visual parent StackPanel while trying to add it as a child of StackPanel.`

The re-entrant visibility update clears and rebuilds `OverflowItems` while `PanelContainerGenerator.InsertContainer` is still inserting the same control into the popup panel.

## What is the updated/expected behavior with this PR?
Opening the overflow popup no longer mutates `OverflowItems` during the unsafe synchronous item-realization window. A visibility-triggered overflow rebuild is deferred until after `Popup.IsOpen = true` returns, then applied immediately so existing synchronous overflow state behavior is preserved outside that opening path.

## How was the solution implemented (if it's not obvious)?
`CommandBar` now routes dynamic overflow rebuild requests through a small guard. While the overflow popup is synchronously opening, rebuild requests are marked as deferred. After the popup finishes opening, a single deferred rebuild is applied.

A regression test covers a secondary command that changes `IsVisible` as it becomes parented by the overflow presenter, reproducing the same visual-parent collision path without depending on a particular binding engine timing detail.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #21694

## Verification
- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -- --filter-method "*Open_DoesNotThrow_WhenSecondaryCommandVisibilityChangesDuringOverflowRealization"`
- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -- --filter-class "Avalonia.Controls.UnitTests.CommandBar*"`
- `dotnet build src/Avalonia.Controls/Avalonia.Controls.csproj -p:AvsSkipBuildingLegacyTargetFrameworks=True`
- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj`
