### PR TITLE
fix(VirtualizingStackPanel): hide cached focused items

### DIFF
--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Utils;
+using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
@@ -78,8 +79,8 @@ namespace Avalonia.Controls
         private Dictionary<object, Stack<Control>>? _recyclePool;
         private Control? _focusedElement;
         private int _focusedIndex = -1;
-        private double _focusedElementOpacity = 1;
-        private bool _focusedElementIsHitTestVisible = true;
+        private IDisposable? _focusedElementOpacityOverride;
+        private IDisposable? _focusedElementHitTestOverride;
         private Control? _realizingElement;
         private int _realizingIndex = -1;
         private double _bufferFactor; 
@@ -1004,7 +1005,7 @@ namespace Avalonia.Controls
             Debug.Assert(_focusedElement is not null);
 
             var result = _focusedElement;
-            RestoreFocusedElementOpacity();
+            ClearFocusedElementSuppression();
             _focusedIndex = -1;
             _focusedElement = null;
             return result;
@@ -1107,12 +1108,16 @@ namespace Avalonia.Controls
                 // Keep the container attached so it can retain keyboard focus, but prevent an
                 // estimated off-viewport position from rendering or receiving input in the
                 // visible viewport.
-                _focusedElementOpacity = element.Opacity;
-                _focusedElementIsHitTestVisible = element.IsHitTestVisible;
-                element.SetCurrentValue(Visual.OpacityProperty, 0);
-                element.SetCurrentValue(InputElement.IsHitTestVisibleProperty, false);
                 _focusedElement = element;
                 _focusedIndex = index;
