### PR TITLE
Fix headless session hang when cleanup throws

### DIFF
--- a/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
@@ -145,7 +145,16 @@ public sealed class HeadlessUnitTestSession : IDisposable, IAsyncDisposable
             }
             finally
             {
-                application.Dispose();
+                try
+                {
+                    application.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    // Cleanup runs before the TCS is completed, so its failure must be
+                    // reported by this work item instead of escaping the consumer loop.
+                    caught = ex;
+                }
             }
 
             if (caught != null)
@@ -173,8 +182,14 @@ public sealed class HeadlessUnitTestSession : IDisposable, IAsyncDisposable
 
         return Disposable.Create(() =>
         {
-            Dispatcher.UIThread.RunJobs();
-            SynchronizationContext.SetSynchronizationContext(oldContext);
+            try
+            {
+                Dispatcher.UIThread.RunJobs();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
+            }
         });
     }
 
@@ -195,12 +210,25 @@ public sealed class HeadlessUnitTestSession : IDisposable, IAsyncDisposable
 
         return Disposable.Create(() =>
         {
-            ((ToolTipService?)AvaloniaLocator.Current.GetService<IToolTipService>())?.Dispose();
-            (AvaloniaLocator.Current.GetService<FontManager>() as IDisposable)?.Dispose();
-            Dispatcher.ResetForUnitTests();
-            scope.Dispose();
-            Dispatcher.ResetBeforeUnitTests();
-            SynchronizationContext.SetSynchronizationContext(oldContext);
+            try
+            {
+                ((ToolTipService?)AvaloniaLocator.Current.GetService<IToolTipService>())?.Dispose();
+                (AvaloniaLocator.Current.GetService<FontManager>() as IDisposable)?.Dispose();
+                Dispatcher.ResetForUnitTests();
+            }
+            finally
+            {
+                // Cleanup jobs can throw, but the ambient state still belongs to this dispatch.
+                try
+                {
+                    scope.Dispose();
+                }
+                finally
+                {
+                    Dispatcher.ResetBeforeUnitTests();
+                    SynchronizationContext.SetSynchronizationContext(oldContext);
+                }
+            }
         });
     }
 

--- a/tests/Avalonia.Headless.UnitTests/HeadlessUnitTestSessionTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/HeadlessUnitTestSessionTests.cs
@@ -1,0 +1,32 @@
+#if NUNIT
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+
+namespace Avalonia.Headless.UnitTests;
+
+public class HeadlessUnitTestSessionTests
+{
+    [Test]
+    public async Task Dispatch_Should_Report_Cleanup_Exceptions_And_Continue()
+    {
+        var session = HeadlessUnitTestSession.GetOrStartForAssembly(GetType().Assembly);
+
+        const string message = "Thrown by a dispatcher job during cleanup.";
+        var poisonedDispatch = session.Dispatch(
+            () => Dispatcher.UIThread.Post(() => throw new InvalidOperationException(message)),
+            CancellationToken.None);
+
+        var exception = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await poisonedDispatch.WaitAsync(TimeSpan.FromSeconds(10)));
+
+        Assert.That(exception!.Message, Is.EqualTo(message));
+
+        var result = await session.Dispatch(() => 42, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.That(result, Is.EqualTo(42));
+    }
+}
+#endif


### PR DESCRIPTION
## What does the pull request do?

Fixes a deterministic `HeadlessUnitTestSession` hang when a dispatcher job throws during work-item cleanup. The cleanup exception is now reported through the affected `Dispatch` task, and the session remains able to process later work.

This is the cleanup-stage counterpart to the application-construction fix in [#21688](https://github.com/AvaloniaUI/Avalonia/pull/21688).

## What is the current behavior?

Cleanup runs before a dispatch's `TaskCompletionSource` is settled, as required by [#21223](https://github.com/AvaloniaUI/Avalonia/pull/21223). If `application.Dispose()` throws, the exception bypasses the completion code and escapes the queued action. The private consumer task faults, the current `Dispatch` task never completes, and all later dispatches remain queued forever.

## What is the updated/expected behavior with this PR?

The affected `Dispatch` task faults with the cleanup exception. Required synchronization context, locator scope, and dispatcher state restoration still runs, so the consumer remains healthy and a subsequent dispatch completes normally.

The regression test posts a dispatcher job that throws during cleanup, verifies the exact `InvalidOperationException` is surfaced, then verifies another dispatch returns successfully. It runs in both NUnit isolation projects.

Validation on macOS ARM64 with .NET 10:

- NUnit PerAssembly: 74 total, 73 passed, 1 intentional skip
- NUnit PerTest: 74 total, 73 passed, 1 intentional skip
- xUnit PerAssembly: 71 total, 70 passed, 1 intentional skip
- xUnit PerTest: 71 total, 70 passed, 1 intentional skip

## How was the solution implemented (if it's not obvious)?

`DispatchCore` catches exceptions from application disposal and stores them as the work item's result before completing its `TaskCompletionSource`. Cleanup callbacks use `finally` blocks to restore ambient state even when a dispatcher cleanup job throws.

The commits follow the repository's bug-fix convention: the first commit adds the failing behavioral test, and the second commit contains the fix.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes? No public API changes.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation. No documentation change is needed for this internal failure-path fix.

## Breaking changes

None. The failure path now completes with the original cleanup exception instead of hanging indefinitely.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21770
