### PR TITLE
Fix off-thread accessibility hit-test crash on macOS

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -633,9 +633,6 @@
     auto parent = _parent.tryGet();
     if (parent && _automationPeer == nullptr)
     {
-        // GetAutomationPeer() returns null off the UI thread (e.g. an accessibility
-        // hit-test dispatched on a background thread), so guard against a null peer
-        // before SetNode rather than crashing. See #21777.
         auto peer = parent->BaseEvents->GetAutomationPeer();
         if (peer != nullptr)
         {

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -628,14 +628,21 @@
     return GetNSStringAndRelease(automationPeer->GetAutomationId());
 }
 
-- (IAvnAutomationPeer* _Nonnull) automationPeer
+- (IAvnAutomationPeer* _Nullable) automationPeer
 {
     auto parent = _parent.tryGet();
     if (parent && _automationPeer == nullptr)
     {
-        _automationPeer = parent->BaseEvents->GetAutomationPeer();
-        _automationNode = new AvnAutomationNode(self);
-        _automationPeer->SetNode(_automationNode);
+        // GetAutomationPeer() returns null off the UI thread (e.g. an accessibility
+        // hit-test dispatched on a background thread), so guard against a null peer
+        // before SetNode rather than crashing. See #21777.
+        auto peer = parent->BaseEvents->GetAutomationPeer();
+        if (peer != nullptr)
+        {
+            _automationPeer = peer;
+            _automationNode = new AvnAutomationNode(self);
+            _automationPeer->SetNode(_automationNode);
+        }
     }
 
     return _automationPeer;

--- a/native/Avalonia.Native/src/OSX/WindowProtocol.h
+++ b/native/Avalonia.Native/src/OSX/WindowProtocol.h
@@ -17,7 +17,7 @@ struct IAvnAutomationPeer;
 -(void) showAppMenuOnly;
 -(void) showWindowMenuWithAppMenu;
 -(void) applyMenu:(AvnMenu* _Nullable)menu;
--(IAvnAutomationPeer* _Nonnull) automationPeer;
+-(IAvnAutomationPeer* _Nullable) automationPeer;
 
 -(double) getExtendedTitleBarHeight;
 -(void) setIsExtended:(bool)value;


### PR DESCRIPTION
Fixes #21777

On macOS if the system does an accessibility hit test off the UI thread it crashes with a SIGSEGV in -[AvnWindow automationPeer]. You can hit it by calling AXUIElementCopyElementAtPosition from a background thread over one of the app's own windows.

Reason is GetAutomationPeer() returns null when it gets called off the UI thread, since building the peer walks the visual tree which is thread affine. automationPeer didn't check for that and went straight to SetNode on the null pointer, so it blows up.

Fix is just a null check before SetNode so it returns nil instead. All the callers of automationPeer already handle nil so nothing else had to change. Also flipped the return annotation from _Nonnull to _Nullable since it can obviously be null.

No test on this one, it's all in the native objc code and there's no test project for that side, and I couldn't find a way to repro it from the managed automation tests.