### PR TITLE
Fix UnsetValue converter binding precedence

### DIFF
--- a/src/Avalonia.Base/Data/Core/BindingExpression.cs
+++ b/src/Avalonia.Base/Data/Core/BindingExpression.cs
@@ -154,6 +154,21 @@ internal class BindingExpression : UntypedBindingExpressionBase, IDescription, I
     public object? TargetNullValue => _uncommon?._targetNullValue ?? AvaloniaProperty.UnsetValue;
     public UpdateSourceTrigger UpdateSourceTrigger => _uncommon?._updateSourceTrigger ?? UpdateSourceTrigger.PropertyChanged;
 
+    protected override bool HasPublishedValue()
+    {
+        if (TargetProperty?.IsDirect == false)
+            return GetValue() != AvaloniaProperty.UnsetValue;
+
+        return true;
+    }
+
+    protected override object? GetPublishedValue()
+    {
+        // A styled-property BindingExpression returning UnsetValue should stop participating in
+        // value precedence. Direct properties have no lower-priority value to reveal.
+        return TargetProperty is { IsDirect: true } ? GetValueOrDefault() : GetValue();
+    }
+
     public override void UpdateSource()
     {
         if (_mode is BindingMode.TwoWay or BindingMode.OneWayToSource)

--- a/src/Avalonia.Base/Data/Core/UntypedBindingExpressionBase.cs
+++ b/src/Avalonia.Base/Data/Core/UntypedBindingExpressionBase.cs
@@ -144,6 +144,16 @@ public abstract class UntypedBindingExpressionBase : BindingExpressionBase,
     }
 
     /// <summary>
+    /// Gets a value indicating whether the expression currently has a value for the property store.
+    /// </summary>
+    protected virtual bool HasPublishedValue() => true;
+
+    /// <summary>
+    /// Gets the value that should be published to the expression sink.
+    /// </summary>
+    protected virtual object? GetPublishedValue() => GetValueOrDefault();
+
+    /// <summary>
     /// Starts the binding expression following a call to <see cref="AttachCore"/>.
     /// </summary>
     public void Start() => Start(produceValue: true);
@@ -172,13 +182,13 @@ public abstract class UntypedBindingExpressionBase : BindingExpressionBase,
     bool IValueEntry.HasValue()
     {
         Start(produceValue: false);
-        return true;
+        return HasPublishedValue();
     }
 
     object? IValueEntry.GetValue()
     {
         Start(produceValue: false);
-        return GetValueOrDefault();
+        return GetPublishedValue();
     }
 
     void IValueEntry.Unsubscribe() => Stop();
@@ -437,7 +447,7 @@ public abstract class UntypedBindingExpressionBase : BindingExpressionBase,
 
         if (Dispatcher.UIThread.CheckAccess())
         {
-            _sink.OnChanged(this, hasValueChanged, hasErrorChanged, GetValueOrDefault(), _error);
+            _sink.OnChanged(this, hasValueChanged, hasErrorChanged, GetPublishedValue(), _error);
         }
         else
         {
@@ -446,7 +456,7 @@ public abstract class UntypedBindingExpressionBase : BindingExpressionBase,
             var sink = _sink;
             var vc = hasValueChanged;
             var ec = hasErrorChanged;
-            var v = GetValueOrDefault();
+            var v = GetPublishedValue();
             var e = _error;
             Dispatcher.UIThread.Post(() => sink.OnChanged(this, vc, ec, v, e));
         }

--- a/src/Avalonia.Base/PropertyStore/EffectiveValue.cs
+++ b/src/Avalonia.Base/PropertyStore/EffectiveValue.cs
@@ -128,6 +128,21 @@ namespace Avalonia.PropertyStore
         }
 
         /// <summary>
+        /// Removes the entry from the current effective value without unsubscribing it.
+        /// </summary>
+        /// <param name="entry">The entry to detach.</param>
+        /// <remarks>
+        /// Used when an active frame still owns the entry, but the entry temporarily has no value.
+        /// </remarks>
+        public void DetachValueEntry(IValueEntry entry)
+        {
+            if (ValueEntry == entry)
+                ValueEntry = null;
+            if (BaseValueEntry == entry)
+                BaseValueEntry = null;
+        }
+
+        /// <summary>
         /// Sets the value and base value for a non-LocalValue priority, raising 
         /// <see cref="AvaloniaObject.PropertyChanged"/> where necessary.
         /// </summary>

--- a/src/Avalonia.Base/PropertyStore/ValueStore.cs
+++ b/src/Avalonia.Base/PropertyStore/ValueStore.cs
@@ -944,8 +944,8 @@ namespace Avalonia.PropertyStore
         }
 
         /// <summary>
