### PR TITLE
Avoid unbounded NavigationPage transition layout for virtualized pages

### DIFF
--- a/src/Avalonia.Controls/Page/NavigationPage.cs
+++ b/src/Avalonia.Controls/Page/NavigationPage.cs
@@ -79,6 +79,7 @@ namespace Avalonia.Controls
         private bool _hasOverrideTransition;
         private readonly HashSet<object> _pageSet = new(ReferenceEqualityComparer.Instance);
         private bool _restoringPagesProperty;
+        private PageTransitionPresenterConstraints? _pageTransitionPresenterConstraints;
 
         private bool IsRtl => FlowDirection == FlowDirection.RightToLeft;
 
@@ -661,6 +662,8 @@ namespace Avalonia.Controls
         {
             base.OnApplyTemplate(e);
 
+            ClearPageTransitionPresenterConstraints();
+
             BackButton = e.NameScope.Get<Button>("PART_BackButton");
             _backButtonDefaultIcon = e.NameScope.Find<Control>("PART_BackButtonDefaultIcon");
             _backButtonContentPresenter = e.NameScope.Find<ContentPresenter>("PART_BackButtonContentPresenter");
@@ -736,6 +739,7 @@ namespace Avalonia.Controls
 
             var t = _currentTransition;
             _currentTransition = null;
+            ClearPageTransitionPresenterConstraints();
             t?.Cancel();
             t?.Dispose();
 
@@ -1796,9 +1800,11 @@ namespace Avalonia.Controls
                     resolvedTransition = PageTransition;
                 }
 
-                _currentTransition?.Cancel();
-                _currentTransition?.Dispose();
+                var currentTransition = _currentTransition;
                 _currentTransition = null;
+                ClearPageTransitionPresenterConstraints();
+                currentTransition?.Cancel();
+                currentTransition?.Dispose();
 
                 _pageBackPresenter.IsVisible = false;
                 _pageBackPresenter.Content = null;
@@ -1833,7 +1839,18 @@ namespace Avalonia.Controls
                         oldPresenter.ZIndex = 0;
                     }
 
-                    _lastPageTransitionTask = RunPageTransitionAsync(resolvedTransition, oldPresenter, newPresenter, !isPop, cancel.Token);
+                    var presenterConstraints = ApplyPageTransitionPresenterConstraints(
+                        cancel,
+                        oldPresenter,
+                        newPresenter);
+
+                    _lastPageTransitionTask = RunPageTransitionAsync(
+                        resolvedTransition,
+                        oldPresenter,
+                        newPresenter,
+                        !isPop,
+                        cancel.Token,
+                        presenterConstraints);
 
                     (_pagePresenter, _pageBackPresenter) = (newPresenter, oldPresenter);
                 }
@@ -1913,7 +1930,8 @@ namespace Avalonia.Controls
             ContentPresenter from,
             ContentPresenter to,
             bool forward,
