### PR TITLE
Fix line break enumerator infinite loop

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/LineBreakEnumerator.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/LineBreakEnumerator.cs
@@ -24,6 +24,11 @@ namespace Avalonia.Media.TextFormatting.Unicode
         {
             lineBreak = default;
 
+            if (_text.IsEmpty)
+            {
+                return false;
+            }
+
             if (_state.Current.EndOfText)
             {
                 return false;

--- a/tests/Avalonia.Base.UnitTests/Media/TextFormatting/LineBreakEnumeratorTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/TextFormatting/LineBreakEnumeratorTests.cs
@@ -20,6 +20,14 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
         }
 
         [Fact]
+        public void ShouldHandleEmptyString()
+        {
+            var lineBreaker = new LineBreakEnumerator(string.Empty);
+
+            Assert.False(lineBreaker.MoveNext(out _));
+        }
+
+        [Fact]
         public void BasicLatinTest()
         {
             var lineBreaker = new LineBreakEnumerator("Hello World\r\nThis is a test.");


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
LineBreakEnumerator now goes to infinite loop when breaking an empty string. This PR resolves this issue. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Infinite loop

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Immediately returns false when moving next.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Obvious

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
No, I don't think anyone is utilizing this feature or bug. 

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
