### PR TITLE
Vulkan Popup Transparency Issue.

### DIFF
--- a/src/Avalonia.Vulkan/Interop/VulkanDisplay.cs
+++ b/src/Avalonia.Vulkan/Interop/VulkanDisplay.cs
@@ -119,7 +119,10 @@ internal class VulkanDisplay : IDisposable
             preTransform = supportsIdentityTransform && isRotated
                 ? VkSurfaceTransformFlagsKHR.VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR
                 : capabilities.currentTransform,
-            compositeAlpha = VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+            compositeAlpha = capabilities.supportedCompositeAlpha.HasAllFlags(
+                VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR)
+                ? VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR
+                : VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
             presentMode = presentMode,
             clipped = 1,
             oldSwapchain = oldDisplay?._swapchain ?? default


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Makes the Vulkan backend request a **supported** swapchain composite-alpha mode instead of
unconditionally hardcoding `VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR`, so transparent windows and popups
(e.g. `ComboBox` / light-dismiss popups and their drop shadows) render with per-pixel alpha under
the Vulkan rendering mode.

`VulkanDisplay.CreateSwapchain` now prefers `VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR` when the
surface advertises it in `VkSurfaceCapabilitiesKHR.supportedCompositeAlpha`, and falls back to
`VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR` otherwise.

Maybe related: #19378

## What is the current behavior?

With `RenderingMode = [Vulkan]`, a `TopLevel` with `TransparencyLevelHint="Transparent"` and a
transparent background renders **opaque** — most visibly, `ComboBox` popups show a hard black box
where the drop shadow / rounded-corner margin should be transparent. `ActualTransparencyLevel` also
reports `Transparent` while nothing is actually transparent (#19378).

Root cause: `VulkanDisplay.CreateSwapchain` always passed `VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR`. Per
the Vulkan spec, `OPAQUE` means *"the alpha channel, if it exists, is ignored… the image is treated
as if it has a constant alpha of 1.0."* So the presented surface is opaque by definition, regardless
of the alpha Skia produced.

## How this was observed

I noticed this after an NVIDIA driver update on Windows (Vulkan rendering mode): `ComboBox` popups
that had previously looked transparent started showing an opaque black box around the popup margin.
The change correlated with a driver-branch update on this machine (`591.86` → `610.74` /
`32.0.16.1074`, R610 branch), though I have not isolated the driver as the definitive cause.

On the current driver, `vulkaninfo` reports the Win32 surface supports both composite-alpha modes:

```
supportedCompositeAlpha: count = 2
    COMPOSITE_ALPHA_OPAQUE_BIT_KHR
    COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR
```

With the hardcoded `OPAQUE` mode the window is opaque (as the spec defines); switching to the
`PRE_MULTIPLIED` mode the surface advertises restores transparent windows and popups. Regardless of
what changed in my environment, requesting a supported non-opaque mode is the spec-correct behavior
for transparent windows — which is why this fix queries `supportedCompositeAlpha` rather than
assuming a fixed mode, and falls back to `OPAQUE` where premultiplied isn't offered.

<img width="333" height="261" alt="image" src="https://github.com/user-attachments/assets/cd7c2591-2ea4-46ec-90ac-0674802c2613" />
<img width="288" height="261" alt="image" src="https://github.com/user-attachments/assets/c236cb91-b0d7-4472-a48f-c6092d1ed880" />


## What is the updated/expected behavior with this PR?

The swapchain is created with a composite-alpha mode the surface actually supports, so the OS
compositor blends the window's alpha channel and transparent windows/popups render correctly. Where
`PRE_MULTIPLIED` is not offered by the surface, the code falls back to `OPAQUE` exactly as before —
so there is no change on platforms/drivers that only expose opaque.

To test:
1. Run a desktop app with `RenderingMode = [Win32RenderingMode.Vulkan]` (or `[X11RenderingMode.Vulkan]`).
2. Use a window with `TransparencyLevelHint="Transparent"` / transparent background and open a
   `ComboBox` dropdown.
3. Before: opaque window / black box around the popup shadow. After: transparent window and a
   correctly alpha-blended popup shadow.

## How was the solution implemented (if it's not obvious)?

In `VulkanDisplay.CreateSwapchain`, the already-queried `VkSurfaceCapabilitiesKHR` is inspected and
the composite-alpha value is chosen:

```csharp
compositeAlpha = capabilities.supportedCompositeAlpha.HasAllFlags(
        VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR)
    ? VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR
    : VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
```

`PRE_MULTIPLIED` is chosen (rather than `POST_MULTIPLIED`) because Avalonia's Skia surfaces are
rendered with premultiplied alpha, which matches that mode's contract. The choice is guarded by
`supportedCompositeAlpha`, so it is a no-op wherever premultiplied alpha isn't available.

Note on scope: this prefers premultiplied whenever the surface supports it. An opaque top-level
clears its surface to alpha = 1.0, for which premultiplied compositing is visually identical to
opaque, so no regression is expected for opaque windows. If the core team would prefer to be more
conservative, an alternative is to thread the window's requested `TransparencyLevel` down to
swapchain creation and only request premultiplied when transparency is actually desired — happy to
adjust in that direction.

A unit/render test isn't really feasible here: composite-alpha selection depends on a live Vulkan
surface and OS-compositor behavior, which the existing test harnesses don't exercise. The change is
a single guarded branch with an opaque fallback.

## Checklist

- [ ] Added unit tests (if possible)? — not feasible; requires a live Vulkan surface + OS compositor (see above)
- [ ] Added XML documentation to any related classes? — no public API surface changed
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation — n/a

## Breaking changes

None expected. Behavioral note: on drivers/surfaces that support `PRE_MULTIPLIED`, windows now
composite their alpha channel instead of being forced opaque. This is the intended fix and matches
the Vulkan spec; opaque content (alpha = 1.0) is unaffected, and surfaces that only expose `OPAQUE`
keep the previous behavior.

## Obsoletions / Deprecations

None.

## Related issues

#19378