### PR TITLE
Respect disabled Avalonia name generator

### DIFF
--- a/src/tools/Avalonia.Generators/NameGenerator/AvaloniaNameIncrementalGenerator.cs
+++ b/src/tools/Avalonia.Generators/NameGenerator/AvaloniaNameIncrementalGenerator.cs
@@ -34,6 +34,11 @@ public class AvaloniaNameIncrementalGenerator : IIncrementalGenerator
                 var (options, optionsProvider) = pair.Right;
                 var filePath = text.Path;
 
+                if (!options.AvaloniaNameGeneratorIsEnabled)
+                {
+                    return false;
+                }
+
                 if (!(filePath.EndsWith(".xaml", StringComparison.OrdinalIgnoreCase) ||
                       filePath.EndsWith(".paml", StringComparison.OrdinalIgnoreCase) ||
                       filePath.EndsWith(".axaml", StringComparison.OrdinalIgnoreCase)))


### PR DESCRIPTION
## What does this PR do?

Fixes `AvaloniaNameGeneratorIsEnabled=false` for the Avalonia XAML name generator.

The property is still defined in `Avalonia.Generators.props` and passed to the source generator through `CompilerVisibleProperty`, and it is still read by `GeneratorOptions`. However, after the migration to the incremental source generator pipeline, the value was no longer checked, so setting:

```xml
<AvaloniaNameGeneratorIsEnabled>false</AvaloniaNameGeneratorIsEnabled>
```
did not actually disable the name generator.

This PR restores the missing check and filters out XAML inputs before parsing/generation when the generator is disabled.

Regression
This was introduced in:

fca45c1c1638fc9801bd39da957a4da95b54d27a

Migrate AvaloniaNameSourceGenerator to IIncrementalGenerator (#19216)

Author: @maxkatz6 
Author date: 2025-08-13T13:22:14-07:00

Before that commit, the old AvaloniaNameSourceGenerator had an explicit gate:

```
var options = new GeneratorOptions(context);
if (!options.AvaloniaNameGeneratorIsEnabled)
{
    return null;
}
```

During the migration to AvaloniaNameIncrementalGenerator, the option continued to be read by GeneratorOptions, but the actual enabled check was not ported to the new incremental pipeline.

Fix
The XAML input filter now returns false immediately when AvaloniaNameGeneratorIsEnabled is disabled:

```
if (!options.AvaloniaNameGeneratorIsEnabled)
{
    return false;
}
```

This prevents the name generator from parsing XAML files and from producing generated .g.cs files when disabled, matching the previous behavior.