### PR TITLE
Introduced a better opengl context management API  on top of existing interop APIs

### DIFF
--- a/samples/ControlCatalog/Pages/OpenGl/OpenGlInteropPage.xaml
+++ b/samples/ControlCatalog/Pages/OpenGl/OpenGlInteropPage.xaml
@@ -1,0 +1,9 @@
+<ContentPage xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ControlCatalog.Pages.OpenGlInteropPage"
+             xmlns:openGl="clr-namespace:ControlCatalog.Pages.OpenGl">
+    <Grid>
+        <Control x:Name="Viewport" AttachedToVisualTree="ViewportAttachedToVisualTree" DetachedFromVisualTree="ViewportDetachedFromVisualTree"/>
+        <openGl:GlPageKnobs x:Name="Knobs" PropertyChanged="KnobsPropertyChanged" />
+    </Grid>
+</ContentPage>

--- a/samples/ControlCatalog/Pages/OpenGl/OpenGlInteropPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/OpenGl/OpenGlInteropPage.xaml.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.OpenGL;
+using Avalonia.Rendering.Composition;
+using ControlCatalog.Pages.OpenGl;
+using static Avalonia.OpenGL.GlConsts;
+
+namespace ControlCatalog.Pages;
+
+/// <summary>
+/// Demonstrates the ICompositionGlContext API: an OpenGL context compatible with the compositor
+/// and a texture presented to a CompositionDrawingSurface, without using OpenGlControlBase.
+/// </summary>
+public partial class OpenGlInteropPage : ContentPage
+{
+    private ICompositionGlContext? _context;
+    private ICompositionGlTexture? _texture;
+    private Task? _lastPresent;
+    private CompositionDrawingSurface? _surface;
+    private CompositionSurfaceVisual? _visual;
+    private OpenGlContent? _content;
+    private int _fbo;
+    private int _depthBuffer;
+    private PixelSize _depthBufferSize;
+    private bool _updateQueued;
+    private bool _attached;
+    private int _generation;
+
+    public OpenGlInteropPage()
+    {
+        InitializeComponent();
+    }
+
+    private void ViewportAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        _attached = true;
+        Initialize();
+    }
+
+    private void ViewportDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        _attached = false;
+        Cleanup();
+    }
+
+    private async void Initialize()
+    {
+        var generation = ++_generation;
+        if (ElementComposition.GetElementVisual(Viewport) is not { } elementVisual)
+            return;
+        var compositor = elementVisual.Compositor;
+
+        var context = await compositor.TryCreateCompatibleGlContextAsync();
+        if (context == null)
+        {
+            Knobs.Info = "Compositor OpenGL interop is not available on this platform";
+            return;
+        }
+
+        if (!_attached || generation != _generation)
+        {
+            // The viewport got detached or reinitialized while we were awaiting
+            await context.DisposeAsync();
+            return;
+        }
+
+        _context = context;
+        _surface = compositor.CreateDrawingSurface();
+        _visual = compositor.CreateSurfaceVisual();
+        _visual.Surface = _surface;
+        ElementComposition.SetElementChildVisual(Viewport, _visual);
+
+        using (context.GlContext.MakeCurrent())
+        {
+            var gl = context.GlContext.GlInterface;
+            _fbo = gl.GenFramebuffer();
+            _content = new OpenGlContent();
+            _content.Init(gl, context.GlContext.Version);
+        }
+
+        Knobs.Info = _content.Info;
+        Viewport.SizeChanged += OnViewportSizeChanged;
+        QueueUpdate();
+    }
+
+    private async void Cleanup()
+    {
+        _generation++;
+        Viewport.SizeChanged -= OnViewportSizeChanged;
+        ElementComposition.SetElementChildVisual(Viewport, null);
+        _visual = null;
+
+        var context = _context;
+        _context = null;
+        if (context == null)
+            return;
+
+        try
+        {
+            using (context.GlContext.MakeCurrent())
+            {
+                var gl = context.GlContext.GlInterface;
+                _content?.Deinit(gl);
+                if (_fbo != 0)
+                    gl.DeleteFramebuffer(_fbo);
+                if (_depthBuffer != 0)
+                    gl.DeleteRenderbuffer(_depthBuffer);
+            }
+        }
+        catch
+        {
+            // The context is likely lost
+        }
+
+        _content = null;
+        _fbo = 0;
+        _depthBuffer = 0;
+        _depthBufferSize = default;
+        _texture = null;
+        _lastPresent = null;
+        _surface?.Dispose();
+        _surface = null;
+
+        // Also disposes the textures created from it
+        await context.DisposeAsync();
+    }
+
+    private void OnViewportSizeChanged(object? sender, SizeChangedEventArgs e) => QueueUpdate();
+
+    private void KnobsPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property == GlPageKnobs.YawProperty
+            || e.Property == GlPageKnobs.RollProperty
+            || e.Property == GlPageKnobs.PitchProperty
+            || e.Property == GlPageKnobs.DiscoProperty)
+            QueueUpdate();
+    }
+
+    private void QueueUpdate()
+    {
+        if (_updateQueued || _context == null)
+            return;
+        _updateQueued = true;
+        _context.Compositor.RequestCompositionUpdate(Update);
+    }
+
+    private void Update()
+    {
+        _updateQueued = false;
+        if (_context == null || _content == null || _visual == null || _surface == null)
+            return;
+
+        if (!_context.IsValidForInterop)
+        {
+            // The context is no longer usable for presentation, drop everything and start over
+            Cleanup();
+            Initialize();
+            return;
+        }
+
+        var scaling = TopLevel.GetTopLevel(Viewport)?.RenderScaling ?? 1;
+        var size = new PixelSize(
+            Math.Max(1, (int)(Viewport.Bounds.Width * scaling)),
+            Math.Max(1, (int)(Viewport.Bounds.Height * scaling)));
+        _visual.Size = new Vector(Viewport.Bounds.Width, Viewport.Bounds.Height);
+
+        if (_texture != null && (_texture.Size != size || _lastPresent?.IsFaulted == true))
+        {
+            _texture.DisposeAsync();
+            _texture = null;
+            _lastPresent = null;
+        }
+
+        if (_texture == null)
+            _texture = _context.CreateTexture(_surface, size);
+        else if (!_texture.IsReadyForDraw)
+        {
+            // The previous frame hasn't reached the render thread yet, try again on the next composition update
+            QueueUpdate();
+            return;
+        }
+
+        using (_context.GlContext.MakeCurrent())
+        {
+            var gl = _context.GlContext.GlInterface;
+            using (var lease = _texture.BeginDraw())
+            {
+                var info = lease.Texture;
+                gl.BindFramebuffer(GL_FRAMEBUFFER, _fbo);
+                UpdateDepthBuffer(gl, size);
+                gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, info.Target, info.TextureId, 0);
+
+                _content.OnOpenGlRender(gl, _fbo, size, Knobs.Yaw, Knobs.Pitch, Knobs.Roll, Knobs.Disco);
+
+                gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, info.Target, 0, 0);
+                gl.BindFramebuffer(GL_FRAMEBUFFER, 0);
+                _lastPresent = lease.PresentAsync();
+            }
+        }
+
+        if (Knobs.Disco > 0.01)
+            QueueUpdate();
+    }
+
+    private void UpdateDepthBuffer(GlInterface gl, PixelSize size)
+    {
+        if (size == _depthBufferSize && _depthBuffer != 0)
+            return;
+
+        gl.GetIntegerv(GL_RENDERBUFFER_BINDING, out var oldRenderBuffer);
+        if (_depthBuffer != 0)
+            gl.DeleteRenderbuffer(_depthBuffer);
+
+        _depthBuffer = gl.GenRenderbuffer();
+        gl.BindRenderbuffer(GL_RENDERBUFFER, _depthBuffer);
+        gl.RenderbufferStorage(GL_RENDERBUFFER,
+            _context!.GlContext.Version.Type == GlProfileType.OpenGLES ? GL_DEPTH_COMPONENT16 : GL_DEPTH_COMPONENT,
+            size.Width, size.Height);
+        gl.FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _depthBuffer);
+        gl.BindRenderbuffer(GL_RENDERBUFFER, oldRenderBuffer);
+        _depthBufferSize = size;
+    }
+}

--- a/samples/ControlCatalog/ViewModels/MainWindowViewModel_PageList.cs
+++ b/samples/ControlCatalog/ViewModels/MainWindowViewModel_PageList.cs
@@ -70,6 +70,7 @@ namespace ControlCatalog.ViewModels
             new PageItem("NumericUpDown",() => new NumericUpDownPage(), Icons.Number),
             new PageItem("OpenGL",() => new OpenGlPage(), Icons.Cube3D),
             new PageItem("OpenGL Lease",() => new OpenGlLeasePage(), Icons.Cube3D),