-            CancellationToken ct)
+            CancellationToken ct,
+            PageTransitionPresenterConstraints? presenterConstraints)
         {
             try
             {
@@ -1928,6 +1946,11 @@ namespace Avalonia.Controls
                 Logger.TryGet(LogEventLevel.Error, LogArea.Control)
                     ?.Log(this, "Page transition threw an unhandled exception: {Exception}", e);
             }
+            finally
+            {
+                if (presenterConstraints is { } constraints)
+                    ClearPageTransitionPresenterConstraints(constraints);
+            }
 
             if (ct.IsCancellationRequested)
                 return;
@@ -1936,6 +1959,88 @@ namespace Avalonia.Controls
             from.Content = null;
             from.RenderTransform = null;
             from.Opacity = 1;
+        }
+
+        private PageTransitionPresenterConstraints? ApplyPageTransitionPresenterConstraints(
+            CancellationTokenSource transition,
+            ContentPresenter from,
+            ContentPresenter to)
+        {
+            var size = _contentHost?.Bounds.Size ?? default;
+            if (!double.IsFinite(size.Width) ||
+                !double.IsFinite(size.Height) ||
+                size.Width <= 0 ||
+                size.Height <= 0)
+            {
+                return null;
+            }
+
+            var constraints = new PageTransitionPresenterConstraints(
+                transition,
+                from,
+                to,
+                from.MaxWidth,
+                from.MaxHeight,
+                to.MaxWidth,
+                to.MaxHeight);
+
+            from.SetCurrentValue(MaxWidthProperty, Math.Min(from.MaxWidth, size.Width));
+            from.SetCurrentValue(MaxHeightProperty, Math.Min(from.MaxHeight, size.Height));
+            to.SetCurrentValue(MaxWidthProperty, Math.Min(to.MaxWidth, size.Width));
+            to.SetCurrentValue(MaxHeightProperty, Math.Min(to.MaxHeight, size.Height));
+
+            _pageTransitionPresenterConstraints = constraints;
+            return constraints;
+        }
+
+        private void ClearPageTransitionPresenterConstraints()
+        {
+            if (_pageTransitionPresenterConstraints is not { } activeConstraints)
+                return;
+
+            RestorePageTransitionPresenterConstraints(activeConstraints);
+        }
+
+        private void ClearPageTransitionPresenterConstraints(PageTransitionPresenterConstraints constraints)
+        {
+            if (_pageTransitionPresenterConstraints is not { } activeConstraints ||
+                !ReferenceEquals(activeConstraints.Transition, constraints.Transition))
+                return;
+
+            RestorePageTransitionPresenterConstraints(activeConstraints);
+        }
+
+        private void RestorePageTransitionPresenterConstraints(PageTransitionPresenterConstraints constraints)
+        {
+            constraints.From.SetCurrentValue(MaxWidthProperty, constraints.FromMaxWidth);
+            constraints.From.SetCurrentValue(MaxHeightProperty, constraints.FromMaxHeight);
+            constraints.To.SetCurrentValue(MaxWidthProperty, constraints.ToMaxWidth);
+            constraints.To.SetCurrentValue(MaxHeightProperty, constraints.ToMaxHeight);
+            _pageTransitionPresenterConstraints = null;
+        }
+
+        private readonly struct PageTransitionPresenterConstraints(
+            CancellationTokenSource transition,
+            ContentPresenter from,
+            ContentPresenter to,
+            double fromMaxWidth,
+            double fromMaxHeight,
+            double toMaxWidth,
+            double toMaxHeight)
+        {
+            public CancellationTokenSource Transition { get; } = transition;
+
+            public ContentPresenter From { get; } = from;
+
+            public ContentPresenter To { get; } = to;
+
+            public double FromMaxWidth { get; } = fromMaxWidth;
+
+            public double FromMaxHeight { get; } = fromMaxHeight;
+
+            public double ToMaxWidth { get; } = toMaxWidth;
+
+            public double ToMaxHeight { get; } = toMaxHeight;
         }
 
         private Task AwaitPageTransitionAsync()

--- a/src/Avalonia.Controls/Page/NavigationPage.cs
+++ b/src/Avalonia.Controls/Page/NavigationPage.cs
@@ -1960,9 +1960,7 @@ namespace Avalonia.Controls
             if (_pageTransitionMeasureConstraint is not { } constraint)
                 return availableSize;
 
-            return new Size(
-                Math.Min(availableSize.Width, constraint.Width),
-                Math.Min(availableSize.Height, constraint.Height));
+            return availableSize.Constrain(constraint);
         }
 
         private Size? GetPageTransitionMeasureConstraint()

--- a/src/Avalonia.Controls/Page/NavigationPage.cs
+++ b/src/Avalonia.Controls/Page/NavigationPage.cs
@@ -79,7 +79,7 @@ namespace Avalonia.Controls
         private bool _hasOverrideTransition;
         private readonly HashSet<object> _pageSet = new(ReferenceEqualityComparer.Instance);
         private bool _restoringPagesProperty;
