### PR TITLE
fix(grid): register assigned definition collections with their shared size group

### DIFF
--- a/src/Avalonia.Controls/DefinitionBase.cs
+++ b/src/Avalonia.Controls/DefinitionBase.cs
@@ -60,6 +60,10 @@ namespace Avalonia.Controls
             }
 
             Parent?.InvalidateMeasure();
+
+            //  while this link survives the definition still reads the grid's inherited
+            //  PrivateSharedSizeScope, and the grid holds it as an inheritance child.
+            InheritanceParent = null;
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/DefinitionList.cs
+++ b/src/Avalonia.Controls/DefinitionList.cs
@@ -30,31 +30,45 @@ namespace Avalonia.Controls
                 return;
             }
 
-            //  Definitions already in the collection when the grid claims it never pass through
-            //  OnCollectionChanged, so they have to be joined to (and detached from) the parent tree
-            //  here. Assigning Parent alone is not enough: OnEnterParentTree also establishes the
-            //  property inheritance link the definition needs to see its shared size scope.
-            if (_parent is not null)
-            {
-                foreach (T definition in this)
-                {
-                    definition.OnExitParentTree();
-                }
-            }
-
             _parent = value;
 
+            //  definitions already present when the grid claims the collection never pass through
+            //  OnCollectionChanged, so they have to change trees here.
             var idx = 0;
 
             foreach (T definition in this)
             {
-                definition.Parent = value;
+                SetDefinitionParent(definition, value);
                 definition.Index = idx++;
+            }
+        }
 
-                if (value is not null)
-                {
-                    definition.OnEnterParentTree();
-                }
+        /// <summary>
+        /// Moves a definition from its current parent tree to <paramref name="parent"/>. Every route
+        /// that changes a definition's owner goes through here.
+        /// </summary>
+        /// <remarks>
+        /// Ownership is more than the Parent pointer: entering a tree also establishes the property
+        /// inheritance link a definition needs to see its shared size scope, and leaving one releases
+        /// that link and its shared size registration.
+        /// </remarks>
+        private static void SetDefinitionParent(DefinitionBase definition, Grid? parent)
+        {
+            if (definition.Parent == parent)
+            {
+                return;
+            }
+
+            if (definition.Parent is not null)
+            {
+                definition.OnExitParentTree();
+            }
+
+            definition.Parent = parent;
+
+            if (parent is not null)
+            {
+                definition.OnEnterParentTree();
             }
         }
 
@@ -84,17 +98,7 @@ namespace Avalonia.Controls
 
             for (var i = 0; i < count; i++)
             {
-                var definition = (DefinitionBase) items[i]!;
-
-                if (wasRemoved)
-                {
-                    definition.OnExitParentTree();
-                }
-                else
-                {
-                    definition.Parent = Parent;
-                    definition.OnEnterParentTree();                    
-                }
+                SetDefinitionParent((DefinitionBase)items[i]!, wasRemoved ? null : Parent);
             }
         }
     }