+            new PageItem("OpenGL Interop",() => new OpenGlInteropPage(), Icons.Cube3D),
             new PageItem("PipsPager",() => new PipsPagerPage(), Icons.HorizontalDots),
             new PageItem("Platform Information",() => new PlatformInfoPage(), Icons.Info),
             new PageItem("Pointers",() => new PointersPage(), Icons.Cursor),

--- a/src/Avalonia.OpenGL/Composition/CompositionGlContext.cs
+++ b/src/Avalonia.OpenGL/Composition/CompositionGlContext.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.OpenGL;
+
+internal sealed class CompositionGlContext : ICompositionGlContext
+{
+    private readonly ICompositionGpuInterop _interop;
+    private readonly IOpenGlTextureSharingRenderInterfaceContextFeature? _sharingFeature;
+    private readonly IGlContextExternalObjectsFeature? _externalObjects;
+    private readonly List<CompositionGlTexture> _textures = new();
+    private bool _disposed;
+
+    public CompositionGlContext(Compositor compositor, IGlContext glContext, ICompositionGpuInterop interop,
+        IOpenGlTextureSharingRenderInterfaceContextFeature? sharingFeature,
+        IGlContextExternalObjectsFeature? externalObjects)
+    {
+        Compositor = compositor;
+        GlContext = glContext;
+        _interop = interop;
+        _sharingFeature = sharingFeature;
+        _externalObjects = externalObjects;
+    }
+
+    public Compositor Compositor { get; }
+
+    public IGlContext GlContext { get; }
+
+    public bool IsValidForInterop => !_disposed && !GlContext.IsLost && !_interop.IsLost;
+
+    public ICompositionGlTexture CreateTexture(CompositionDrawingSurface surface, PixelSize size)
+    {
+        if (surface == null)
+            throw new ArgumentNullException(nameof(surface));
+        Compositor.Dispatcher.VerifyAccess();
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(ICompositionGlContext));
+        if (!IsValidForInterop)
+            throw new InvalidOperationException("This context is no longer valid for interop with the compositor");
+        if (surface.Compositor != Compositor)
+            throw new InvalidOperationException("The surface belongs to a different Compositor");
+        if (size.Width < 1 || size.Height < 1)
+            throw new ArgumentOutOfRangeException(nameof(size));
+
+        CompositionGlTexture texture = _sharingFeature != null
+            ? new SharedCompositionGlTexture(this, _sharingFeature, _interop, surface, size)
+            : new ExternalImageCompositionGlTexture(this, _externalObjects!, _interop, surface, size);
+        _textures.Add(texture);
+        return texture;
+    }
+
+    internal void OnTextureDisposed(CompositionGlTexture texture) => _textures.Remove(texture);
+
+    public async ValueTask DisposeAsync()
+    {
+        Compositor.Dispatcher.VerifyAccess();
+        if (_disposed)
+            return;
+        _disposed = true;
+
+        foreach (var texture in _textures.ToArray())
+            await texture.DisposeAsync();
+        _textures.Clear();
+
+        GlContext.Dispose();
+    }
+}

--- a/src/Avalonia.OpenGL/Composition/CompositionGlContextOptions.cs
+++ b/src/Avalonia.OpenGL/Composition/CompositionGlContextOptions.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Avalonia.OpenGL;
+
+/// <summary>
+/// Options for <see cref="OpenGlCompositionInterop.TryCreateCompatibleGlContextAsync"/>.
+/// </summary>
+public class CompositionGlContextOptions
+{
+    /// <summary>
+    /// The list of desired OpenGL(ES) versions in order of preference.
+    /// </summary>
+    public IReadOnlyList<GlVersion>? GlProfiles { get; set; }
+}

--- a/src/Avalonia.OpenGL/Composition/CompositionGlTexture.cs
+++ b/src/Avalonia.OpenGL/Composition/CompositionGlTexture.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Avalonia.Platform;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.OpenGL;
+
+internal abstract class CompositionGlTexture : ICompositionGlTexture
+{
+    private TextureLease? _activeLease;
+    private Task? _lastPresent;
+    private ICompositionImportedGpuImage? _imported;
+    private bool _disposed;
+
+    protected CompositionGlTexture(CompositionGlContext owner, ICompositionGpuInterop interop,
+        CompositionDrawingSurface surface, PixelSize size)
+    {
+        Owner = owner;
+        Interop = interop;
+        Surface = surface;
+        Size = size;
+    }
+
+    protected CompositionGlContext Owner { get; }
+    protected ICompositionGpuInterop Interop { get; }
+    protected CompositionDrawingSurface Surface { get; }
+
+    public PixelSize Size { get; }
+
+    public bool IsReadyForDraw =>
+        !_disposed
+        && _activeLease == null
+        && (_lastPresent == null || _lastPresent.Status == TaskStatus.RanToCompletion);
+
+    public ICompositionGlTextureLease BeginDraw()
+    {
+        Owner.Compositor.Dispatcher.VerifyAccess();
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(ICompositionGlTexture));
+        if (!Owner.IsValidForInterop)
+            throw new InvalidOperationException(
+                "The owning context is no longer valid for interop with the compositor");
+        if (_activeLease != null)
+            throw new InvalidOperationException("The previous drawing session is still active");
+        if (_lastPresent is { Status: not TaskStatus.RanToCompletion } lastPresent)
+            throw new InvalidOperationException(
+                lastPresent.IsCompleted
+                    ? "The previous presentation has failed"
+                    : "The previous presentation hasn't been completed yet");
+
+        using (Owner.GlContext.EnsureCurrent())
+            BeginDrawCore();
+        return _activeLease = new TextureLease(this);
+    }
+
+    private Task Present(TextureLease lease)
+    {
+        Debug.Assert(_activeLease == lease);
+        try
+        {
+            using (Owner.GlContext.EnsureCurrent())
+            {
+                Owner.GlContext.GlInterface.Flush();
+                PresentGlCore();
+            }
+        }
+        finally
+        {
+            _activeLease = null;
+        }
+
+        _imported ??= Import();
+        return _lastPresent = UpdateSurface(_imported);
+    }
+
+    private void DiscardDraw(TextureLease lease)
+    {
+        if (_activeLease != lease)
+            return;
+        Owner.Compositor.Dispatcher.VerifyAccess();
+        _activeLease = null;
+        try
+        {
+            using (Owner.GlContext.EnsureCurrent())
+                DiscardDrawCore();
+        }
+        catch
+        {
+            // The context is likely lost, nothing to unwind
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Owner.Compositor.Dispatcher.VerifyAccess();
+        if (_disposed)
+            return;
+        _activeLease?.Dispose();
+        _disposed = true;
+        Owner.OnTextureDisposed(this);
+
+        // The texture might have already been sent to the compositor, so we need to wait for its
+        // attempts to use the texture before destroying it
+        if (_imported != null)
+        {
+            // No need to wait for import / last present since calls are serialized on the compositor side anyway
+            try
+            {
+                await _imported.DisposeAsync();
+            }
+            catch
+            {
+                // Ignore
+            }
+        }
+
+        try
+        {
+            DisposeGlResources();
+        }
+        catch
+        {
+            // The context is likely lost, nothing to free
+        }
+    }
+
+    protected abstract CompositionGlTextureInfo GetTextureInfo();
+    protected abstract void BeginDrawCore();
+    protected abstract void DiscardDrawCore();
+    protected abstract void PresentGlCore();
+    protected abstract ICompositionImportedGpuImage Import();
+    protected virtual Task UpdateSurface(ICompositionImportedGpuImage imported) => Surface.UpdateAsync(imported);
+    protected abstract void DisposeGlResources();
+
+    private sealed class TextureLease : ICompositionGlTextureLease
+    {
+        private CompositionGlTexture? _texture;
+
+        public TextureLease(CompositionGlTexture texture) => _texture = texture;
+
+        public CompositionGlTextureInfo Texture
+        {
+            get
+            {
+                var texture = _texture ?? throw new ObjectDisposedException(nameof(ICompositionGlTextureLease));
+                texture.Owner.Compositor.Dispatcher.VerifyAccess();
+                return texture.GetTextureInfo();
+            }
+        }
+
+        public Task PresentAsync()
+        {
+            var texture = _texture ?? throw new ObjectDisposedException(nameof(ICompositionGlTextureLease));
+            texture.Owner.Compositor.Dispatcher.VerifyAccess();
+            _texture = null;
+            return texture.Present(this);
+        }
+
+        public void Dispose()
+        {
+            if (_texture is not { } texture)
+                return;
+            _texture = null;
+            texture.DiscardDraw(this);
+        }
+    }
+}
+
+internal sealed class SharedCompositionGlTexture : CompositionGlTexture
+{
+    private readonly ICompositionImportableOpenGlSharedTexture _texture;
+
+    public SharedCompositionGlTexture(CompositionGlContext owner,
+        IOpenGlTextureSharingRenderInterfaceContextFeature sharingFeature,
+        ICompositionGpuInterop interop, CompositionDrawingSurface surface, PixelSize size)
+        : base(owner, interop, surface, size)
+    {
+        _texture = sharingFeature.CreateSharedTextureForComposition(owner.GlContext, size);
+    }
+
+    protected override CompositionGlTextureInfo GetTextureInfo() =>
+        new(_texture.TextureId, GlConsts.GL_TEXTURE_2D, _texture.InternalFormat, Size);
+
+    protected override void BeginDrawCore()
+    {
+    }
+
+    protected override void DiscardDrawCore()
+    {
+    }
+
+    protected override void PresentGlCore()
+    {
+    }
+
+    protected override ICompositionImportedGpuImage Import() => Interop.ImportImage(_texture);
+
+    protected override void DisposeGlResources() => _texture.Dispose();
+}
+
+internal sealed class ExternalImageCompositionGlTexture : CompositionGlTexture
+{
+    private readonly IGlExportableExternalImageTexture _texture;
+
+    public ExternalImageCompositionGlTexture(CompositionGlContext owner,
+        IGlContextExternalObjectsFeature externalObjects,
+        ICompositionGpuInterop interop, CompositionDrawingSurface surface, PixelSize size)
+        : base(owner, interop, surface, size)
+    {
+        _texture = externalObjects.CreateImage(
+            KnownPlatformGraphicsExternalImageHandleTypes.D3D11TextureGlobalSharedHandle,
+            size, PlatformGraphicsExternalImageFormat.R8G8B8A8UNorm);
+    }
+
+    protected override CompositionGlTextureInfo GetTextureInfo() =>
+        new(_texture.TextureId, _texture.TextureType, _texture.InternalFormat, Size);
+
+    protected override void BeginDrawCore() => _texture.AcquireKeyedMutex(0);
+
+    protected override void DiscardDrawCore() => _texture.ReleaseKeyedMutex(0);
+
+    protected override void PresentGlCore() => _texture.ReleaseKeyedMutex(1);
+
+    protected override ICompositionImportedGpuImage Import() =>
+        Interop.ImportImage(_texture.GetHandle(), _texture.Properties);
+
+    protected override Task UpdateSurface(ICompositionImportedGpuImage imported) =>
+        Surface.UpdateWithKeyedMutexAsync(imported, 1, 0);
+
+    protected override void DisposeGlResources() => _texture.Dispose();
+}