-        private PageTransitionPresenterConstraints? _pageTransitionPresenterConstraints;
+        private Size? _pageTransitionMeasureConstraint;
 
         private bool IsRtl => FlowDirection == FlowDirection.RightToLeft;
 
@@ -662,7 +662,7 @@ namespace Avalonia.Controls
         {
             base.OnApplyTemplate(e);
 
-            ClearPageTransitionPresenterConstraints();
+            ClearPageTransitionMeasureConstraint();
 
             BackButton = e.NameScope.Get<Button>("PART_BackButton");
             _backButtonDefaultIcon = e.NameScope.Find<Control>("PART_BackButtonDefaultIcon");
@@ -698,14 +698,16 @@ namespace Avalonia.Controls
 
         protected override Size MeasureOverride(Size availableSize)
         {
-            if (_topCommandBarPresenter?.Content != null && availableSize.Width > 0 && double.IsFinite(availableSize.Width))
+            var constrainedSize = ConstrainPageTransitionMeasure(availableSize);
+
+            if (_topCommandBarPresenter?.Content != null && constrainedSize.Width > 0 && double.IsFinite(constrainedSize.Width))
             {
-                var maxWidth = Math.Floor(availableSize.Width * 0.5);
+                var maxWidth = Math.Floor(constrainedSize.Width * 0.5);
                 if (_topCommandBarPresenter.MaxWidth != maxWidth)
                     _topCommandBarPresenter.MaxWidth = maxWidth;
             }
 
-            return base.MeasureOverride(availableSize);
+            return base.MeasureOverride(constrainedSize);
         }
 
         private void OnNavBarSizeChanged(object? sender, SizeChangedEventArgs e) =>
@@ -737,11 +739,7 @@ namespace Avalonia.Controls
 
             RemoveHandler(InputElement.SwipeGestureEvent, OnSwipeGesture);
 
-            var t = _currentTransition;
-            _currentTransition = null;
-            ClearPageTransitionPresenterConstraints();
-            t?.Cancel();
-            t?.Dispose();
+            CancelCurrentPageTransition();
 
             var mt = _currentModalTransition;
             _currentModalTransition = null;
@@ -1800,11 +1798,7 @@ namespace Avalonia.Controls
                     resolvedTransition = PageTransition;
                 }
 
-                var currentTransition = _currentTransition;
-                _currentTransition = null;
-                ClearPageTransitionPresenterConstraints();
-                currentTransition?.Cancel();
-                currentTransition?.Dispose();
+                CancelCurrentPageTransition();
 
                 _pageBackPresenter.IsVisible = false;
                 _pageBackPresenter.Content = null;
@@ -1821,6 +1815,7 @@ namespace Avalonia.Controls
                 {
                     var cancel = new CancellationTokenSource();
                     _currentTransition = cancel;
+                    _pageTransitionMeasureConstraint = GetPageTransitionMeasureConstraint();
 
                     var oldPresenter = _pagePresenter;
                     var newPresenter = _pageBackPresenter;
@@ -1839,18 +1834,12 @@ namespace Avalonia.Controls
                         oldPresenter.ZIndex = 0;
                     }
 
-                    var presenterConstraints = ApplyPageTransitionPresenterConstraints(
-                        cancel,
-                        oldPresenter,
-                        newPresenter);
-
                     _lastPageTransitionTask = RunPageTransitionAsync(
                         resolvedTransition,
                         oldPresenter,
                         newPresenter,
                         !isPop,
-                        cancel.Token,
-                        presenterConstraints);
+                        cancel);
 
                     (_pagePresenter, _pageBackPresenter) = (newPresenter, oldPresenter);
                 }
@@ -1930,9 +1919,10 @@ namespace Avalonia.Controls
             ContentPresenter from,
             ContentPresenter to,
             bool forward,
