### PR TITLE
macOS: Fall back to the current event in BeginMoveDrag when no mouse-down was recorded

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -330,6 +330,21 @@ HRESULT WindowBaseImpl::BeginMoveDrag() {
         auto lastEvent = [View lastMouseDownEvent];
 
         if (lastEvent == nullptr) {
+            // A press that begins inside an embedded native view (for example a webview hosted
+            // through NativeControlHost) is consumed by that view and never delivered to the
+            // Avalonia view, so no mouse-down is recorded; fall back to the event the
+            // application is tracking right now, provided it is a left-button press or drag
+            // that belongs to this window.
+            auto currentEvent = [NSApp currentEvent];
+
+            if (currentEvent != nullptr && [currentEvent window] == Window &&
+                ([currentEvent type] == NSEventTypeLeftMouseDown ||
+                 [currentEvent type] == NSEventTypeLeftMouseDragged)) {
+                lastEvent = currentEvent;
+            }
+        }
+
+        if (lastEvent == nullptr) {
             return S_OK;
         }
 


### PR DESCRIPTION
## What does the pull request do?

Makes `Window.BeginMoveDrag` work on macOS when the initiating press occurs inside an embedded native
view (for example a webview embedded through `NativeControlHost`, such as
`Avalonia.Controls.WebView`'s `NativeWebView`). Applications that merge the title bar with in-webview
content (`ExtendClientAreaToDecorationsHint`) and relay title-bar presses to the host over a message
bridge can then start the native window drag through the managed API instead of reproducing
`performWindowDragWithEvent:` through platform interop.

Related: #8429

## What is the current behavior?

`WindowBaseImpl::BeginMoveDrag` drags from `[View lastMouseDownEvent]` — the last mouse-down the
Avalonia view recorded. A press that begins inside an embedded native view is consumed by that view
and never delivered to the Avalonia view, so `lastMouseDownEvent` is nil and `BeginMoveDrag` silently
returns without doing anything. There is no managed way to start the window drag in this scenario.

## What is the updated/expected behavior with this PR?

When no mouse-down was recorded, `BeginMoveDrag` falls back to the event the application is currently
tracking (`[NSApp currentEvent]`), guarded to left-button press or drag events that belong to this
window. Presses recorded by the Avalonia view behave exactly as before — the fallback only engages in
the case that previously no-opped.

To test: create a window with `ExtendClientAreaToDecorationsHint = true` hosting a native view that
consumes pointer input (a `NativeWebView` with a page is the practical case); relay a `mousedown` on
the page's title-bar region to the host (for example through `invokeCSharpAction`) and call
`BeginMoveDrag` while the press is held. Before this change nothing happens; after it, the native
window drag begins with the platform behavior intact (drag threshold, space snapping, screen-edge
behavior). Validated on macOS by an application using the equivalent
`performWindowDragWithEvent:[NSApp currentEvent]` call through interop, which this change makes
unnecessary.

## How was the solution implemented (if it's not obvious)?

The fallback mirrors what the existing path does with the recorded event, with three guards: the
current event must exist, must belong to this window, and must be a left-button press
(`NSEventTypeLeftMouseDown`) or drag (`NSEventTypeLeftMouseDragged`) — so an unrelated event being
processed at call time can never start a drag.

## Checklist

- [ ] Added unit tests (if possible)? — native window interaction; not exercisable from the unit
      harness. Manually validated as described above.
- [x] Added XML documentation to any related classes? — no managed API surface changed.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation — no
      documented behavior changed; `BeginMoveDrag` now works where it previously silently failed.

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

None closed directly; related to #8429.