--- a/src/Avalonia.OpenGL/Composition/ICompositionGlContext.cs
+++ b/src/Avalonia.OpenGL/Composition/ICompositionGlContext.cs
@@ -1,0 +1,51 @@
+using System;
+using Avalonia.Metadata;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.OpenGL;
+
+/// <summary>
+/// An OpenGL context that is suitable for interop with a <see cref="Rendering.Composition.Compositor"/>.
+/// Create instances via <see cref="OpenGlCompositionInterop.TryCreateCompatibleGlContextAsync"/>.
+/// </summary>
+/// <remarks>
+/// All members can only be used on the thread the associated <see cref="Rendering.Composition.Compositor"/>
+/// belongs to.
+/// </remarks>
+[NotClientImplementable]
+public interface ICompositionGlContext : IAsyncDisposable
+{
+    /// <summary>
+    /// The associated compositor.
+    /// </summary>
+    Compositor Compositor { get; }
+
+    /// <summary>
+    /// The OpenGL context.
+    /// </summary>
+    IGlContext GlContext { get; }
+
+    /// <summary>
+    /// Returns true if this OpenGL context is still suitable for interop with the Compositor.
+    /// This property might become false in cases like a device loss event on the compositor side.
+    /// In that case presentation is no longer possible, however <see cref="GlContext"/> itself might
+    /// still be usable for salvaging user resources. Once the property becomes false, this instance
+    /// should be disposed and recreated via
+    /// <see cref="OpenGlCompositionInterop.TryCreateCompatibleGlContextAsync"/>.
+    /// A recreated context shares no OpenGL objects with the old one.
+    /// </summary>
+    bool IsValidForInterop { get; }
+
+    /// <summary>
+    /// Creates a texture that can be used to update a <see cref="CompositionDrawingSurface"/> instance.
+    /// </summary>
+    /// <param name="surface">The surface that will be updated by the texture. Must belong to <see cref="Compositor"/>.</param>
+    /// <param name="size">The pixel size of the texture.</param>
+    /// <exception cref="InvalidOperationException">
+    /// The context is no longer valid for interop or the surface belongs to a different compositor.
+    /// </exception>
+    /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="surface"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> is empty or negative.</exception>
+    ICompositionGlTexture CreateTexture(CompositionDrawingSurface surface, PixelSize size);
+}

--- a/src/Avalonia.OpenGL/Composition/ICompositionGlTexture.cs
+++ b/src/Avalonia.OpenGL/Composition/ICompositionGlTexture.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Metadata;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.OpenGL;
+
+/// <summary>
+/// A texture that can be drawn to by user code and presented to a <see cref="CompositionDrawingSurface"/>.
+/// Create instances via <see cref="ICompositionGlContext.CreateTexture"/>.
+/// </summary>
+/// <remarks>
+/// All members can only be used on the thread the associated <see cref="Compositor"/> belongs to.
+/// </remarks>
+[NotClientImplementable]
+public interface ICompositionGlTexture : IAsyncDisposable
+{
+    /// <summary>
+    /// The pixel size of the texture.
+    /// </summary>
+    PixelSize Size { get; }
+
+    /// <summary>
+    /// Returns true when the texture can be drawn to: there is no active lease and the last
+    /// presentation, if any, has completed successfully.
+    /// A presentation failure leaves this property permanently false, check
+    /// <see cref="ICompositionGlContext.IsValidForInterop"/> in that case.
+    /// </summary>
+    bool IsReadyForDraw { get; }
+
+    /// <summary>
+    /// Prepares the texture to be rendered to by user code.
+    /// User code can bind the texture to their framebuffer, however the texture should be unbound
+    /// before ending the returned lease.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The texture is not ready for drawing (<see cref="IsReadyForDraw"/> is false) or the owning
+    /// context is no longer valid for interop.
+    /// </exception>
+    /// <exception cref="ObjectDisposedException">The texture has been disposed.</exception>
+    ICompositionGlTextureLease BeginDraw();
+}
+
+/// <summary>
+/// An active drawing session on an <see cref="ICompositionGlTexture"/>.
+/// The lease is ended either by <see cref="PresentAsync"/> or by <see cref="IDisposable.Dispose"/>,
+/// the latter discards the frame. Disposing after <see cref="PresentAsync"/> is a no-op.
+/// </summary>
+[NotClientImplementable]
+public interface ICompositionGlTextureLease : IDisposable
+{
+    /// <summary>
+    /// Describes the OpenGL texture to draw into. Only valid until the lease ends;
+    /// <see cref="CompositionGlTextureInfo.TextureId"/> is not guaranteed to be stable between leases.
+    /// </summary>
+    CompositionGlTextureInfo Texture { get; }
+
+    /// <summary>
+    /// Ends the lease and asynchronously presents the texture to the associated
+    /// <see cref="CompositionDrawingSurface"/>. This will happen when the next composition commit
+    /// is processed by the render thread.
+    /// The texture must be unbound from user framebuffers before calling this method.
+    /// The returned task completes when the texture can be drawn to again, NOT when the frame
+    /// becomes visible on the screen.
+    /// You should NOT await the returned task while keeping hold of a
+    /// <see cref="IGlContext.MakeCurrent"/> disposable.
+    /// </summary>
+    Task PresentAsync();
+}
+
+/// <summary>
+/// Describes an OpenGL texture provided by <see cref="ICompositionGlTextureLease"/>.
+/// </summary>
+public readonly record struct CompositionGlTextureInfo(int TextureId, int Target, int InternalFormat, PixelSize Size);

