### PR TITLE
Properly wire CompositionInterop.IsLost

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/CompositionInterop.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionInterop.cs
@@ -56,7 +56,7 @@ internal class CompositionInterop : ICompositionGpuInterop
         throw new System.NotSupportedException();
     }
 
-    public bool IsLost { get; }
+    public bool IsLost => _context.IsLost;
     public byte[]? DeviceLuid { get; set; }
     public byte[]? DeviceUuid { get; set; }
 }


### PR DESCRIPTION
It wasn't pointing to anything for years somehow.