### PR TITLE
Fix X11 active window tracking

### DIFF
--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -239,6 +239,8 @@ namespace Avalonia.Controls
             {
                 IsVisible = false;
 
+                if (IsActive)
+                    HandleDeactivated();
                 if (this is IFocusScope scope)
                 {
                     ((FocusManager?)FocusManager)?.RemoveFocusRoot(scope);

--- a/src/Avalonia.X11/ActivityTrackingHelper.cs
+++ b/src/Avalonia.X11/ActivityTrackingHelper.cs
@@ -10,15 +10,22 @@ internal class WindowActivationTrackingHelper : IDisposable
     private readonly X11Window _window;
     private bool _active;
 
+    // Set when the current active state came from a speculative transfer (see SetActiveSpeculatively).
+    // Only meaningful in _NET_WM_STATE_FOCUSED mode, where the guess is re-verified against the real
+    // _NET_WM_STATE the next time the active window changes.
+    private bool _speculative;
+
     public event Action<bool>? ActivationChanged;
-    
+
     public WindowActivationTrackingHelper(AvaloniaX11Platform platform, X11Window window)
     {
         _platform = platform;
         _window = window;
-        _platform.Globals.NetActiveWindowPropertyChanged += OnNetActiveWindowChanged;
+        _platform.ActiveWindowTracker.ActiveWindowChanged += OnActiveWindowChanged;
         _platform.Globals.WindowActivationTrackingModeChanged += OnWindowActivationTrackingModeChanged;
     }
+
+    public bool IsActive => _active;
 
     void SetActive(bool active)
     {
@@ -29,23 +36,23 @@ internal class WindowActivationTrackingHelper : IDisposable
         }
     }
 
+    private X11Globals.WindowActivationTrackingMode Mode => _platform.Globals.ActivationTrackingMode;
+
+    void RequeryNetWmState() =>
+        OnNetWmStateChanged(XLib.XGetWindowPropertyAsIntPtrArray(_platform.Display, _window.Handle.Handle,
+            _platform.Info.Atoms._NET_WM_STATE, _platform.Info.Atoms.ATOM) ?? []);
+
     void RequeryActivation()
     {
-        // Update the active state from WM-set properties
-        
-        if (Mode == X11Globals.WindowActivationTrackingMode._NET_ACTIVE_WINDOW) 
-            OnNetActiveWindowChanged();
-        
+        // The _NET_ACTIVE_WINDOW mode is driven by the shared X11ActiveWindowTracker, so only the
+        // per-window _NET_WM_STATE needs re-reading here.
         if (Mode == X11Globals.WindowActivationTrackingMode._NET_WM_STATE_FOCUSED)
-            OnNetWmStateChanged(XLib.XGetWindowPropertyAsIntPtrArray(_platform.Display, _window.Handle.Handle,
-                _platform.Info.Atoms._NET_WM_STATE, _platform.Info.Atoms.ATOM) ?? []);
+            RequeryNetWmState();
     }
 
     private void OnWindowActivationTrackingModeChanged() =>
         DispatcherTimer.RunOnce(RequeryActivation, TimeSpan.FromSeconds(1), DispatcherPriority.Input);
 
-    private X11Globals.WindowActivationTrackingMode Mode => _platform.Globals.ActivationTrackingMode;
-    
     public void OnEvent(ref XEvent ev)
     {
         if (ev.type is not XEventName.FocusIn and not XEventName.FocusOut)
@@ -63,30 +70,46 @@ internal class WindowActivationTrackingHelper : IDisposable
         
         SetActive(ev.type == XEventName.FocusIn);
     }
-    
-    private void OnNetActiveWindowChanged()
+
+    private void OnActiveWindowChanged(IntPtr activeWindow)
     {
         if (Mode == X11Globals.WindowActivationTrackingMode._NET_ACTIVE_WINDOW)
         {
-            var value = XLib.XGetWindowPropertyAsIntPtrArray(_platform.Display, _platform.Info.RootWindow,
-                _platform.Info.Atoms._NET_ACTIVE_WINDOW,
-                (IntPtr)_platform.Info.Atoms.WINDOW);
-            if (value == null || value.Length == 0)
-                SetActive(false);
-            else
-                SetActive(value[0] == _window.Handle.Handle);
+            // Authoritative in this mode — the published XID is the active window.
+            _speculative = false;
+            SetActive(activeWindow == _window.Handle.Handle);
         }
+        // In _NET_WM_STATE_FOCUSED mode the root _NET_ACTIVE_WINDOW change is only a "focus moved"
+        // pulse; use it to re-verify a speculative activation against the authoritative _NET_WM_STATE.
+        else if (Mode == X11Globals.WindowActivationTrackingMode._NET_WM_STATE_FOCUSED && _speculative)
+            RequeryNetWmState();
+    }
+
+    /// <summary>
+    /// Marks the window as active without waiting for the real activation notification. Used when
+    /// handing activation back to a dialog owner. The next active window change re-verifies the guess
+    /// (see <see cref="OnActiveWindowChanged"/>): authoritatively via the published XID in
+    /// _NET_ACTIVE_WINDOW mode, or by re-reading our own _NET_WM_STATE in _NET_WM_STATE_FOCUSED mode.
+    /// </summary>
+    public void SetActiveSpeculatively()
+    {
+        _speculative = true;
+        SetActive(true);
     }
 
     public void Dispose()
     {
-        _platform.Globals.NetActiveWindowPropertyChanged -= OnNetActiveWindowChanged;
+        _platform.ActiveWindowTracker.ActiveWindowChanged -= OnActiveWindowChanged;
         _platform.Globals.WindowActivationTrackingModeChanged -= OnWindowActivationTrackingModeChanged;
     }
 
     public void OnNetWmStateChanged(IntPtr[] atoms)
     {
         if (Mode == X11Globals.WindowActivationTrackingMode._NET_WM_STATE_FOCUSED)
+        {
+            // Authoritative signal — it overrides any speculative guess.
+            _speculative = false;
             SetActive(atoms.Contains(_platform.Info.Atoms._NET_WM_STATE_FOCUSED));
+        }
     }
 }