--- a/src/Avalonia.OpenGL/Composition/OpenGlCompositionInterop.cs
+++ b/src/Avalonia.OpenGL/Composition/OpenGlCompositionInterop.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Logging;
+using Avalonia.Platform;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.OpenGL;
+
+/// <summary>
+/// Provides OpenGL interop facilities for the composition engine.
+/// </summary>
+public static class OpenGlCompositionInterop
+{
+    /// <summary>
+    /// Attempts to create an OpenGL context that is suitable for interop with the compositor's GPU context.
+    /// Must be called on the thread the compositor belongs to.
+    /// </summary>
+    /// <returns>
+    /// The created context, or null when the current platform or compositor configuration doesn't
+    /// support OpenGL interop. The concrete reason is logged to the "OpenGL" log area.
+    /// </returns>
+    public static async ValueTask<ICompositionGlContext?> TryCreateCompatibleGlContextAsync(
+        this Compositor compositor, CompositionGlContextOptions? options = null)
+    {
+        if (compositor == null)
+            throw new ArgumentNullException(nameof(compositor));
+        compositor.Dispatcher.VerifyAccess();
+
+        var gpuInteropTask = compositor.TryGetCompositionGpuInterop();
+
+        var sharingFeature =
+            (IOpenGlTextureSharingRenderInterfaceContextFeature?)
+            await compositor.TryGetRenderInterfaceFeature(
+                typeof(IOpenGlTextureSharingRenderInterfaceContextFeature));
+        var interop = await gpuInteropTask;
+
+        if (interop == null)
+        {
+            // Expected on platforms without GPU interop support, so not an error
+            LogUnsupported("Compositor backend doesn't support GPU interop");
+            return null;
+        }
+
+        if (sharingFeature?.CanCreateSharedContext == true)
+        {
+            IGlContext? context = null;
+            try
+            {
+                context = sharingFeature.CreateSharedContext(options?.GlProfiles);
+            }
+            catch (Exception e)
+            {
+                LogError("Unable to create a context shared with the compositor: {exception}", e);
+            }
+
+            if (context == null)
+                LogError("Unable to create a context shared with the compositor");
+            else
+                return new CompositionGlContext(compositor, context, interop, sharingFeature, null);
+        }
+
+        if (AvaloniaLocator.Current.GetService<IPlatformGraphicsOpenGlContextFactory>() is not { } contextFactory)
+        {
+            LogUnsupported("The current platform doesn't provide an OpenGL context factory");
+            return null;
+        }
+
+        IGlContext? ctx = null;
+        try
+        {
+            ctx = contextFactory.CreateContext(options?.GlProfiles);
+            if (ctx.TryGetFeature<IGlContextExternalObjectsFeature>(out var externalObjects)
+                && interop.SupportedImageHandleTypes.Contains(
+                    KnownPlatformGraphicsExternalImageHandleTypes.D3D11TextureGlobalSharedHandle)
+                && externalObjects.SupportedExportableExternalImageTypes.Contains(
+                    KnownPlatformGraphicsExternalImageHandleTypes.D3D11TextureGlobalSharedHandle))
+                return new CompositionGlContext(compositor, ctx, interop, null, externalObjects);
+
+            LogUnsupported("The current platform doesn't support OpenGL context sharing with the compositor " +
+                "or a compatible shared memory type");
+            ctx.Dispose();
+            return null;
+        }
+        catch (Exception e)
+        {
+            LogError("Unable to create an OpenGL context: {exception}", e);
+            ctx?.Dispose();
+            return null;
+        }
+    }
+
+    private static void LogUnsupported(string message) =>
+        Logger.TryGet(LogEventLevel.Warning, "OpenGL")?.Log(nameof(OpenGlCompositionInterop), message);
+
+    private static void LogError(string message, params object?[] args) =>
+        Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log(nameof(OpenGlCompositionInterop), message, args);
+}

--- a/src/Avalonia.OpenGL/Controls/CompositionOpenGlSwapchain.cs
+++ b/src/Avalonia.OpenGL/Controls/CompositionOpenGlSwapchain.cs
@@ -1,162 +1,108 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using Avalonia.Platform;
-using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
 
 namespace Avalonia.OpenGL.Controls;
 
