### PR TITLE
Expose AutomationId as resource-id for Android automation

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
+++ b/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
@@ -232,7 +232,9 @@ namespace Avalonia.Android
 
             // UI debug metadata
             nodeInfo.ClassName = peer.GetClassName();
-            nodeInfo.UniqueId = peer.GetAutomationId();
+            var automationId = peer.GetAutomationId();
+            nodeInfo.UniqueId = automationId;
+            nodeInfo.ViewIdResourceName = automationId;
 
             // Common control state
             nodeInfo.Enabled = peer.IsEnabled();


### PR DESCRIPTION
## What does the pull request do?
Adds uiautomator visibility to `AutomationProperties.AutomationId` to Android.

## What is the current behavior?
Android automation tree does not have the automation id available.

## What is the updated/expected behavior with this PR?
Tested with ControlCatalog.Android on a physical device with only the XAML changes below. When using automation properties such as:

```xml
<Button
	AutomationProperties.AutomationId="NoBorderButtonTestId"
	AutomationProperties.HelpText="A button with no border"
	AutomationProperties.Name="NoBorderButtonTestName"
	BorderThickness="0"
	IsEnabled="False">
	No Border
</Button>
```

`resource-id` is now populated (previously empty) when dumping the automation tree with: `adb exec-out uiautomator dump /dev/tty`

```xml
<node index="0" text="NoBorderButtonTestName" resource-id="NoBorderButtonTestId" class="Button" package="com.Avalonia.ControlCatalog" content-desc="A button with no border" checkable="false" checked="false" clickable="true" enabled="false" focusable="true" focused="false" scrollable="false" long-clickable="false" password="false" selected="false" bounds="[573,506][794,585]" drawing-order="0" hint="">
```

## How was the solution implemented (if it's not obvious)?
Assigns `AutomationProperties.AutomationId` to `AccessibilityNodeInfoCompat.ViewIdResourceName`

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None expected. Didn't notice any restrictions on string length or character set.

## Obsoletions / Deprecations
None

## Fixed issues
None

# Background
We're evaluating using Maestro for Android end-to-end testing on physical devices. This works, but matching based on `text` or `content-desc` is not ideal.

iOS, too, when accessibility is implemented there.