### PR TITLE
Fix: BuildToNuGetCache target should not open duplicate file handles

### DIFF
--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -456,9 +456,10 @@ partial class Build : NukeBuild
             
             foreach (var path in Parameters.NugetRoot.GlobFiles("*.nupkg"))
             {
+                var packageId = SbomGenerator.ReadPackageId(path);
+
                 using var f = File.Open(path.ToString(), FileMode.Open, FileAccess.Read);
                 using var zip = new ZipArchive(f, ZipArchiveMode.Read);
-                var packageId = SbomGenerator.ReadPackageId(path);
 
                 var packagePath = Path.Combine(
                     globalPackagesFolder,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR fixes a concurrency issue introduced by #21681 where multiple read-only handles are allocated by the build process for the same file. This causes the deployment to the local NuGet feed to fail entirely. 


## What is the current behavior?
The current behavior is for the build process to follow these steps in order, for each package:
1. Open given NuGet package for reading
2. Call `SbomGenerator.ReadPackageId()`
3. -> this call internally opens the file again, which fails due to mutual exclusion principle
4. Exit prematurely


## What is the updated/expected behavior with this PR?
The new behavior is as follows, for each package:
1. Call `SbomGenerator.ReadPackageId()`
2. -> internally open NuGet package for reading, grab metadata, then close cleanly
3. Open given NuGet package for reading
4. Rejoice!


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