-internal class CompositionOpenGlSwapchain : SwapchainBase<IGlSwapchainImage>
+internal sealed class CompositionOpenGlSwapchain : IAsyncDisposable
 {
-    private readonly IGlContext _context;
-    private readonly IGlContextExternalObjectsFeature? _externalObjectsFeature;
-    private readonly IOpenGlTextureSharingRenderInterfaceContextFeature? _sharingFeature;
-
-    public CompositionOpenGlSwapchain(IGlContext context, ICompositionGpuInterop interop, CompositionDrawingSurface target,
-        IOpenGlTextureSharingRenderInterfaceContextFeature sharingFeature
-        ) : base(interop, target)
-    {
-        _context = context;
-        _sharingFeature = sharingFeature;
-    }
-    
-    public CompositionOpenGlSwapchain(IGlContext context, ICompositionGpuInterop interop, CompositionDrawingSurface target,
-        IGlContextExternalObjectsFeature? externalObjectsFeature) : base(interop, target)
-    {
-        _context = context;
-        _externalObjectsFeature = externalObjectsFeature;
-    }
-    
-    
-
-    protected override IGlSwapchainImage CreateImage(PixelSize size)
-    {
-        if (_sharingFeature != null)
-            return new CompositionOpenGlSwapChainImage(_context, _sharingFeature, size, Interop, Target);
-        return new DxgiMutexOpenGlSwapChainImage(Interop, Target, _externalObjectsFeature!, size);
-    }
-
-    public IDisposable BeginDraw(PixelSize size, out IGlTexture texture)
-    {
-        var rv = BeginDrawCore(size, out var tex);
-        texture = tex;
-        return rv;
-    }
-}
-
-internal interface IGlTexture
-{
-    int TextureId { get; }
-    int InternalFormat { get; }
-    PixelSize Size { get; }
-}
-
-
-interface IGlSwapchainImage : ISwapchainImage, IGlTexture
-{
-    
-}
-internal class DxgiMutexOpenGlSwapChainImage : IGlSwapchainImage
-{
-    private readonly ICompositionGpuInterop _interop;
+    private readonly ICompositionGlContext _context;
     private readonly CompositionDrawingSurface _surface;
-    private readonly IGlExportableExternalImageTexture _texture;
-    private Task? _lastPresent;
-    private ICompositionImportedGpuImage? _imported;
+    private readonly List<Entry> _entries = new();
 
-    public DxgiMutexOpenGlSwapChainImage(ICompositionGpuInterop interop, CompositionDrawingSurface surface,
-        IGlContextExternalObjectsFeature externalObjects, PixelSize size)
+    internal class Entry
     {
-        _interop = interop;
+        public required ICompositionGlTexture Texture { get; init; }
+        public Task? LastPresent { get; set; }
+    }
+
+    public CompositionOpenGlSwapchain(ICompositionGlContext context, CompositionDrawingSurface surface)
+    {
+        _context = context;
         _surface = surface;
-        _texture = externalObjects.CreateImage(KnownPlatformGraphicsExternalImageHandleTypes.D3D11TextureGlobalSharedHandle,
-            size, PlatformGraphicsExternalImageFormat.R8G8B8A8UNorm);
     }
-    public async ValueTask DisposeAsync()
+
+    private Entry? CleanupAndFindNextEntry(PixelSize size)
     {
-        // The texture is already sent to the compositor, so we need to wait for its attempts to use the texture
-        // before destroying it
-        if (_imported != null)
+        Entry? firstFound = null;
+        var foundMultiple = false;
+
+        for (var c = _entries.Count - 1; c > -1; c--)
         {
-            // No need to wait for import / LastPresent since calls are serialized on the compositor side anyway
-            try
+            var entry = _entries[c];
+            var ready = entry.Texture.IsReadyForDraw;
+            var matches = entry.Texture.Size == size;
+            var broken = entry.LastPresent is { IsCompleted: true, Status: not TaskStatus.RanToCompletion };
+            if (broken || (!matches && ready))
             {
-                await _imported.DisposeAsync();
+                entry.Texture.DisposeAsync();
+                _entries.RemoveAt(c);
             }
-            catch
+
+            if (matches && ready)
             {
-                // Ignore
-            }
-        }
-        _texture.Dispose();
-    }
-
-    public int TextureId => _texture.TextureId;
-    public int InternalFormat => _texture.InternalFormat;
-    public PixelSize Size => new(_texture.Properties.Width, _texture.Properties.Height);
-    public Task? LastPresent => _lastPresent;
-    public void BeginDraw() => _texture.AcquireKeyedMutex(0);
-
-    public void Present()
-    {
-        _texture.ReleaseKeyedMutex(1);
-        _imported ??= _interop.ImportImage(_texture.GetHandle(), _texture.Properties);
-        _lastPresent = _surface.UpdateWithKeyedMutexAsync(_imported, 1, 0);
-    }
-}
-
-internal class CompositionOpenGlSwapChainImage : IGlSwapchainImage
-{
-    private readonly ICompositionGpuInterop _interop;
-    private readonly CompositionDrawingSurface _target;
-    private readonly ICompositionImportableOpenGlSharedTexture _texture;
-    private ICompositionImportedGpuImage? _imported;
-
-    public CompositionOpenGlSwapChainImage(
-        IGlContext context,
-        IOpenGlTextureSharingRenderInterfaceContextFeature sharingFeature,
-        PixelSize size,
-        ICompositionGpuInterop interop,
-        CompositionDrawingSurface target)
-    {
-        _interop = interop;
-        _target = target;
-        _texture = sharingFeature.CreateSharedTextureForComposition(context, size);
-    }
-
-    
-    public async ValueTask DisposeAsync()
-    {
-        // The texture is already sent to the compositor, so we need to wait for its attempts to use the texture
-        // before destroying it
-        if (_imported != null)
-        {
-            // No need to wait for import / LastPresent since calls are serialized on the compositor side anyway
-            try
-            {
-                await _imported.DisposeAsync();
-            }
-            catch
-            {
-                // Ignore
+                if (firstFound == null)
+                    firstFound = entry;
+                else
+                    foundMultiple = true;
             }
         }
 
-        _texture.Dispose();
+        // We are making sure that there was at least one texture of the same size in flight
+        // Otherwise we might encounter UI thread lockups
+        return foundMultiple ? firstFound : null;
     }
 
-    public int TextureId => _texture.TextureId;
-    public int InternalFormat => _texture.InternalFormat;
-    public PixelSize Size => _texture.Size;
-    public Task? LastPresent { get; private set; }
-    public void BeginDraw()
+    public Lease BeginDraw(PixelSize size, out CompositionGlTextureInfo texture)
     {
-        // No-op for texture sharing
+        var entry = CleanupAndFindNextEntry(size);
+        if (entry == null)
+        {
+            entry = new Entry { Texture = _context.CreateTexture(_surface, size) };
+            _entries.Add(entry);
+        }
+
+        var lease = entry.Texture.BeginDraw();
+        texture = lease.Texture;
+        return new Lease(entry, lease);
     }
 
-    public void Present()
+    /// <summary>
+    /// Presents the frame on <see cref="Dispose"/>, unless it was discarded via <see cref="Discard"/>.
+    /// </summary>
+    public sealed class Lease : IDisposable
     {
-        _imported ??= _interop.ImportImage(_texture);
-        LastPresent = _target.UpdateAsync(_imported);
+        private readonly Entry _entry;
+        private ICompositionGlTextureLease? _lease;
+
+        internal Lease(Entry entry, ICompositionGlTextureLease lease)
+        {
+            _entry = entry;
+            _lease = lease;
+        }
+
+        public void Discard()
+        {
+            var lease = _lease;
+            _lease = null;
+            lease?.Dispose();
+        }
+
+        public void Dispose()
+        {
+            var lease = _lease;
+            _lease = null;
+            if (lease != null)
+                _entry.LastPresent = lease.PresentAsync();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Snapshot, since awaiting the disposal can pump the dispatcher
+        foreach (var entry in _entries.ToArray())
+            await entry.Texture.DisposeAsync();
+        _entries.Clear();
     }
 }

--- a/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
+++ b/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Logging;
 using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
 using Avalonia.VisualTree;
-using Avalonia.Platform;
 using System.ComponentModel;
 
 namespace Avalonia.OpenGL.Controls
@@ -35,6 +33,7 @@ namespace Avalonia.OpenGL.Controls
         private Task<bool>? _initialization;
         private OpenGlControlBaseResources? _resources;
         private Compositor? _compositor;
+        private int _generation;
 
         [MemberNotNullWhen(true, nameof(_resources))]
         private bool IsInitializedSuccessfully => _initialization is { Status: TaskStatus.RanToCompletion, Result: true };
@@ -54,6 +53,7 @@ namespace Avalonia.OpenGL.Controls
 
         private void DoCleanup()
         {
+            _generation++;
             if (IsInitializedSuccessfully)
             {
                 try
@@ -94,51 +94,6 @@ namespace Avalonia.OpenGL.Controls
             RequestNextFrameRendering();
         }
 
-        [MemberNotNullWhen(true, nameof(_resources))]
-        private bool EnsureInitializedCore(
-            ICompositionGpuInterop interop,
-            IOpenGlTextureSharingRenderInterfaceContextFeature? contextSharingFeature)
-        {
-            var surface = _compositor!.CreateDrawingSurface();
-
-            IGlContext? ctx = null;
-            try
-            {
-                if (contextSharingFeature?.CanCreateSharedContext == true)
-                    _resources = OpenGlControlBaseResources.TryCreate(surface, interop, contextSharingFeature);
-
-                if(_resources == null)
-                {
-                    var contextFactory = AvaloniaLocator.Current.GetRequiredService<IPlatformGraphicsOpenGlContextFactory>();
-                    ctx = contextFactory.CreateContext(null);
-                    if (ctx.TryGetFeature<IGlContextExternalObjectsFeature>(out var externalObjects))
-                        _resources = OpenGlControlBaseResources.TryCreate(ctx, surface, interop, externalObjects);
-                }
-                
-                if(_resources == null)
-                {
-                    Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log("OpenGlControlBase",
-                        "Unable to initialize OpenGL: current platform does not support multithreaded context sharing and shared memory");
-                    ctx?.Dispose();
-                    return false;
-                }
-            }
-            catch (Exception e)
-            {
-                Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log("OpenGlControlBase",
-                    "Unable to initialize OpenGL: {exception}", e);
-                ctx?.Dispose();
-                return false;
-            }
-            
-            _visual = _compositor.CreateSurfaceVisual();
-            _visual.Size = new Vector(Bounds.Width, Bounds.Height);
-            _visual.Surface = _resources.Surface;
-            ElementComposition.SetElementChildVisual(this, _visual);
-            return true;
-
-        }
-
         /// <inheritdoc/>
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
@@ -155,6 +110,7 @@ namespace Avalonia.OpenGL.Controls
         {
             _initialization = null;
             _resources?.DisposeAsync();
+            _resources = null;
             OnOpenGlLost();
         }
 
@@ -170,7 +126,7 @@ namespace Avalonia.OpenGL.Controls
                     return false;
                 }
 
-                if (_resources.Context.IsLost)
+                if (_resources.IsLost)
                     ContextLost();
                 else 
                     return true;
@@ -217,31 +173,47 @@ namespace Avalonia.OpenGL.Controls
                     "Unable to obtain Compositor instance");
                 return false;
             }
-            
-            var gpuInteropTask = _compositor.TryGetCompositionGpuInterop();
 
-            var contextSharingFeature =
-                (IOpenGlTextureSharingRenderInterfaceContextFeature?)
-                await _compositor.TryGetRenderInterfaceFeature(
-                    typeof(IOpenGlTextureSharingRenderInterfaceContextFeature));
-            var interop = await gpuInteropTask;
-
-            if (interop == null)
+            var generation = _generation;
+            var context = await _compositor.TryCreateCompatibleGlContextAsync();
+            if (context == null)
             {
                 Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log("OpenGlControlBase",
-                    "Compositor backend doesn't support GPU interop");
+                    "Unable to initialize OpenGL: current platform doesn't support OpenGL interop with the compositor");
                 return false;
             }
 
-            if (!EnsureInitializedCore(interop, contextSharingFeature))
+            if (generation != _generation)
             {
+                // The control was detached while we were awaiting
+                await context.DisposeAsync();
+                return false;
+            }
+
+            var surface = _compositor.CreateDrawingSurface();
+            try
+            {
+                _resources = new OpenGlControlBaseResources(context, surface);
+            }
+            catch (Exception e)
+            {
+                Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log("OpenGlControlBase",
+                    "Unable to initialize OpenGL: {exception}", e);
+                surface.Dispose();
+                await context.DisposeAsync();
+                // The failure might be transient, allow the next invalidation to retry
                 DoCleanup();
                 return false;
             }
 
+            _visual = _compositor.CreateSurfaceVisual();
+            _visual.Size = new Vector(Bounds.Width, Bounds.Height);
+            _visual.Surface = _resources.Surface;
+            ElementComposition.SetElementChildVisual(this, _visual);
+
             using (_resources.Context.MakeCurrent())
                 OnOpenGlInit(_resources.Context.GlInterface);
-            
+
             return true;
         }
 

--- a/src/Avalonia.OpenGL/Controls/OpenGlControlResources.cs
+++ b/src/Avalonia.OpenGL/Controls/OpenGlControlResources.cs
@@ -1,74 +1,31 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Logging;
-using Avalonia.Platform;
 using Avalonia.Reactive;
 using Avalonia.Rendering.Composition;
 using static Avalonia.OpenGL.GlConsts;
 namespace Avalonia.OpenGL.Controls;
 