-            CancellationToken ct,
-            PageTransitionPresenterConstraints? presenterConstraints)
+            CancellationTokenSource cancellation)
         {
+            var ct = cancellation.Token;
+
             try
             {
                 await transition.Start(from, to, forward, ct);
@@ -1948,8 +1938,12 @@ namespace Avalonia.Controls
             }
             finally
             {
-                if (presenterConstraints is { } constraints)
-                    ClearPageTransitionPresenterConstraints(constraints);
+                if (ReferenceEquals(_currentTransition, cancellation))
+                {
+                    _currentTransition = null;
+                    ClearPageTransitionMeasureConstraint();
+                    cancellation.Dispose();
+                }
             }
 
             if (ct.IsCancellationRequested)
@@ -1961,86 +1955,45 @@ namespace Avalonia.Controls
             from.Opacity = 1;
         }
 
-        private PageTransitionPresenterConstraints? ApplyPageTransitionPresenterConstraints(
-            CancellationTokenSource transition,
-            ContentPresenter from,
-            ContentPresenter to)
+        private Size ConstrainPageTransitionMeasure(Size availableSize)
         {
-            var size = _contentHost?.Bounds.Size ?? default;
-            if (!double.IsFinite(size.Width) ||
-                !double.IsFinite(size.Height) ||
-                size.Width <= 0 ||
-                size.Height <= 0)
-            {
-                return null;
-            }
+            if (_pageTransitionMeasureConstraint is not { } constraint)
+                return availableSize;
 
-            var constraints = new PageTransitionPresenterConstraints(
-                transition,
-                from,
-                to,
-                from.MaxWidth,
-                from.MaxHeight,
-                to.MaxWidth,
-                to.MaxHeight);
-
-            from.SetCurrentValue(MaxWidthProperty, Math.Min(from.MaxWidth, size.Width));
-            from.SetCurrentValue(MaxHeightProperty, Math.Min(from.MaxHeight, size.Height));
-            to.SetCurrentValue(MaxWidthProperty, Math.Min(to.MaxWidth, size.Width));
-            to.SetCurrentValue(MaxHeightProperty, Math.Min(to.MaxHeight, size.Height));
-
-            _pageTransitionPresenterConstraints = constraints;
-            return constraints;
+            return new Size(
+                Math.Min(availableSize.Width, constraint.Width),
+                Math.Min(availableSize.Height, constraint.Height));
         }
 
-        private void ClearPageTransitionPresenterConstraints()
+        private Size? GetPageTransitionMeasureConstraint()
         {
-            if (_pageTransitionPresenterConstraints is not { } activeConstraints)
+            // Measure is constrained at the NavigationPage boundary so templates can subtract bars
+            // and other chrome through their normal layout rules.
+            var size = Bounds.Size;
+            return double.IsFinite(size.Width) &&
+                   double.IsFinite(size.Height) &&
+                   size.Width > 0 &&
+                   size.Height > 0
+                ? size
+                : null;
+        }
+
+        private void CancelCurrentPageTransition()
+        {
+            var transition = _currentTransition;
+            _currentTransition = null;
+            ClearPageTransitionMeasureConstraint();
+            transition?.Cancel();
+            transition?.Dispose();
+        }
+
+        private void ClearPageTransitionMeasureConstraint()
+        {
+            if (_pageTransitionMeasureConstraint == null)
                 return;
 
-            RestorePageTransitionPresenterConstraints(activeConstraints);
-        }
-
-        private void ClearPageTransitionPresenterConstraints(PageTransitionPresenterConstraints constraints)
-        {
-            if (_pageTransitionPresenterConstraints is not { } activeConstraints ||
-                !ReferenceEquals(activeConstraints.Transition, constraints.Transition))
-                return;
-
-            RestorePageTransitionPresenterConstraints(activeConstraints);
-        }
-
-        private void RestorePageTransitionPresenterConstraints(PageTransitionPresenterConstraints constraints)
-        {
-            constraints.From.SetCurrentValue(MaxWidthProperty, constraints.FromMaxWidth);
-            constraints.From.SetCurrentValue(MaxHeightProperty, constraints.FromMaxHeight);
-            constraints.To.SetCurrentValue(MaxWidthProperty, constraints.ToMaxWidth);
-            constraints.To.SetCurrentValue(MaxHeightProperty, constraints.ToMaxHeight);
-            _pageTransitionPresenterConstraints = null;
-        }
-
-        private readonly struct PageTransitionPresenterConstraints(
-            CancellationTokenSource transition,
-            ContentPresenter from,
-            ContentPresenter to,
-            double fromMaxWidth,
-            double fromMaxHeight,
-            double toMaxWidth,
-            double toMaxHeight)
-        {
-            public CancellationTokenSource Transition { get; } = transition;
-
-            public ContentPresenter From { get; } = from;
-
-            public ContentPresenter To { get; } = to;
-
-            public double FromMaxWidth { get; } = fromMaxWidth;
-
-            public double FromMaxHeight { get; } = fromMaxHeight;
-
-            public double ToMaxWidth { get; } = toMaxWidth;
-
-            public double ToMaxHeight { get; } = toMaxHeight;
+            _pageTransitionMeasureConstraint = null;
+            InvalidateMeasure();
         }
 
         private Task AwaitPageTransitionAsync()