+                _focusedElementOpacityOverride = element.SetValue(
+                    Visual.OpacityProperty,
+                    0,
+                    BindingPriority.Animation);
+                _focusedElementHitTestOverride = element.SetValue(
+                    InputElement.IsHitTestVisibleProperty,
+                    false,
+                    BindingPriority.Animation);
             }
             else
             {
@@ -1153,25 +1158,19 @@ namespace Avalonia.Controls
         {
             if (_focusedElement != null)
             {
-                RestoreFocusedElementOpacity();
+                ClearFocusedElementSuppression();
                 RecycleElementOnItemRemoved(_focusedElement);
             }
             _focusedElement = null;
             _focusedIndex = -1;
         }
 
-        private void RestoreFocusedElementOpacity()
+        private void ClearFocusedElementSuppression()
         {
-            if (_focusedElement is not null)
-            {
-                _focusedElement.SetCurrentValue(Visual.OpacityProperty, _focusedElementOpacity);
-                _focusedElement.SetCurrentValue(
-                    InputElement.IsHitTestVisibleProperty,
-                    _focusedElementIsHitTestVisible);
-            }
-
-            _focusedElementOpacity = 1;
-            _focusedElementIsHitTestVisible = true;
+            _focusedElementOpacityOverride?.Dispose();
+            _focusedElementOpacityOverride = null;
+            _focusedElementHitTestOverride?.Dispose();
+            _focusedElementHitTestOverride = null;
         }
         
         private void RecycleScrollToElement()
@@ -1374,7 +1373,7 @@ namespace Avalonia.Controls
                 e.GetOldValue<IInputElement?>() == _focusedElement)
             {
                 // TabOnceActiveElement has moved away from _focusedElement so we can recycle it.
-                RestoreFocusedElementOpacity();
+                ClearFocusedElementSuppression();
                 RecycleElement(_focusedElement, _focusedIndex);
                 _focusedElement = null;
                 _focusedIndex = -1;

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -78,6 +78,8 @@ namespace Avalonia.Controls
         private Dictionary<object, Stack<Control>>? _recyclePool;
         private Control? _focusedElement;
         private int _focusedIndex = -1;
+        private double _focusedElementOpacity = 1;
+        private bool _focusedElementIsHitTestVisible = true;
         private Control? _realizingElement;
         private int _realizingIndex = -1;
         private double _bufferFactor; 
@@ -971,7 +973,7 @@ namespace Avalonia.Controls
             Debug.Assert(ItemContainerGenerator is not null);
 
             if ((GetRealizedElement(index) ??
-                 GetRealizedElement(index, ref _focusedIndex, ref _focusedElement) ??
+                 GetFocusedElement(index) ??
                  GetRealizedElement(index, ref _scrollToIndex, ref _scrollToElement)) is { } realized)
                 return realized;
 
@@ -992,6 +994,20 @@ namespace Avalonia.Controls
         private Control? GetRealizedElement(int index)
         {
             return _realizedElements?.GetElement(index);
+        }
+
+        private Control? GetFocusedElement(int index)
+        {
+            if (_focusedIndex != index)
+                return null;
+
+            Debug.Assert(_focusedElement is not null);
+
+            var result = _focusedElement;
+            RestoreFocusedElementOpacity();
+            _focusedIndex = -1;
+            _focusedElement = null;
+            return result;
         }
         
         private static Control? GetRealizedElement(
@@ -1088,6 +1104,13 @@ namespace Avalonia.Controls
             }
             else if (KeyboardNavigation.GetTabOnceActiveElement(ItemsControl) == element)
             {
+                // Keep the container attached so it can retain keyboard focus, but prevent an
+                // estimated off-viewport position from rendering or receiving input in the
+                // visible viewport.
+                _focusedElementOpacity = element.Opacity;
+                _focusedElementIsHitTestVisible = element.IsHitTestVisible;
+                element.SetCurrentValue(Visual.OpacityProperty, 0);
+                element.SetCurrentValue(InputElement.IsHitTestVisibleProperty, false);
                 _focusedElement = element;
                 _focusedIndex = index;
             }
@@ -1130,10 +1153,25 @@ namespace Avalonia.Controls
         {
             if (_focusedElement != null)
             {
+                RestoreFocusedElementOpacity();
                 RecycleElementOnItemRemoved(_focusedElement);
             }
             _focusedElement = null;
             _focusedIndex = -1;
+        }
+
+        private void RestoreFocusedElementOpacity()
+        {
+            if (_focusedElement is not null)
+            {
+                _focusedElement.SetCurrentValue(Visual.OpacityProperty, _focusedElementOpacity);
+                _focusedElement.SetCurrentValue(
+                    InputElement.IsHitTestVisibleProperty,
+                    _focusedElementIsHitTestVisible);
+            }
+
+            _focusedElementOpacity = 1;
+            _focusedElementIsHitTestVisible = true;
         }
         
         private void RecycleScrollToElement()
@@ -1336,6 +1374,7 @@ namespace Avalonia.Controls
                 e.GetOldValue<IInputElement?>() == _focusedElement)
             {
                 // TabOnceActiveElement has moved away from _focusedElement so we can recycle it.
+                RestoreFocusedElementOpacity();
                 RecycleElement(_focusedElement, _focusedIndex);
                 _focusedElement = null;
                 _focusedIndex = -1;

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Linq;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Utils;
-using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
@@ -79,8 +78,6 @@ namespace Avalonia.Controls
         private Dictionary<object, Stack<Control>>? _recyclePool;
         private Control? _focusedElement;
         private int _focusedIndex = -1;
-        private IDisposable? _focusedElementOpacityOverride;
-        private IDisposable? _focusedElementHitTestOverride;
         private Control? _realizingElement;
         private int _realizingIndex = -1;
         private double _bufferFactor; 
@@ -289,10 +286,28 @@ namespace Avalonia.Controls
                 // Ensure that the focused element is in the correct position.
                 if (_focusedElement is not null && _focusedIndex >= 0)
                 {
+                    var realizedEndU = u;
+                    var sizeU = orientation == Orientation.Horizontal ?
+                        _focusedElement.DesiredSize.Width :
+                        _focusedElement.DesiredSize.Height;
+
                     u = GetOrEstimateElementU(_focusedIndex);
+
+                    // The focused element's position is estimated as it's outside the realized
+                    // range. A bad estimate must not place it over the realized elements in the
+                    // viewport: an element before the realized range always ends at or before its
+                    // start, and one after it always starts at or after its end.
+                    if (_realizedElements.Count > 0 && !double.IsNaN(_realizedElements.StartU))
+                    {
+                        if (_focusedIndex < _realizedElements.FirstIndex)
+                            u = Math.Min(u, _realizedElements.StartU - sizeU);
+                        else if (_focusedIndex > _realizedElements.LastIndex)
+                            u = Math.Max(u, realizedEndU);
+                    }
+
                     var rect = orientation == Orientation.Horizontal ?
-                        new Rect(u, 0, _focusedElement.DesiredSize.Width, finalSize.Height) :
-                        new Rect(0, u, finalSize.Width, _focusedElement.DesiredSize.Height);
+                        new Rect(u, 0, sizeU, finalSize.Height) :
+                        new Rect(0, u, finalSize.Width, sizeU);
 
                     _focusedElement.Arrange(rect);
                 }
@@ -974,7 +989,7 @@ namespace Avalonia.Controls
             Debug.Assert(ItemContainerGenerator is not null);
 
             if ((GetRealizedElement(index) ??
-                 GetFocusedElement(index) ??
+                 GetRealizedElement(index, ref _focusedIndex, ref _focusedElement) ??
                  GetRealizedElement(index, ref _scrollToIndex, ref _scrollToElement)) is { } realized)
                 return realized;
 
@@ -995,20 +1010,6 @@ namespace Avalonia.Controls
         private Control? GetRealizedElement(int index)
         {
             return _realizedElements?.GetElement(index);
-        }
-
-        private Control? GetFocusedElement(int index)
-        {
-            if (_focusedIndex != index)
-                return null;
-
-            Debug.Assert(_focusedElement is not null);
-
-            var result = _focusedElement;
-            ClearFocusedElementSuppression();
-            _focusedIndex = -1;
-            _focusedElement = null;
-            return result;
         }
         
         private static Control? GetRealizedElement(
@@ -1105,19 +1106,8 @@ namespace Avalonia.Controls
             }
             else if (KeyboardNavigation.GetTabOnceActiveElement(ItemsControl) == element)
             {
-                // Keep the container attached so it can retain keyboard focus, but prevent an
-                // estimated off-viewport position from rendering or receiving input in the
-                // visible viewport.
                 _focusedElement = element;
                 _focusedIndex = index;
-                _focusedElementOpacityOverride = element.SetValue(
-                    Visual.OpacityProperty,
-                    0,
-                    BindingPriority.Animation);
-                _focusedElementHitTestOverride = element.SetValue(
-                    InputElement.IsHitTestVisibleProperty,
-                    false,
-                    BindingPriority.Animation);
             }
             else
             {
@@ -1158,19 +1148,10 @@ namespace Avalonia.Controls
         {
             if (_focusedElement != null)
             {
-                ClearFocusedElementSuppression();
                 RecycleElementOnItemRemoved(_focusedElement);
             }
             _focusedElement = null;
             _focusedIndex = -1;
-        }
-
-        private void ClearFocusedElementSuppression()
-        {
-            _focusedElementOpacityOverride?.Dispose();
-            _focusedElementOpacityOverride = null;
-            _focusedElementHitTestOverride?.Dispose();
-            _focusedElementHitTestOverride = null;
         }
         
         private void RecycleScrollToElement()
@@ -1373,7 +1354,6 @@ namespace Avalonia.Controls
                 e.GetOldValue<IInputElement?>() == _focusedElement)
             {
                 // TabOnceActiveElement has moved away from _focusedElement so we can recycle it.
-                ClearFocusedElementSuppression();
                 RecycleElement(_focusedElement, _focusedIndex);
                 _focusedElement = null;
                 _focusedIndex = -1;

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -446,6 +446,7 @@ namespace Avalonia.Controls.UnitTests
             Assert.All(target.GetRealizedElements(), x => Assert.False(x!.IsKeyboardFocusWithin));
             Assert.True(focused.IsKeyboardFocusWithin);
             Assert.Equal(0, focused.Opacity);
+            Assert.False(focused.IsHitTestVisible);
         }
 
         [Theory]
@@ -478,23 +479,33 @@ namespace Avalonia.Controls.UnitTests
         public void Scrolling_Back_To_Focused_Element_Uses_Correct_Element(double bufferFactor)
         {
             using var app = App();
-            var (target, scroll, itemsControl) = CreateTarget(bufferFactor: bufferFactor);
+            var styles = new[]
+            {
+                new Style(x => x.OfType<ContentPresenter>())
+                {
+                    Setters = { new Setter(Visual.OpacityProperty, 0.5) },
+                },
+            };
+            var (target, scroll, itemsControl) = CreateTarget(styles: styles, bufferFactor: bufferFactor);
 
             var focused = target.GetRealizedElements().First()!;
             focused.Focusable = true;
             focused.Focus();
             Assert.True(focused.IsKeyboardFocusWithin);
+            Assert.Equal(0.5, focused.Opacity);
 
             scroll.Offset = new Vector(0, 200);
             Layout(target);
 
             Assert.Equal(0, focused.Opacity);
+            Assert.False(focused.IsHitTestVisible);
 
             scroll.Offset = new Vector(0, 0);
             Layout(target);
 
             Assert.Same(focused, target.GetRealizedElements().First());
-            Assert.Equal(1, focused.Opacity);
+            Assert.Equal(0.5, focused.Opacity);
+            Assert.True(focused.IsHitTestVisible);
         }
 
         [Theory]

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -479,14 +479,18 @@ namespace Avalonia.Controls.UnitTests
         public void Scrolling_Back_To_Focused_Element_Uses_Correct_Element(double bufferFactor)
         {
             using var app = App();
+            var items = Enumerable.Range(0, 100).Select(x => new ItemWithOpacity(x, 0.5)).ToList();
             var styles = new[]
             {
                 new Style(x => x.OfType<ContentPresenter>())
                 {
-                    Setters = { new Setter(Visual.OpacityProperty, 0.5) },
+                    Setters = { new Setter(Visual.OpacityProperty, new Binding("Opacity")) },
                 },
             };
-            var (target, scroll, itemsControl) = CreateTarget(styles: styles, bufferFactor: bufferFactor);
+            var (target, scroll, itemsControl) = CreateTarget(
+                items: items,
+                styles: styles,
+                bufferFactor: bufferFactor);
 
             var focused = target.GetRealizedElements().First()!;
             focused.Focusable = true;
@@ -500,11 +504,12 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(0, focused.Opacity);
             Assert.False(focused.IsHitTestVisible);
 
+            items[0].Opacity = 0.75;
             scroll.Offset = new Vector(0, 0);
             Layout(target);
 
             Assert.Same(focused, target.GetRealizedElements().First());
-            Assert.Equal(0.5, focused.Opacity);
+            Assert.Equal(0.75, focused.Opacity);
             Assert.True(focused.IsHitTestVisible);
         }
 
@@ -2555,6 +2560,25 @@ namespace Avalonia.Controls.UnitTests
             {
                 get => _width;
                 set => SetField(ref _width, value);
+            }
+        }
+
+        private class ItemWithOpacity : NotifyingBase
+        {
+            private double _opacity;
+
+            public ItemWithOpacity(int index, double opacity)
+            {
+                Caption = $"Item {index}";
+                Opacity = opacity;
+            }
+
+            public string Caption { get; set; }
+
+            public double Opacity
+            {
+                get => _opacity;
+                set => SetField(ref _opacity, value);
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -444,6 +444,8 @@ namespace Avalonia.Controls.UnitTests
             Layout(target);
 
             Assert.All(target.GetRealizedElements(), x => Assert.False(x!.IsKeyboardFocusWithin));
+            Assert.True(focused.IsKeyboardFocusWithin);
+            Assert.Equal(0, focused.Opacity);
         }
 
         [Theory]
@@ -486,10 +488,13 @@ namespace Avalonia.Controls.UnitTests
             scroll.Offset = new Vector(0, 200);
             Layout(target);
 
+            Assert.Equal(0, focused.Opacity);
+
             scroll.Offset = new Vector(0, 0);
             Layout(target);
 
             Assert.Same(focused, target.GetRealizedElements().First());
+            Assert.Equal(1, focused.Opacity);
         }
 
         [Theory]

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -444,9 +444,6 @@ namespace Avalonia.Controls.UnitTests
             Layout(target);
 
             Assert.All(target.GetRealizedElements(), x => Assert.False(x!.IsKeyboardFocusWithin));