--- a/src/Avalonia.X11/X11ActiveWindowTracker.cs
+++ b/src/Avalonia.X11/X11ActiveWindowTracker.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+using Avalonia.Threading;
+
+namespace Avalonia.X11;
+
+/// <summary>
+/// Watches the root <c>_NET_ACTIVE_WINDOW</c> property and raises <see cref="ActiveWindowChanged"/>
+/// whenever the active window changes. This is a single, always-updated global notification that
+/// <c>_NET_WM_STATE_FOCUSED</c> mode lacks (that one only notifies the window whose own state changed),
+/// so windows use it both to track activation (in <c>_NET_ACTIVE_WINDOW</c> mode) and to re-verify a
+/// speculative activation (in <c>_NET_WM_STATE_FOCUSED</c> mode).
+/// </summary>
+internal class X11ActiveWindowTracker
+{
+    private readonly AvaloniaX11Platform _platform;
+    private IntPtr _activeWindow;
+
+    public event Action<IntPtr>? ActiveWindowChanged;
+
+    public X11ActiveWindowTracker(AvaloniaX11Platform platform)
+    {
+        _platform = platform;
+        _platform.Globals.NetActiveWindowPropertyChanged += Requery;
+        _platform.Globals.WindowActivationTrackingModeChanged += OnModeChanged;
+        _platform.Globals.NetSupportedChanged += Requery;
+        Requery();
+    }
+
+    // Whether the WM publishes root _NET_ACTIVE_WINDOW at all. Speculative activations can only be
+    // auto-corrected when it does, since that's the notification we re-verify against.
+    public bool TracksRootActiveWindow =>
+        _platform.Globals.NetSupported?.Contains(_platform.Info.Atoms._NET_ACTIVE_WINDOW) ?? false;
+
+    private void SetActiveWindow(IntPtr window)
+    {
+        if (_activeWindow != window)
+        {
+            _activeWindow = window;
+            ActiveWindowChanged?.Invoke(window);
+        }
+    }
+
+    private void Requery()
+    {
+        if (!TracksRootActiveWindow)
+            return;
+        var value = XLib.XGetWindowPropertyAsIntPtrArray(_platform.Info.Display, _platform.Info.RootWindow,
+            _platform.Info.Atoms._NET_ACTIVE_WINDOW, (IntPtr)_platform.Info.Atoms.WINDOW);
+        SetActiveWindow(value is { Length: > 0 } ? value[0] : IntPtr.Zero);
+    }
+
+    private void OnModeChanged() =>
+        DispatcherTimer.RunOnce(Requery, TimeSpan.FromSeconds(1), DispatcherPriority.Input);
+}

--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -45,6 +45,7 @@ namespace Avalonia.X11
         public X11PlatformOptions Options { get; private set; } = null!;
         public IntPtr OrphanedWindow { get; private set; }
         public X11Globals Globals { get; private set; } = null!;
+        public X11ActiveWindowTracker ActiveWindowTracker { get; private set; } = null!;
         public XResources Resources { get; private set; } = null!;
         public ManualRawEventGrouperDispatchQueue EventGrouperDispatchQueue { get; } = new();
         public IX11PlatformDispatcher DispatcherImpl { get; private set; } = null!;
@@ -75,6 +76,7 @@ namespace Avalonia.X11
 
             Info = new X11Info(Display, DeferredDisplay, useXim);
             Globals = new X11Globals(this);
+            ActiveWindowTracker = new X11ActiveWindowTracker(this);
             Resources = new XResources(this);
 
             IRenderTimer timer = options.ShouldRenderOnUIThread

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -66,6 +66,7 @@ namespace Avalonia.X11
         private bool _disabled;
         private TransparencyHelper? _transparencyHelper;
         private WindowActivationTrackingHelper? _activationTracker;
