### PR TITLE
fix(text): preserve lines at rounded fractional heights

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
@@ -603,7 +603,7 @@ namespace Avalonia.Media.TextFormatting
 
                     //Fulfill max height constraint
                     if (textLines.Count > 0 && !double.IsPositiveInfinity(MaxHeight)
-                        && Height + textLine.Height > MaxHeight)
+                        && MathUtilities.GreaterThan(Height + textLine.Height, MaxHeight))
                     {
                         if (previousLine?.TextLineBreak != null && _textTrimming != TextTrimming.None)
                         {

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -537,6 +537,32 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void TextBlock_With_Fractional_LineHeight_Should_Not_Cull_Last_Line_At_Fractional_Scaling()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var target = new TextBlock
+            {
+                Text = "first second third",
+                FontSize = 16,
+                LineHeight = 20.8,
+                TextWrapping = TextWrapping.Wrap,
+                Width = 50,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Top,
+            };
+            var root = new TestRoot(target)
+            {
+                LayoutScaling = 1.25,
+            };
+
+            root.Measure(Size.Infinity);
+            root.Arrange(new Rect(root.DesiredSize));
+
+            Assert.Equal(3, target.TextLayout.TextLines.Count);
+        }
+
+        [Fact]
         public void TextBlock_With_UseLayoutRounding_False_Should_Not_Round_Padding_In_MeasureOverride()
         {
             using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);


### PR DESCRIPTION
## What does the pull request do?

Fixes #21786 by preventing a wrapped `TextBlock` from omitting its final line when a fractional `LineHeight` lands exactly on a display-scale rounded height.

## What is the current behavior?

At 125% scaling, three 20.8-unit lines round to 62.4 logical units. Floating-point accumulation can evaluate the total as marginally above 62.4, so `TextLayout` treats the last line as exceeding `MaxHeight` and omits it.

## What is the updated/expected behavior with this PR?

All three wrapped lines remain visible when the rounded layout height exactly fits them. Real max-height overflow continues to clip or trim text.

Validation:

- Added a regression test for a 125%-scaled, wrapped `TextBlock` with `LineHeight=20.8`. The test fails before the fix with 2 lines instead of 3.
- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -- --filter-class "Avalonia.Controls.UnitTests.TextBlockTests"`
  - Passed: 31 tests
- `dotnet run --project tests/Avalonia.Skia.UnitTests/Avalonia.Skia.UnitTests.csproj -- --filter-class "Avalonia.Skia.UnitTests.Media.TextFormatting.TextLayoutTests"`
  - Passed: 69 tests; skipped: 2 platform/profiling-only tests

## How was the solution implemented (if it is not obvious)?

The max-height comparison now uses the established tolerant `MathUtilities.GreaterThan` check instead of exact `>`. This is already used for text-width overflow and avoids treating ordinary floating-point precision error as an extra line.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes? Not applicable: no public API changed.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation. Not applicable: this corrects existing behavior.

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21786