### PR TITLE
fix(TextBox): clear undo history on external text updates

### DIFF
--- a/src/Avalonia.Controls/MaskedTextBox.cs
+++ b/src/Avalonia.Controls/MaskedTextBox.cs
@@ -190,7 +190,7 @@ namespace Avalonia.Controls
         {
             if (HidePromptOnLeave == true && MaskProvider != null)
             {
-                SetTextCurrentValue(MaskProvider.ToDisplayString());
+                SetTextFromInternalSynchronization(MaskProvider.ToDisplayString());
             }
             base.OnGotFocus(e);
         }
@@ -241,7 +241,7 @@ namespace Avalonia.Controls
                     }
                 }
 
-                SetTextCurrentValue(MaskProvider.ToDisplayString());
+                SetTextFromEdit(MaskProvider.ToDisplayString());
                 e.Handled = true;
                 return;
             }
@@ -291,7 +291,7 @@ namespace Avalonia.Controls
         {
             if (HidePromptOnLeave && MaskProvider != null)
             {
-                SetTextCurrentValue(MaskProvider.ToString(!HidePromptOnLeave, true));
+                SetTextFromInternalSynchronization(MaskProvider.ToString(!HidePromptOnLeave, true));
             }
             base.OnLostFocus(e);
         }
@@ -306,7 +306,7 @@ namespace Avalonia.Controls
                 {
                     MaskProvider.Set(Text);
                 }
-                RefreshText(MaskProvider, 0);
+                RefreshText(MaskProvider, 0, isEdit: false);
             }
             if (change.Property == MaskProperty)
             {
@@ -426,11 +426,18 @@ namespace Avalonia.Controls
             return startPosition;
         }
 
-        private void RefreshText(MaskedTextProvider? provider, int position)
+        private void RefreshText(MaskedTextProvider? provider, int position, bool isEdit = true)
         {
             if (provider != null)
             {
-                SetTextCurrentValue(provider.ToDisplayString());
+                if (isEdit)
+                {
+                    SetTextFromEdit(provider.ToDisplayString());
+                }
+                else
+                {
+                    SetTextFromInternalSynchronization(provider.ToDisplayString());
+                }
                 SetCurrentValue(CaretIndexProperty, position);
             }
         }

--- a/src/Avalonia.Controls/MaskedTextBox.cs
+++ b/src/Avalonia.Controls/MaskedTextBox.cs
@@ -190,7 +190,7 @@ namespace Avalonia.Controls
         {
             if (HidePromptOnLeave == true && MaskProvider != null)
             {
-                SetCurrentValue(TextProperty, MaskProvider.ToDisplayString());
+                SetTextCurrentValue(MaskProvider.ToDisplayString());
             }
             base.OnGotFocus(e);
         }
@@ -241,7 +241,7 @@ namespace Avalonia.Controls
                     }
                 }
 
-                SetCurrentValue(TextProperty, MaskProvider.ToDisplayString());
+                SetTextCurrentValue(MaskProvider.ToDisplayString());
                 e.Handled = true;
                 return;
             }
@@ -291,7 +291,7 @@ namespace Avalonia.Controls
         {
             if (HidePromptOnLeave && MaskProvider != null)
             {
-                SetCurrentValue(TextProperty, MaskProvider.ToString(!HidePromptOnLeave, true));
+                SetTextCurrentValue(MaskProvider.ToString(!HidePromptOnLeave, true));
             }
             base.OnLostFocus(e);
         }
@@ -430,7 +430,7 @@ namespace Avalonia.Controls
         {
             if (provider != null)
             {
-                SetCurrentValue(TextProperty, provider.ToDisplayString());
+                SetTextCurrentValue(provider.ToDisplayString());
                 SetCurrentValue(CaretIndexProperty, position);
             }
         }

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -367,6 +367,9 @@ namespace Avalonia.Controls
         private readonly TextBoxTextInputMethodClient _imClient = new();
         private readonly UndoRedoHelper<UndoRedoState> _undoRedoHelper;
         private bool _isUndoingRedoing;
+        private bool _isTextChangeFromTextBox;
+        private bool _needsUndoRedoBaseline;
+        private bool _needsUndoRedoSnapshotAfterTextChange;
         private bool _canCut;
         private bool _canCopy;
         private bool _canPaste;