-        /// Adds a new effective value, raises the initial <see cref="AvaloniaObject.PropertyChanged"/>
-        /// event and notifies inheritance children if necessary .
+        /// Adds a new effective value if the entry has a value, raises the initial
+        /// <see cref="AvaloniaObject.PropertyChanged"/> event and notifies inheritance children if necessary.
         /// </summary>
         /// <param name="property">The property.</param>
         /// <param name="entry">The value entry.</param>
@@ -953,6 +953,9 @@ namespace Avalonia.PropertyStore
         private void AddEffectiveValueAndRaise(AvaloniaProperty property, IValueEntry entry, BindingPriority priority)
         {
             Debug.Assert(priority < BindingPriority.Inherited);
+            if (!entry.HasValue())
+                return;
+
             var effectiveValue = property.CreateEffectiveValue(Owner);
             AddEffectiveValue(property, effectiveValue);
             effectiveValue.SetAndRaise(this, entry, priority);
@@ -1051,22 +1054,29 @@ namespace Avalonia.PropertyStore
                     }
 
                     // If the frame has an entry for this property with a higher priority than the
-                    // current effective value (and that entry has a value), then we have a new 
-                    // value for the property. Note that the check for entry.HasValue must be 
-                    // evaluated last as it can cause bindings to be subscribed.
+                    // current effective value, then apply it when it has a value. If the changed
+                    // entry has no value, the active frame keeps it subscribed for future updates.
+                    // Note that the check for entry.HasValue must be evaluated last as it can
+                    // cause bindings to be subscribed.
                     if (foundEntry &&
-                        HasHigherPriority(entry!, priority, current, changedValueEntry) &&
-                        entry!.HasValue())
+                        HasHigherPriority(entry!, priority, current, changedValueEntry))
                     {
-                        if (current is not null)
+                        if (entry!.HasValue())
                         {
-                            current.SetAndRaise(this, entry, priority);
+                            if (current is not null)
+                            {
+                                current.SetAndRaise(this, entry, priority);
+                            }
+                            else
+                            {
+                                current = property.CreateEffectiveValue(Owner);
+                                AddEffectiveValue(property, current);
+                                current.SetAndRaise(this, entry, priority);
+                            }
                         }
-                        else
+                        else if (entry == changedValueEntry)
                         {
-                            current = property.CreateEffectiveValue(Owner);
-                            AddEffectiveValue(property, current);
-                            current.SetAndRaise(this, entry, priority);
+                            current?.DetachValueEntry(entry);
                         }
                     }
 
@@ -1141,7 +1151,11 @@ namespace Avalonia.PropertyStore
                             continue;
 
                         if (!entry.HasValue())
+                        {
+                            if (entry == changedValueEntry)
+                                effectiveValue?.DetachValueEntry(entry);
                             continue;
+                        }
 
                         if (effectiveValue is not null)
                         {

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Converters.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Converters.cs
@@ -158,6 +158,38 @@ namespace Avalonia.Markup.UnitTests.Data
             Assert.Same(localBrush, textBlock.Foreground);
         }
 
+        [Fact]
+        public void Converter_UnsetValue_With_NonLocal_Priority_Should_Not_Create_Effective_Value()
+        {
+            var source = new BrushSource(-1);
+            var localBrush = Brushes.Red;
+            var textBlock = new TextBlock
+            {
+                DataContext = source,
+            };
+
+            textBlock.Bind(
+                TextBlock.ForegroundProperty,
+                new Binding(nameof(BrushSource.Value))
+                {
+                    Converter = new IntToBrushConverter(localBrush),
+                    Priority = BindingPriority.Style,
+                });
+
+            Assert.Same(Brushes.Black, textBlock.Foreground);
+            Assert.False(textBlock.IsSet(TextBlock.ForegroundProperty));
+
+            source.Value = 1;
+            Assert.Same(localBrush, textBlock.Foreground);
+
+            source.Value = -1;
+            Assert.Same(Brushes.Black, textBlock.Foreground);
+            Assert.False(textBlock.IsSet(TextBlock.ForegroundProperty));
+
+            source.Value = 2;
+            Assert.Same(localBrush, textBlock.Foreground);
+        }
+
         private class Class1
         {
             public string Foo { get; set; } = "foo";

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Converters.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Converters.cs
@@ -1,9 +1,12 @@
 using System;
+using System.ComponentModel;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Data.Core;
+using Avalonia.Media;
 using Avalonia.UnitTests;
 using Moq;
 using Xunit;
@@ -124,9 +127,75 @@ namespace Avalonia.Markup.UnitTests.Data
                 Times.Once);
         }
 
