### PR TITLE
Fix app activation for macOS

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -21,6 +21,24 @@
 
 @class AutoFitContentView;
 
+
+// Activates the app, but defers until the run loop is running if it isn't yet.
+// Windows are shown (and the app activated) from OnFrameworkInitializationCompleted,
+// which runs before -[NSApplication run]. Activating that early yields a "degraded"
+// activation: the app looks frontmost but the WindowServer never does a real
+// become-active, which leaves the out-of-process file picker unable to receive
+// clicks in its file list/sidebar until a manual app switch. Deferring makes the first
+// activation a clean transition.
+static void ActivateApplication() {
+    if ([NSApp isRunning]) {
+        [NSApp activateIgnoringOtherApps:YES];
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [NSApp activateIgnoringOtherApps:YES];
+        });
+    }
+}
+
 WindowBaseImpl::~WindowBaseImpl() {
     View = nullptr;
     Window = nullptr;
@@ -99,7 +117,7 @@ HRESULT WindowBaseImpl::Show(bool activate, bool isDialog) {
             [Window orderFront:Window];
             [Window makeKeyAndOrderFront:Window];
             [Window makeFirstResponder:View];
-            [NSApp activateIgnoringOtherApps:YES];
+            ActivateApplication();
         } else {
             [Window orderFront:Window];
         }
@@ -177,7 +195,7 @@ HRESULT WindowBaseImpl::Activate() {
     @autoreleasepool {
         if (Window != nullptr) {
             [Window makeKeyAndOrderFront:nil];
-            [NSApp activateIgnoringOtherApps:YES];
+            ActivateApplication();
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?

On macOS, opening a file picker shortly after launch can leave it permanently
unresponsive: the dialog appears and Cancel, path navigation and right-click work,
but the file list and left sidebar don't respond to clicks for the rest of the
app's lifetime. The only user workaround is switching to another app and back.

## What is the current behavior?

Avalonia shows the main window and activates the app via `[NSApp activateIgnoringOtherApps:YES]`
from `Show`, which runs during `OnFrameworkInitializationCompleted` — **before** the
native run loop is entered (`-[NSApplication run]`). Activating the app before it has
finished launching produces a *degraded* activation: the app reports as active and is
frontmost in the menu bar, but the WindowServer never performs a real become-active
transition. As a result the out-of-process open/save panel view never starts routing
mouse-selection events to its file list and sidebar. A genuine app switch (resign →
become active) is the only thing that repairs it.

This is timing-dependent; anything that slows early startup makes the window easier to
hit — e.g. `WindowState="Maximized"` or running under a debugger.

## What is the updated/expected behavior?

The first app activation is deferred to the next run-loop turn when the app isn't
running yet, so it becomes a clean WindowServer transition and the picker is fully
interactive immediately. Activations once the app is running are unchanged.

## How was the solution implemented (if it's not obvious)?

Added a small `ActivateApplication()` helper in `WindowBaseImpl.mm` used by `Show`
and `Activate`:

```objc
if ([NSApp isRunning]) {
    [NSApp activateIgnoringOtherApps:YES];
} else {
    dispatch_async(dispatch_get_main_queue(), ^{
        [NSApp activateIgnoringOtherApps:YES];
    });
}
```


## Checklist

- [x] Added unit tests — N/A: native macOS launch-timing/activation race in libAvaloniaNative; not reproducible in the unit or Appium integration test suites.
- [x] Added XML documentation — N/A: change is Objective-C++ (`WindowBaseImpl.mm`), no public API affected.
- [x] avalonia-docs PR — N/A: internal fix, no user-facing documentation impact.

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes #21718
