### PR TITLE
Add a parameterless Window.BeginMoveDrag overload for presses that never enter Avalonia's input pipeline

### DIFF
--- a/src/Avalonia.Controls/Platform/IWindowImpl.cs
+++ b/src/Avalonia.Controls/Platform/IWindowImpl.cs
@@ -141,6 +141,14 @@ namespace Avalonia.Platform
         void BeginMoveDrag(PointerPressedEventArgs e);
 
         /// <summary>
+        /// Starts moving a window using the platform's current input state, without an originating
+        /// Avalonia pointer event. Used when the initiating press is handled by hosted native content
+        /// (for example a WebView) and never enters Avalonia's input pipeline. Called while the
+        /// primary pointer button is held down.
+        /// </summary>
+        void BeginMoveDrag();
+
+        /// <summary>
         /// Starts resizing a window. This function is used if an application has window resizing controls. 
         /// Should be called from left mouse button press event handler
         /// </summary>

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -551,6 +551,14 @@ namespace Avalonia.Controls
         public void BeginMoveDrag(PointerPressedEventArgs e) => PlatformImpl?.BeginMoveDrag(e);
 
         /// <summary>
+        /// Starts moving a window using the platform's current input state, without an originating
+        /// Avalonia pointer event. Intended for presses handled by hosted native content (for example
+        /// a WebView), which never enter Avalonia's input pipeline. Should be called while the
+        /// primary pointer button is held down.
+        /// </summary>
+        public void BeginMoveDrag() => PlatformImpl?.BeginMoveDrag();
+
+        /// <summary>
         /// Starts resizing a window. This function is used if an application has window resizing controls. 
         /// Should be called from left mouse button press event handler
         /// </summary>

--- a/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
+++ b/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
@@ -33,6 +33,10 @@ namespace Avalonia.DesignerSupport.Remote
         {
         }
 
+        public void BeginMoveDrag()
+        {
+        }
+
         public void BeginResizeDrag(WindowEdge edge, PointerPressedEventArgs e)
         {
         }

--- a/src/Avalonia.DesignerSupport/Remote/Stubs.cs
+++ b/src/Avalonia.DesignerSupport/Remote/Stubs.cs
@@ -107,6 +107,10 @@ namespace Avalonia.DesignerSupport.Remote
         {
         }
 
+        public void BeginMoveDrag()
+        {
+        }
+
         public void BeginResizeDrag(WindowEdge edge, PointerPressedEventArgs e)
         {
         }

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -102,6 +102,11 @@ namespace Avalonia.Native
             Native?.BeginMoveDrag();
         }
 
+        public void BeginMoveDrag()
+        {
+            Native?.BeginMoveDrag();
+        }
+
         public Size MaxAutoSizeHint => this.TryGetFeature<IScreenImpl>()!.AllScreens
             .Select(s => s.Bounds.Size.ToSize(1))
             .OrderByDescending(x => x.Width + x.Height).FirstOrDefault();

--- a/src/Avalonia.Wayland/WindowImpl.cs
+++ b/src/Avalonia.Wayland/WindowImpl.cs
@@ -317,6 +317,14 @@ internal partial class WindowImpl : WindowBaseImpl, IWindowImpl
         _surfaceProxy?.Move(cookie, WaylandDispatchPriority.Oob);
     }
 
