### PR TITLE
Position popup using the screen containing the anchor point

### DIFF
--- a/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
@@ -109,10 +109,12 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             Rect GetBounds()
             {
                 var screens = _popup.Screens;
+                var anchorPoint = GetAnchorPoint(anchorRect, anchor);
+                var parentGeometryPoint = GetAnchorPoint(parentGeometry, anchor);
                 
-                var targetScreen =  screens.FirstOrDefault(s => s.Bounds.ContainsExclusive(anchorRect.TopLeft))
+                var targetScreen =  screens.FirstOrDefault(s => s.Bounds.ContainsExclusive(anchorPoint))
                                    ?? screens.FirstOrDefault(s => s.Bounds.Intersects(anchorRect))
-                                   ?? screens.FirstOrDefault(s => s.Bounds.ContainsExclusive(parentGeometry.TopLeft))
+                                   ?? screens.FirstOrDefault(s => s.Bounds.ContainsExclusive(parentGeometryPoint))
                                    ?? screens.FirstOrDefault(s => s.Bounds.Intersects(parentGeometry))
                                    ?? screens.FirstOrDefault();
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/ManagedPopupPositionerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/ManagedPopupPositionerTests.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using Avalonia.Controls.Primitives.PopupPositioning;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests.Primitives;
+
+public class ManagedPopupPositionerTests : ScopedTestBase
+{
+    // The anchor rectangle overlaps the 4 screens, so each corner lands on a different screen.
+    // With no gravity the popup is centered on the anchor point and is slid back into the screen containing that point.
+    [Theory]
+    [InlineData(PopupAnchor.TopLeft, 600, 600)]
+    [InlineData(PopupAnchor.TopRight, 1000, 600)]
+    [InlineData(PopupAnchor.BottomLeft, 600, 1000)]
+    [InlineData(PopupAnchor.BottomRight, 1000, 1000)]
+    public void Uses_Screen_Containing_The_Anchor_Point(PopupAnchor anchor, double expectedX, double expectedY)
+    {
+        var popup = new MockManagedPopupPositionerPopup();
+        var positioner = new ManagedPopupPositioner(popup);
+
+        positioner.Update(new PopupPositionerParameters
+        {
+            Size = new Size(400, 400),
+            AnchorRectangle = new Rect(900, 900, 200, 200),
+            Anchor = anchor,
+            Gravity = PopupGravity.None,
+            ConstraintAdjustment = PopupPositionerConstraintAdjustment.All
+        });
+
+        Assert.Equal(new Point(expectedX, expectedY), popup.LastPosition);
+    }
+
+    private sealed class MockManagedPopupPositionerPopup : IManagedPopupPositionerPopup
+    {
+        // Four screens arranged in a 2x2 grid, meeting at (1000, 1000).
+        public IReadOnlyList<ManagedPopupPositionerScreenInfo> Screens { get; } =
+        [
+            new(new Rect(0, 0, 1000, 1000), new Rect(0, 0, 1000, 1000)),
+            new(new Rect(1000, 0, 1000, 1000), new Rect(1000, 0, 1000, 1000)),
+            new(new Rect(0, 1000, 1000, 1000), new Rect(0, 1000, 1000, 1000)),
+            new(new Rect(1000, 1000, 1000, 1000), new Rect(1000, 1000, 1000, 1000))
+        ];
+
+        public Rect ParentClientAreaScreenGeometry => new(0, 0, 1000, 1000);
+
+        public double Scaling => 1.0;
+
+        public Point LastPosition { get; private set; }
+
+        public Size LastSize { get; private set; }
+
+        public void MoveAndResize(Point devicePoint, Size virtualSize)
+        {
+            LastPosition = devicePoint;
+            LastSize = virtualSize;
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that popups are positioned on the screen containing their anchor point by default.
Before this PR, the screen containing the top-left point of the anchor rect was always used, resulting in unexpected placements (see #15261).

This PR only changes the default position before gravity or constraints are applied.

Unit tests have been added.
(Apparently, we didn't have any unit tests for `ManagedPopupPositioner` before, so we might as well start now.)

## Fixed issues
Fixes #15261