### PR TITLE
fix(binding): reapply cached source values during UpdateTarget

### DIFF
--- a/src/Avalonia.Base/Data/Core/BindingExpression.cs
+++ b/src/Avalonia.Base/Data/Core/BindingExpression.cs
@@ -31,6 +31,7 @@ internal class BindingExpression : UntypedBindingExpressionBase, IDescription, I
     private readonly List<ExpressionNode> _nodes;
     private readonly TargetTypeConverter? _targetTypeConverter;
     private readonly UncommonFields? _uncommon;
+    private int _updateTargetDepth;
     private bool _shouldUpdateOneTimeBindingTarget;
 
     /// <summary>
@@ -167,10 +168,19 @@ internal class BindingExpression : UntypedBindingExpressionBase, IDescription, I
 
         var source = _nodes[0].Source;
 
-        for (var i = 0; i < _nodes.Count; ++i)
-            _nodes[i].SetSource(AvaloniaProperty.UnsetValue, null);
+        ++_updateTargetDepth;
 
-        _nodes[0].SetSource(source, null);
+        try
+        {
+            for (var i = 0; i < _nodes.Count; ++i)
+                _nodes[i].SetSource(AvaloniaProperty.UnsetValue, null);
+
+            _nodes[0].SetSource(source, null);
+        }
+        finally
+        {
+            --_updateTargetDepth;
+        }
     }
 
     /// <summary>
@@ -206,7 +216,9 @@ internal class BindingExpression : UntypedBindingExpressionBase, IDescription, I
                     new BindingError(dataValidationError, BindingErrorType.DataValidationError) :
                     null;
 
-                var forceUpdate = _mode == BindingMode.OneWay;
+                // UpdateTarget must reapply the source value even if this expression already
+                // has it cached: a two-way target may contain an uncommitted local value.
+                var forceUpdate = _mode == BindingMode.OneWay || _updateTargetDepth > 0;
                 ConvertAndPublishValue(value, error, forceUpdate);
             }
         }

--- a/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.UpdateSourceTrigger.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.UpdateSourceTrigger.cs
@@ -111,5 +111,31 @@ namespace Avalonia.Base.UnitTests.Data.Core
             Assert.Equal("bar", target.String);
             Assert.Equal("bar", data.StringValue);
         }
+
+        [Fact]
+        public void TwoWay_Explicit_Should_Update_Target_On_Call_To_UpdateTarget()
+        {
+            var data = new ViewModel { StringValue = "foo" };
+            var (target, expression) = CreateTargetAndExpression<ViewModel, string?>(
+                o => o.StringValue,
+                mode: BindingMode.TwoWay,
+                source: data,
+                updateSourceTrigger: UpdateSourceTrigger.Explicit);
+
+            Assert.Equal("foo", target.String);
+            Assert.Equal("foo", data.StringValue);
+
+            target.String = "bar";
+
+            Assert.Equal("bar", target.String);
+            Assert.Equal("foo", data.StringValue);
+
+            // UpdateTarget forces a transfer from source to target, discarding the
+            // value set on the target.
+            expression.UpdateTarget();
+
+            Assert.Equal("foo", target.String);
+            Assert.Equal("foo", data.StringValue);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Fixes #21746. Restores the documented UpdateTarget contract for explicit two-way bindings when a target edit has not been written to the source.

## What is the current behavior?

After a target is changed under UpdateSourceTrigger=Explicit, UpdateTarget rebuilds the binding path but does not restore the unchanged source value. The binding expression already caches that value, so equal-value suppression prevents the value store from receiving a refresh and the target remains edited.

## What is the updated/expected behavior with this PR?

UpdateTarget re-applies the source value even when it matches the expression cache. Calling it after an uncommitted explicit two-way target edit now restores the target from the source without modifying the source.

## How was the solution implemented (if it's not obvious)?

The binding tracks the synchronous UpdateTarget rebuild and forces value publication only while that rebuild is in progress. Normal binding notification deduplication is unchanged. A counter and finally block keep the state correct for nested calls and exceptions.

## Checklist

- [x] Added unit tests (if possible)
- [ ] Added XML documentation to any related classes
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21746

## Validation

- dotnet build src/Avalonia.Base/Avalonia.Base.csproj -p:AvsSkipBuildingLegacyTargetFrameworks=True
- dotnet run --project tests/Avalonia.Base.UnitTests/Avalonia.Base.UnitTests.csproj -- --filter-class Avalonia.Base.UnitTests.Data.Core.BindingExpressionTests+Reflection Avalonia.Base.UnitTests.Data.Core.BindingExpressionTests+Compiled

The focused regression runs in both the reflection and compiled paths.