+    public void BeginMoveDrag()
+    {
+        // No Avalonia event exists for the initiating press (it was handled by hosted native
+        // content), so consume the serial of the latest press delivered to this surface —
+        // the same serial an event-carried cookie would hold for that press.
+        _surfaceProxy?.Move(LatestPressCookie, WaylandDispatchPriority.Oob);
+    }
+
     public void BeginResizeDrag(WindowEdge edge, PointerPressedEventArgs e)
     {
         var resizeEdge = edge switch

--- a/src/Avalonia.Wayland/WindowImplBase.Pointer.cs
+++ b/src/Avalonia.Wayland/WindowImplBase.Pointer.cs
@@ -35,6 +35,8 @@ partial class WindowBaseImpl
         void IWSurfaceEventSink.OnPointerButton(ulong timestamp, uint serial, RawPointerEventType type,
             RawInputModifiers modifiers, Point position, object? platformCookie)
         {
+            if (platformCookie != null)
+                Parent.LatestPressCookie = platformCookie;
             if (InputRoot is null)
                 return;
             ScheduleInput(new RawPointerEventArgs(Mouse, timestamp, InputRoot,
@@ -52,6 +54,8 @@ partial class WindowBaseImpl
 
         void IWSurfaceEventSink.OnTouchDown(ulong timestamp, int touchId, Point position, object? platformCookie)
         {
+            if (platformCookie != null)
+                Parent.LatestPressCookie = platformCookie;
             if (InputRoot is null)
                 return;
             ScheduleInput(new RawTouchEventArgs(Touch, timestamp, InputRoot,

--- a/src/Avalonia.Wayland/WindowImplBase.cs
+++ b/src/Avalonia.Wayland/WindowImplBase.cs
@@ -39,6 +39,13 @@ internal abstract partial class WindowBaseImpl : IWindowBaseImpl
     
     internal IReadOnlyList<object> CurrentOutputIds { get; set; } = Array.Empty<object>();
 
+    /// <summary>
+    /// The platform cookie of the most recent pointer or touch press delivered to this surface.
+    /// Consumed by the parameterless BeginMoveDrag, whose initiating press is handled by hosted
+    /// native content and therefore has no Avalonia event to read a cookie from.
+    /// </summary>
+    internal object? LatestPressCookie { get; private protected set; }
+
     protected WindowBaseImpl(WaylandWorkerClient client)
     {
         Client = client;

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -1409,18 +1409,27 @@ namespace Avalonia.X11
 
         private void BeginMoveResize(NetWmMoveResize side, PointerPressedEventArgs e)
         {
+            BeginMoveResizeCore(side);
+            e.Pointer.Capture(null);
+        }
+
+        private void BeginMoveResizeCore(NetWmMoveResize side)
+        {
             var pos = GetCursorPos(_x11);
             XUngrabPointer(_x11.Display, new IntPtr(0));
             SendNetWMMessage (_x11.Atoms._NET_WM_MOVERESIZE, (IntPtr) pos.x, (IntPtr) pos.y,
                 (IntPtr) side,
                 (IntPtr) 1, (IntPtr)1); // left button
-                
-            e.Pointer.Capture(null);
         }
 
         public void BeginMoveDrag(PointerPressedEventArgs e)
         {
             BeginMoveResize(NetWmMoveResize._NET_WM_MOVERESIZE_MOVE, e);
+        }
+
+        public void BeginMoveDrag()
+        {
+            BeginMoveResizeCore(NetWmMoveResize._NET_WM_MOVERESIZE_MOVE);
         }
 
         public void BeginResizeDrag(WindowEdge edge, PointerPressedEventArgs e)

--- a/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -420,7 +420,12 @@ namespace Avalonia.Headless
 
         public void BeginMoveDrag(PointerPressedEventArgs e)
         {
-            
+
+        }
+
+        public void BeginMoveDrag()
+        {
+
         }
 
         public void BeginResizeDrag(WindowEdge edge, PointerPressedEventArgs e)

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -788,7 +788,15 @@ namespace Avalonia.Win32
             }, DispatcherPriority.Send);
         }
 
-        public void BeginMoveDrag() => Dispatcher.UIThread.Post(BeginMoveDragCore, DispatcherPriority.Send);
+        public void BeginMoveDrag() => Dispatcher.UIThread.Post(() =>
+        {
+            // The initiating press was handled by hosted native content, which may hold the mouse
+            // capture on this thread (WebView2's in-process input window does) — the interactive
+            // move loop never receives the input stream while it does. The event-args overload
+            // receives this release implicitly through e.Pointer.Capture(null).
+            ReleaseCapture();
+            BeginMoveDragCore();
+        }, DispatcherPriority.Send);
 
         private void BeginMoveDragCore()
         {

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -779,18 +779,25 @@ namespace Avalonia.Win32
             {
                 if (e.Pointer.IsPrimary)
                 {
-                    // SendMessage's return value is dependent on the message send.  WM_SYSCOMMAND
-                    // and WM_LBUTTONUP return value just signify whether the WndProc handled the
-                    // message or not, so they are not interesting
-
-                    SendMessage(_hwnd, (int)WindowsMessage.WM_SYSCOMMAND, (IntPtr)SC_MOUSEMOVE, IntPtr.Zero);
-                    SendMessage(_hwnd, (int)WindowsMessage.WM_LBUTTONUP, IntPtr.Zero, IntPtr.Zero);
+                    BeginMoveDragCore();
                 }
                 else
                 {
                     throw new InvalidOperationException("BeginMoveDrag Failed");
                 }
             }, DispatcherPriority.Send);
+        }
+
+        public void BeginMoveDrag() => Dispatcher.UIThread.Post(BeginMoveDragCore, DispatcherPriority.Send);
+
+        private void BeginMoveDragCore()
+        {
+            // SendMessage's return value is dependent on the message send.  WM_SYSCOMMAND
+            // and WM_LBUTTONUP return value just signify whether the WndProc handled the
+            // message or not, so they are not interesting
+
+            SendMessage(_hwnd, (int)WindowsMessage.WM_SYSCOMMAND, (IntPtr)SC_MOUSEMOVE, IntPtr.Zero);
+            SendMessage(_hwnd, (int)WindowsMessage.WM_LBUTTONUP, IntPtr.Zero, IntPtr.Zero);
         }
 
         public void BeginResizeDrag(WindowEdge edge, PointerPressedEventArgs e)


### PR DESCRIPTION
## What does the pull request do?

Adds a parameterless `Window.BeginMoveDrag()` overload (and the matching member on the `[Unstable]`
`IWindowImpl`) that starts an interactive window move from the platform's current input state, for
presses that never enter Avalonia's input pipeline.

The motivating scenario is custom window chrome drawn by hosted native content: an application that
merges the title bar with an embedded native view (for example a webview embedded through
`NativeControlHost`, such as `Avalonia.Controls.WebView`'s `NativeWebView`) receives the title-bar
press inside that native view and relays it to the host over a message bridge. At that point there is
no `PointerPressedEventArgs` to satisfy the existing `BeginMoveDrag(PointerPressedEventArgs)`
signature, so today every such application reproduces platform interop by hand (`WM_SYSCOMMAND` /
`performWindowDragWithEvent:` / `_NET_WM_MOVERESIZE`). #21827 made the macOS native side able to
serve this case; this PR completes the picture with a managed API that every desktop backend
implements honestly.

Related: #21827, #8429

## What is the current behavior?

`BeginMoveDrag` requires a `PointerPressedEventArgs` from Avalonia's input pipeline. A press handled
by an embedded native view is consumed by that view and never becomes an Avalonia pointer event, so
there is no legitimate argument to pass — applications fall back to per-platform interop, which the
Wayland backend cannot even offer (compositors require the input serial of a real event, which only
the backend holds).

## What is the updated/expected behavior with this PR?

`Window.BeginMoveDrag()` starts the interactive move while the primary pointer button is held down,
regardless of where the press was delivered. Per backend:

- **Win32**: releases the mouse capture, then posts the same `WM_SYSCOMMAND`/`SC_MOUSEMOVE` +
  `WM_LBUTTONUP` sequence as the existing overload (extracted into a shared core). The explicit
  `ReleaseCapture()` is required because hosted native content may hold the capture from the press
  (WebView2's in-process input window does, verified on hardware), which starves the interactive
  move loop of input — the event-args overload receives the same release implicitly through
  `e.Pointer.Capture(null)` and is unchanged, including its primary-pointer check.
- **macOS (Avalonia.Native)**: calls `Native.BeginMoveDrag()`, which since #21827 falls back to the
  event the application is currently tracking when no view-recorded mouse-down exists.
- **X11**: sends the same `_NET_WM_MOVERESIZE` message as the existing overload (extracted into a
  shared core — the position already comes from `XQueryPointer`, not the event); the event-args path
  additionally releases capture, exactly as before.
- **Wayland**: consumes the input-event cookie (seat + serial) of the latest pointer or touch press
  delivered to the surface, recorded as presses flow through the window's event sink — the same
  cookie an Avalonia-delivered event would have carried for that press, following the precedent of
  `DataDevice.LastInputSerial`. The cookie's single-use and display-validity guards apply unchanged,
  so a stale or already-consumed serial results in no move, matching compositor semantics.
- **Headless / DesignerSupport previewer and stubs**: no-op, matching the existing overload.

The existing `BeginMoveDrag(PointerPressedEventArgs)` behavior is unchanged on every backend, and the
addition to `IWindowImpl` is additive on an `[Unstable]` interface.

To test: create a window with `ExtendClientAreaToDecorationsHint = true` hosting a native view that
consumes pointer input (a `NativeWebView` with a page is the practical case); relay a `mousedown` on
the page's title-bar region to the host (for example through `invokeCSharpAction`) and call
`window.BeginMoveDrag()` while the press is held. The native interactive move begins with platform
behavior intact (drag threshold, snap layouts on Windows, space snapping on macOS, compositor move on
Linux). Calling it with no button held is a no-op on all backends (Win32's move loop exits
immediately; Wayland's serial no longer denotes an active grab).

## Checklist

- [x] Builds green on all touched backends (`Avalonia.Controls`, `Avalonia.Win32`, `Avalonia.X11`,
      `Avalonia.Native`, `Avalonia.Wayland`, `Avalonia.Headless`, `Avalonia.DesignerSupport`)
- [x] Existing overload behavior preserved (pure extraction refactors on Win32 and X11)
- [x] API addition is additive; no breaking changes for callers