@@ -641,16 +644,25 @@ namespace Avalonia.Controls
         /// </remarks>
         protected virtual string? CoerceText(string? value)
         {
-            // Before #9490, snapshot here was done AFTER text change - this doesn't make sense
-            // since initial state would never be no text and you'd always have to make a text
-            // change before undo would be available
-            // The undo/redo stacks were also cleared at this point, which also doesn't make sense
-            // as it is still valid to want to undo a programmatic text set
-            // So we snapshot text now BEFORE the change so we can always revert
-            // Also don't need to check IsUndoEnabled here, that's done in SnapshotUndoRedo
             if (!_isUndoingRedoing)
             {
-                SnapshotUndoRedo();
+                // TextBox-initiated edits belong to the current document's undo history. All other
+                // updates establish a new document baseline, including bindings and direct property sets.
+                if (_isTextChangeFromTextBox)
+                {
+                    SnapshotUndoRedo();
+
+                    if (!_undoRedoHelper.CanUndo &&
+                        !string.Equals(Text, value, StringComparison.Ordinal))
+                    {
+                        _needsUndoRedoSnapshotAfterTextChange = true;
+                    }
+                }
+                else
+                {
+                    ClearUndoRedo();
+                    _needsUndoRedoBaseline = true;
+                }
             }
 
             return value;
@@ -878,9 +890,7 @@ namespace Avalonia.Controls
             // from docs at
             // https://docs.microsoft.com/en-us/dotnet/api/system.windows.controls.primitives.textboxbase.isundoenabled:
             // "Setting UndoLimit clears the undo queue."
-            _undoRedoHelper.Clear();
-            _selectedTextChangesMadeSinceLastUndoSnapshot = 0;
-            _hasDoneSnapshotOnce = false;
+            ClearUndoRedo();
         }
 
         /// <summary>
@@ -1032,6 +1042,13 @@ namespace Avalonia.Controls
 
             if (change.Property == TextProperty)
             {
+                if (_needsUndoRedoBaseline || _needsUndoRedoSnapshotAfterTextChange)
+                {
+                    _needsUndoRedoBaseline = false;
+                    _needsUndoRedoSnapshotAfterTextChange = false;
+                    SnapshotUndoRedo();
+                }
+
                 CoerceValue(CaretIndexProperty);
                 CoerceValue(SelectionStartProperty);
                 CoerceValue(SelectionEndProperty);
@@ -1078,9 +1095,7 @@ namespace Avalonia.Controls
                 // "Setting this property to false clears the undo stack.
                 // Therefore, if you disable undo and then re-enable it, undo commands still do not work
                 // because the undo stack was emptied when you disabled undo."
-                _undoRedoHelper.Clear();
-                _selectedTextChangesMadeSinceLastUndoSnapshot = 0;
-                _hasDoneSnapshotOnce = false;
+                ClearUndoRedo();
             }
         }
 
@@ -1206,7 +1221,7 @@ namespace Avalonia.Controls
 
                 var text = StringBuilderCache.GetStringAndRelease(textBuilder);
 
-                SetCurrentValue(TextProperty, text);
+                SetTextCurrentValue(text);
 
                 ClearSelection();
 
@@ -1611,7 +1626,7 @@ namespace Avalonia.Controls
                                     sb.Append(text);
                                     sb.Remove(start, end - start);
 
-                                    SetCurrentValue(TextProperty, StringBuilderCache.GetStringAndRelease(sb));
+                                    SetTextCurrentValue(StringBuilderCache.GetStringAndRelease(sb));
 
                                     SetCurrentValue(CaretIndexProperty, start);
 
@@ -1650,7 +1665,7 @@ namespace Avalonia.Controls
                                     sb.Append(text);
                                     sb.Remove(start, end - start);
 
-                                    SetCurrentValue(TextProperty, StringBuilderCache.GetStringAndRelease(sb));
+                                    SetTextCurrentValue(StringBuilderCache.GetStringAndRelease(sb));
                                 }
                             }
 
@@ -2139,7 +2154,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Clears the text in the TextBox
         /// </summary>