-            Assert.True(focused.IsKeyboardFocusWithin);
-            Assert.Equal(0, focused.Opacity);
-            Assert.False(focused.IsHitTestVisible);
         }
 
         [Theory]
@@ -479,38 +476,54 @@ namespace Avalonia.Controls.UnitTests
         public void Scrolling_Back_To_Focused_Element_Uses_Correct_Element(double bufferFactor)
         {
             using var app = App();
-            var items = Enumerable.Range(0, 100).Select(x => new ItemWithOpacity(x, 0.5)).ToList();
-            var styles = new[]
-            {
-                new Style(x => x.OfType<ContentPresenter>())
-                {
-                    Setters = { new Setter(Visual.OpacityProperty, new Binding("Opacity")) },
-                },
-            };
+            var (target, scroll, itemsControl) = CreateTarget(bufferFactor: bufferFactor);
+
+            var focused = target.GetRealizedElements().First()!;
+            focused.Focusable = true;
+            focused.Focus();
+            Assert.True(focused.IsKeyboardFocusWithin);
+
+            scroll.Offset = new Vector(0, 200);
+            Layout(target);
+
+            scroll.Offset = new Vector(0, 0);
+            Layout(target);
+
+            Assert.Same(focused, target.GetRealizedElements().First());
+        }
+
+        [Theory]
+        [InlineData(0d)]
+        [InlineData(0.5d)]
+        public void Focused_Element_Outside_Realized_Range_Is_Not_Arranged_In_Viewport(double bufferFactor)
+        {
+            using var app = App();
+
+            // Item 0 is much taller than the others, so the average-based position estimated for
+            // it once it has left the realized range lands inside the viewport (#17935).
+            var items = Enumerable.Range(0, 100).Select(x => new ItemWithHeight(x, x == 0 ? 100 : 10));
             var (target, scroll, itemsControl) = CreateTarget(
                 items: items,
-                styles: styles,
+                itemTemplate: CanvasWithHeightTemplate,
                 bufferFactor: bufferFactor);
 
             var focused = target.GetRealizedElements().First()!;
             focused.Focusable = true;
             focused.Focus();
             Assert.True(focused.IsKeyboardFocusWithin);
-            Assert.Equal(0.5, focused.Opacity);
 
-            scroll.Offset = new Vector(0, 200);
+            scroll.Offset = new Vector(0, 160);
             Layout(target);
 
-            Assert.Equal(0, focused.Opacity);
-            Assert.False(focused.IsHitTestVisible);
+            var viewport = new Rect(scroll.Offset.X, scroll.Offset.Y, scroll.Viewport.Width, scroll.Viewport.Height);
+            Assert.True(focused.IsKeyboardFocusWithin);
+            Assert.False(focused.Bounds.Intersects(viewport));
 
-            items[0].Opacity = 0.75;
             scroll.Offset = new Vector(0, 0);
             Layout(target);
 
             Assert.Same(focused, target.GetRealizedElements().First());
-            Assert.Equal(0.75, focused.Opacity);
-            Assert.True(focused.IsHitTestVisible);
+            Assert.Equal(new Rect(0, 0, 100, 100), focused.Bounds);
         }
 
         [Theory]