--- a/tests/Avalonia.Controls.UnitTests/NavigationPageTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NavigationPageTests.cs
@@ -2441,19 +2441,29 @@ public class NavigationPageTests
             Assert.False(navigatedToDuringTransition);
         }
 
-        [Fact]
-        public async Task ReplaceAsync_Does_Not_Measure_Virtualized_Page_With_Unbounded_Size_During_Transition()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ReplaceAsync_Does_Not_Measure_Virtualized_Page_With_Unbounded_Size_During_Transition(
+            bool virtualizedPageIsOutgoing)
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
                 var tcs = new TaskCompletionSource();
                 var nav = CreateNavigationPage(null, out var root, new Size(400, 300));
-                await nav.PushAsync(CreateContentPage(new TextBlock { Text = "Root" }));
+                var listBox = CreateVirtualizedListBox();
+                var simpleContent = new TextBlock { Text = "Simple page" };
+                Control outgoingContent = virtualizedPageIsOutgoing ? listBox : simpleContent;
+                Control incomingContent = virtualizedPageIsOutgoing ? simpleContent : listBox;
+
+                await nav.PushAsync(CreateContentPage(outgoingContent));
                 root.LayoutManager.ExecuteLayoutPass();
 
+                if (virtualizedPageIsOutgoing)
+                    Assert.InRange(listBox.GetRealizedContainers().Count(), 1, 100);
+
                 nav.PageTransition = new ControllableTransition(tcs.Task);
-                var listBox = CreateVirtualizedListBox();
-                var replaceTask = nav.ReplaceAsync(CreateContentPage(listBox));
+                var replaceTask = nav.ReplaceAsync(CreateContentPage(incomingContent));
 
                 try
                 {
@@ -2464,7 +2474,51 @@ public class NavigationPageTests
 
                     var realizedDuringTransition = listBox.GetRealizedContainers().Count();
                     Assert.InRange(realizedDuringTransition, 1, 100);
-                    Assert.InRange(listBox.DesiredSize.Height, 1, root.ClientSize.Height);
+                    if (!virtualizedPageIsOutgoing)
+                        Assert.InRange(listBox.DesiredSize.Height, 1, root.ClientSize.Height);
+                }
+                finally
+                {
+                    tcs.TrySetResult();
+                    await replaceTask;
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ReplaceAsync_Does_Not_Constrain_Measure_After_Transition_Cleanup(bool cancelTransition)
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var tcs = new TaskCompletionSource();
+                var nav = CreateNavigationPage(null, out var root, new Size(400, 300));
+                await nav.PushAsync(CreateContentPage(new TextBlock { Text = "Root" }));
+                root.LayoutManager.ExecuteLayoutPass();
+
+                nav.PageTransition = new ControllableTransition(tcs.Task);
+                var content = new MeasureConstraintControl();
+                var replaceTask = nav.ReplaceAsync(CreateContentPage(content));
+
+                try
+                {
+                    Assert.False(replaceTask.IsCompleted);
+
+                    nav.InvalidateMeasure();
+                    nav.Measure(Size.Infinity);
+                    Assert.True(double.IsFinite(content.MeasureConstraint.Width));
+                    Assert.True(double.IsFinite(content.MeasureConstraint.Height));
+
+                    if (cancelTransition)
+                        root.Child = null;
+                    else
+                        tcs.SetResult();
+
+                    await replaceTask;
+                    nav.Measure(Size.Infinity);
+
+                    Assert.Equal(Size.Infinity, content.MeasureConstraint);
                 }
                 finally
                 {
@@ -2599,9 +2653,20 @@ public class NavigationPageTests
             {
                 if (to != null)
                     to.IsVisible = true;
-                await _gate;
+                await _gate.WaitAsync(cancellationToken);
                 if (from != null)
                     from.IsVisible = false;
+            }
+        }
+
+        private class MeasureConstraintControl : Control
+        {
+            public Size MeasureConstraint { get; private set; }
+
+            protected override Size MeasureOverride(Size availableSize)
+            {
+                MeasureConstraint = availableSize;
+                return new Size(800, 600).Constrain(availableSize);
             }
         }
     }

