### PR TITLE
fix(Input): clear focus on detached element when PresentationSource is torn down

### DIFF
--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -568,8 +568,19 @@ namespace Avalonia.Input
             if (IsFocused)
             {
                 var root = e.AttachmentPoint ?? e.RootVisual;
-                ((FocusManager?)e.PresentationSource.InputRoot.FocusManager)
-                    ?.ClearFocusOnElementRemoved(this, root);
+                // The PresentationSource (and its InputRoot) may already be torn
+                // down by the time a focused element is detached — for example
+                // when a popup that hosts a focused menu item closes. The
+                // previous direct chain (e.PresentationSource.InputRoot.FocusManager)
+                // was not null-safe on the intermediate accesses and would either
+                // throw a NullReferenceException or silently skip focus clearing,
+                // leaving keyboard focus on a detached element so that shortcuts
+                // stopped working until the user clicked elsewhere (see #21759).
+                // Use GetFocusManager, which falls back to the locator, mirroring
+                // the Focus() method below.
+                var focusManager = (FocusManager?)e.PresentationSource?.InputRoot?.FocusManager
+                    ?? FocusManager.GetFocusManager(this);
+                focusManager?.ClearFocusOnElementRemoved(this, root);
             }
 
             IsKeyboardFocusWithin = false;

--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -568,16 +568,6 @@ namespace Avalonia.Input
             if (IsFocused)
             {
                 var root = e.AttachmentPoint ?? e.RootVisual;
-                // The PresentationSource (and its InputRoot) may already be torn
-                // down by the time a focused element is detached — for example
-                // when a popup that hosts a focused menu item closes. The
-                // previous direct chain (e.PresentationSource.InputRoot.FocusManager)
-                // was not null-safe on the intermediate accesses and would either
-                // throw a NullReferenceException or silently skip focus clearing,
-                // leaving keyboard focus on a detached element so that shortcuts
-                // stopped working until the user clicked elsewhere (see #21759).
-                // Use GetFocusManager, which falls back to the locator, mirroring
-                // the Focus() method below.
                 var focusManager = (FocusManager?)e.PresentationSource?.InputRoot?.FocusManager
                     ?? FocusManager.GetFocusManager(this);
                 focusManager?.ClearFocusOnElementRemoved(this, root);


### PR DESCRIPTION
## Summary

Fixes #21759 — after clicking a menu item in a popup menu (e.g. "Delete"), the menu item is detached from the visual tree but **keyboard focus stays on it**, so shortcuts (Up arrow, Ctrl+Z, …) stop working until the user clicks another element.

## Root cause

In `src/Avalonia.Base/Input/InputElement.cs`, `OnDetachedFromVisualTreeCore` clears focus with:

```csharp
((FocusManager?)e.PresentationSource.InputRoot.FocusManager)
    ?.ClearFocusOnElementRemoved(this, root);
```

The `?.` only guards the final `ClearFocusOnElementRemoved` call. When a popup closes, `Popup.CloseCore()` → `popupHost.SetChild(null)` detaches the menu items, and at that point the popup host's `PresentationSource` (or its `InputRoot`) may already be torn down. The direct chain `e.PresentationSource.InputRoot.FocusManager` is **not null-safe on the intermediate accesses**, so it either throws a `NullReferenceException` or silently skips `ClearFocusOnElementRemoved` — leaving `KeyboardDevice.FocusedElement` pointing at the detached element, which then has no visual parent to bubble key events to the window.

## The fix

Use the existing `FocusManager.GetFocusManager(this)` helper, which already has a locator fallback (`AvaloniaLocator.Current.GetService<IFocusManager>()`) and is the pattern the `Focus()` method in this same file already uses. Null-guard the `PresentationSource` chain and fall back to `GetFocusManager`:

```csharp
var focusManager = (FocusManager?)e.PresentationSource?.InputRoot?.FocusManager
    ?? FocusManager.GetFocusManager(this);
focusManager?.ClearFocusOnElementRemoved(this, root);
```

Minimal, no public-API change, and mirrors an established in-file pattern.

## Notes
- I have not been able to run the full Avalonia build/test matrix locally; I'd welcome guidance on the preferred test for this (a headless focus/popup test) and am happy to add one.
- .NET Foundation CLA: please point me to the sign-in flow if one is required and I'll complete it before merge.

## AI usage

An AI assistant was used to help locate the relevant code and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.

Fixes #21759