### PR TITLE
Fix ListBox crash when scrolling after item removal

### DIFF
--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -251,6 +251,13 @@ namespace Avalonia.Controls
                 var orientation = Orientation;
                 var u = _realizedElements!.StartU;
 
+                // Collection changes before the realized range make its exact position unstable
+                // until the next measure. ScrollIntoView can intentionally defer that measure
+                // while waiting for an updated viewport, so use the same position estimate used
+                // when realizing an element instead of arranging the range at NaN.
+                if (double.IsNaN(u))
+                    u = GetOrEstimateElementU(_realizedElements.FirstIndex);
+
                 for (var i = 0; i < _realizedElements.Count; ++i)
                 {
                     var e = _realizedElements.Elements[i];

--- a/tests/Avalonia.Controls.UnitTests/ListBoxVirtualizationIssueTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxVirtualizationIssueTests.cs
@@ -12,6 +12,31 @@ namespace Avalonia.Controls.UnitTests;
 public class ListBoxVirtualizationIssueTests : ScopedTestBase
 {
     [Fact]
+    public void Removing_First_Item_After_Scrolling_To_End_Should_Allow_Scrolling_To_Start()
+    {
+        using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+        {
+            var items = new ObservableCollection<int>(Enumerable.Range(0, 100));
+            var target = new ListBox
+            {
+                Template = new FuncControlTemplate(CreateListBoxTemplate),
+                ItemsSource = items,
+                ItemTemplate = new FuncDataTemplate<int>((_, _) => new TextBlock { Height = 50 }),
+                ItemsPanel = new FuncTemplate<Panel?>(() => new VirtualizingStackPanel()),
+            };
+
+            Prepare(target);
+            target.ScrollIntoView(99);
+
+            items.RemoveAt(0);
+            target.ScrollIntoView(0);
+
+            var firstContainer = Assert.IsType<ListBoxItem>(target.ContainerFromIndex(0));
+            Assert.Equal(1, firstContainer.Content);
+        }
+    }
+
+    [Fact]
     public void Replaced_ItemsSource_Should_Not_Show_Old_Selected_Item_When_Scrolled_Back()
     {
         using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Prevents `VirtualizingStackPanel` from arranging realized containers at a `NaN` position while `ScrollIntoView` is waiting for a viewport update. This fixes the deterministic `ListBox` crash reported in [#20085](https://github.com/AvaloniaUI/Avalonia/issues/20085).

## What is the current behavior?

After scrolling a virtualized `ListBox` to its end, removing an item before the realized range marks that range's stored start position as unstable. Calling `ScrollIntoView(0)` then intentionally defers measure until the effective viewport changes, but the intervening arrange consumes the unstable `NaN` position and throws `InvalidOperationException: Invalid Arrange rectangle`.

## What is the updated/expected behavior with this PR?

The transitional arrange uses the panel's existing element-position estimator when the realized range has an unstable start position. Once the viewport update arrives, the normal measure pass replaces the estimate with the exact position. The list can scroll back to the new first item without throwing.

Validation on macOS ARM64 with .NET 10:

- Added [`Removing_First_Item_After_Scrolling_To_End_Should_Allow_Scrolling_To_Start`](https://github.com/NathanDrake2406/Avalonia/blob/nathan/fix-20085-listbox-invalid-arrange/tests/Avalonia.Controls.UnitTests/ListBoxVirtualizationIssueTests.cs#L14-L37), which reproduced the exception before the fix and verifies the new first item after scrolling.
- Ran `ListBoxVirtualizationIssueTests`: 6 passed, 0 failed.
- Ran `VirtualizingStackPanelTests`: 130 passed, 0 failed.
- Ran the full `Avalonia.Controls.UnitTests` executable: 3,648 passed, 1 existing intentional skip, 0 failed.

## How was the solution implemented (if it's not obvious)?

[`RealizedStackElements.StartU`](https://github.com/AvaloniaUI/Avalonia/blob/fb09d611062b199f70551e9c26b2316f0173ff09/src/Avalonia.Controls/Utils/RealizedStackElements.cs#L48-L49) deliberately returns `NaN` when collection changes make the cached position unreliable. [`ArrangeOverride`](https://github.com/NathanDrake2406/Avalonia/blob/nathan/fix-20085-listbox-invalid-arrange/src/Avalonia.Controls/VirtualizingStackPanel.cs#L251-L259) now recognizes that sentinel and obtains a finite transitional position through `GetOrEstimateElementU`, the same estimator already used when positioning unrealized and focused elements.

The commits follow the repository's bug-fix convention: the first commit adds the failing behavioral test, and the second commit contains the fix.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes? No public API was added or changed.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation. No documentation change is needed for an internal layout fix.

## Breaking changes

None. The change only replaces an invalid transitional arrange coordinate with the panel's existing estimate.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #20085