-        public void Clear() => SetCurrentValue(TextProperty, string.Empty);
+        public void Clear() => SetTextCurrentValue(string.Empty);
 
         private void MoveHorizontal(int direction, bool wholeWord, bool isSelecting, bool moveCaretPosition)
         {
@@ -2396,7 +2411,7 @@ namespace Avalonia.Controls
                 textBuilder.Append(text);
                 textBuilder.Remove(start, end - start);
 
-                SetCurrentValue(TextProperty, StringBuilderCache.GetStringAndRelease(textBuilder));
+                SetTextCurrentValue(StringBuilderCache.GetStringAndRelease(textBuilder));
 
                 _presenter?.MoveCaretToTextPosition(start);
 
@@ -2432,6 +2447,23 @@ namespace Avalonia.Controls
             }
 
             return text.Substring(start, end - start);
+        }
+
+        internal void SetTextCurrentValue(string? value)
+        {
+            var wasTextChangeFromTextBox = _isTextChangeFromTextBox;
+            _isTextChangeFromTextBox = true;
+
+            try
+            {
+                // Keep the flag set through synchronous TwoWay source notifications so the source
+                // echo is not mistaken for a replacement from outside this control.
+                SetCurrentValue(TextProperty, value);
+            }
+            finally
+            {
+                _isTextChangeFromTextBox = wasTextChangeFromTextBox;
+            }
         }
 
         /// <summary>
@@ -2559,6 +2591,13 @@ namespace Avalonia.Controls
                     _hasDoneSnapshotOnce = true;
                 }
             }
+        }
+
+        private void ClearUndoRedo()
+        {
+            _undoRedoHelper.Clear();
+            _selectedTextChangesMadeSinceLastUndoSnapshot = 0;
+            _hasDoneSnapshotOnce = false;
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -362,13 +362,20 @@ namespace Avalonia.Controls
             public override int GetHashCode() => Text?.GetHashCode() ?? 0;
         }
 
+        private enum TextMutationKind
+        {
+            ExternalReplacement,
+            Edit,
+            InternalSynchronization,
+        }
+
         private TextPresenter? _presenter;
         private ScrollViewer? _scrollViewer;
         private readonly TextBoxTextInputMethodClient _imClient = new();
         private readonly UndoRedoHelper<UndoRedoState> _undoRedoHelper;
         private bool _isUndoingRedoing;
-        private bool _isTextChangeFromTextBox;
-        private bool _needsUndoRedoBaseline;
+        private TextMutationKind _textMutationKind;
+        // Coercion runs before the new value is committed, so a snapshot taken there would capture the old text.
         private bool _needsUndoRedoSnapshotAfterTextChange;
         private bool _canCut;
         private bool _canCopy;
@@ -646,22 +653,26 @@ namespace Avalonia.Controls
         {
             if (!_isUndoingRedoing)
             {
-                // TextBox-initiated edits belong to the current document's undo history. All other
-                // updates establish a new document baseline, including bindings and direct property sets.
-                if (_isTextChangeFromTextBox)
+                switch (_textMutationKind)
                 {
-                    SnapshotUndoRedo();
+                    case TextMutationKind.Edit:
+                        SnapshotUndoRedo();
 
-                    if (!_undoRedoHelper.CanUndo &&
-                        !string.Equals(Text, value, StringComparison.Ordinal))
-                    {
+                        if (!_undoRedoHelper.CanUndo &&
+                            !string.Equals(Text, value, StringComparison.Ordinal))
+                        {
+                            _needsUndoRedoSnapshotAfterTextChange = true;
+                        }
+                        break;
+
+                    case TextMutationKind.InternalSynchronization:
+                        break;
+
+                    case TextMutationKind.ExternalReplacement:
+                    default:
+                        ClearUndoRedo();
                         _needsUndoRedoSnapshotAfterTextChange = true;
-                    }
-                }
-                else
-                {
-                    ClearUndoRedo();
-                    _needsUndoRedoBaseline = true;
+                        break;
                 }
             }
 
@@ -1042,9 +1053,8 @@ namespace Avalonia.Controls
 
             if (change.Property == TextProperty)
             {
-                if (_needsUndoRedoBaseline || _needsUndoRedoSnapshotAfterTextChange)
+                if (_needsUndoRedoSnapshotAfterTextChange)
                 {
-                    _needsUndoRedoBaseline = false;
                     _needsUndoRedoSnapshotAfterTextChange = false;
                     SnapshotUndoRedo();
                 }
@@ -1221,7 +1231,7 @@ namespace Avalonia.Controls
 
                 var text = StringBuilderCache.GetStringAndRelease(textBuilder);
 
-                SetTextCurrentValue(text);
+                SetTextFromEdit(text);
 
                 ClearSelection();
 
@@ -1626,7 +1636,7 @@ namespace Avalonia.Controls
                                     sb.Append(text);
                                     sb.Remove(start, end - start);
 
-                                    SetTextCurrentValue(StringBuilderCache.GetStringAndRelease(sb));
+                                    SetTextFromEdit(StringBuilderCache.GetStringAndRelease(sb));
 
                                     SetCurrentValue(CaretIndexProperty, start);
 
@@ -1665,7 +1675,7 @@ namespace Avalonia.Controls
                                     sb.Append(text);
                                     sb.Remove(start, end - start);
 
-                                    SetTextCurrentValue(StringBuilderCache.GetStringAndRelease(sb));
+                                    SetTextFromEdit(StringBuilderCache.GetStringAndRelease(sb));
                                 }
                             }
 