-internal class OpenGlControlBaseResources : IAsyncDisposable
+internal sealed class OpenGlControlBaseResources : IAsyncDisposable
 {
     private int _depthBuffer;
     public int Fbo { get; private set; }
     private PixelSize _depthBufferSize;
     public CompositionDrawingSurface Surface { get; }
     private readonly CompositionOpenGlSwapchain _swapchain;
-    public IGlContext Context { get; private set; }
+    private readonly ICompositionGlContext _compositionContext;
 
-    public static OpenGlControlBaseResources? TryCreate(CompositionDrawingSurface surface,
-        ICompositionGpuInterop interop,
-        IOpenGlTextureSharingRenderInterfaceContextFeature feature)
+    public IGlContext Context => _compositionContext.GlContext;
+
+    public bool IsLost => !_compositionContext.IsValidForInterop;
+
+    public OpenGlControlBaseResources(ICompositionGlContext context, CompositionDrawingSurface surface)
     {
-        IGlContext? context;
-        try
-        {
-            context = feature.CreateSharedContext();
-        }
-        catch (Exception e)
-        {
-            Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log("OpenGlControlBase",
-                "Unable to initialize OpenGL: unable to create additional OpenGL context: {exception}", e);
-            return null;
-        }
-
-        if (context == null)
-        {
-            Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log("OpenGlControlBase",
-                "Unable to initialize OpenGL: unable to create additional OpenGL context.");
-            return null;
-        }
-
-        return new OpenGlControlBaseResources(context, surface, interop, feature, null);
-    }
-
-    public static OpenGlControlBaseResources? TryCreate(IGlContext context, CompositionDrawingSurface surface,
-        ICompositionGpuInterop interop, IGlContextExternalObjectsFeature externalObjects)
-    {
-        if (!interop.SupportedImageHandleTypes.Contains(KnownPlatformGraphicsExternalImageHandleTypes
-                .D3D11TextureGlobalSharedHandle)
-            || !externalObjects.SupportedExportableExternalImageTypes.Contains(
-                KnownPlatformGraphicsExternalImageHandleTypes.D3D11TextureGlobalSharedHandle))
-            return null;
-        return new OpenGlControlBaseResources(context, surface, interop, null, externalObjects);
-    }
-    
-    private OpenGlControlBaseResources(IGlContext context,
-        CompositionDrawingSurface surface,
-        ICompositionGpuInterop interop,
-        IOpenGlTextureSharingRenderInterfaceContextFeature? feature,
-        IGlContextExternalObjectsFeature? externalObjects
-        )
-    {
-        Context = context;
+        _compositionContext = context;
         Surface = surface;
-        using (context.MakeCurrent())
-            Fbo = context.GlInterface.GenFramebuffer();
-        _swapchain =
-            feature != null ?
-                new CompositionOpenGlSwapchain(context, interop, Surface, feature) :
-                new CompositionOpenGlSwapchain(context, interop, Surface, externalObjects);
+        using (Context.MakeCurrent())
+            Fbo = Context.GlInterface.GenFramebuffer();
+        _swapchain = new CompositionOpenGlSwapchain(context, surface);
     }
 
     private void UpdateDepthRenderbuffer(PixelSize size)
@@ -89,20 +46,20 @@ internal class OpenGlControlBaseResources : IAsyncDisposable
         gl.BindRenderbuffer(GL_RENDERBUFFER, oldRenderBuffer);
         _depthBufferSize = size;
     }
-    
+
     public IDisposable BeginDraw(PixelSize size)
     {
         var restoreContext = Context.EnsureCurrent();
-        IDisposable? imagePresent = null;
+        CompositionOpenGlSwapchain.Lease? lease = null;
         var success = false;
         try
         {
             var gl = Context.GlInterface;
-            Context.GlInterface.BindFramebuffer(GL_FRAMEBUFFER, Fbo);
+            gl.BindFramebuffer(GL_FRAMEBUFFER, Fbo);
             UpdateDepthRenderbuffer(size);
 
-            imagePresent = _swapchain.BeginDraw(size, out var texture);
-            gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture.TextureId, 0);
+            lease = _swapchain.BeginDraw(size, out var texture);
+            gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, texture.Target, texture.TextureId, 0);
 
             var status = gl.CheckFramebufferStatus(GL_FRAMEBUFFER);
             if (status != GL_FRAMEBUFFER_COMPLETE)
@@ -118,8 +75,13 @@ internal class OpenGlControlBaseResources : IAsyncDisposable
             {
                 try
                 {
-                    Context.GlInterface.Flush();
-                    imagePresent.Dispose();
+                    // The texture should be unbound from user framebuffers before it's presented.
+                    // User code could have bound another framebuffer, so rebind ours first
+                    var glDone = Context.GlInterface;
+                    glDone.BindFramebuffer(GL_FRAMEBUFFER, Fbo);
+                    glDone.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                        texture.Target, 0, 0);
+                    lease.Dispose();
                 }
                 finally
                 {
@@ -131,15 +93,22 @@ internal class OpenGlControlBaseResources : IAsyncDisposable
         {
             if (!success)
             {
-                imagePresent?.Dispose();
-                restoreContext.Dispose();
+                try
+                {
+                    // The frame wasn't rendered, so it shouldn't reach the surface
+                    lease?.Discard();
+                }
+                finally
+                {
+                    restoreContext.Dispose();
+                }
             }
         }
     }
 
     public async ValueTask DisposeAsync()
     {
-        if (Context is { IsLost: false })
+        if (!IsLost)
         {
             try
             {
@@ -153,19 +122,16 @@ internal class OpenGlControlBaseResources : IAsyncDisposable
                         gl.DeleteRenderbuffer(_depthBuffer);
                     _depthBuffer = 0;
                 }
-
             }
             catch
             {
                 //
             }
-
-            Surface.Dispose();
-           
-            await _swapchain.DisposeAsync();
-            Context.Dispose();
-
-            Context = null!;
         }
+
+        Surface.Dispose();
+
+        await _swapchain.DisposeAsync();
+        await _compositionContext.DisposeAsync();
     }
 }