+        private X11Window? _transientParent;
         private RawEventGrouper? _rawEventGrouper;
         private bool _useRenderWindow = false;
         private bool _useCompositorDrivenRenderWindowResize = false;
@@ -1125,6 +1126,22 @@ namespace Avalonia.X11
                     atSpiServer.RemoveWindow(atSpiPeer);
             }
 
+            // If we're closing the active window, speculatively hand activation back to its owner so an
+            // awaited ShowDialog() sees the owner as active immediately, instead of waiting for the
+            // asynchronous activation notification (auto-corrected later if the guess is wrong).
+            // Mirroring win32's BeforeCloseCleanup, the owner has to be re-enabled before it's activated:
+            // while it's still modally disabled the activation would be swallowed by
+            // ActivateTransientChildIfNeeded. The managed layer sets the final enabled state afterwards.
+            // Only speculate when there's a root _NET_ACTIVE_WINDOW notification to auto-correct against.
+            if (_handle != IntPtr.Zero
+                && _transientParent is { } parent && parent._handle != IntPtr.Zero
+                && _activationTracker?.IsActive == true
+                && _platform.ActiveWindowTracker.TracksRootActiveWindow)
+            {
+                parent.SetEnabled(true);
+                parent.SetActiveSpeculatively();
+            }
+
             // Before doing anything else notify the TopLevel that ITopLevelImpl is no longer valid
             if (_handle != IntPtr.Zero)
                 Closed?.Invoke();
@@ -1201,12 +1218,20 @@ namespace Avalonia.X11
             return false;
         }
 
+        private void SetActiveSpeculatively() => _activationTracker?.SetActiveSpeculatively();
+
         public void SetParent(IWindowImpl? parent)
         {
             if (parent == null || parent.Handle == null || parent.Handle.Handle == IntPtr.Zero)
+            {
+                _transientParent = null;
                 XDeleteProperty(_x11.Display, _handle, _x11.Atoms.WM_TRANSIENT_FOR);
+            }
             else
+            {
+                _transientParent = parent as X11Window;
                 XSetTransientForHint(_x11.Display, _handle, parent.Handle.Handle);
+            }
         }
 
         public void Show(bool activate, bool isDialog)

--- a/tests/Avalonia.Controls.UnitTests/WindowBaseTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowBaseTests.cs
@@ -99,6 +99,61 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Active_Window_Should_Be_Deactivated_When_Impl_Signals_Close()
+        {
+            var windowImpl = new Mock<IPopupImpl>();
+            windowImpl.Setup(x => x.Compositor).Returns(RendererMocks.CreateDummyCompositor());
+            windowImpl.Setup(x => x.DesktopScaling).Returns(1);
+            windowImpl.Setup(x => x.RenderScaling).Returns(1);
+            windowImpl.SetupProperty(x => x.Activated);
+            windowImpl.SetupProperty(x => x.Closed);
+
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var target = new TestWindowBase(windowImpl.Object);
+                var deactivated = 0;
+                target.Deactivated += (s, e) => deactivated++;
+
+                target.Show();
+                windowImpl.Object.Activated!();
+                Assert.True(target.IsActive);
+
+                // Some backends (e.g. X11) never deliver a deactivation notification on close.
+                windowImpl.Object.Closed!();
+
+                Assert.False(target.IsActive);
+                Assert.Equal(1, deactivated);
+            }
+        }
+
+        [Fact]
+        public void Inactive_Window_Should_Not_Raise_Deactivated_When_Impl_Signals_Close()
+        {
+            var windowImpl = new Mock<IPopupImpl>();
+            windowImpl.Setup(x => x.Compositor).Returns(RendererMocks.CreateDummyCompositor());
+            windowImpl.Setup(x => x.DesktopScaling).Returns(1);
+            windowImpl.Setup(x => x.RenderScaling).Returns(1);
+            windowImpl.SetupProperty(x => x.Deactivated);
+            windowImpl.SetupProperty(x => x.Closed);
+
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var target = new TestWindowBase(windowImpl.Object);
+                var deactivated = 0;
+                target.Deactivated += (s, e) => deactivated++;
+
+                target.Show();
+                Assert.False(target.IsActive);
+
+                // Backends that deactivate before closing must not produce a duplicate event.
+                windowImpl.Object.Closed!();
+
+                Assert.False(target.IsActive);
+                Assert.Equal(0, deactivated);
+            }
+        }
+
+        [Fact]
         public void IsVisible_Should_Be_False_Atfer_Impl_Signals_Close()
         {
             var windowImpl = new Mock<IPopupImpl>();


### PR DESCRIPTION
This masks disparity between X11 and win32/macos backends. Unlike those window activation arrives asynchronously, when dialog gets closed its parent doesn't become active window immediately.

So in modes where we can reliably track current active window, we speculatively mark the parent as new active window. If another window becomes active, it auto-corrects on the next _NET_ACTIVE_WINDOW property change (which is bound to arrive since we just closed the current active window).

The PR also addresses window.IsActive staying true after window got closed if backend haven't triggered deactivation event for some reason

Fixes #21841