### PR TITLE
Add :empty pseudoclass for ContentControl

### DIFF
--- a/src/Avalonia.Controls/ContentControl.cs
+++ b/src/Avalonia.Controls/ContentControl.cs
@@ -8,8 +8,6 @@ using Avalonia.Data;
 using Avalonia.Layout;
 using Avalonia.LogicalTree;
 using Avalonia.Metadata;
-using Avalonia.Platform;
-using Avalonia.Styling;
 
 namespace Avalonia.Controls
 {
@@ -17,8 +15,11 @@ namespace Avalonia.Controls
     /// Displays <see cref="Content"/> according to an <see cref="IDataTemplate"/>.
     /// </summary>
     [TemplatePart("PART_ContentPresenter", typeof(ContentPresenter))]
+    [PseudoClasses(pcEmpty)]
     public class ContentControl : TemplatedControl, IContentControl, IContentPresenterHost
     {
+        private const string pcEmpty = ":empty";
+
         /// <summary>
         /// Defines the <see cref="Content"/> property.
         /// </summary>
@@ -59,6 +60,11 @@ namespace Avalonia.Controls
                 [~VerticalContentAlignmentProperty] = new TemplateBinding(VerticalContentAlignmentProperty),
                 [~HorizontalContentAlignmentProperty] = new TemplateBinding(HorizontalContentAlignmentProperty)
             }.RegisterInNameScope(ns)));
+        }
+
+        public ContentControl()
+        {
+            UpdatePseudoClasses();
         }
 
         /// <summary>
@@ -116,7 +122,7 @@ namespace Avalonia.Controls
         {
             return RegisterContentPresenter(presenter);
         }
-        
+
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
             base.OnPropertyChanged(change);
@@ -153,6 +159,13 @@ namespace Avalonia.Controls
             {
                 LogicalChildren.Add(newChild);
             }
+
+            UpdatePseudoClasses();
+        }
+
+        private void UpdatePseudoClasses()
+        {
+            PseudoClasses.Set(pcEmpty, Content is null);
         }
 
         internal override void BuildDebugDisplay(StringBuilder builder, bool includeContent)

--- a/tests/Avalonia.Controls.UnitTests/ContentControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContentControlTests.cs
@@ -18,6 +18,20 @@ namespace Avalonia.Controls.UnitTests
     public class ContentControlTests : ScopedTestBase
     {
         [Fact]
+        public void Empty_PseudoClass_Should_Track_Content()
+        {
+            var target = new ContentControl();
+
+            Assert.Contains(":empty", target.Classes);
+
+            target.Content = "Content";
+            Assert.DoesNotContain(":empty", target.Classes);
+
+            target.Content = null;
+            Assert.Contains(":empty", target.Classes);
+        }
+
+        [Fact]
         public void Template_Should_Be_Instantiated()
         {
             var target = new ContentControl();

--- a/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
@@ -215,7 +215,7 @@ namespace Avalonia.Controls.UnitTests
                 window.ApplyTemplate();
                 window.Presenter!.ApplyTemplate();
 
-                Assert.Empty(toolTip.Classes);
+                Assert.DoesNotContain(":open", toolTip.Classes);
             }
         }
 
@@ -240,7 +240,7 @@ namespace Avalonia.Controls.UnitTests
 
                 ToolTip.SetIsOpen(decorator, true);
 
-                Assert.Equal(new[] { ":open" }, toolTip.Classes);
+                Assert.Contains(":open", toolTip.Classes);
                 VerifyToolTipType(decorator);
             }
         }
@@ -271,7 +271,7 @@ namespace Avalonia.Controls.UnitTests
                 AssertToolTipOpen(decorator);
                 ToolTip.SetIsOpen(decorator, false);
 
-                Assert.Empty(toolTip.Classes);
+                Assert.DoesNotContain(":open", toolTip.Classes);
             }
         }
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
@@ -113,7 +113,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             Assert.Equal("Foo", ToolTip.GetTip(target));
         }
-        
+
         [Fact]
         public void NonExistent_Property_Throws()
         {
@@ -279,7 +279,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
             Assert.Equal(expected3, grid.RowDefinitions[2].Height);
             Assert.Equal(expected4, grid.RowDefinitions[3].Height);
         }
-        
+
         [Fact]
         public void Grid_Row_Col_Definitions_Are_Parsed_Space_Delimiter()
         {
@@ -905,7 +905,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
             var xaml = "<Button xmlns='https://github.com/avaloniaui' Classes='foo bar'/>";
             var target = (Button)AvaloniaRuntimeXamlLoader.Load(xaml);
 
-            Assert.Equal(new[] { "foo", "bar" }, target.Classes);
+            Assert.Contains("foo", target.Classes);
+            Assert.Contains("bar", target.Classes);
         }
 
         [Fact]
@@ -921,7 +922,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 </Button>";
             var target = (Button)AvaloniaRuntimeXamlLoader.Load(xaml);
 
-            Assert.Equal(new[] { "foo", "bar" }, target.Classes);
+            Assert.Contains("foo", target.Classes);
+            Assert.Contains("bar", target.Classes);
         }
 
         [Fact]
@@ -970,16 +972,16 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
             Child = child;
         }
     }
-    
+
     public class ObjectWithoutPublicCtor
     {
         public ObjectWithoutPublicCtor(string param)
         {
             Test1 = param;
         }
-        
+
         public string? Test1 { get; set; }
-        
+
         public string? Test2 { get; set; }
     }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds the `:empty` pseudo-class to `ContentControl`.

This allows styles and control themes to target a `ContentControl` directly based on whether its `Content` is `null`.


## What is the current behavior?
`ContentPresenter` exposes the `:empty` pseudo-class, but `ContentControl` itself does not.

As a result, selectors such as `ContentControl:empty` cannot be used to style the control based on whether it has content.


## What is the updated/expected behavior with this PR?
Adds an `:empty` pseudo-class to `ContentControl`, implemented in the same way as `ContentPresenter`.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