--- a/tests/Avalonia.RenderTests/Composition/OpenGlCompositionInteropTests.cs
+++ b/tests/Avalonia.RenderTests/Composition/OpenGlCompositionInteropTests.cs
@@ -1,0 +1,373 @@
+#if AVALONIA_SKIA
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.OpenGL;
+using Avalonia.OpenGL.Controls;
+using Avalonia.Platform;
+using Avalonia.Platform.Surfaces;
+using Avalonia.Rendering;
+using Avalonia.Rendering.Composition;
+using Avalonia.Threading;
+using Avalonia.UnitTests;
+using Xunit;
+using static Avalonia.OpenGL.GlConsts;
+
+namespace Avalonia.Skia.RenderTests;
+
+public class OpenGlCompositionInteropTests : TestBase
+{
+    public OpenGlCompositionInteropTests()
+        : base(@"Composition\OpenGlInterop")
+    {
+    }
+
+    private sealed unsafe class CompositorScaffolding : IDisposable
+    {
+        private readonly IPlatformGraphics _gpu;
+        public ManualRenderTimer Timer { get; } = new();
+        public Compositor Compositor { get; }
+        public TestRenderRoot Root { get; }
+        public CompositingRenderer Renderer { get; }
+        public IWriteableBitmapImpl Bitmap { get; }
+
+        public CompositorScaffolding(Control content, IPlatformGraphics gpu, PixelSize pixelSize)
+        {
+            _gpu = gpu;
+            var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
+            Bitmap = factory.CreateWriteableBitmap(pixelSize, new Vector(96, 96), PixelFormats.Rgba8888,
+                factory.DefaultAlphaFormat);
+            Compositor = new Compositor(RenderLoop.FromTimer(Timer), gpu, true,
+                new DispatcherCompositorScheduler(), true, Dispatcher.UIThread);
+            IPlatformRenderSurface surface = gpu is Avalonia.OpenGL.Egl.EglPlatformGraphics
+                ? new FboReadbackGlPlatformSurface(Bitmap, 1)
+                : new VulkanReadbackPlatformSurface(Bitmap, 1);
+            Root = new TestRenderRoot(1, null!);
+            Renderer = new CompositingRenderer(Root, Compositor, () => new[] { surface });
+            // TestRenderRoot sizes itself from the child, so the content must have explicit dimensions
+            Root.Initialize(Renderer, content);
+            Renderer.Start();
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        public void Pump()
+        {
+            Dispatcher.UIThread.RunJobs();
+            Timer.TriggerTick();
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        public T WaitFor<T>(ValueTask<T> task) => WaitFor(task.AsTask());
+
+        public void WaitFor(ValueTask task) => WaitFor(task.AsTask());
+
+        public T WaitFor<T>(Task<T> task)
+        {
+            WaitFor((Task)task);
+            return task.GetAwaiter().GetResult();
+        }
+
+        public void WaitFor(Task task)
+        {
+            for (var c = 0; c < 1000 && !task.IsCompleted; c++)
+            {
+                Pump();
+                if (!task.IsCompleted)
+                    // Parts of the commit chain hop through the thread pool, give them a chance to run
+                    System.Threading.Thread.Sleep(1);
+            }
+            Assert.True(task.IsCompleted, "The task hasn't been completed after pumping the event loop");
+            task.GetAwaiter().GetResult();
+        }
+
+        public ICompositionGlContext CreateGlContext(CompositionGlContextOptions? options = null)
+        {
+            var context = WaitFor(Compositor.TryCreateCompatibleGlContextAsync(options));
+            Assert.NotNull(context);
+            return context;
+        }
+
+        public (byte R, byte G, byte B, byte A) GetPixel(int x, int y)
+        {
+            Renderer.Paint(new Rect(0, 0, Bitmap.PixelSize.Width, Bitmap.PixelSize.Height), false);
+            using var fb = Bitmap.Lock();
+            var px = (byte*)fb.Address + fb.RowBytes * y + x * 4;
+            return (px[0], px[1], px[2], px[3]);
+        }
+
+        public void Dispose()
+        {
+            Root.Child = null;
+            Dispatcher.UIThread.RunJobs();
+            Renderer.Dispose();
+            // Compositors are created per test, so their backend contexts have to be
+            // disposed deterministically instead of piling up until finalization
+            var renderInterface = Compositor.Server.RenderInterface;
+            using (renderInterface.EnsureCurrent())
+                Compositor.Server.ResetAllGpuResources();
+            if (!_gpu.UsesSharedContext)
+                renderInterface.GpuContext?.Dispose();
+            Bitmap.Dispose();
+        }
+    }
+
+    private static ICompositionGlTexture ClearTexture(ICompositionGlContext context, ICompositionGlTexture texture,
+        float r, float g, float b, float a, out Task present)
+    {
+        using (context.GlContext.MakeCurrent())
+        {
+            var gl = context.GlContext.GlInterface;
+            var fbo = gl.GenFramebuffer();
+            using (var lease = texture.BeginDraw())
+            {
+                var info = lease.Texture;
+                gl.BindFramebuffer(GL_FRAMEBUFFER, fbo);
+                gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, info.Target, info.TextureId, 0);
+                gl.ClearColor(r, g, b, a);
+                gl.Clear(GL_COLOR_BUFFER_BIT);
+                gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, info.Target, 0, 0);
+                gl.BindFramebuffer(GL_FRAMEBUFFER, 0);
+                present = lease.PresentAsync();
+            }
+
+            gl.DeleteFramebuffer(fbo);
+        }
+
+        return texture;
+    }
+
+    private static Exception? RunOnOtherThread(Action action)
+    {
+        // A dedicated thread instead of Task.Run, since waiting for a task can inline it on the current thread
+        Exception? exception = null;
+        var thread = new System.Threading.Thread(() => exception = Record.Exception(action));
+        thread.Start();
+        thread.Join();
+        return exception;
+    }
+
+    private static CompositionSurfaceVisual AttachSurfaceVisual(CompositorScaffolding scaffolding, Control host,
+        CompositionDrawingSurface surface, Size size)
+    {
+        var visual = scaffolding.Compositor.CreateSurfaceVisual();
+        visual.Size = new Vector(size.Width, size.Height);
+        visual.Surface = surface;
+        ElementComposition.SetElementChildVisual(host, visual);
+        Dispatcher.UIThread.RunJobs();
+        return visual;
+    }
+
+    [Fact]
+    public void Can_Create_Compatible_Context_With_Gl_Compositor()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        using var scaffolding = new CompositorScaffolding(new Border { Width = 100, Height = 100 }, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+
+        var context = scaffolding.CreateGlContext();
+        Assert.Same(scaffolding.Compositor, context.Compositor);
+        Assert.NotNull(context.GlContext);
+        Assert.True(context.IsValidForInterop);
+        var version = context.GlContext.Version;
+        scaffolding.WaitFor(context.DisposeAsync());
+        Assert.False(context.IsValidForInterop);
+
+        // GlProfiles preference is plumbed through
+        var context2 = scaffolding.CreateGlContext(new CompositionGlContextOptions { GlProfiles = new[] { version } });
+        Assert.Equal(version, context2.GlContext.Version);
+        scaffolding.WaitFor(context2.DisposeAsync());
+    }
+
+    [Fact]
+    public void Context_Creation_Returns_Null_With_Vulkan_Compositor()
+    {
+        if (!MesaSoftwareRenderer.VulkanEnabled)
+            return;
+        using var scaffolding = new CompositorScaffolding(new Border { Width = 100, Height = 100 }, MesaSoftwareRenderer.Vulkan, new PixelSize(100, 100));
+
+        // lavapipe Vulkan backend has no OpenGL sharing feature and no D3D11 shared memory support
+        var context = scaffolding.WaitFor(scaffolding.Compositor.TryCreateCompatibleGlContextAsync());
+        Assert.Null(context);
+    }
+
+    [Fact]
+    public void Presented_Texture_Is_Composited()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        var host = new Border { Width = 100, Height = 100, Background = Brushes.Black };
+        using var scaffolding = new CompositorScaffolding(host, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+        var context = scaffolding.CreateGlContext();
+        var surface = scaffolding.Compositor.CreateDrawingSurface();
+        AttachSurfaceVisual(scaffolding, host, surface, new Size(100, 100));
+
+        var texture = context.CreateTexture(surface, new PixelSize(100, 100));
+        Assert.True(texture.IsReadyForDraw);
+        ClearTexture(context, texture, 1, 0, 0, 1, out var present);
+
+        scaffolding.WaitFor(present);
+        Assert.True(texture.IsReadyForDraw);
+        Assert.Equal(((byte)255, (byte)0, (byte)0, (byte)255), scaffolding.GetPixel(50, 50));
+
+        // The texture is reusable, present another frame
+        ClearTexture(context, texture, 0, 0, 1, 1, out present);
+        scaffolding.WaitFor(present);
+        Assert.Equal(((byte)0, (byte)0, (byte)255, (byte)255), scaffolding.GetPixel(50, 50));
+
+        scaffolding.WaitFor(texture.DisposeAsync());
+        surface.Dispose();
+        scaffolding.WaitFor(context.DisposeAsync());
+    }
+
+    [Fact]
+    public void Lease_State_Machine_Is_Enforced()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        using var scaffolding = new CompositorScaffolding(new Border { Width = 100, Height = 100 }, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+        var context = scaffolding.CreateGlContext();
+        var surface = scaffolding.Compositor.CreateDrawingSurface();
+
+        var texture = context.CreateTexture(surface, new PixelSize(64, 64));
+
+        // Draw session is exclusive
+        var lease = texture.BeginDraw();
+        Assert.False(texture.IsReadyForDraw);
+        Assert.NotEqual(0, lease.Texture.TextureId);
+        Assert.Throws<InvalidOperationException>(() => texture.BeginDraw());
+
+        // Dispose without present discards the frame and makes the texture immediately reusable
+        lease.Dispose();
+        Assert.True(texture.IsReadyForDraw);
+        Assert.Throws<ObjectDisposedException>(() => lease.Texture);
+
+        // While a present is pending the texture is busy. Commits are only processed when the event
+        // loop is pumped, so the present can't have been completed at this point.
+        ClearTexture(context, texture, 1, 1, 1, 1, out var present);
+        Assert.False(present.IsCompleted);
+        Assert.False(texture.IsReadyForDraw);
+        Assert.Throws<InvalidOperationException>(() => texture.BeginDraw());
+
+        scaffolding.WaitFor(present);
+        Assert.True(texture.IsReadyForDraw);
+
+        // Present is terminal for the lease
+        var lease2 = texture.BeginDraw();
+        var present2 = lease2.PresentAsync();
+        Assert.IsType<ObjectDisposedException>(Record.Exception(() => { _ = lease2.PresentAsync(); }));
+        Assert.Throws<ObjectDisposedException>(() => lease2.Texture);
+        lease2.Dispose(); // no-op after present
+        scaffolding.WaitFor(present2);
+
+        scaffolding.WaitFor(texture.DisposeAsync());
+        Assert.Throws<ObjectDisposedException>(() => texture.BeginDraw());
+        surface.Dispose();
+        scaffolding.WaitFor(context.DisposeAsync());
+    }
+
+    [Fact]
+    public void Entry_Points_Verify_Compositor_Thread_Access()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        using var scaffolding = new CompositorScaffolding(new Border { Width = 100, Height = 100 }, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+        var context = scaffolding.CreateGlContext();
+        var surface = scaffolding.Compositor.CreateDrawingSurface();
+        var texture = context.CreateTexture(surface, new PixelSize(64, 64));
+
+        Assert.IsType<InvalidOperationException>(
+            RunOnOtherThread(() => context.CreateTexture(surface, new PixelSize(64, 64))),
+            exactMatch: false);
+        Assert.IsType<InvalidOperationException>(
+            RunOnOtherThread(() => texture.BeginDraw()),
+            exactMatch: false);
+
+        scaffolding.WaitFor(texture.DisposeAsync());
+        surface.Dispose();
+        scaffolding.WaitFor(context.DisposeAsync());
+    }
+
+    [Fact]
+    public void Create_Texture_Validates_Arguments()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        using var scaffolding = new CompositorScaffolding(new Border { Width = 100, Height = 100 }, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+        var context = scaffolding.CreateGlContext();
+        var surface = scaffolding.Compositor.CreateDrawingSurface();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => context.CreateTexture(surface, new PixelSize(0, 0)));
+
+        // A surface from a different compositor is rejected.
+        // This compositor has no GPU backend and no started renderer, so there is nothing to dispose deterministically.
+        var foreignCompositor = new Compositor(RenderLoop.FromTimer(new ManualRenderTimer()), null, true,
+            new DispatcherCompositorScheduler(), true, Dispatcher.UIThread);
+        var foreignSurface = foreignCompositor.CreateDrawingSurface();
+        Assert.Throws<InvalidOperationException>(() => context.CreateTexture(foreignSurface, new PixelSize(64, 64)));
+        foreignSurface.Dispose();
+
+        surface.Dispose();
+        scaffolding.WaitFor(context.DisposeAsync());
+    }
+
+    [Fact]
+    public void Disposing_Context_Disposes_Textures()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        using var scaffolding = new CompositorScaffolding(new Border { Width = 100, Height = 100 }, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+        var context = scaffolding.CreateGlContext();
+        var surface = scaffolding.Compositor.CreateDrawingSurface();
+
+        var texture = context.CreateTexture(surface, new PixelSize(64, 64));
+        ClearTexture(context, texture, 1, 0, 1, 1, out var present);
+        scaffolding.WaitFor(present);
+
+        scaffolding.WaitFor(context.DisposeAsync());
+        Assert.False(context.IsValidForInterop);
+        Assert.False(texture.IsReadyForDraw);
+        Assert.Throws<ObjectDisposedException>(() => texture.BeginDraw());
+        surface.Dispose();
+    }
+
+    private class ClearColorGlControl : OpenGlControlBase
+    {
+        public int RenderCount;
+
+        protected override void OnOpenGlRender(GlInterface gl, int fb)
+        {
+            RenderCount++;
+            gl.ClearColor(0, 1, 0, 1);
+            gl.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        }
+    }
+
+    [Fact]
+    public void OpenGlControlBase_Renders_Through_Composition_Interop()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        var control = new ClearColorGlControl { Width = 100, Height = 100 };
+        using var scaffolding = new CompositorScaffolding(control, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+
+        // The control initializes asynchronously after being attached
+        (byte, byte, byte, byte) pixel = default;
+        for (var c = 0; c < 100; c++)
+        {
+            scaffolding.Pump();
+            pixel = scaffolding.GetPixel(50, 50);
+            if (pixel == ((byte)0, (byte)255, (byte)0, (byte)255))
+                break;
+        }
+
+        Assert.Equal(((byte)0, (byte)255, (byte)0, (byte)255), pixel);
+        Assert.True(control.RenderCount > 0);
+
+        // Detach triggers the cleanup path
+        scaffolding.Root.Child = null;
+        for (var c = 0; c < 10; c++)
+            scaffolding.Pump();
+    }
+}
+#endif


