### PR TITLE
Add ToolTip.ShouldUseOverlayLayer attached property

### DIFF
--- a/src/Avalonia.Controls/ToolTip.cs
+++ b/src/Avalonia.Controls/ToolTip.cs
@@ -305,11 +305,24 @@ namespace Avalonia.Controls
         public static void SetServiceEnabled(Control element, bool value) => 
             element.SetValue(ServiceEnabledProperty, value);
 
-        /// <inheritdoc cref="Popup.ShouldUseOverlayLayer"/>
+        /// <summary>
+        /// Gets whether the tooltip popup for <paramref name="element"/> is shown in the overlay layer.
+        /// </summary>
+        /// <param name="element">The control to get the property from.</param>
+        /// <remarks>
+        /// See <see cref="Popup.ShouldUseOverlayLayer"/> for details.
+        /// </remarks>
         public static bool GetShouldUseOverlayLayer(Control element) =>
             element.GetValue(ShouldUseOverlayLayerProperty);
 
-        /// <inheritdoc cref="Popup.ShouldUseOverlayLayer"/>
+        /// <summary>
+        /// Sets whether the tooltip popup for <paramref name="element"/> is shown in the overlay layer.
+        /// </summary>
+        /// <param name="element">The control to set the property on.</param>
+        /// <param name="value">Whether to show the tooltip popup in the overlay layer.</param>
+        /// <remarks>
+        /// See <see cref="Popup.ShouldUseOverlayLayer"/> for details.
+        /// </remarks>
         public static void SetShouldUseOverlayLayer(Control element, bool value) =>
             element.SetValue(ShouldUseOverlayLayerProperty, value);
 

--- a/src/Avalonia.Controls/ToolTip.cs
+++ b/src/Avalonia.Controls/ToolTip.cs
@@ -81,6 +81,10 @@ namespace Avalonia.Controls
         public static readonly AttachedProperty<bool> ServiceEnabledProperty =
             AvaloniaProperty.RegisterAttached<ToolTip, Control, bool>("ServiceEnabled", defaultValue: true, inherits: true);
 
+        /// <inheritdoc cref="Popup.ShouldUseOverlayLayer"/>
+        public static readonly AttachedProperty<bool> ShouldUseOverlayLayerProperty =
+            AvaloniaProperty.RegisterAttached<ToolTip, Control, bool>("ShouldUseOverlayLayer");
+
         /// <summary>
         /// Stores the current <see cref="ToolTip"/> instance in the control.
         /// </summary>
@@ -301,6 +305,14 @@ namespace Avalonia.Controls
         public static void SetServiceEnabled(Control element, bool value) => 
             element.SetValue(ServiceEnabledProperty, value);
 
+        /// <inheritdoc cref="Popup.ShouldUseOverlayLayer"/>
+        public static bool GetShouldUseOverlayLayer(Control element) =>
+            element.GetValue(ShouldUseOverlayLayerProperty);
+
+        /// <inheritdoc cref="Popup.ShouldUseOverlayLayer"/>
+        public static void SetShouldUseOverlayLayer(Control element, bool value) =>
+            element.SetValue(ShouldUseOverlayLayerProperty, value);
+
         /// <summary>
         /// Adds a handler for the <see cref="ToolTipOpeningEvent"/> attached event.
         /// </summary>
@@ -421,7 +433,8 @@ namespace Avalonia.Controls
                 _popup.Bind(Popup.HorizontalOffsetProperty, control.GetBindingObservable(HorizontalOffsetProperty)),
                 _popup.Bind(Popup.VerticalOffsetProperty, control.GetBindingObservable(VerticalOffsetProperty)),
                 _popup.Bind(Popup.PlacementProperty, control.GetBindingObservable(PlacementProperty)),
-                _popup.Bind(Popup.CustomPopupPlacementCallbackProperty, control.GetBindingObservable(CustomPopupPlacementCallbackProperty))
+                _popup.Bind(Popup.CustomPopupPlacementCallbackProperty, control.GetBindingObservable(CustomPopupPlacementCallbackProperty)),
+                _popup.Bind(Popup.ShouldUseOverlayLayerProperty, control.GetBindingObservable(ShouldUseOverlayLayerProperty))
             });
 
             _popup.PlacementTarget = control;


### PR DESCRIPTION
Add ShouldUseOverlayLayer attached property to ToolTip, which is bound to Popup.ShouldUseOverlayLayer when the tooltip popup is created. This allows per-control control over whether the tooltip popup uses the overlay layer.

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Close https://github.com/AvaloniaUI/Avalonia/issues/21258

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