--- a/tests/Avalonia.Controls.UnitTests/NavigationPageTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NavigationPageTests.cs
@@ -2441,16 +2441,77 @@ public class NavigationPageTests
             Assert.False(navigatedToDuringTransition);
         }
 
+        [Fact]
+        public async Task ReplaceAsync_Does_Not_Measure_Virtualized_Page_With_Unbounded_Size_During_Transition()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var tcs = new TaskCompletionSource();
+                var nav = CreateNavigationPage(null, out var root, new Size(400, 300));
+                await nav.PushAsync(CreateContentPage(new TextBlock { Text = "Root" }));
+                root.LayoutManager.ExecuteLayoutPass();
+
+                nav.PageTransition = new ControllableTransition(tcs.Task);
+                var listBox = CreateVirtualizedListBox();
+                var replaceTask = nav.ReplaceAsync(CreateContentPage(listBox));
+
+                try
+                {
+                    Assert.False(replaceTask.IsCompleted);
+
+                    nav.InvalidateMeasure();
+                    nav.Measure(Size.Infinity);
+
+                    var realizedDuringTransition = listBox.GetRealizedContainers().Count();
+                    Assert.InRange(realizedDuringTransition, 1, 100);
+                    Assert.InRange(listBox.DesiredSize.Height, 1, root.ClientSize.Height);
+                }
+                finally
+                {
+                    tcs.TrySetResult();
+                    await replaceTask;
+                }
+            }
+        }
+
         private static NavigationPage CreateNavigationPage(IPageTransition? transition)
+            => CreateNavigationPage(transition, out _);
+
+        private static NavigationPage CreateNavigationPage(
+            IPageTransition? transition,
+            out TestRoot root,
+            Size? clientSize = null)
         {
             var nav = new NavigationPage
             {
                 PageTransition = transition,
                 Template = NavigationPageTemplate()
             };
-            var root = new TestRoot { Child = nav };
+            root = new TestRoot { Child = nav };
+            if (clientSize.HasValue)
+                root.ClientSize = clientSize.Value;
             root.LayoutManager.ExecuteInitialLayoutPass();
             return nav;
+        }
+
+        private static ContentPage CreateContentPage(Control content)
+        {
+            return new ContentPage
+            {
+                Content = content,
+                Template = ContentPageTemplate()
+            };
+        }
+
+        private static ListBox CreateVirtualizedListBox()
+        {
+            return new ListBox
+            {
+                Template = new FuncControlTemplate(CreateListBoxTemplate),
+                ItemsSource = Enumerable.Range(0, 10000).ToArray(),
+                ItemTemplate = new FuncDataTemplate<int>((_, _) => new TextBlock { Height = 20 }),
+                ItemsPanel = new FuncTemplate<Panel?>(() => new VirtualizingStackPanel { CacheLength = 0 }),
+            };
         }
 
         private static IControlTemplate NavigationPageTemplate()