### PR DESCRIPTION
Supercedes https://github.com/AvaloniaUI/Avalonia/pull/14653

This PR allows:
1) creation of long-lived OpenGL contexts that aren't bound to a particular control 
2) presentation of OpenGL textures created with such contexts via `CompositionDrawingSurface` without touching low-level graphics interop APIs

The existing OpenGLControlBase.cs is refactored to use the new API internally.

```cs

/// <summary>
/// Provides OpenGL interop facilities for the composition engine.
/// </summary>
public static class OpenGlCompositionInterop
{
    /// <summary>
    /// Attempts to create an OpenGL context that is suitable for interop with the compositor's GPU context.
    /// Must be called on the thread the compositor belongs to.
    /// </summary>
    /// <returns>
    /// The created context, or null when the current platform or compositor configuration doesn't
    /// support OpenGL interop. The concrete reason is logged to the "OpenGL" log area.
    /// </returns>
    public static async ValueTask<ICompositionGlContext?> TryCreateCompatibleGlContextAsync(
        this Compositor compositor, CompositionGlContextOptions? options = null);
}


/// <summary>
/// Options for <see cref="OpenGlCompositionInterop.TryCreateCompatibleGlContextAsync"/>.
/// </summary>
public class CompositionGlContextOptions
{
    /// <summary>
    /// The list of desired OpenGL(ES) versions in order of preference.
    /// </summary>
    public IReadOnlyList<GlVersion>? GlProfiles { get; set; }
}

/// <summary>
/// An OpenGL context that is suitable for interop with a <see cref="Rendering.Composition.Compositor"/>.
/// Create instances via <see cref="OpenGlCompositionInterop.TryCreateCompatibleGlContextAsync"/>.
/// </summary>
/// <remarks>
/// All members can only be used on the thread the associated <see cref="Rendering.Composition.Compositor"/>
/// belongs to.
/// </remarks>
[NotClientImplementable]
public interface ICompositionGlContext : IAsyncDisposable
{
    /// <summary>
    /// The associated compositor.
    /// </summary>
    Compositor Compositor { get; }

    /// <summary>
    /// The OpenGL context.
    /// </summary>
    IGlContext GlContext { get; }

    /// <summary>
    /// Returns true if this OpenGL context is still suitable for interop with the Compositor.
    /// This property might become false in cases like a device loss event on the compositor side.
    /// In that case presentation is no longer possible, however <see cref="GlContext"/> itself might
    /// still be usable for salvaging user resources. Once the property becomes false, this instance
    /// should be disposed and recreated via
    /// <see cref="OpenGlCompositionInterop.TryCreateCompatibleGlContextAsync"/>.
    /// A recreated context shares no OpenGL objects with the old one.
    /// </summary>
    bool IsValidForInterop { get; }

    /// <summary>
    /// Creates a texture that can be used to update a <see cref="CompositionDrawingSurface"/> instance.
    /// </summary>
    ICompositionGlTexture CreateTexture(CompositionDrawingSurface surface, PixelSize size);
}

/// <summary>
/// A texture that can be drawn to by user code and presented to a <see cref="CompositionDrawingSurface"/>.
/// Create instances via <see cref="ICompositionGlContext.CreateTexture"/>.
/// </summary>
/// <remarks>
/// All members can only be used on the thread the associated <see cref="Compositor"/> belongs to.
/// </remarks>
[NotClientImplementable]
public interface ICompositionGlTexture : IAsyncDisposable
{
    /// <summary>
    /// The pixel size of the texture.
    /// </summary>
    PixelSize Size { get; }

    /// <summary>
    /// Returns true when the texture can be drawn to: there is no active lease and the last
    /// presentation, if any, has completed successfully.
    /// A presentation failure leaves this property permanently false, check
    /// <see cref="ICompositionGlContext.IsValidForInterop"/> in that case.
    /// </summary>
    bool IsReadyForDraw { get; }

    /// <summary>
    /// Prepares the texture to be rendered to by user code.
    /// User code can bind the texture to their framebuffer, however the texture should be unbound
    /// before ending the returned lease.
    /// </summary>
    /// <exception cref="InvalidOperationException">
    /// The texture is not ready for drawing (<see cref="IsReadyForDraw"/> is false) or the owning
    /// context is no longer valid for interop.
    /// </exception>
    /// <exception cref="ObjectDisposedException">The texture has been disposed.</exception>
    ICompositionGlTextureLease BeginDraw();
}

/// <summary>
/// An active drawing session on an <see cref="ICompositionGlTexture"/>.
/// The lease is ended either by <see cref="PresentAsync"/> or by <see cref="IDisposable.Dispose"/>,
/// the latter discards the frame. Disposing after <see cref="PresentAsync"/> is a no-op.
/// </summary>
[NotClientImplementable]
public interface ICompositionGlTextureLease : IDisposable
{
    /// <summary>
    /// Describes the OpenGL texture to draw into. Only valid until the lease ends;
    /// <see cref="CompositionGlTextureInfo.TextureId"/> is not guaranteed to be stable between leases.
    /// </summary>
    CompositionGlTextureInfo Texture { get; }

    /// <summary>
    /// Ends the lease and asynchronously presents the texture to the associated
    /// <see cref="CompositionDrawingSurface"/>. This will happen when the next composition commit
    /// is processed by the render thread.
    /// The texture must be unbound from user framebuffers before calling this method.
    /// The returned task completes when the texture can be drawn to again, NOT when the frame
    /// becomes visible on the screen.
    /// You should NOT await the returned task while keeping hold of a
    /// <see cref="IGlContext.MakeCurrent"/> disposable.
    /// </summary>
    Task PresentAsync();
}

/// <summary>
/// Describes an OpenGL texture provided by <see cref="ICompositionGlTextureLease"/>.
/// </summary>
public readonly record struct CompositionGlTextureInfo(int TextureId, int Target, int InternalFormat, PixelSize Size);


```