### PR TITLE
Support {Binding ^} pattern for IObservable DataContext

### DIFF
--- a/src/Avalonia.Base/Data/Core/Parsers/BindingExpressionGrammar.cs
+++ b/src/Avalonia.Base/Data/Core/Parsers/BindingExpressionGrammar.cs
@@ -138,7 +138,13 @@ namespace Avalonia.Data.Core.Parsers
             else if (ParseDot(ref r))
             {
                 nodes.Add(new EmptyExpressionNode());
-                return State.End;
+                return State.AfterMember;
+            }
+            else if (ParseStreamOperator(ref r))
+            {
+                nodes.Add(new EmptyExpressionNode());
+                nodes.Add(new StreamNode());
+                return State.AfterMember;
             }
             else
             {

--- a/tests/Avalonia.Base.UnitTests/Data/Core/Parsers/BindingExpressionGrammarTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/Parsers/BindingExpressionGrammarTests.cs
@@ -224,6 +224,26 @@ namespace Avalonia.Base.UnitTests.Data.Core.Parsers
             Assert.IsType<BindingExpressionGrammar.StreamNode>(result[1]);
         }
 
+        [Fact]
+        public void Should_Parse_Stream_Node_On_Empty_Expression()
+        {
+            var result = Parse("^");
+
+            Assert.Equal(2, result.Count);
+            Assert.IsType<BindingExpressionGrammar.EmptyExpressionNode>(result[0]);
+            Assert.IsType<BindingExpressionGrammar.StreamNode>(result[1]);
+        }
+
+        [Fact]
+        public void Should_Parse_Stream_Node_After_Dot()
+        {
+            var result = Parse(".^");
+
+            Assert.Equal(2, result.Count);
+            Assert.IsType<BindingExpressionGrammar.EmptyExpressionNode>(result[0]);
+            Assert.IsType<BindingExpressionGrammar.StreamNode>(result[1]);
+        }
+
         private static void AssertIsProperty(
             BindingExpressionGrammar.INode node,
             string name,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Previously {Binding ^} was not parsed because ParseStart did not recognize the ^ stream operator. Also, {Binding .^} failed because ParseDot returned State.End immediately, preventing subsequent operators.

Changes:
- ParseStart: recognize ^, emit EmptyExpressionNode + StreamNode
- ParseDot: return State.AfterMember instead of State.End, so .^ works
- Add grammar tests for ^ and .^ patterns

I have verified and it works in BindingDemo project. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Expression not supported

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