@@ -2154,7 +2164,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Clears the text in the TextBox
         /// </summary>
-        public void Clear() => SetTextCurrentValue(string.Empty);
+        public void Clear() => SetTextFromEdit(string.Empty);
 
         private void MoveHorizontal(int direction, bool wholeWord, bool isSelecting, bool moveCaretPosition)
         {
@@ -2411,7 +2421,7 @@ namespace Avalonia.Controls
                 textBuilder.Append(text);
                 textBuilder.Remove(start, end - start);
 
-                SetTextCurrentValue(StringBuilderCache.GetStringAndRelease(textBuilder));
+                SetTextFromEdit(StringBuilderCache.GetStringAndRelease(textBuilder));
 
                 _presenter?.MoveCaretToTextPosition(start);
 
@@ -2449,20 +2459,24 @@ namespace Avalonia.Controls
             return text.Substring(start, end - start);
         }
 
-        internal void SetTextCurrentValue(string? value)
+        internal void SetTextFromEdit(string? value) => SetTextCore(value, TextMutationKind.Edit);
+
+        internal void SetTextFromInternalSynchronization(string? value) =>
+            SetTextCore(value, TextMutationKind.InternalSynchronization);
+
+        private void SetTextCore(string? value, TextMutationKind mutationKind)
         {
-            var wasTextChangeFromTextBox = _isTextChangeFromTextBox;
-            _isTextChangeFromTextBox = true;
+            // Stays set through the synchronous TwoWay source echo so it isn't mistaken for an external replacement.
+            var previousMutationKind = _textMutationKind;
+            _textMutationKind = mutationKind;
 
             try
             {
-                // Keep the flag set through synchronous TwoWay source notifications so the source
-                // echo is not mistaken for a replacement from outside this control.
                 SetCurrentValue(TextProperty, value);
             }
             finally
             {
-                _isTextChangeFromTextBox = wasTextChangeFromTextBox;
+                _textMutationKind = previousMutationKind;
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/MaskedTextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MaskedTextBoxTests.cs
@@ -921,6 +921,127 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        [Fact]
+        public void Focusing_And_Unfocusing_Does_Not_Create_Undo_Operation()
+        {
+            using (Start(FocusServices))
+            {
+                var target = new MaskedTextBox
+                {
+                    Template = CreateTemplate(),
+                    Mask = "000",
+                    HidePromptOnLeave = true,
+                    Text = "123"
+                };
+
+                var other = new MaskedTextBox { Template = CreateTemplate() };
+
+                var sp = new StackPanel();
+                sp.Children.Add(target);
+                sp.Children.Add(other);
+
+                target.ApplyTemplate();
+                other.ApplyTemplate();
+
+                var root = new TestRoot() { Child = sp };
+
+                target.Focus();
+                other.Focus();
+
+                Assert.False(target.CanUndo);
+            }
+        }
+
+        [Fact]
+        public void Masked_Edit_Remains_Undoable()
+        {
+            using (Start(FocusServices))
+            {
+                var target = new MaskedTextBox
+                {
+                    Template = CreateTemplate(),
+                    Mask = "000",
+                    Text = "123"
+                };
+
+                target.ApplyTemplate();
+
+                var root = new TestRoot() { Child = target };
+
+                target.Focus();
+                target.CaretIndex = 3;
+
+                RaiseKeyEvent(target, Key.Back, KeyModifiers.None);
+
+                Assert.Equal("12_", target.Text);
+                Assert.True(target.CanUndo);
+
+                target.Undo();
+
+                Assert.Equal("123", target.Text);
+            }
+        }
+
+        [Fact]
+        public void External_Replacement_After_Masked_Edit_Clears_Undo_History()
+        {
+            using (Start(FocusServices))
+            {
+                var target = new MaskedTextBox
+                {
+                    Template = CreateTemplate(),
+                    Mask = "000",
+                    Text = "123"
+                };
+
+                target.ApplyTemplate();
+
+                var root = new TestRoot() { Child = target };
+
+                target.Focus();
+                target.CaretIndex = 3;
+
+                RaiseKeyEvent(target, Key.Back, KeyModifiers.None);
+
+                Assert.True(target.CanUndo);
+
+                target.Text = "456";
+
+                Assert.False(target.CanUndo);
+                Assert.False(target.CanRedo);
+            }
+        }
+
+        [Fact]
+        public void Clear_And_SelectedText_Replacement_Remain_Undoable()
+        {
+            using (Start(FocusServices))
+            {
+                var target = new MaskedTextBox
+                {
+                    Template = CreateTemplate(),
+                    Mask = "000",
+                    Text = "123"
+                };
+
+                target.ApplyTemplate();
+
+                var root = new TestRoot() { Child = target };
+
+                target.Focus();
+
+                target.Clear();
+                Assert.True(target.CanUndo);
+
+                target.Undo();
+                target.SelectionStart = 0;
+                target.SelectionEnd = 1;
+                target.SelectedText = "9";
+
+                Assert.True(target.CanUndo);
+            }
+        }
+
         private static TestServices FocusServices => TestServices.MockThreadingInterface.With(
             keyboardDevice: () => new KeyboardDevice(),
             keyboardNavigation: () => new KeyboardNavigationHandler(),

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -1407,6 +1407,73 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Binding_Source_Change_Clears_Undo_History()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var source = new Class1 { Bar = "initial" };
+                var textBox = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    DataContext = source,
+                };
+
+                textBox.Bind(TextBox.TextProperty, new Binding(nameof(Class1.Bar))
+                {
+                    Mode = BindingMode.TwoWay,
+                });
+                textBox.Measure(Size.Infinity);
+                textBox.CaretIndex = textBox.Text!.Length;
+
+                RaiseTextEvent(textBox, " edit");
+                RaiseKeyEvent(textBox, Key.Space, KeyModifiers.None);
+                RaiseTextEvent(textBox, " more");
+
+                Assert.Equal("initial edit more", source.Bar);
+                Assert.True(textBox.CanUndo);
+
+                source.Bar = "replacement";
+
+                Assert.Equal("replacement", textBox.Text);
+                Assert.False(textBox.CanUndo);
+                Assert.False(textBox.CanRedo);
+            }
+        }
+
+        [Fact]
+        public void TwoWay_Binding_Source_Echo_Does_Not_Clear_Undo_History()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var source = new Class1 { Bar = "initial" };
+                var textBox = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    DataContext = source,
+                };
+
+                textBox.Bind(TextBox.TextProperty, new Binding(nameof(Class1.Bar))
+                {
+                    Mode = BindingMode.TwoWay,
+                });
+                textBox.Measure(Size.Infinity);
+                textBox.CaretIndex = textBox.Text!.Length;
+
+                RaiseTextEvent(textBox, " edit");
+                RaiseKeyEvent(textBox, Key.Space, KeyModifiers.None);
+                RaiseTextEvent(textBox, " more");
+
+                Assert.Equal("initial edit more", source.Bar);
+                Assert.True(textBox.CanUndo);
+
+                textBox.Undo();
+
+                Assert.Equal("initial edit", textBox.Text);
+                Assert.Equal("initial edit", source.Bar);
+            }
+        }
+
+        [Fact]
         public void Setting_UndoLimit_Clears_Undo_Redo()
         {
             using (UnitTestApplication.Start(Services))


### PR DESCRIPTION
## What does the pull request do?

This PR restores the `TextBox` undo boundary between user edits and external `Text` updates.

Mutations to `TextProperty` are now classified into three kinds, tracked internally as a `TextMutationKind`:

- **Edit** — typing, paste, delete, `Clear()`, `SelectedText` replacement. Undoable, belongs to the current document's history.
- **Internal synchronization** — presentation-only reformatting of the same document (e.g. `MaskedTextBox` toggling prompt characters on focus/blur, or refreshing its display after the mask configuration changes). Leaves undo/redo history untouched.
- **External replacement** — anything else, including bindings and direct property sets. Clears undo/redo history and establishes the new value as the baseline, so a reused TwoWay-bound editor cannot replay text from a previously selected model into the current one.

This restores the behavior originally introduced for [#336](https://github.com/AvaloniaUI/Avalonia/issues/336), which regressed when [#9490](https://github.com/AvaloniaUI/Avalonia/pull/9490) made every `Text` coercion create an undo snapshot.

## What is the current behavior?

Every `Text` change is added to the same undo timeline, including values supplied by a binding.

In a master-detail editor that reuses one TwoWay-bound `TextBox`, changing the selected model leaves the previous model's text in the undo stack. Undo can then write that stale text into the newly selected model.

## What is the updated/expected behavior with this PR?

External `Text` updates clear both undo and redo history and establish the new value as the baseline. Normal typing remains undoable, including the synchronous source notification produced by a TwoWay binding.

`MaskedTextBox`'s own display-only reformatting (prompt characters shown/hidden on focus and blur, and the text re-parsed after `Mask`, `PromptChar`, `Culture`, etc. change) does not create undo entries, since it isn't an edit to the logical document. Actual masked edits (typing, paste, Delete/Space/Backspace) remain undoable, and `Clear()` / `SelectedText` replacement are deliberately kept undoable as editing commands.

Regression coverage verifies:

- replacing the binding source value clears `CanUndo` and `CanRedo`
- a user edit propagated through a TwoWay binding remains undoable and updates the source when undone
- focusing and unfocusing a `MaskedTextBox` does not create an undo operation
- an actual masked edit remains undoable
- an external replacement after a masked edit clears history
- `Clear()` and `SelectedText` replacement remain undoable

<details>
<summary>Validation</summary>

- `dotnet build src/Avalonia.Controls/Avalonia.Controls.csproj -p:AvsSkipBuildingLegacyTargetFrameworks=True --no-restore`: succeeded with 0 warnings and 0 errors
- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -p:AvsSkipBuildingLegacyTargetFrameworks=True -- --filter-class "Avalonia.Controls.UnitTests.TextBoxTests" "Avalonia.Controls.UnitTests.MaskedTextBoxTests"`: 225 passed
- Full `Avalonia.Controls.UnitTests` run: 3653 passed, 0 failed, 1 pre-existing unrelated skip

</details>

## How was the solution implemented (if it's not obvious)?

`TextBox` tracks a `TextMutationKind` (`Edit` / `InternalSynchronization` / `ExternalReplacement`) while calling `SetCurrentValue(TextProperty, ...)` through two internal entry points, `SetTextFromEdit` and `SetTextFromInternalSynchronization`. The kind stays set through synchronous TwoWay source notifications, so a binding echo of an edit is not mistaken for an external replacement. Any coercion that doesn't go through either entry point (bindings, direct property sets) is treated as an external replacement, clearing history and starting a fresh baseline.

`MaskedTextBox` routes its own mutations through whichever entry point matches their intent: `SetTextFromEdit` for keyboard editing and paste, `SetTextFromInternalSynchronization` for prompt-character display toggling on focus/blur and for reformatting after mask configuration changes.

This replaces an earlier single-bool version of this seam (`_isTextChangeFromTextBox`) that conflated "should this clear history" with "should this create an undo entry" and routed all `MaskedTextBox` mutations, including focus-only display changes, through the undoable path.

The behavior change is intentionally limited to undo/redo state. There are no public API or serialization changes. The compatibility risk is that programmatic `Text` assignments are no longer undoable; they now match binding updates and the non-user-input semantics established by #336.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21578