--- a/src/Avalonia.Controls/DefinitionList.cs
+++ b/src/Avalonia.Controls/DefinitionList.cs
@@ -25,6 +25,23 @@ namespace Avalonia.Controls
 
         private void SetParent(Grid? value)
         {
+            if (_parent == value)
+            {
+                return;
+            }
+
+            //  Definitions already in the collection when the grid claims it never pass through
+            //  OnCollectionChanged, so they have to be joined to (and detached from) the parent tree
+            //  here. Assigning Parent alone is not enough: OnEnterParentTree also establishes the
+            //  property inheritance link the definition needs to see its shared size scope.
+            if (_parent is not null)
+            {
+                foreach (T definition in this)
+                {
+                    definition.OnExitParentTree();
+                }
+            }
+
             _parent = value;
 
             var idx = 0;
@@ -33,6 +50,11 @@ namespace Avalonia.Controls
             {
                 definition.Parent = value;
                 definition.Index = idx++;
+
+                if (value is not null)
+                {
+                    definition.OnEnterParentTree();
+                }
             }
         }
 

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -198,6 +198,12 @@ namespace Avalonia.Controls
             set
             {
                 if (_extData == null) { _extData = new ExtendedData(); }
+                //  release the outgoing definitions, otherwise they stay registered with their
+                //  shared size group and keep contributing to its minimum.
+                if (_extData.ColumnDefinitions is { } oldDefinitions && !ReferenceEquals(oldDefinitions, value))
+                {
+                    oldDefinitions.Parent = null;
+                }
                 _extData.ColumnDefinitions = value;
                 _extData.ColumnDefinitions.Parent = this;
                 InvalidateMeasure();
@@ -220,6 +226,12 @@ namespace Avalonia.Controls
             set
             {
                 if (_extData == null) { _extData = new ExtendedData(); }
+                //  release the outgoing definitions, otherwise they stay registered with their
+                //  shared size group and keep contributing to its minimum.
+                if (_extData.RowDefinitions is { } oldDefinitions && !ReferenceEquals(oldDefinitions, value))
+                {
+                    oldDefinitions.Parent = null;
+                }
                 _extData.RowDefinitions = value;
                 _extData.RowDefinitions.Parent = this;
                 InvalidateMeasure();

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -198,8 +198,8 @@ namespace Avalonia.Controls
             set
             {
                 if (_extData == null) { _extData = new ExtendedData(); }
-                //  release the outgoing definitions, otherwise they stay registered with their
-                //  shared size group and keep contributing to its minimum.
+                //  otherwise the outgoing definitions stay registered with their shared size
+                //  group and keep contributing to its minimum.
                 if (_extData.ColumnDefinitions is { } oldDefinitions && !ReferenceEquals(oldDefinitions, value))
                 {
                     oldDefinitions.Parent = null;
@@ -226,8 +226,8 @@ namespace Avalonia.Controls
             set
             {
                 if (_extData == null) { _extData = new ExtendedData(); }
-                //  release the outgoing definitions, otherwise they stay registered with their
-                //  shared size group and keep contributing to its minimum.
+                //  otherwise the outgoing definitions stay registered with their shared size
+                //  group and keep contributing to its minimum.
                 if (_extData.RowDefinitions is { } oldDefinitions && !ReferenceEquals(oldDefinitions, value))
                 {
                     oldDefinitions.Parent = null;

--- a/tests/Avalonia.Controls.UnitTests/GridTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/GridTests.cs
@@ -1294,6 +1294,163 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Removing_Definition_Detaches_It_From_The_Grid()
+        {
+            var shared = new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "A" };
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(shared);
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            grid.Children.Add(new Border { Width = 50, Height = 10 });
+
+            var other = new Grid();
+            other.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "A" });
+            other.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+            var scope = new StackPanel
+            {
+                [Grid.IsSharedSizeScopeProperty] = true,
+                Children = { grid, other },
+            };
+            var root = new TestRoot(scope);
+
+            root.ExecuteInitialLayoutPass();
+            root.LayoutManager.ExecuteLayoutPass();
+            Assert.Equal(50, other.ColumnDefinitions[0].ActualWidth);
+
+            grid.ColumnDefinitions.Remove(shared);
+            root.LayoutManager.ExecuteLayoutPass();
+            root.LayoutManager.ExecuteLayoutPass();
+            Assert.Equal(0, other.ColumnDefinitions[0].ActualWidth);
+            Assert.Null(shared.Parent);
+
+            // A definition that has left the grid must no longer see the grid's scope.
+            shared.SharedSizeGroup = null;
+            shared.SharedSizeGroup = "A";
+            root.LayoutManager.ExecuteLayoutPass();
+            root.LayoutManager.ExecuteLayoutPass();
+            Assert.Equal(0, other.ColumnDefinitions[0].ActualWidth);
+        }
+
+        [Fact]
+        public void Moving_Definition_Between_Grids_Moves_Its_Shared_Size_Registration()
+        {
+            var shared = new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "A" };
+            var source = new Grid();
+            source.ColumnDefinitions.Add(shared);
+            source.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            source.Children.Add(new Border { Width = 50, Height = 10 });
+
+            var sourcePartner = new Grid();
+            sourcePartner.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "A" });
+            sourcePartner.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+            var target = new Grid();
+            target.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+            var targetPartner = new Grid();
+            targetPartner.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "A" });
+            targetPartner.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            targetPartner.Children.Add(new Border { Width = 20, Height = 10 });
+
+            var sourceScope = new StackPanel
+            {
+                [Grid.IsSharedSizeScopeProperty] = true,
+                Children = { source, sourcePartner },
+            };
+            var targetScope = new StackPanel
+            {
+                [Grid.IsSharedSizeScopeProperty] = true,
+                Children = { target, targetPartner },
+            };
+            var root = new TestRoot(new StackPanel { Children = { sourceScope, targetScope } });
+
+            root.ExecuteInitialLayoutPass();
+            root.LayoutManager.ExecuteLayoutPass();
+            Assert.Equal(50, sourcePartner.ColumnDefinitions[0].ActualWidth);
+            Assert.Equal(20, targetPartner.ColumnDefinitions[0].ActualWidth);
+
+            source.ColumnDefinitions.Remove(shared);
+            target.ColumnDefinitions.Insert(0, shared);
+            root.LayoutManager.ExecuteLayoutPass();
+            root.LayoutManager.ExecuteLayoutPass();
+
+            Assert.Same(target, shared.Parent);
+            Assert.Equal(0, sourcePartner.ColumnDefinitions[0].ActualWidth);
+            Assert.Equal(20, target.ColumnDefinitions[0].ActualWidth);
+        }
+
+        [Fact]
+        public void Reassigning_The_Same_Definition_Collection_Is_Inert()
+        {
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "A" });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            grid.Children.Add(new Border { Width = 50, Height = 10 });
+
+            var other = new Grid();
+            other.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "A" });
+            other.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+            var scope = new StackPanel
+            {
+                [Grid.IsSharedSizeScopeProperty] = true,
+                Children = { grid, other },
+            };
+            var root = new TestRoot(scope);
+
+            root.ExecuteInitialLayoutPass();
+            root.LayoutManager.ExecuteLayoutPass();
+            Assert.Equal(50, other.ColumnDefinitions[0].ActualWidth);
+
+            var definitions = grid.ColumnDefinitions;
+            grid.ColumnDefinitions = definitions;
+            root.LayoutManager.ExecuteLayoutPass();
+            root.LayoutManager.ExecuteLayoutPass();
+
+            Assert.Same(definitions, grid.ColumnDefinitions);
+            Assert.Equal(50, other.ColumnDefinitions[0].ActualWidth);
+        }
+
+        [Fact]
+        public void Shared_Size_Group_Is_Registered_For_Row_Definitions_Assigned_As_A_Collection()
+        {
+            var grids = new[]
+            {
+                new Grid
+                {
+                    RowDefinitions = new RowDefinitions
+                    {
+                        new RowDefinition { Height = GridLength.Auto, SharedSizeGroup = "A" },
+                        new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                    },
+                },
+                new Grid
+                {
+                    RowDefinitions = new RowDefinitions
+                    {
+                        new RowDefinition { Height = GridLength.Auto, SharedSizeGroup = "A" },
+                        new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                    },
+                },
+            };
+            grids[0].Children.Add(new Border { Width = 10, Height = 50 });
+
+            var scope = new StackPanel
+            {
+                Orientation = Layout.Orientation.Horizontal,
+                [Grid.IsSharedSizeScopeProperty] = true,
+                Children = { grids[0], grids[1] },
+            };
+            var root = new TestRoot(scope);
+
+            root.ExecuteInitialLayoutPass();
+            root.LayoutManager.ExecuteLayoutPass();
+
+            Assert.Equal(50, grids[0].RowDefinitions[0].ActualHeight);
+            Assert.Equal(50, grids[1].RowDefinitions[0].ActualHeight);
+        }
+
+        [Fact]
         public void Collection_Changes_Are_Tracked()
         {
             var grid = CreateGrid(

--- a/tests/Avalonia.Controls.UnitTests/GridTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/GridTests.cs
@@ -1213,6 +1213,87 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Shared_Size_Group_Is_Registered_For_Definitions_Assigned_As_A_Collection()
+        {
+            // Definitions supplied through the ColumnDefinitions setter - an object initializer, a
+            // shared resource, or ColumnDefinitions="Auto,*" - are already in the collection when the
+            // grid claims it, so they never pass through the collection-changed handler that joins
+            // them to the parent tree.
+            var grids = new[]
+            {
+                new Grid
+                {
+                    ColumnDefinitions = new ColumnDefinitions
+                    {
+                        new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "A" },
+                        new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                    },
+                },
+                new Grid
+                {
+                    ColumnDefinitions = new ColumnDefinitions
+                    {
+                        new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "A" },
+                        new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                    },
+                },
+            };
+            grids[0].Children.Add(new Border { Width = 50, Height = 10 });
+
+            var scope = new StackPanel
+            {
+                [Grid.IsSharedSizeScopeProperty] = true,
+                Children = { grids[0], grids[1] },
+            };
+            var root = new TestRoot(scope);
+
+            root.ExecuteInitialLayoutPass();
+            // Shared groups validate after layout and apply any resulting invalidation on the next pass.
+            root.LayoutManager.ExecuteLayoutPass();
+
+            Assert.Equal(50, grids[0].ColumnDefinitions[0].ActualWidth);
+            Assert.Equal(50, grids[1].ColumnDefinitions[0].ActualWidth);
+        }
+
+        [Fact]
+        public void Replacing_Definition_Collection_Releases_Its_Shared_Size_Group()
+        {
+            // The outgoing definitions are no longer reachable from the grid, so nothing resets their
+            // measured minimum. Left registered, they keep the group pinned at whatever size they
+            // last contributed.
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "A" });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            grid.Children.Add(new Border { Width = 50, Height = 10 });
+
+            var other = new Grid();
+            other.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "A" });
+            other.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+            var scope = new StackPanel
+            {
+                [Grid.IsSharedSizeScopeProperty] = true,
+                Children = { grid, other },
+            };
+            var root = new TestRoot(scope);
+
+            root.ExecuteInitialLayoutPass();
+            // Shared groups validate after layout and apply any resulting invalidation on the next pass.
+            root.LayoutManager.ExecuteLayoutPass();
+            Assert.Equal(50, other.ColumnDefinitions[0].ActualWidth);
+
+            grid.ColumnDefinitions = new ColumnDefinitions
+            {
+                new ColumnDefinition { Width = GridLength.Auto },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            };
+            root.LayoutManager.ExecuteLayoutPass();
+            root.LayoutManager.ExecuteLayoutPass();
+
+            Assert.Equal(0, other.ColumnDefinitions[0].ActualWidth);
+        }
+
+        [Fact]
         public void Collection_Changes_Are_Tracked()
         {
             var grid = CreateGrid(


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Makes `Grid` join a definition collection to the parent tree when the collection is assigned, rather than only when definitions are added to an already-parented collection. Without this, definitions supplied through the `ColumnDefinitions` / `RowDefinitions` setter are silently absent from their `SharedSizeGroup`.

Found while addressing review feedback on #21837.

## What is the current behavior?

`DefinitionList.SetParent` assigns each definition's `Parent` but never calls `OnEnterParentTree`, which only runs from the collection-changed handler. Definitions already present when the grid claims the collection therefore never join the parent tree.

Assigning `Parent` is not sufficient. `OnEnterParentTree` also sets `InheritanceParent`, and a definition cannot read the inherited `PrivateSharedSizeScope` that registers it with its group until that link exists. The failure is silent: the grid lays out correctly in every other respect, and only the group membership is missing.

This affects every route through the setter:

```csharp
new Grid
{
    ColumnDefinitions = new ColumnDefinitions
    {
        new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "A" },
    },
}
```

as well as `ColumnDefinitions="Auto,*"` and a `ColumnDefinitions` supplied as a shared resource.

The reverse case leaks. When a grid swaps in a new collection, the outgoing definitions keep their registration. They are no longer reachable from the grid, so nothing resets their measured minimum, and they pin the group at whatever size they last contributed — a shared column stays wide after the definitions that made it wide are gone.

## What is the updated/expected behavior with this PR?

Definitions assigned as a collection register with their shared size group, and definitions replaced by a new collection unregister from it.

Validation on macOS ARM64 with .NET 10:

- Added `Shared_Size_Group_Is_Registered_For_Definitions_Assigned_As_A_Collection` and `Replacing_Definition_Collection_Releases_Its_Shared_Size_Group`. Each fails against unmodified sources on its own defect (0 instead of 50; 50 instead of 0) and passes with the fix.
- `GridTests`: 95 passed, 0 failed.
- `Avalonia.Controls.UnitTests`: 3,651 total, 3,650 passed, 1 pre-existing skip, 0 failed.
- `Avalonia.Markup.Xaml.UnitTests`: 591 total, 588 passed, 3 skipped, 0 failed.
- `Avalonia.Base.UnitTests`: 2,994 total, 2,982 passed, 12 skipped, 0 failed.
- `Avalonia.Markup.UnitTests`: 252 passed, 0 failed.

## How was the solution implemented (if it's not obvious)?

`SetParent` now exits the old parent tree and enters the new one, so a definition's tree membership follows the collection however it was populated. It returns early when the parent is unchanged, which keeps the `Grid` setter's unconditional `Parent = this` idempotent.

`Grid` releases the previous collection before adopting a new one. That release is what unregisters the outgoing definitions, so it depends on the `SetParent` change.

The commits follow the repository's bug-fix convention: the first adds the failing behavioral tests, the second contains the fix.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes? No public API was added or changed.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation. No documentation change is needed; this restores the behavior the existing documentation already describes.

## Breaking changes

None. Both changes affect internal parent-tree bookkeeping only.

## Obsoletions / Deprecations

None.

## Fixed issues

None filed for this specific path. It may be the underlying cause of some reports of `SharedSizeGroup` not applying, but I have not verified any individual issue against it.
