### PR TITLE
fix: detach platform input when presentation source closes

### DIFF
--- a/src/Avalonia.Controls/PresentationSource/PresentationSource.cs
+++ b/src/Avalonia.Controls/PresentationSource/PresentationSource.cs
@@ -77,6 +77,12 @@ internal partial class PresentationSource : IPresentationSource, IInputRoot, IDi
 
     public void Dispose()
     {
+        if (PlatformImpl is { } platformImpl)
+        {
+            platformImpl.Input = null;
+            platformImpl.ScalingChanged -= HandleScalingChanged;
+        }
+
         _layoutDiagnosticBridge?.Dispose();
         _layoutDiagnosticBridge = null;
         LayoutManager.Dispose();
@@ -84,7 +90,6 @@ internal partial class PresentationSource : IPresentationSource, IInputRoot, IDi
         // We need to wait for the renderer to complete any in-flight operations
         Renderer.Dispose();
 
-        PlatformImpl?.ScalingChanged -= HandleScalingChanged;
         PlatformImpl = null;
         _pointerOverPreProcessor?.OnCompleted();
         _pointerOverPreProcessorSubscription?.Dispose();

--- a/tests/Avalonia.Controls.UnitTests/PresentationSourceTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/PresentationSourceTests.cs
@@ -20,6 +20,20 @@ namespace Avalonia.Controls.UnitTests;
 public sealed class PresentationSourceTests : ScopedTestBase
 {
     [Fact]
+    public void Closing_Should_Detach_Platform_Input_Handler()
+    {
+        using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+        var windowImpl = MockWindowingPlatform.CreateWindowMock();
+        var window = new Window(windowImpl.Object);
+
+        Assert.NotNull(windowImpl.Object.Input);
+
+        windowImpl.Object.Closed!();
+
+        Assert.Null(windowImpl.Object.Input);
+    }
+
+    [Fact]
     public void ChromeHitTest_Prefers_Overlay_Over_Content()
     {
         var overlay = new Border


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Detaches the platform input callback when a presentation source closes. This prevents late native input, including Win32 `WM_CAPTURECHANGED`, from reaching an already disposed popup or window.

## What is the current behavior?

The Win32 handling added by [#19685](https://github.com/AvaloniaUI/Avalonia/pull/19685) forwards `WM_CAPTURECHANGED` through `ITopLevelImpl.Input`. When a menu item closes a native popup while that popup owns mouse capture, Win32 can destroy the popup and then send the capture-loss message.

`PresentationSource.Dispose` clears its `PlatformImpl` reference but leaves `ITopLevelImpl.Input` assigned to `PresentationSource.HandleInput`. The late message therefore enters the disposed presentation source, logs `PlatformImpl is null, couldn't handle input`, and can route later input work toward a detached visual tree.

## What is the updated/expected behavior with this PR?

Closing a top level clears `ITopLevelImpl.Input` before layout and renderer teardown, so the native implementation cannot dispatch input after close handling starts.

Validation:

- Added `Closing_Should_Detach_Platform_Input_Handler`, which fails before the fix because the closed top level retains the callback.
- Ran the presentation source, context menu, menu item, and popup root tests: 66 passed.
- Ran the full `Avalonia.Controls.UnitTests` executable: 3,643 passed, 1 existing test skipped, 0 failed.

## How was the solution implemented (if it's not obvious)?

`PresentationSource` assigns and owns the platform input callback. Disposal now clears it alongside `ScalingChanged` before layout and renderer teardown.

The change does not alter pointer capture, popup close ordering, or public API. The regression test verifies the framework/platform ownership boundary using the mock top-level implementation. Native Win32 UI automation was not run because the development host is macOS.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes? No public API was added or changed.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation. No documentation change is needed for an internal lifecycle fix.

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #19892
