### PR TITLE
fix: Set the LogicalParent of the TableViewColumn

### DIFF
--- a/src/Avalonia.Controls/TableView.cs
+++ b/src/Avalonia.Controls/TableView.cs
@@ -5,6 +5,7 @@ using Avalonia.Collections;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.LogicalTree;
 using Avalonia.Metadata;
 using static Avalonia.Controls.Presenters.TableViewLayoutHelper;
 
@@ -139,6 +140,7 @@ public class TableView : ListBox
         }
 
         column.TableView = this;
+        ((ISetLogicalParent)column).SetParent(this);
     }
 
     private void DetachColumn(TableViewColumn column)
@@ -146,6 +148,7 @@ public class TableView : ListBox
         Debug.Assert(column.TableView == this || column.TableView is null);
 
         column.TableView = null;
+        ((ISetLogicalParent)column).SetParent(null);
         column.ActualWidth = double.NaN;
     }
 

--- a/tests/Avalonia.Controls.UnitTests/TableViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TableViewTests.cs
@@ -71,6 +71,47 @@ public sealed class TableViewTests : ScopedTestBase
     }
 
     [Fact]
+    public void Column_LogicalParent_Is_Set_When_Added_And_Unset_When_Removed()
+    {
+        using var app = Start();
+
+        var target = CreateTarget(new[] { "Foo" });
+        var column = new TableViewColumn();
+        target.Columns.Add(column);
+
+        Prepare(target);
+
+        Assert.Same(target, column.GetLogicalParent());
+
+        target.Columns.Remove(column);
+
+        Assert.Null(column.GetLogicalParent());
+    }
+
+    [Fact]
+    public void Column_Receives_Styles_From_TableView()
+    {
+        using var app = Start();
+
+        var target = CreateTarget(new[] { "Foo" });
+        var style = new Style(x => x.OfType<TableViewColumn>().Class("right-align"))
+        {
+            Setters = { new Setter(TableViewColumn.HorizontalContentAlignmentProperty, HorizontalAlignment.Right) }
+        };
+        target.Styles.Add(style);
+
+        var column = new TableViewColumn
+        {
+            Classes = { "right-align" }
+        };
+        target.Columns.Add(column);
+
+        Prepare(target);
+
+        Assert.Equal(HorizontalAlignment.Right, column.HorizontalContentAlignment);
+    }
+
+    [Fact]
     public void Column_Cannot_Belong_To_Two_TableViews()
     {
         using var app = Start();


### PR DESCRIPTION
## What does the pull request do?

`TableViewColumn` extends `StyledElement`. However, many features such as StyleSelectors did not work because no logical parent was set.

This is solved by registering the `TableView` as a logical parent when the `TableViewColumn` is attached (and setting it to null when detacting).

Please note: I am not sure if this is really the way to go, but I just wanted to try anyway. All other DataGrid-like controls I know don't have the columns as a stylable element. It might make more sense to undo the decision to make columns stylable and add the possibilty to add `CellClasses` that apply to every cell in a column (or something similar) instead. But that would be a breaking change and I don't know what was the reasoning behind making this a `StylableElement`.

## What is the current behavior?
StyleSelectors do not work.


## What is the updated/expected behavior with this PR?
StyleSelectors work.

As we know have a logical parent, other things such as bindings to the properties of the `DataViewColumn` (e.g., `Width`/`Header`) should now infer the (correct?) data context of the `TableView`. Also, that should effect stuff such as the Resource lookup, ... (I honestly don't know much about the implications here xD)

<img width="603" height="272" alt="image" src="https://github.com/user-attachments/assets/b424b205-e784-4729-9806-eb9d4fc7baa5" />

## How was the solution implemented (if it's not obvious)?
Setting/Unsetting the logical parent of a `TableViewColumn` when attaching/detaching to a `TableView`

I decided against adding it to the logical children of the `TableView` because I felt like there was a decision against that in the [original PR](https://github.com/AvaloniaUI/Avalonia/pull/21511#issuecomment-4647676507).

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues

Fixes #21819