+        [Fact]
+        public void Converter_UnsetValue_Should_Reveal_Lower_Priority_Value()
+        {
+            var source = new BrushSource(-1);
+            var styleBrush = Brushes.White;
+            var localBrush = Brushes.Red;
+            var textBlock = new TextBlock
+            {
+                DataContext = source,
+            };
+
+            textBlock.SetValue(TextBlock.ForegroundProperty, styleBrush, BindingPriority.Style);
+            textBlock.Bind(
+                TextBlock.ForegroundProperty,
+                new Binding(nameof(BrushSource.Value))
+                {
+                    Converter = new IntToBrushConverter(localBrush),
+                });
+
+            Assert.Same(styleBrush, textBlock.Foreground);
+
+            source.Value = 1;
+            Assert.Same(localBrush, textBlock.Foreground);
+
+            source.Value = -1;
+            Assert.Same(styleBrush, textBlock.Foreground);
+
+            source.Value = 2;
+            Assert.Same(localBrush, textBlock.Foreground);
+        }
+
         private class Class1
         {
             public string Foo { get; set; } = "foo";
+        }
+
+        private class BrushSource(int value) : INotifyPropertyChanged
+        {
+            private int _value = value;
+
+            public event PropertyChangedEventHandler? PropertyChanged;
+
+            public int Value
+            {
+                get => _value;
+                set
+                {
+                    _value = value;
+                    RaisePropertyChanged();
+                }
+            }
+
+            private void RaisePropertyChanged([CallerMemberName] string propertyName = "")
+            {
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+
+        private class IntToBrushConverter(IBrush brush) : IValueConverter
+        {
+            public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+            {
+                return value is int { } i && i >= 0 ? brush : AvaloniaProperty.UnsetValue;
+            }
+
+            public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+            {
+                throw new NotSupportedException();
+            }
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Fixes #21330.

This fixes `Binding` value converters that return `AvaloniaProperty.UnsetValue` for styled properties. The binding now stops contributing a value at its priority, so lower-priority values such as styles, templates, inheritance, and theme-provided foreground brushes can apply.

The behavior is covered for both local-value bindings and non-local binding priorities such as `BindingPriority.Style`.

## What is the current behavior?

`BindingExpression` stores the converter result as `AvaloniaProperty.UnsetValue`, but `UntypedBindingExpressionBase` publishes `GetValueOrDefault()` to the property store. For `TextBlock.Foreground`, that materializes the metadata default `Brushes.Black`, which masks lower-priority styled or inherited foreground values. In a dark theme, a converter that returns `UnsetValue` can therefore make text render black instead of reverting to the expected themed foreground.

For non-local binding priorities, the property store also had paths that treated an existing value entry as if it always contributed a value. That could either try to materialize an absent entry or unsubscribe a frame-owned binding after it temporarily returned `UnsetValue`, preventing later real converter values from reapplying.

## What is the updated/expected behavior with this PR?

When a `BindingExpression` targets a styled property and its current value is `AvaloniaProperty.UnsetValue`, the expression reports that it has no value to the property store and publishes the raw unset sentinel to local-value updates. Lower-priority values become visible until the converter later produces a real value again.

For non-local binding priorities, absent entries do not create an `EffectiveValue`, and an active frame-owned binding entry remains subscribed while it temporarily has no published value. That lets later converter updates participate in value precedence again.

Direct properties keep the previous default-value materialization because they do not have a lower-priority styled value to reveal.

Validated with:

- `dotnet run --project tests/Avalonia.Markup.UnitTests/Avalonia.Markup.UnitTests.csproj -- --filter-method '*Converter_UnsetValue_With_NonLocal_Priority_Should_Not_Create_Effective_Value'` - 1 passed
- `dotnet run --project tests/Avalonia.Markup.UnitTests/Avalonia.Markup.UnitTests.csproj -- --filter-class 'Avalonia.Markup.UnitTests.Data.BindingTests_Converters'` - 7 passed
- `dotnet run --project tests/Avalonia.Markup.UnitTests/Avalonia.Markup.UnitTests.csproj` - 254 passed
- `dotnet run --project tests/Avalonia.Markup.Xaml.UnitTests/Avalonia.Markup.Xaml.UnitTests.csproj` - 588 passed, 3 skipped
- `dotnet run --project tests/Avalonia.Base.UnitTests/Avalonia.Base.UnitTests.csproj` - 2976 passed, 12 skipped

## How was the solution implemented (if it's not obvious)?

`UntypedBindingExpressionBase` now has small virtual hooks for the value and value-presence state that are published to the property store. The base implementation preserves existing behavior by continuing to publish `GetValueOrDefault()`.

`BindingExpression` overrides those hooks so styled-property bindings treat `UnsetValue` as absence from the value precedence stack. This keeps other expression types, such as dynamic resources, on their existing default-value behavior.

`ValueStore` now checks `IValueEntry.HasValue()` before creating an `EffectiveValue` for non-local binding entries. During reevaluation, if the changed entry is still owned by an active value frame but currently has no value, the current `EffectiveValue` detaches the entry without unsubscribing it. This keeps subscription ownership with the frame and avoids storing `UnsetValue` as a real property value.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21330
