### PR TITLE
fix(ScrollBar): use large scroll events for ScrollToHome and ScrollToEnd

### DIFF
--- a/src/Avalonia.Controls/Primitives/ScrollBar.cs
+++ b/src/Avalonia.Controls/Primitives/ScrollBar.cs
@@ -579,7 +579,7 @@ namespace Avalonia.Controls.Primitives
         public void ScrollToHome()
         {
             SetCurrentValue(ValueProperty, Minimum);
-            OnScroll(ScrollEventType.SmallDecrement);
+            OnScroll(ScrollEventType.LargeDecrement);
         }
 
         /// <summary>
@@ -588,7 +588,7 @@ namespace Avalonia.Controls.Primitives
         public void ScrollToEnd()
         {
             SetCurrentValue(ValueProperty, Maximum);
-            OnScroll(ScrollEventType.SmallIncrement);
+            OnScroll(ScrollEventType.LargeIncrement);
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/Primitives/ScrollBarTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/ScrollBarTests.cs
@@ -338,8 +338,8 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 {
                     ScrollEventType.SmallIncrement,
                     ScrollEventType.LargeIncrement,
-                    ScrollEventType.SmallDecrement,
-                    ScrollEventType.SmallIncrement,
+                    ScrollEventType.LargeDecrement,
+                    ScrollEventType.LargeIncrement,
                 },
                 events);
         }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes the `ScrollBar` context menu commands Scroll to Top, Scroll to Bottom, Left Edge and Right Edge by raising the correct `ScrollEventType` values in` ScrollToHome()` and `ScrollToEnd()`.


## What is the current behavior?
`ScrollToHome()` raises `SmallDecrement` and `ScrollToEnd()` raises `SmallIncrement`, causing the corresponding `ScrollBar` context menu commands to scroll to incorrect positions in controls such as `DataGrid`.


## What is the updated/expected behavior with this PR?
`ScrollToHome()` now raises `LargeDecrement`, and `ScrollToEnd()` now raises `LargeIncrement`, allowing the affected context menu commands to scroll to the expected positions.


## How was the solution implemented (if it's not obvious)?
`ScrollToHome()` was changed to raise `ScrollEventType.LargeDecrement` instead of `SmallDecrement`, and `ScrollToEnd()` was changed to raise `ScrollEventType.LargeIncrement` instead of `SmallIncrement`.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes AvaloniaUI/Avalonia.Controls.DataGrid#258 
