### PR TITLE
[iOS] Block external roles from activating UIScene

### DIFF
--- a/src/iOS/Avalonia.iOS/AvaloniaSceneDelegate.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaSceneDelegate.cs
@@ -13,7 +13,9 @@ internal sealed class AvaloniaSceneDelegate : UIResponder, IUIWindowSceneDelegat
     [Export("scene:willConnectToSession:options:")]
     public void WillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
     {
-        if (session.Configuration.Name is not null ||
+        // Protect against non-application scenes, which can be created by the system for external displays, CarPlay, etc. 
+        if (session.Role != UIWindowSceneSessionRole.Application ||
+            session.Configuration.Name is not null ||
             scene is not UIWindowScene windowScene ||
             Application.Current?.ApplicationLifetime is not SingleViewLifetime lifetime)
         {


### PR DESCRIPTION
Fixes #21832

This PR updates the scene connection logic in `AvaloniaSceneDelegate` to better protect against non-application scenes. When you screen mirror, the UIScene would be invoked with roles that would end up stealing views. Long-term, we need to refactor how scene delegates work with UIKit, but for now, to keep everything working and consistent, we only support the Application instance and ignore the others. That will allow stuff like AirPlay to work.

**Copilot stuff below:**

Scene connection safety:

* Added a check to ensure that only scenes with the `Application` role are handled, preventing unintended handling of system-created scenes (e.g., for external displays or CarPlay) in the `WillConnect` method of `AvaloniaSceneDelegate` (`Avalonia.iOS/AvaloniaSceneDelegate.cs`).