@@ -2483,6 +2544,46 @@ public class NavigationPageTests
                     }
                 };
             });
+        }
+
+        private static IControlTemplate ContentPageTemplate()
+        {
+            return new FuncControlTemplate<ContentPage>((parent, ns) =>
+            {
+                return new ContentPresenter
+                {
+                    Name = "PART_ContentPresenter",
+                    [~ContentPresenter.ContentProperty] =
+                        parent.GetObservable(ContentPage.ContentProperty).ToBinding(),
+                    [~ContentPresenter.ContentTemplateProperty] =
+                        parent.GetObservable(ContentPage.ContentTemplateProperty).ToBinding(),
+                }.RegisterInNameScope(ns);
+            });
+        }
+
+        private static Control CreateListBoxTemplate(TemplatedControl parent, INameScope scope)
+        {
+            return new ScrollViewer
+            {
+                Name = "PART_ScrollViewer",
+                Template = new FuncControlTemplate(CreateScrollViewerTemplate),
+                Content = new ItemsPresenter
+                {
+                    Name = "PART_ItemsPresenter",
+                    [~ItemsPresenter.ItemsPanelProperty] =
+                        ((ListBox)parent).GetObservable(ItemsControl.ItemsPanelProperty).ToBinding(),
+                }.RegisterInNameScope(scope)
+            }.RegisterInNameScope(scope);
+        }
+
+        private static Control CreateScrollViewerTemplate(TemplatedControl parent, INameScope scope)
+        {
+            return new ScrollContentPresenter
+            {
+                Name = "PART_ContentPresenter",
+                [~ContentPresenter.ContentProperty] =
+                    parent.GetObservable(ContentControl.ContentProperty).ToBinding(),
+            }.RegisterInNameScope(scope);
         }
 
         private class ControllableTransition : IPageTransition


### PR DESCRIPTION
## What does the pull request do?

Prevents `NavigationPage` page transitions from remeasuring active page content under an unbounded constraint after the control has already been arranged to a finite viewport. This keeps virtualized pages, including a large replacement `ListBox`, bounded during a pending transition.

## What is the current behavior?

When `NavigationPage.PageTransition` is enabled, the old and new pages remain hosted until the transition completes. A later layout pass can measure that transition subtree with `Size.Infinity`, which makes virtualizing panels treat the full item range as visible. The regression test reproduces this with a 10,000 item `ListBox` during `ReplaceAsync`.

## What is the updated/expected behavior with this PR?

A pending page transition is measured under the last finite arranged `NavigationPage` viewport. The constraint is only captured once the control has a real finite size, and it is cleared when the transition completes, is cancelled, is interrupted by another transition, the control detaches, or the template reapplies.

## How was the solution implemented (if it is not obvious)?

`NavigationPage` now owns the transition measurement invariant in `MeasureOverride`. It records a private transition measure constraint at transition start and applies it at the `NavigationPage` layout boundary, leaving templates to subtract navigation bars and other chrome through their normal layout rules.

This avoids mutating presenter `MaxWidth` or `MaxHeight` properties and keeps the fix independent of the default theme template.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Verification

- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -- --filter-method 'Avalonia.Controls.UnitTests.NavigationPageTests+LifecycleAfterTransitionTests.ReplaceAsync_Does_Not_Measure_Virtualized_Page_With_Unbounded_Size_During_Transition' --no-progress`
- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -- --filter-class 'Avalonia.Controls.UnitTests.NavigationPageTests*' --no-progress`
- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -- --filter-class Avalonia.Controls.UnitTests.ListBoxVirtualizationIssueTests --no-progress`
- `dotnet build src/Avalonia.Controls/Avalonia.Controls.csproj -p:AvsSkipBuildingLegacyTargetFrameworks=True`

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21737