### PR TITLE
fix(grid): allow shared size groups to shrink

### DIFF
--- a/src/Avalonia.Controls/DefinitionBase.cs
+++ b/src/Avalonia.Controls/DefinitionBase.cs
@@ -270,6 +270,17 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
+        /// Returns min size, never taking into account shared state.
+        /// </summary>
+        /// <remarks>
+        /// This is the definition's own intrinsic contribution to its group. It is the counterpart
+        /// of <see cref="SetMinSize"/>: code that saves and restores a min size across a measure
+        /// must round-trip this value, because feeding the group minimum back into
+        /// <see cref="_minSize"/> would make the group unable to shrink.
+        /// </remarks>
+        internal double RawMinSize => _minSize;
+
+        /// <summary>
         /// Offset.
         /// </summary>
         internal double FinalOffset

--- a/src/Avalonia.Controls/DefinitionBase.cs
+++ b/src/Avalonia.Controls/DefinitionBase.cs
@@ -626,7 +626,7 @@ namespace Avalonia.Controls
                 //  accumulate min size of all participating definitions
                 for (int i = 0, count = _registry.Count; i < count; ++i)
                 {
-                    sharedMinSize = Math.Max(sharedMinSize, _registry[i].MinSize);
+                    sharedMinSize = Math.Max(sharedMinSize, _registry[i]._minSize);
                 }
 
                 bool sharedMinSizeChanged = !MathUtilities.AreClose(_minSize, sharedMinSize);

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -946,11 +946,11 @@ namespace Avalonia.Controls
             {
                 if (isRows)
                 {
-                    minSizes[PrivateCells[i].RowIndex] = DefinitionsV[PrivateCells[i].RowIndex].MinSize;
+                    minSizes[PrivateCells[i].RowIndex] = DefinitionsV[PrivateCells[i].RowIndex].RawMinSize;
                 }
                 else
                 {
-                    minSizes[PrivateCells[i].ColumnIndex] = DefinitionsU[PrivateCells[i].ColumnIndex].MinSize;
+                    minSizes[PrivateCells[i].ColumnIndex] = DefinitionsU[PrivateCells[i].ColumnIndex].RawMinSize;
                 }
 
                 i = PrivateCells[i].Next;

--- a/tests/Avalonia.Controls.UnitTests/GridTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/GridTests.cs
@@ -1213,6 +1213,50 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Shared_Size_Group_Shrinks_When_Content_Is_Hidden()
+        {
+            var grids = new[]
+            {
+                CreateGrid(("A", GridLength.Auto)),
+                CreateGrid(("A", GridLength.Auto)),
+            };
+            var content = new Border
+            {
+                Width = 50,
+                IsVisible = false,
+            };
+            grids[1].Children.Add(content);
+
+            var scope = new StackPanel
+            {
+                [Grid.IsSharedSizeScopeProperty] = true,
+                Children =
+                {
+                    grids[0],
+                    grids[1],
+                },
+            };
+            var root = new TestRoot(scope);
+            void ExecuteSharedSizeLayoutPass()
+            {
+                // Shared groups validate after layout and apply any resulting invalidation on the next pass.
+                root.LayoutManager.ExecuteLayoutPass();
+                root.LayoutManager.ExecuteLayoutPass();
+            }
+
+            root.ExecuteInitialLayoutPass();
+            Assert.All(grids, grid => Assert.Equal(0, grid.ColumnDefinitions[0].ActualWidth));
+
+            content.IsVisible = true;
+            ExecuteSharedSizeLayoutPass();
+            Assert.All(grids, grid => Assert.Equal(50, grid.ColumnDefinitions[0].ActualWidth));
+
+            content.IsVisible = false;
+            ExecuteSharedSizeLayoutPass();
+            Assert.All(grids, grid => Assert.Equal(0, grid.ColumnDefinitions[0].ActualWidth));
+        }
+
+        [Fact]
         public void Collection_Changes_Are_Tracked()
         {
             var grid = CreateGrid(

--- a/tests/Avalonia.Controls.UnitTests/GridTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/GridTests.cs
@@ -1257,6 +1257,59 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Shared_Size_Group_Shrinks_When_Participant_Uses_Cyclic_Measure_Path()
+        {
+            // A grid mixing an auto-column/star-row cell with a star-column/auto-row cell cannot
+            // resolve stars in either direction up front, so Grid measures it through its cyclic
+            // dependency path. That path saves definition min sizes before the repeated measure and
+            // restores them afterwards. Saving the effective min size folds the group minimum into
+            // the definition's own contribution, which then reclassifies it as a long pole - and
+            // long poles are deliberately never remeasured, so the group stays pinned open.
+            var cyclicGrid = CreateGrid(("A", GridLength.Auto), (null, new GridLength(1, GridUnitType.Star)));
+            cyclicGrid.Height = 100;  // star rows collapse to auto under an infinite constraint.
+            cyclicGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            cyclicGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+
+            var autoColumnStarRowChild = new Border { Width = 10, Height = 10 };
+            Grid.SetColumn(autoColumnStarRowChild, 0);
+            Grid.SetRow(autoColumnStarRowChild, 1);
+
+            var starColumnAutoRowChild = new Border { Width = 10, Height = 10 };
+            Grid.SetColumn(starColumnAutoRowChild, 1);
+            Grid.SetRow(starColumnAutoRowChild, 0);
+
+            cyclicGrid.Children.Add(autoColumnStarRowChild);
+            cyclicGrid.Children.Add(starColumnAutoRowChild);
+
+            var plainGrid = CreateGrid(("A", GridLength.Auto), (null, new GridLength(1, GridUnitType.Star)));
+            var wideContent = new Border { Width = 50, Height = 10 };
+            plainGrid.Children.Add(wideContent);
+
+            var scope = new StackPanel
+            {
+                [Grid.IsSharedSizeScopeProperty] = true,
+                Children = { cyclicGrid, plainGrid },
+            };
+            var root = new TestRoot(scope);
+            void ExecuteSharedSizeLayoutPass()
+            {
+                // Shared groups validate after layout and apply any resulting invalidation on the next pass.
+                root.LayoutManager.ExecuteLayoutPass();
+                root.LayoutManager.ExecuteLayoutPass();
+            }
+
+            root.ExecuteInitialLayoutPass();
+            ExecuteSharedSizeLayoutPass();
+            Assert.Equal(50, cyclicGrid.ColumnDefinitions[0].ActualWidth);
+            Assert.Equal(50, plainGrid.ColumnDefinitions[0].ActualWidth);
+
+            wideContent.IsVisible = false;
+            ExecuteSharedSizeLayoutPass();
+            Assert.Equal(10, cyclicGrid.ColumnDefinitions[0].ActualWidth);
+            Assert.Equal(10, plainGrid.ColumnDefinitions[0].ActualWidth);
+        }
+
+        [Fact]
         public void Collection_Changes_Are_Tracked()
         {
             var grid = CreateGrid(


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Allows synchronized `Grid` definitions in a `SharedSizeGroup` to shrink when the content that established the group minimum becomes smaller or hidden, fixing [#21562](https://github.com/AvaloniaUI/Avalonia/issues/21562).

## What is the current behavior?

Shared auto columns expand when grouped content grows, but retain that width after the content is hidden. During deferred validation, the group minimum is recomputed through `DefinitionBase.MinSize`, which includes the previous shared minimum. The old maximum therefore feeds back into the next calculation and becomes self-sustaining.

## What is the updated/expected behavior with this PR?

Shared definitions continue to expand together and now shrink together after their intrinsic measured minimum decreases.

Validation on macOS ARM64 with .NET 10:

- Added `Shared_Size_Group_Shrinks_When_Content_Is_Hidden`, covering the initial, expanded, and shrunk states across the deferred shared-size layout cycle.
- Ran `GridTests`: 80 passed, 0 failed.
- Ran the full `Avalonia.Controls.UnitTests` executable: 3,649 total, 3,648 passed, 1 pre-existing skipped, 0 failed.

## How was the solution implemented (if it's not obvious)?

Deferred shared-size validation now aggregates each definition's intrinsic measured `_minSize` instead of its effective `MinSize`, which can include the group minimum from the previous layout cycle. This restores the existing long-pole/short-pole invariant and matches the [canonical WPF shared-size algorithm](https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DefinitionBase.cs).

The commits follow the repository's bug-fix convention: the first commit adds the failing behavioral test, and the second commit contains the fix.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes? No public API was added or changed.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation. No documentation change is needed for this internal layout correction.

## Breaking changes

None. This restores the expected `SharedSizeGroup` shrink behavior without changing public API.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21562