@@ -2560,25 +2573,6 @@ namespace Avalonia.Controls.UnitTests
             {
                 get => _width;
                 set => SetField(ref _width, value);
-            }
-        }
-
-        private class ItemWithOpacity : NotifyingBase
-        {
-            private double _opacity;
-
-            public ItemWithOpacity(int index, double opacity)
-            {
-                Caption = $"Item {index}";
-                Opacity = opacity;
-            }
-
-            public string Caption { get; set; }
-
-            public double Opacity
-            {
-                get => _opacity;
-                set => SetField(ref _opacity, value);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

Fixes [#17935](https://github.com/AvaloniaUI/Avalonia/issues/17935). The container of a focused item that leaves the realized range is retained to preserve keyboard focus; it is now arranged so that it can never overlap the viewport.

## What is the current behavior?

The retained focused container is arranged at a position estimated from the average realized element size. When containers have differing sizes, that estimate can place the container so that it overlaps the viewport, where it renders as a ghost item and can intercept pointer input.

## What is the updated/expected behavior with this PR?

The focused item keeps keyboard focus while virtualized, but its container is always arranged outside the viewport. Scrolling back realizes the same container at its correct position.

## How was the solution implemented (if it is not obvious)?

An unrealized item before the realized range always ends at or before the range's start (`StartU`), and one after it always starts at or after the range's end. `ArrangeOverride` now clamps the estimated position of the retained focused container to that invariant, so a bad estimate cannot place it over the realized elements. No property overrides, no changes to size estimation or realization.

## Risks

Low. The change only affects the arrange position of the retained focused container, which is off-viewport bookkeeping. No public API, binding, or platform-specific behavior change. The regression test uses differing item heights to reproduce the ghost and asserts the container's bounds never intersect the viewport.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes? Not applicable: no public API changed.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation. Not applicable: no user-facing API changed.

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Validation

- `dotnet build tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -p:AvsSkipBuildingLegacyTargetFrameworks=True`
- `dotnet run --no-build --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -- --filter-class Avalonia.Controls.UnitTests.VirtualizingStackPanelTests`

Result: build succeeded with 0 warnings and 0 errors; all 132 `VirtualizingStackPanel` tests passed. The new test fails without the fix.

## Fixed issues

Fixes #17935
