### PR TITLE
Remove doc comment that CanResize=false implies CanMaximize=false

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -494,7 +494,6 @@ namespace Avalonia.Controls
         /// Enables or disables maximizing the window.
         /// </summary>
         /// <remarks>
-        /// <para>When <see cref="CanResize"/> is false, this property is always false.</para>
         /// <para>On macOS, setting this property to false also disables the full screen mode.</para>
         /// <para>This property might be ignored by some window managers on Linux.</para>
         /// </remarks>


### PR DESCRIPTION
This is no longer true on Wayland

## What does the pull request do?
Fixes an invalid doc comment that is no longer true with the wayland backend.