### PR TITLE
Allow GPU interop APIs to be used from non-UI threads

### DIFF
--- a/samples/ControlCatalog/Pages/OpenGl/OpenGlInteropPage.xaml
+++ b/samples/ControlCatalog/Pages/OpenGl/OpenGlInteropPage.xaml
@@ -1,0 +1,9 @@
+<ContentPage xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ControlCatalog.Pages.OpenGlInteropPage"
+             xmlns:openGl="clr-namespace:ControlCatalog.Pages.OpenGl">
+    <Grid>
+        <Control x:Name="Viewport" AttachedToVisualTree="ViewportAttachedToVisualTree" DetachedFromVisualTree="ViewportDetachedFromVisualTree"/>
+        <openGl:GlPageKnobs x:Name="Knobs" PropertyChanged="KnobsPropertyChanged" />
+    </Grid>
+</ContentPage>

--- a/samples/ControlCatalog/Pages/OpenGl/OpenGlInteropPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/OpenGl/OpenGlInteropPage.xaml.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.OpenGL;
+using Avalonia.Rendering.Composition;
+using ControlCatalog.Pages.OpenGl;
+using static Avalonia.OpenGL.GlConsts;
+
+namespace ControlCatalog.Pages;
+
+/// <summary>
+/// Demonstrates the ICompositionGlContext API: an OpenGL context compatible with the compositor
+/// and a texture presented to a CompositionDrawingSurface, without using OpenGlControlBase.
+/// </summary>
+public partial class OpenGlInteropPage : ContentPage
+{
+    private ICompositionGlContext? _context;
+    private ICompositionGlTexture? _texture;
+    private Task? _lastPresent;
+    private CompositionDrawingSurface? _surface;
+    private CompositionSurfaceVisual? _visual;
+    private OpenGlContent? _content;
+    private int _fbo;
+    private int _depthBuffer;
+    private PixelSize _depthBufferSize;
+    private bool _updateQueued;
+    private bool _attached;
+    private int _generation;
+
+    public OpenGlInteropPage()
+    {
+        InitializeComponent();
+    }
+
+    private void ViewportAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        _attached = true;
+        Initialize();
+    }
+
+    private void ViewportDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        _attached = false;
+        Cleanup();
+    }
+
+    private async void Initialize()
+    {
+        var generation = ++_generation;
+        if (ElementComposition.GetElementVisual(Viewport) is not { } elementVisual)
+            return;
+        var compositor = elementVisual.Compositor;
+
+        var context = await compositor.TryCreateCompatibleGlContextAsync();
+        if (context == null)
+        {
+            Knobs.Info = "Compositor OpenGL interop is not available on this platform";
+            return;
+        }
+
+        if (!_attached || generation != _generation)
+        {
+            // The viewport got detached or reinitialized while we were awaiting
+            await context.DisposeAsync();
+            return;
+        }
+
+        _context = context;
+        _surface = compositor.CreateDrawingSurface();
+        _visual = compositor.CreateSurfaceVisual();
+        _visual.Surface = _surface;
+        ElementComposition.SetElementChildVisual(Viewport, _visual);
+
+        using (context.GlContext.MakeCurrent())
+        {
+            var gl = context.GlContext.GlInterface;
+            _fbo = gl.GenFramebuffer();
+            _content = new OpenGlContent();
+            _content.Init(gl, context.GlContext.Version);
+        }
+
+        Knobs.Info = _content.Info;
+        Viewport.SizeChanged += OnViewportSizeChanged;
+        QueueUpdate();
+    }
+
+    private async void Cleanup()
+    {
+        _generation++;
+        Viewport.SizeChanged -= OnViewportSizeChanged;
+        ElementComposition.SetElementChildVisual(Viewport, null);
+        _visual = null;
+
+        var context = _context;
+        _context = null;
+        if (context == null)
+            return;
+
+        try
+        {
+            using (context.GlContext.MakeCurrent())
+            {
+                var gl = context.GlContext.GlInterface;
+                _content?.Deinit(gl);
+                if (_fbo != 0)
+                    gl.DeleteFramebuffer(_fbo);
+                if (_depthBuffer != 0)
+                    gl.DeleteRenderbuffer(_depthBuffer);
+            }
+        }
+        catch
+        {
+            // The context is likely lost
+        }
+
+        _content = null;
+        _fbo = 0;
+        _depthBuffer = 0;
+        _depthBufferSize = default;
+        _texture = null;
+        _lastPresent = null;
+        _surface?.Dispose();
+        _surface = null;
+
+        // Also disposes the textures created from it
+        await context.DisposeAsync();
+    }
+
+    private void OnViewportSizeChanged(object? sender, SizeChangedEventArgs e) => QueueUpdate();
+
+    private void KnobsPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property == GlPageKnobs.YawProperty
+            || e.Property == GlPageKnobs.RollProperty
+            || e.Property == GlPageKnobs.PitchProperty
+            || e.Property == GlPageKnobs.DiscoProperty)
+            QueueUpdate();
+    }
+
+    private void QueueUpdate()
+    {
+        if (_updateQueued || _context == null)
+            return;
+        _updateQueued = true;
+        _context.Compositor.RequestCompositionUpdate(Update);
+    }
+
+    private void Update()
+    {
+        _updateQueued = false;
+        if (_context == null || _content == null || _visual == null || _surface == null)
+            return;
+
+        if (!_context.IsValidForInterop)
+        {
+            // The context is no longer usable for presentation, drop everything and start over
+            Cleanup();
+            Initialize();
+            return;
+        }
+
+        var scaling = TopLevel.GetTopLevel(Viewport)?.RenderScaling ?? 1;
+        var size = new PixelSize(
+            Math.Max(1, (int)(Viewport.Bounds.Width * scaling)),
+            Math.Max(1, (int)(Viewport.Bounds.Height * scaling)));
+        _visual.Size = new Vector(Viewport.Bounds.Width, Viewport.Bounds.Height);
+
+        if (_texture != null && (_texture.Size != size || _lastPresent?.IsFaulted == true))
+        {
+            _texture.DisposeAsync();
+            _texture = null;
+            _lastPresent = null;
+        }
+
+        if (_texture == null)
+            _texture = _context.CreateTexture(_surface, size);
+        else if (!_texture.IsReadyForDraw)
+        {
+            // The previous frame hasn't reached the render thread yet, try again on the next composition update
+            QueueUpdate();
+            return;
+        }
+
+        using (_context.GlContext.MakeCurrent())
+        {
+            var gl = _context.GlContext.GlInterface;
+            using (var lease = _texture.BeginDraw())
+            {
+                var info = lease.Texture;
+                gl.BindFramebuffer(GL_FRAMEBUFFER, _fbo);
+                UpdateDepthBuffer(gl, size);
+                gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, info.Target, info.TextureId, 0);
+
+                _content.OnOpenGlRender(gl, _fbo, size, Knobs.Yaw, Knobs.Pitch, Knobs.Roll, Knobs.Disco);
+
+                gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, info.Target, 0, 0);
+                gl.BindFramebuffer(GL_FRAMEBUFFER, 0);
+                _lastPresent = lease.PresentAsync();
+            }
+        }
+
+        if (Knobs.Disco > 0.01)
+            QueueUpdate();
+    }
+
+    private void UpdateDepthBuffer(GlInterface gl, PixelSize size)
+    {
+        if (size == _depthBufferSize && _depthBuffer != 0)
+            return;
+
+        gl.GetIntegerv(GL_RENDERBUFFER_BINDING, out var oldRenderBuffer);
+        if (_depthBuffer != 0)
+            gl.DeleteRenderbuffer(_depthBuffer);
+
+        _depthBuffer = gl.GenRenderbuffer();
+        gl.BindRenderbuffer(GL_RENDERBUFFER, _depthBuffer);
+        gl.RenderbufferStorage(GL_RENDERBUFFER,
+            _context!.GlContext.Version.Type == GlProfileType.OpenGLES ? GL_DEPTH_COMPONENT16 : GL_DEPTH_COMPONENT,
+            size.Width, size.Height);
+        gl.FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _depthBuffer);
+        gl.BindRenderbuffer(GL_RENDERBUFFER, oldRenderBuffer);
+        _depthBufferSize = size;
+    }
+}

--- a/samples/ControlCatalog/Pages/OpenGl/OpenGlOffThreadPage.xaml
+++ b/samples/ControlCatalog/Pages/OpenGl/OpenGlOffThreadPage.xaml
@@ -1,0 +1,12 @@
+<ContentPage xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ControlCatalog.Pages.OpenGlOffThreadPage"
+             xmlns:openGl="clr-namespace:ControlCatalog.Pages.OpenGl">
+    <Grid>
+        <Control x:Name="Viewport" AttachedToVisualTree="ViewportAttachedToVisualTree" DetachedFromVisualTree="ViewportDetachedFromVisualTree"/>
+        <openGl:GlPageKnobs x:Name="Knobs" PropertyChanged="KnobsPropertyChanged" />
+        <Button HorizontalAlignment="Right" VerticalAlignment="Top" Margin="8" Click="StallUiThread">
+            Stall the UI thread for 3 seconds
+        </Button>
+    </Grid>
+</ContentPage>

--- a/samples/ControlCatalog/Pages/OpenGl/OpenGlOffThreadPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/OpenGl/OpenGlOffThreadPage.xaml.cs
@@ -187,7 +187,7 @@ public partial class OpenGlOffThreadPage : ContentPage
 
         private async Task RunAsync()
         {
-            var controller = new CompositorController(_uiCompositor);
+            var controller = _uiCompositor.CreateCompositorController();
             var compositor = controller.Compositor;
 
             var proxy = await Dispatcher.UIThread.InvokeAsync(() => _createProxy(compositor));

--- a/samples/ControlCatalog/Pages/OpenGl/OpenGlOffThreadPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/OpenGl/OpenGlOffThreadPage.xaml.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.OpenGL;
+using Avalonia.Rendering.Composition;
+using Avalonia.Threading;
+using ControlCatalog.Pages.OpenGl;
+using static Avalonia.OpenGL.GlConsts;
+
+namespace ControlCatalog.Pages;
+
+/// <summary>
+/// Demonstrates rendering to a CompositionDrawingSurface from a dedicated thread:
+/// a CompositorController provides a Compositor attached to the render thread of the UI compositor,
+/// and a proxy of the surface is fed from the worker thread. The scene keeps animating
+/// even while the UI thread is stalled.
+/// </summary>
+public partial class OpenGlOffThreadPage : ContentPage
+{
+    private CompositionDrawingSurface? _surface;
+    private CompositionSurfaceVisual? _visual;
+    private GlRenderWorker? _worker;
+    private int _generation;
+
+    public OpenGlOffThreadPage()
+    {
+        InitializeComponent();
+    }
+
+    private void ViewportAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e) => Initialize();
+
+    private void ViewportDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e) => Cleanup();
+
+    private void Initialize()
+    {
+        var generation = ++_generation;
+        if (ElementComposition.GetElementVisual(Viewport) is not { } elementVisual)
+            return;
+        var compositor = elementVisual.Compositor;
+
+        _surface = compositor.CreateDrawingSurface();
+        _visual = compositor.CreateSurfaceVisual();
+        _visual.Surface = _surface;
+        ElementComposition.SetElementChildVisual(Viewport, _visual);
+
+        _worker = new GlRenderWorker(compositor,
+            createProxy: workerCompositor =>
+                generation == _generation && _surface is { IsDisposed: false } surface
+                    ? surface.CreateProxyForCompositor(workerCompositor)
+                    : null,
+            reportInfo: info =>
+            {
+                if (generation == _generation)
+                    Knobs.Info = info;
+            },
+            restartRequested: () =>
+            {
+                // The GL context is no longer usable for interop, drop everything and start over
+                if (generation == _generation)
+                {
+                    Cleanup();
+                    Initialize();
+                }
+            });
+
+        Viewport.SizeChanged += OnViewportSizeChanged;
+        UpdateWorkerParameters();
+        _worker.Start();
+    }
+
+    private void Cleanup()
+    {
+        _generation++;
+        Viewport.SizeChanged -= OnViewportSizeChanged;
+        ElementComposition.SetElementChildVisual(Viewport, null);
+        _visual = null;
+        _worker?.Stop();
+        _worker = null;
+        // The worker holds a proxy, so the server-side surface stays alive until the worker is done with it
+        _surface?.Dispose();
+        _surface = null;
+    }
+
+    private void OnViewportSizeChanged(object? sender, SizeChangedEventArgs e) => UpdateWorkerParameters();
+
+    private void KnobsPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property == GlPageKnobs.YawProperty
+            || e.Property == GlPageKnobs.RollProperty
+            || e.Property == GlPageKnobs.PitchProperty
+            || e.Property == GlPageKnobs.DiscoProperty)
+            UpdateWorkerParameters();
+    }
+
+    private void UpdateWorkerParameters()
+    {
+        if (_worker == null)
+            return;
+        var scaling = TopLevel.GetTopLevel(Viewport)?.RenderScaling ?? 1;
+        var size = new PixelSize(
+            Math.Max(1, (int)(Viewport.Bounds.Width * scaling)),
+            Math.Max(1, (int)(Viewport.Bounds.Height * scaling)));
+        if (_visual != null)
+            _visual.Size = new Vector(Viewport.Bounds.Width, Viewport.Bounds.Height);
+        _worker.SetParameters(size, Knobs.Yaw, Knobs.Pitch, Knobs.Roll, Knobs.Disco);
+    }
+
+    private void StallUiThread(object? sender, RoutedEventArgs e) => Thread.Sleep(3000);
+
+    private sealed class GlRenderWorker
+    {
+        private readonly Compositor _uiCompositor;
+        private readonly Func<Compositor, CompositionDrawingSurface?> _createProxy;
+        private readonly Action<string> _reportInfo;
+        private readonly Action _restartRequested;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Thread _thread;
+        private readonly object _parametersLock = new();
+        private Parameters _parameters;
+
+        private struct Parameters
+        {
+            public PixelSize Size;
+            public float Yaw, Pitch, Roll, Disco;
+        }
+
+        public GlRenderWorker(Compositor uiCompositor,
+            Func<Compositor, CompositionDrawingSurface?> createProxy,
+            Action<string> reportInfo, Action restartRequested)
+        {
+            _uiCompositor = uiCompositor;
+            _createProxy = createProxy;
+            _reportInfo = reportInfo;
+            _restartRequested = restartRequested;
+            _thread = new Thread(ThreadMain) { Name = "GL interop worker", IsBackground = true };
+        }
+
+        public void Start() => _thread.Start();
+
+        public void Stop() => _cts.Cancel();
+
+        public void SetParameters(PixelSize size, float yaw, float pitch, float roll, float disco)
+        {
+            lock (_parametersLock)
+                _parameters = new Parameters { Size = size, Yaw = yaw, Pitch = pitch, Roll = roll, Disco = disco };
+        }
+
+        private void ReportInfo(string info) => Dispatcher.UIThread.Post(() => _reportInfo(info));
+
+        private void ThreadMain()
+        {
+            try
+            {
+                var dispatcher = Dispatcher.CurrentDispatcher;
+                var frame = new DispatcherFrame();
+                dispatcher.InvokeAsync(async () =>
+                {
+                    try
+                    {
+                        await RunAsync();
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                    catch (Exception e)
+                    {
+                        ReportInfo("Off-thread rendering failed: " + e.Message);
+                    }
+                    finally
+                    {
+                        frame.Continue = false;
+                    }
+                });
+                // Pumps posted jobs and keeps await continuations on this thread
+                dispatcher.PushFrame(frame);
+                dispatcher.InvokeShutdown();
+            }
+            catch (Exception e)
+            {
+                ReportInfo("Off-thread rendering failed: " + e.Message);
+            }
+        }
+
+        private async Task RunAsync()
+        {
+            var controller = new CompositorController(_uiCompositor);
+            var compositor = controller.Compositor;
+
+            var proxy = await Dispatcher.UIThread.InvokeAsync(() => _createProxy(compositor));
+            if (proxy == null)
+                return;
+
+            ICompositionGlContext? context = null;
+            try
+            {
+                context = await compositor.TryCreateCompatibleGlContextAsync();
+                if (context == null)
+                {
+                    ReportInfo("Compositor OpenGL interop is not available on this platform");
+                    return;
+                }
+
+                await RenderLoop(context, proxy, _cts.Token);
+            }
+            finally
+            {
+                proxy.Dispose();
+                if (context != null)
+                    await context.DisposeAsync();
+                // Make sure the dispose jobs reach the render thread even though the loop is exiting
+                controller.Commit();
+            }
+
+            if (!_cts.IsCancellationRequested)
+                Dispatcher.UIThread.Post(_restartRequested);
+        }
+
+        private async Task RenderLoop(ICompositionGlContext context, CompositionDrawingSurface proxy,
+            CancellationToken cancellationToken)
+        {
+            var gl = context.GlContext.GlInterface;
+            var content = new OpenGlContent();
+            int fbo;
+            var depthBuffer = 0;
+            var depthBufferSize = default(PixelSize);
+            ICompositionGlTexture? texture = null;
+            var clock = Stopwatch.StartNew();
+
+            using (context.GlContext.MakeCurrent())
+            {
+                fbo = gl.GenFramebuffer();
+                content.Init(gl, context.GlContext.Version);
+            }
+            ReportInfo($"{content.Info}\nRendering from a dedicated thread");
+
+            void UpdateDepthBuffer(PixelSize size)
+            {
+                if (size == depthBufferSize && depthBuffer != 0)
+                    return;
+                gl.GetIntegerv(GL_RENDERBUFFER_BINDING, out var oldRenderBuffer);
+                if (depthBuffer != 0)
+                    gl.DeleteRenderbuffer(depthBuffer);
+                depthBuffer = gl.GenRenderbuffer();
+                gl.BindRenderbuffer(GL_RENDERBUFFER, depthBuffer);
+                gl.RenderbufferStorage(GL_RENDERBUFFER,
+                    context.GlContext.Version.Type == GlProfileType.OpenGLES
+                        ? GL_DEPTH_COMPONENT16
+                        : GL_DEPTH_COMPONENT,
+                    size.Width, size.Height);
+                gl.FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthBuffer);
+                gl.BindRenderbuffer(GL_RENDERBUFFER, oldRenderBuffer);
+                depthBufferSize = size;
+            }
+
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested && context.IsValidForInterop)
+                {
+                    Parameters parameters;
+                    lock (_parametersLock)
+                        parameters = _parameters;
+
+                    if (parameters.Size.Width < 1 || parameters.Size.Height < 1)
+                    {
+                        await Task.Delay(100, cancellationToken);
+                        continue;
+                    }
+
+                    if (texture != null && texture.Size != parameters.Size)
+                    {
+                        await texture.DisposeAsync();
+                        texture = null;
+                    }
+                    texture ??= context.CreateTexture(proxy, parameters.Size);
+
+                    Task present;
+                    using (context.GlContext.MakeCurrent())
+                    {
+                        using var lease = texture.BeginDraw();
+                        var textureInfo = lease.Texture;
+                        gl.BindFramebuffer(GL_FRAMEBUFFER, fbo);
+                        UpdateDepthBuffer(parameters.Size);
+                        gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                            textureInfo.Target, textureInfo.TextureId, 0);
+
+                        // Extra time-based spin so the scene visibly animates on its own
+                        var spin = (float)(clock.Elapsed.TotalSeconds * 0.5);
+                        content.OnOpenGlRender(gl, fbo, parameters.Size,
+                            parameters.Yaw + spin, parameters.Pitch, parameters.Roll, parameters.Disco);
+
+                        gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, textureInfo.Target, 0, 0);
+                        gl.BindFramebuffer(GL_FRAMEBUFFER, 0);
+                        present = lease.PresentAsync();
+                    }
+
+                    try
+                    {
+                        // Frame pacing comes from the compositor's render loop processing the frame
+                        await present;
+                    }
+                    catch
+                    {
+                        // Presentation failures indicate a lost context, exit and let the page reinitialize
+                        break;
+                    }
+                }
+            }
+            finally
+            {
+                if (texture != null)
+                    await texture.DisposeAsync();
+                try
+                {
+                    using (context.GlContext.MakeCurrent())
+                    {
+                        content.Deinit(gl);
+                        if (depthBuffer != 0)
+                            gl.DeleteRenderbuffer(depthBuffer);
+                        gl.DeleteFramebuffer(fbo);
+                    }
+                }
+                catch
+                {
+                    // The context is likely lost
+                }
+            }
+        }
+    }
+}

--- a/samples/ControlCatalog/ViewModels/MainWindowViewModel_PageList.cs
+++ b/samples/ControlCatalog/ViewModels/MainWindowViewModel_PageList.cs
@@ -71,6 +71,7 @@ namespace ControlCatalog.ViewModels
             new PageItem("OpenGL",() => new OpenGlPage(), Icons.Cube3D),
             new PageItem("OpenGL Lease",() => new OpenGlLeasePage(), Icons.Cube3D),
             new PageItem("OpenGL Interop",() => new OpenGlInteropPage(), Icons.Cube3D),
+            new PageItem("OpenGL Off-Thread",() => new OpenGlOffThreadPage(), Icons.Cube3D),
             new PageItem("PipsPager",() => new PipsPagerPage(), Icons.HorizontalDots),
             new PageItem("Platform Information",() => new PlatformInfoPage(), Icons.Info),
             new PageItem("Pointers",() => new PointersPage(), Icons.Cursor),

--- a/samples/ControlCatalog/ViewModels/MainWindowViewModel_PageList.cs
+++ b/samples/ControlCatalog/ViewModels/MainWindowViewModel_PageList.cs
@@ -70,6 +70,7 @@ namespace ControlCatalog.ViewModels
             new PageItem("NumericUpDown",() => new NumericUpDownPage(), Icons.Number),
             new PageItem("OpenGL",() => new OpenGlPage(), Icons.Cube3D),
             new PageItem("OpenGL Lease",() => new OpenGlLeasePage(), Icons.Cube3D),
+            new PageItem("OpenGL Interop",() => new OpenGlInteropPage(), Icons.Cube3D),
             new PageItem("PipsPager",() => new PipsPagerPage(), Icons.HorizontalDots),
             new PageItem("Platform Information",() => new PlatformInfoPage(), Icons.Info),
             new PageItem("Pointers",() => new PointersPage(), Icons.Cursor),

--- a/src/Avalonia.Base/Rendering/Composition/CompositionDrawingSurface.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionDrawingSurface.cs
@@ -12,6 +12,60 @@ public sealed class CompositionDrawingSurface : CompositionSurface, IDisposable
     {
     }
 
+    private CompositionDrawingSurface(Compositor compositor, ServerCompositionDrawingSurface server)
+        : base(compositor, server)
+    {
+    }
+
+    /// <summary>
+    /// Creates a proxy surface sharing the server-side surface with this one, but bound to
+    /// <paramref name="compositor"/> and usable from that compositor's thread
+    /// </summary>
+    /// <remarks>
+    /// This method can only be called from the thread of the compositor this surface belongs to.
+    /// The server-side surface is kept alive until this surface and all of its proxies are disposed,
+    /// so the returned proxy must be disposed too.
+    /// The target compositor must share the server-side compositor with this surface's compositor,
+    /// see <see cref="CompositorController"/>.
+    /// </remarks>
+    /// <param name="compositor">The compositor the proxy is created for</param>
+    /// <returns>A proxy surface bound to <paramref name="compositor"/></returns>
+    /// <exception cref="ObjectDisposedException">This surface is already disposed</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The target compositor is the compositor of this surface or doesn't share its server-side compositor
+    /// </exception>
+    public CompositionDrawingSurface CreateProxyForCompositor(Compositor compositor)
+    {
+        Compositor.Dispatcher.VerifyAccess();
+        if (IsDisposed)
+            throw new ObjectDisposedException(nameof(CompositionDrawingSurface));
+        if (compositor == Compositor)
+            throw new InvalidOperationException("The surface already belongs to the target compositor");
+        if (compositor.Server != Compositor.Server)
+            throw new InvalidOperationException(
+                "The target compositor is attached to a different server-side compositor");
+        Server.AddRef();
+        return new CompositionDrawingSurface(compositor, Server);
+    }
+
+    private CompositionImportedGpuImage VerifyOwnership(ICompositionImportedGpuImage image)
+    {
+        var img = (CompositionImportedGpuImage)image;
+        if (img.Compositor != Compositor)
+            throw new InvalidOperationException(
+                "The image was imported with an interop context belonging to a different Compositor");
+        return img;
+    }
+
+    private CompositionImportedGpuSemaphore VerifyOwnership(ICompositionImportedGpuSemaphore semaphore)
+    {
+        var sem = (CompositionImportedGpuSemaphore)semaphore;
+        if (sem.Compositor != Compositor)
+            throw new InvalidOperationException(
+                "The semaphore was imported with an interop context belonging to a different Compositor");
+        return sem;
+    }
+
     /// <summary>
     /// Updates the surface contents using an imported memory image using a keyed mutex as the means of synchronization
     /// </summary>
@@ -21,7 +75,7 @@ public sealed class CompositionDrawingSurface : CompositionSurface, IDisposable
     /// <returns>A task that completes when update operation is completed and user code is free to destroy or dispose the image</returns>
     public Task UpdateWithKeyedMutexAsync(ICompositionImportedGpuImage image, uint acquireIndex, uint releaseIndex)
     {
-        var img = (CompositionImportedGpuImage)image;
+        var img = VerifyOwnership(image);
         return Compositor.InvokeServerJobAsync(() => Server.UpdateWithKeyedMutex(img, acquireIndex, releaseIndex));
     }
 
@@ -36,9 +90,9 @@ public sealed class CompositionDrawingSurface : CompositionSurface, IDisposable
         ICompositionImportedGpuSemaphore waitForSemaphore,
         ICompositionImportedGpuSemaphore signalSemaphore)
     {
-        var img = (CompositionImportedGpuImage)image;
-        var wait = (CompositionImportedGpuSemaphore)waitForSemaphore;
-        var signal = (CompositionImportedGpuSemaphore)signalSemaphore;
+        var img = VerifyOwnership(image);
+        var wait = VerifyOwnership(waitForSemaphore);
+        var signal = VerifyOwnership(signalSemaphore);
         return Compositor.InvokeServerJobAsync(() => Server.UpdateWithSemaphores(img, wait, signal));
     }
 
@@ -55,9 +109,9 @@ public sealed class CompositionDrawingSurface : CompositionSurface, IDisposable
         ICompositionImportedGpuSemaphore waitForSemaphore, ulong waitForValue,
         ICompositionImportedGpuSemaphore signalSemaphore, ulong signalValue)
     {
-        var img = (CompositionImportedGpuImage)image;
-        var wait = (CompositionImportedGpuSemaphore)waitForSemaphore;
-        var signal = (CompositionImportedGpuSemaphore)signalSemaphore;
+        var img = VerifyOwnership(image);
+        var wait = VerifyOwnership(waitForSemaphore);
+        var signal = VerifyOwnership(signalSemaphore);
         return Compositor.InvokeServerJobAsync(() => Server.UpdateWithTimelineSemaphores(img, wait, waitForValue, signal, signalValue));
     }
 
@@ -69,7 +123,7 @@ public sealed class CompositionDrawingSurface : CompositionSurface, IDisposable
     /// <returns>A task that completes when update operation is completed and user code is free to destroy or dispose the image</returns>
     public Task UpdateAsync(ICompositionImportedGpuImage image)
     {
-        var img = (CompositionImportedGpuImage)image;
+        var img = VerifyOwnership(image);
         return Compositor.InvokeServerJobAsync(() => Server.UpdateWithAutomaticSync(img));
     }
 

--- a/src/Avalonia.Base/Rendering/Composition/CompositionInterop.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionInterop.cs
@@ -63,7 +63,7 @@ internal class CompositionInterop : ICompositionGpuInterop
 
 abstract class CompositionGpuImportedObjectBase : ICompositionGpuImportedObject
 {
-    protected Compositor Compositor { get; }
+    internal Compositor Compositor { get; }
     public IPlatformRenderInterfaceContext Context { get; }
     public IExternalObjectsRenderInterfaceContextFeature Feature { get; }
 

--- a/src/Avalonia.Base/Rendering/Composition/Compositor.Factories.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Compositor.Factories.cs
@@ -4,6 +4,7 @@ using Avalonia.Platform;
 using Avalonia.Platform.Surfaces;
 using Avalonia.Rendering.Composition.Animations;
 using Avalonia.Rendering.Composition.Server;
+using Avalonia.Threading;
 
 namespace Avalonia.Rendering.Composition;
 
@@ -40,4 +41,15 @@ public partial class Compositor
     public CompositionSurfaceVisual CreateSurfaceVisual() => new(this, new ServerCompositionSurfaceVisual(_server));
 
     public CompositionDrawingSurface CreateDrawingSurface() => new(this);
+
+    /// <summary>
+    /// Creates a compositor attached to the same server-side compositor as this one, but bound to a
+    /// different dispatcher and driven by the returned <see cref="CompositorController"/> instead of
+    /// the framework's scheduler
+    /// </summary>
+    /// <param name="dispatcher">
+    /// The dispatcher the new compositor is bound to, the dispatcher of the current thread by default
+    /// </param>
+    public CompositorController CreateCompositorController(Dispatcher? dispatcher = null) =>
+        new(this, dispatcher ?? Dispatcher.CurrentDispatcher);
 }

--- a/src/Avalonia.Base/Rendering/Composition/Compositor.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Compositor.cs
@@ -120,13 +120,32 @@ namespace Avalonia.Rendering.Composition
                 var pending = _pendingBatch;
                 if (pending != null)
                     pending.Processed.ContinueWith(
-                        _ => Dispatcher.Post(_triggerCommitRequested, DispatcherPriority.Send),
+                        _ => PostDeferredTriggerCommitRequested(),
                         CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
                 else
                     _triggerCommitRequested();
             }
 
             return _nextCommit;
+        }
+
+        private DispatcherOperation? _deferredTriggerCommitRequestedOperation;
+        private Action? _deferredTriggerCommitRequested;
+
+        private void PostDeferredTriggerCommitRequested()
+        {
+            // Keep at most one trigger operation in the dispatcher queue, so batches committed
+            // while the dispatcher isn't pumped don't accumulate stale operations
+            if (_deferredTriggerCommitRequestedOperation is { Status: DispatcherOperationStatus.Pending })
+                return;
+            _deferredTriggerCommitRequested ??= () =>
+            {
+                // The batch could have been committed while this operation was in the queue
+                if (HasPendingCommit)
+                    _triggerCommitRequested();
+            };
+            _deferredTriggerCommitRequestedOperation =
+                Dispatcher.InvokeAsync(_deferredTriggerCommitRequested, DispatcherPriority.Send);
         }
 
         internal CompositionBatch Commit()

--- a/src/Avalonia.Base/Rendering/Composition/Compositor.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Compositor.cs
@@ -78,6 +78,29 @@ namespace Avalonia.Rendering.Composition
         }
 
         /// <summary>
+        /// Creates a compositor attached to the same server-side compositor as <paramref name="shareServerWith"/>,
+        /// but bound to a different dispatcher and driven by a different scheduler
+        /// </summary>
+        internal Compositor(Compositor shareServerWith, ICompositorScheduler scheduler, Dispatcher dispatcher)
+        {
+            Loop = shareServerWith.Loop;
+            // Rendering the server compositor inline on a synchronous commit is a UI-thread-only mechanism,
+            // any synchronous wait on this compositor has to block on the batch instead
+            UseUiThreadForSynchronousCommits = false;
+            Dispatcher = dispatcher;
+            // The server compositor returns batch buffers to the pools it was created with,
+            // so batches from all compositors must be produced from those same pools
+            _batchMemoryPool = shareServerWith._batchMemoryPool;
+            _batchObjectPool = shareServerWith._batchObjectPool;
+            _server = shareServerWith._server;
+            _triggerCommitRequested = () => scheduler.CommitRequested(this);
+
+            DefaultEasing = shareServerWith.DefaultEasing;
+        }
+
+        internal bool HasPendingCommit => _nextCommit != null;
+
+        /// <summary>
         /// Requests pending changes in the composition objects to be serialized and sent to the render thread
         /// </summary>
         /// <returns>A task that completes when sent changes are applied on the render thread</returns>
@@ -228,6 +251,7 @@ namespace Avalonia.Rendering.Composition
 
         internal void DisposeOnNextBatch(SimpleServerObject obj)
         {
+            Dispatcher.VerifyAccess();
             if (obj is IDisposable disposable && _disposeOnNextBatch.Add(disposable))
                 RequestCommitAsync();
         }
@@ -280,7 +304,9 @@ namespace Avalonia.Rendering.Composition
         {
             if (Server.AT_TryGetCachedRenderInterfaceFeatures() is { } rv)
                 return new(rv);
-            if (!Loop.RunsInBackground)
+            // When the render loop is driven by the UI thread, the render interface can only be
+            // safely accessed inline from that thread
+            if (!Loop.RunsInBackground && Dispatcher.UIThread.CheckAccess())
                 return new(Server.RT_GetRenderInterfaceFeatures());
             return new(InvokeServerJobAsync(Server.RT_GetRenderInterfaceFeatures));
         }

--- a/src/Avalonia.Base/Rendering/Composition/CompositorController.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositorController.cs
@@ -9,6 +9,7 @@ namespace Avalonia.Rendering.Composition;
 /// existing compositor, but is bound to a different dispatcher and is not driven by the framework's scheduler.
 /// </summary>
 /// <remarks>
+/// Created via <see cref="Rendering.Composition.Compositor.CreateCompositorController"/>.
 /// The controlled compositor is intended for feeding composition surfaces from non-UI threads,
 /// see <see cref="CompositionDrawingSurface.CreateProxyForCompositor"/>.
 /// Batches are committed either explicitly via <see cref="Commit"/> or by a job posted to the compositor's
@@ -31,16 +32,8 @@ public sealed class CompositorController : ICompositorScheduler
     private bool _commitJobScheduled;
     private readonly Action _commitJob;
 
-    /// <summary>
-    /// Creates a compositor attached to the same render thread as <paramref name="shareServerWith"/>
-    /// </summary>
-    /// <param name="shareServerWith">The compositor to share the server-side state with</param>
-    /// <param name="dispatcher">
-    /// The dispatcher the new compositor is bound to, the dispatcher of the current thread by default
-    /// </param>
-    public CompositorController(Compositor shareServerWith, Dispatcher? dispatcher = null)
+    internal CompositorController(Compositor shareServerWith, Dispatcher dispatcher)
     {
-        dispatcher ??= Dispatcher.CurrentDispatcher;
         _commitJob = ExecuteScheduledCommit;
         Compositor = new Compositor(shareServerWith, this, dispatcher);
         // Flush pending batches so already requested server-side jobs and disposals aren't lost.

--- a/src/Avalonia.Base/Rendering/Composition/CompositorController.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositorController.cs
@@ -1,0 +1,84 @@
+using System;
+using Avalonia.Rendering.Composition.Transport;
+using Avalonia.Threading;
+
+namespace Avalonia.Rendering.Composition;
+
+/// <summary>
+/// Provides a <see cref="Rendering.Composition.Compositor"/> that is attached to the same render thread as an
+/// existing compositor, but is bound to a different dispatcher and is not driven by the framework's scheduler.
+/// </summary>
+/// <remarks>
+/// The controlled compositor is intended for feeding composition surfaces from non-UI threads,
+/// see <see cref="CompositionDrawingSurface.CreateProxyForCompositor"/>.
+/// Batches are committed either explicitly via <see cref="Commit"/> or by a job posted to the compositor's
+/// dispatcher, so the dispatcher's thread is expected to run a dispatcher loop. The loop also installs the
+/// synchronization context that keeps continuations of awaited composition APIs on the compositor's thread;
+/// without it those continuations resume on the thread pool.
+/// All <see cref="Rendering.Composition.Compositor"/> APIs are bound to the dispatcher's thread.
+/// Composition objects created for the compositor, including surface proxies, should be disposed before
+/// the dispatcher is shut down: jobs posted to a shut down dispatcher are discarded, so cleanup requested
+/// afterwards never reaches the render thread.
+/// </remarks>
+public sealed class CompositorController : ICompositorScheduler
+{
+    /// <summary>
+    /// The compositor managed by this controller
+    /// </summary>
+    public Compositor Compositor { get; }
+
+    // Only accessed from the compositor's dispatcher thread
+    private bool _commitJobScheduled;
+    private readonly Action _commitJob;
+
+    /// <summary>
+    /// Creates a compositor attached to the same render thread as <paramref name="shareServerWith"/>
+    /// </summary>
+    /// <param name="shareServerWith">The compositor to share the server-side state with</param>
+    /// <param name="dispatcher">
+    /// The dispatcher the new compositor is bound to, the dispatcher of the current thread by default
+    /// </param>
+    public CompositorController(Compositor shareServerWith, Dispatcher? dispatcher = null)
+    {
+        dispatcher ??= Dispatcher.CurrentDispatcher;
+        _commitJob = ExecuteScheduledCommit;
+        Compositor = new Compositor(shareServerWith, this, dispatcher);
+        // Flush pending batches so already requested server-side jobs and disposals aren't lost.
+        // Commit callbacks can request another commit, hence the bounded loop
+        dispatcher.ShutdownStarted += (_, _) =>
+        {
+            for (var c = 0; c < 16 && Compositor.HasPendingCommit; c++)
+                Compositor.Commit();
+        };
+    }
+
+    /// <summary>
+    /// Synchronously serializes pending changes and submits them to the render thread.
+    /// Can only be called on the compositor's dispatcher thread.
+    /// </summary>
+    /// <returns>
+    /// The submitted batch. Note that this method returns once the batch is submitted, without waiting for it
+    /// to be applied, use <see cref="CompositionBatch.Processed"/> or <see cref="CompositionBatch.Rendered"/>
+    /// for synchronization with the render thread.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">The method is called on a wrong thread</exception>
+    public CompositionBatch Commit() => Compositor.Commit();
+
+    void ICompositorScheduler.CommitRequested(Compositor compositor)
+    {
+        // Invoked on the compositor's dispatcher thread.
+        // At most one job is kept in flight, so manual Commit calls on a never-pumped dispatcher
+        // don't accumulate stale jobs
+        if (_commitJobScheduled)
+            return;
+        _commitJobScheduled = true;
+        Compositor.Dispatcher.Post(_commitJob, DispatcherPriority.Render);
+    }
+
+    private void ExecuteScheduledCommit()
+    {
+        _commitJobScheduled = false;
+        if (Compositor.HasPendingCommit)
+            Compositor.Commit();
+    }
+}

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionDrawingSurface.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionDrawingSurface.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 using Avalonia.Platform;
 using Avalonia.Utilities;
 
@@ -9,6 +10,9 @@ internal class ServerCompositionDrawingSurface : ServerCompositionSurface, IDisp
 {
     private IRef<IBitmapImpl>? _bitmap;
     private IPlatformRenderInterfaceContext? _createdWithContext;
+    // The surface can be shared between multiple client-side proxies, each of them owns one reference
+    // and enqueues one dispose job via its own compositor
+    private int _refCount = 1;
     public override IRef<IBitmapImpl>? Bitmap
     {
         get
@@ -41,10 +45,28 @@ internal class ServerCompositionDrawingSurface : ServerCompositionSurface, IDisp
 
     void Update(IBitmapImpl newImage, IPlatformRenderInterfaceContext context)
     {
+        if (Volatile.Read(ref _refCount) <= 0)
+        {
+            newImage.Dispose();
+            throw new ObjectDisposedException(nameof(ServerCompositionDrawingSurface));
+        }
         _bitmap?.Dispose();
         _bitmap = RefCountable.Create(newImage);
         _createdWithContext = context;
         Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// Adds a reference for a new client-side proxy. Must be called while the caller
+    /// holds a not-yet-disposed client-side reference
+    /// </summary>
+    public void AddRef()
+    {
+        if (Interlocked.Increment(ref _refCount) <= 1)
+        {
+            Interlocked.Decrement(ref _refCount);
+            throw new ObjectDisposedException(nameof(ServerCompositionDrawingSurface));
+        }
     }
 
     public void UpdateWithAutomaticSync(CompositionImportedGpuImage image)
@@ -91,6 +113,10 @@ internal class ServerCompositionDrawingSurface : ServerCompositionSurface, IDisp
 
     public void Dispose()
     {
-        _bitmap?.Dispose();
+        if (Interlocked.Decrement(ref _refCount) == 0)
+        {
+            _bitmap?.Dispose();
+            _bitmap = null;
+        }
     }
 }

--- a/src/Avalonia.Base/Threading/Dispatcher.MainLoop.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.MainLoop.cs
@@ -75,7 +75,7 @@ public partial class Dispatcher
     {
         if (_controlledImpl == null)
             throw new PlatformNotSupportedException();
-        var frame = new DispatcherFrame();
+        var frame = new DispatcherFrame(this, true);
         cancellationToken.Register(() => frame.Continue = false);
         PushFrame(frame);
     }

--- a/src/Avalonia.Base/Threading/DispatcherFrame.cs
+++ b/src/Avalonia.Base/Threading/DispatcherFrame.cs
@@ -38,7 +38,7 @@ public class DispatcherFrame
     ///        for their important criteria to be met.  These frames
     ///        should have a timeout associated with them.
     /// </param>
-    public DispatcherFrame(bool exitWhenRequested) : this(Dispatcher.UIThread, exitWhenRequested)
+    public DispatcherFrame(bool exitWhenRequested) : this(Dispatcher.CurrentDispatcher, exitWhenRequested)
     {
         Dispatcher.VerifyAccess();
     }

--- a/src/Avalonia.OpenGL/Composition/CompositionGlContext.cs
+++ b/src/Avalonia.OpenGL/Composition/CompositionGlContext.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.OpenGL;
+
+internal sealed class CompositionGlContext : ICompositionGlContext
+{
+    private readonly ICompositionGpuInterop _interop;
+    private readonly IOpenGlTextureSharingRenderInterfaceContextFeature? _sharingFeature;
+    private readonly IGlContextExternalObjectsFeature? _externalObjects;
+    private readonly List<CompositionGlTexture> _textures = new();
+    private bool _disposed;
+
+    public CompositionGlContext(Compositor compositor, IGlContext glContext, ICompositionGpuInterop interop,
+        IOpenGlTextureSharingRenderInterfaceContextFeature? sharingFeature,
+        IGlContextExternalObjectsFeature? externalObjects)
+    {
+        Compositor = compositor;
+        GlContext = glContext;
+        _interop = interop;
+        _sharingFeature = sharingFeature;
+        _externalObjects = externalObjects;
+    }
+
+    public Compositor Compositor { get; }
+
+    public IGlContext GlContext { get; }
+
+    public bool IsValidForInterop => !_disposed && !GlContext.IsLost && !_interop.IsLost;
+
+    public ICompositionGlTexture CreateTexture(CompositionDrawingSurface surface, PixelSize size)
+    {
+        if (surface == null)
+            throw new ArgumentNullException(nameof(surface));
+        Compositor.Dispatcher.VerifyAccess();
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(ICompositionGlContext));
+        if (!IsValidForInterop)
+            throw new InvalidOperationException("This context is no longer valid for interop with the compositor");
+        if (surface.Compositor != Compositor)
+            throw new InvalidOperationException("The surface belongs to a different Compositor");
+        if (size.Width < 1 || size.Height < 1)
+            throw new ArgumentOutOfRangeException(nameof(size));
+
+        CompositionGlTexture texture = _sharingFeature != null
+            ? new SharedCompositionGlTexture(this, _sharingFeature, _interop, surface, size)
+            : new ExternalImageCompositionGlTexture(this, _externalObjects!, _interop, surface, size);
+        _textures.Add(texture);
+        return texture;
+    }
+
+    internal void OnTextureDisposed(CompositionGlTexture texture) => _textures.Remove(texture);
+
+    public async ValueTask DisposeAsync()
+    {
+        Compositor.Dispatcher.VerifyAccess();
+        if (_disposed)
+            return;
+        _disposed = true;
+
+        foreach (var texture in _textures.ToArray())
+            await texture.DisposeAsync();
+        _textures.Clear();
+
+        GlContext.Dispose();
+    }
+}

--- a/src/Avalonia.OpenGL/Composition/CompositionGlContextOptions.cs
+++ b/src/Avalonia.OpenGL/Composition/CompositionGlContextOptions.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Avalonia.OpenGL;
+
+/// <summary>
+/// Options for <see cref="OpenGlCompositionInterop.TryCreateCompatibleGlContextAsync"/>.
+/// </summary>
+public class CompositionGlContextOptions
+{
+    /// <summary>
+    /// The list of desired OpenGL(ES) versions in order of preference.
+    /// </summary>
+    public IReadOnlyList<GlVersion>? GlProfiles { get; set; }
+}

--- a/src/Avalonia.OpenGL/Composition/CompositionGlTexture.cs
+++ b/src/Avalonia.OpenGL/Composition/CompositionGlTexture.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Avalonia.Platform;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.OpenGL;
+
+internal abstract class CompositionGlTexture : ICompositionGlTexture
+{
+    private TextureLease? _activeLease;
+    private Task? _lastPresent;
+    private ICompositionImportedGpuImage? _imported;
+    private bool _disposed;
+
+    protected CompositionGlTexture(CompositionGlContext owner, ICompositionGpuInterop interop,
+        CompositionDrawingSurface surface, PixelSize size)
+    {
+        Owner = owner;
+        Interop = interop;
+        Surface = surface;
+        Size = size;
+    }
+
+    protected CompositionGlContext Owner { get; }
+    protected ICompositionGpuInterop Interop { get; }
+    protected CompositionDrawingSurface Surface { get; }
+
+    public PixelSize Size { get; }
+
+    public bool IsReadyForDraw =>
+        !_disposed
+        && _activeLease == null
+        && (_lastPresent == null || _lastPresent.Status == TaskStatus.RanToCompletion);
+
+    public ICompositionGlTextureLease BeginDraw()
+    {
+        Owner.Compositor.Dispatcher.VerifyAccess();
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(ICompositionGlTexture));
+        if (!Owner.IsValidForInterop)
+            throw new InvalidOperationException(
+                "The owning context is no longer valid for interop with the compositor");
+        if (_activeLease != null)
+            throw new InvalidOperationException("The previous drawing session is still active");
+        if (_lastPresent is { Status: not TaskStatus.RanToCompletion } lastPresent)
+            throw new InvalidOperationException(
+                lastPresent.IsCompleted
+                    ? "The previous presentation has failed"
+                    : "The previous presentation hasn't been completed yet");
+
+        using (Owner.GlContext.EnsureCurrent())
+            BeginDrawCore();
+        return _activeLease = new TextureLease(this);
+    }
+
+    private Task Present(TextureLease lease)
+    {
+        Debug.Assert(_activeLease == lease);
+        try
+        {
+            using (Owner.GlContext.EnsureCurrent())
+            {
+                Owner.GlContext.GlInterface.Flush();
+                PresentGlCore();
+            }
+        }
+        finally
+        {
+            _activeLease = null;
+        }
+
+        _imported ??= Import();
+        return _lastPresent = UpdateSurface(_imported);
+    }
+
+    private void DiscardDraw(TextureLease lease)
+    {
+        if (_activeLease != lease)
+            return;
+        Owner.Compositor.Dispatcher.VerifyAccess();
+        _activeLease = null;
+        try
+        {
+            using (Owner.GlContext.EnsureCurrent())
+                DiscardDrawCore();
+        }
+        catch
+        {
+            // The context is likely lost, nothing to unwind
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Owner.Compositor.Dispatcher.VerifyAccess();
+        if (_disposed)
+            return;
+        _activeLease?.Dispose();
+        _disposed = true;
+        Owner.OnTextureDisposed(this);
+
+        // The texture might have already been sent to the compositor, so we need to wait for its
+        // attempts to use the texture before destroying it
+        if (_imported != null)
+        {
+            // No need to wait for import / last present since calls are serialized on the compositor side anyway
+            try
+            {
+                await _imported.DisposeAsync();
+            }
+            catch
+            {
+                // Ignore
+            }
+        }
+
+        try
+        {
+            DisposeGlResources();
+        }
+        catch
+        {
+            // The context is likely lost, nothing to free
+        }
+    }
+
+    protected abstract CompositionGlTextureInfo GetTextureInfo();
+    protected abstract void BeginDrawCore();
+    protected abstract void DiscardDrawCore();
+    protected abstract void PresentGlCore();
+    protected abstract ICompositionImportedGpuImage Import();
+    protected virtual Task UpdateSurface(ICompositionImportedGpuImage imported) => Surface.UpdateAsync(imported);
+    protected abstract void DisposeGlResources();
+
+    private sealed class TextureLease : ICompositionGlTextureLease
+    {
+        private CompositionGlTexture? _texture;
+
+        public TextureLease(CompositionGlTexture texture) => _texture = texture;
+
+        public CompositionGlTextureInfo Texture
+        {
+            get
+            {
+                var texture = _texture ?? throw new ObjectDisposedException(nameof(ICompositionGlTextureLease));
+                texture.Owner.Compositor.Dispatcher.VerifyAccess();
+                return texture.GetTextureInfo();
+            }
+        }
+
+        public Task PresentAsync()
+        {
+            var texture = _texture ?? throw new ObjectDisposedException(nameof(ICompositionGlTextureLease));
+            texture.Owner.Compositor.Dispatcher.VerifyAccess();
+            _texture = null;
+            return texture.Present(this);
+        }
+
+        public void Dispose()
+        {
+            if (_texture is not { } texture)
+                return;
+            _texture = null;
+            texture.DiscardDraw(this);
+        }
+    }
+}
+
+internal sealed class SharedCompositionGlTexture : CompositionGlTexture
+{
+    private readonly ICompositionImportableOpenGlSharedTexture _texture;
+
+    public SharedCompositionGlTexture(CompositionGlContext owner,
+        IOpenGlTextureSharingRenderInterfaceContextFeature sharingFeature,
+        ICompositionGpuInterop interop, CompositionDrawingSurface surface, PixelSize size)
+        : base(owner, interop, surface, size)
+    {
+        _texture = sharingFeature.CreateSharedTextureForComposition(owner.GlContext, size);
+    }
+
+    protected override CompositionGlTextureInfo GetTextureInfo() =>
+        new(_texture.TextureId, GlConsts.GL_TEXTURE_2D, _texture.InternalFormat, Size);
+
+    protected override void BeginDrawCore()
+    {
+    }
+
+    protected override void DiscardDrawCore()
+    {
+    }
+
+    protected override void PresentGlCore()
+    {
+    }
+
+    protected override ICompositionImportedGpuImage Import() => Interop.ImportImage(_texture);
+
+    protected override void DisposeGlResources() => _texture.Dispose();
+}
+
+internal sealed class ExternalImageCompositionGlTexture : CompositionGlTexture
+{
+    private readonly IGlExportableExternalImageTexture _texture;
+
+    public ExternalImageCompositionGlTexture(CompositionGlContext owner,
+        IGlContextExternalObjectsFeature externalObjects,
+        ICompositionGpuInterop interop, CompositionDrawingSurface surface, PixelSize size)
+        : base(owner, interop, surface, size)
+    {
+        _texture = externalObjects.CreateImage(
+            KnownPlatformGraphicsExternalImageHandleTypes.D3D11TextureGlobalSharedHandle,
+            size, PlatformGraphicsExternalImageFormat.R8G8B8A8UNorm);
+    }
+
+    protected override CompositionGlTextureInfo GetTextureInfo() =>
+        new(_texture.TextureId, _texture.TextureType, _texture.InternalFormat, Size);
+
+    protected override void BeginDrawCore() => _texture.AcquireKeyedMutex(0);
+
+    protected override void DiscardDrawCore() => _texture.ReleaseKeyedMutex(0);
+
+    protected override void PresentGlCore() => _texture.ReleaseKeyedMutex(1);
+
+    protected override ICompositionImportedGpuImage Import() =>
+        Interop.ImportImage(_texture.GetHandle(), _texture.Properties);
+
+    protected override Task UpdateSurface(ICompositionImportedGpuImage imported) =>
+        Surface.UpdateWithKeyedMutexAsync(imported, 1, 0);
+
+    protected override void DisposeGlResources() => _texture.Dispose();
+}

--- a/src/Avalonia.OpenGL/Composition/ICompositionGlContext.cs
+++ b/src/Avalonia.OpenGL/Composition/ICompositionGlContext.cs
@@ -1,0 +1,51 @@
+using System;
+using Avalonia.Metadata;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.OpenGL;
+
+/// <summary>
+/// An OpenGL context that is suitable for interop with a <see cref="Rendering.Composition.Compositor"/>.
+/// Create instances via <see cref="OpenGlCompositionInterop.TryCreateCompatibleGlContextAsync"/>.
+/// </summary>
+/// <remarks>
+/// All members can only be used on the thread the associated <see cref="Rendering.Composition.Compositor"/>
+/// belongs to.
+/// </remarks>
+[NotClientImplementable]
+public interface ICompositionGlContext : IAsyncDisposable
+{
+    /// <summary>
+    /// The associated compositor.
+    /// </summary>
+    Compositor Compositor { get; }
+
+    /// <summary>
+    /// The OpenGL context.
+    /// </summary>
+    IGlContext GlContext { get; }
+
+    /// <summary>
+    /// Returns true if this OpenGL context is still suitable for interop with the Compositor.
+    /// This property might become false in cases like a device loss event on the compositor side.
+    /// In that case presentation is no longer possible, however <see cref="GlContext"/> itself might
+    /// still be usable for salvaging user resources. Once the property becomes false, this instance
+    /// should be disposed and recreated via
+    /// <see cref="OpenGlCompositionInterop.TryCreateCompatibleGlContextAsync"/>.
+    /// A recreated context shares no OpenGL objects with the old one.
+    /// </summary>
+    bool IsValidForInterop { get; }
+
+    /// <summary>
+    /// Creates a texture that can be used to update a <see cref="CompositionDrawingSurface"/> instance.
+    /// </summary>
+    /// <param name="surface">The surface that will be updated by the texture. Must belong to <see cref="Compositor"/>.</param>
+    /// <param name="size">The pixel size of the texture.</param>
+    /// <exception cref="InvalidOperationException">
+    /// The context is no longer valid for interop or the surface belongs to a different compositor.
+    /// </exception>
+    /// <exception cref="ObjectDisposedException">The context has been disposed.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="surface"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> is empty or negative.</exception>
+    ICompositionGlTexture CreateTexture(CompositionDrawingSurface surface, PixelSize size);
+}

--- a/src/Avalonia.OpenGL/Composition/ICompositionGlTexture.cs
+++ b/src/Avalonia.OpenGL/Composition/ICompositionGlTexture.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Metadata;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.OpenGL;
+
+/// <summary>
+/// A texture that can be drawn to by user code and presented to a <see cref="CompositionDrawingSurface"/>.
+/// Create instances via <see cref="ICompositionGlContext.CreateTexture"/>.
+/// </summary>
+/// <remarks>
+/// All members can only be used on the thread the associated <see cref="Compositor"/> belongs to.
+/// </remarks>
+[NotClientImplementable]
+public interface ICompositionGlTexture : IAsyncDisposable
+{
+    /// <summary>
+    /// The pixel size of the texture.
+    /// </summary>
+    PixelSize Size { get; }
+
+    /// <summary>
+    /// Returns true when the texture can be drawn to: there is no active lease and the last
+    /// presentation, if any, has completed successfully.
+    /// A presentation failure leaves this property permanently false, check
+    /// <see cref="ICompositionGlContext.IsValidForInterop"/> in that case.
+    /// </summary>
+    bool IsReadyForDraw { get; }
+
+    /// <summary>
+    /// Prepares the texture to be rendered to by user code.
+    /// User code can bind the texture to their framebuffer, however the texture should be unbound
+    /// before ending the returned lease.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The texture is not ready for drawing (<see cref="IsReadyForDraw"/> is false) or the owning
+    /// context is no longer valid for interop.
+    /// </exception>
+    /// <exception cref="ObjectDisposedException">The texture has been disposed.</exception>
+    ICompositionGlTextureLease BeginDraw();
+}
+
+/// <summary>
+/// An active drawing session on an <see cref="ICompositionGlTexture"/>.
+/// The lease is ended either by <see cref="PresentAsync"/> or by <see cref="IDisposable.Dispose"/>,
+/// the latter discards the frame. Disposing after <see cref="PresentAsync"/> is a no-op.
+/// </summary>
+[NotClientImplementable]
+public interface ICompositionGlTextureLease : IDisposable
+{
+    /// <summary>
+    /// Describes the OpenGL texture to draw into. Only valid until the lease ends;
+    /// <see cref="CompositionGlTextureInfo.TextureId"/> is not guaranteed to be stable between leases.
+    /// </summary>
+    CompositionGlTextureInfo Texture { get; }
+
+    /// <summary>
+    /// Ends the lease and asynchronously presents the texture to the associated
+    /// <see cref="CompositionDrawingSurface"/>. This will happen when the next composition commit
+    /// is processed by the render thread.
+    /// The texture must be unbound from user framebuffers before calling this method.
+    /// The returned task completes when the texture can be drawn to again, NOT when the frame
+    /// becomes visible on the screen.
+    /// You should NOT await the returned task while keeping hold of a
+    /// <see cref="IGlContext.MakeCurrent"/> disposable.
+    /// </summary>
+    Task PresentAsync();
+}
+
+/// <summary>
+/// Describes an OpenGL texture provided by <see cref="ICompositionGlTextureLease"/>.
+/// </summary>
+public readonly record struct CompositionGlTextureInfo(int TextureId, int Target, int InternalFormat, PixelSize Size);

--- a/src/Avalonia.OpenGL/Composition/OpenGlCompositionInterop.cs
+++ b/src/Avalonia.OpenGL/Composition/OpenGlCompositionInterop.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Logging;
+using Avalonia.Platform;
+using Avalonia.Rendering.Composition;
+
+namespace Avalonia.OpenGL;
+
+/// <summary>
+/// Provides OpenGL interop facilities for the composition engine.
+/// </summary>
+public static class OpenGlCompositionInterop
+{
+    /// <summary>
+    /// Attempts to create an OpenGL context that is suitable for interop with the compositor's GPU context.
+    /// Must be called on the thread the compositor belongs to.
+    /// </summary>
+    /// <returns>
+    /// The created context, or null when the current platform or compositor configuration doesn't
+    /// support OpenGL interop. The concrete reason is logged to the "OpenGL" log area.
+    /// </returns>
+    public static async ValueTask<ICompositionGlContext?> TryCreateCompatibleGlContextAsync(
+        this Compositor compositor, CompositionGlContextOptions? options = null)
+    {
+        if (compositor == null)
+            throw new ArgumentNullException(nameof(compositor));
+        compositor.Dispatcher.VerifyAccess();
+
+        var gpuInteropTask = compositor.TryGetCompositionGpuInterop();
+
+        var sharingFeature =
+            (IOpenGlTextureSharingRenderInterfaceContextFeature?)
+            await compositor.TryGetRenderInterfaceFeature(
+                typeof(IOpenGlTextureSharingRenderInterfaceContextFeature));
+        var interop = await gpuInteropTask;
+
+        if (interop == null)
+        {
+            // Expected on platforms without GPU interop support, so not an error
+            LogUnsupported("Compositor backend doesn't support GPU interop");
+            return null;
+        }
+
+        if (sharingFeature?.CanCreateSharedContext == true)
+        {
+            IGlContext? context = null;
+            try
+            {
+                context = sharingFeature.CreateSharedContext(options?.GlProfiles);
+            }
+            catch (Exception e)
+            {
+                LogError("Unable to create a context shared with the compositor: {exception}", e);
+            }
+
+            if (context == null)
+                LogError("Unable to create a context shared with the compositor");
+            else
+                return new CompositionGlContext(compositor, context, interop, sharingFeature, null);
+        }
+
+        if (AvaloniaLocator.Current.GetService<IPlatformGraphicsOpenGlContextFactory>() is not { } contextFactory)
+        {
+            LogUnsupported("The current platform doesn't provide an OpenGL context factory");
+            return null;
+        }
+
+        IGlContext? ctx = null;
+        try
+        {
+            ctx = contextFactory.CreateContext(options?.GlProfiles);
+            if (ctx.TryGetFeature<IGlContextExternalObjectsFeature>(out var externalObjects)
+                && interop.SupportedImageHandleTypes.Contains(
+                    KnownPlatformGraphicsExternalImageHandleTypes.D3D11TextureGlobalSharedHandle)
+                && externalObjects.SupportedExportableExternalImageTypes.Contains(
+                    KnownPlatformGraphicsExternalImageHandleTypes.D3D11TextureGlobalSharedHandle))
+                return new CompositionGlContext(compositor, ctx, interop, null, externalObjects);
+
+            LogUnsupported("The current platform doesn't support OpenGL context sharing with the compositor " +
+                "or a compatible shared memory type");
+            ctx.Dispose();
+            return null;
+        }
+        catch (Exception e)
+        {
+            LogError("Unable to create an OpenGL context: {exception}", e);
+            ctx?.Dispose();
+            return null;
+        }
+    }
+
+    private static void LogUnsupported(string message) =>
+        Logger.TryGet(LogEventLevel.Warning, "OpenGL")?.Log(nameof(OpenGlCompositionInterop), message);
+
+    private static void LogError(string message, params object?[] args) =>
+        Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log(nameof(OpenGlCompositionInterop), message, args);
+}

--- a/src/Avalonia.OpenGL/Controls/CompositionOpenGlSwapchain.cs
+++ b/src/Avalonia.OpenGL/Controls/CompositionOpenGlSwapchain.cs
@@ -1,162 +1,108 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using Avalonia.Platform;
-using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
 
 namespace Avalonia.OpenGL.Controls;
 
-internal class CompositionOpenGlSwapchain : SwapchainBase<IGlSwapchainImage>
+internal sealed class CompositionOpenGlSwapchain : IAsyncDisposable
 {
-    private readonly IGlContext _context;
-    private readonly IGlContextExternalObjectsFeature? _externalObjectsFeature;
-    private readonly IOpenGlTextureSharingRenderInterfaceContextFeature? _sharingFeature;
-
-    public CompositionOpenGlSwapchain(IGlContext context, ICompositionGpuInterop interop, CompositionDrawingSurface target,
-        IOpenGlTextureSharingRenderInterfaceContextFeature sharingFeature
-        ) : base(interop, target)
-    {
-        _context = context;
-        _sharingFeature = sharingFeature;
-    }
-    
-    public CompositionOpenGlSwapchain(IGlContext context, ICompositionGpuInterop interop, CompositionDrawingSurface target,
-        IGlContextExternalObjectsFeature? externalObjectsFeature) : base(interop, target)
-    {
-        _context = context;
-        _externalObjectsFeature = externalObjectsFeature;
-    }
-    
-    
-
-    protected override IGlSwapchainImage CreateImage(PixelSize size)
-    {
-        if (_sharingFeature != null)
-            return new CompositionOpenGlSwapChainImage(_context, _sharingFeature, size, Interop, Target);
-        return new DxgiMutexOpenGlSwapChainImage(Interop, Target, _externalObjectsFeature!, size);
-    }
-
-    public IDisposable BeginDraw(PixelSize size, out IGlTexture texture)
-    {
-        var rv = BeginDrawCore(size, out var tex);
-        texture = tex;
-        return rv;
-    }
-}
-
-internal interface IGlTexture
-{
-    int TextureId { get; }
-    int InternalFormat { get; }
-    PixelSize Size { get; }
-}
-
-
-interface IGlSwapchainImage : ISwapchainImage, IGlTexture
-{
-    
-}
-internal class DxgiMutexOpenGlSwapChainImage : IGlSwapchainImage
-{
-    private readonly ICompositionGpuInterop _interop;
+    private readonly ICompositionGlContext _context;
     private readonly CompositionDrawingSurface _surface;
-    private readonly IGlExportableExternalImageTexture _texture;
-    private Task? _lastPresent;
-    private ICompositionImportedGpuImage? _imported;
+    private readonly List<Entry> _entries = new();
 
-    public DxgiMutexOpenGlSwapChainImage(ICompositionGpuInterop interop, CompositionDrawingSurface surface,
-        IGlContextExternalObjectsFeature externalObjects, PixelSize size)
+    internal class Entry
     {
-        _interop = interop;
+        public required ICompositionGlTexture Texture { get; init; }
+        public Task? LastPresent { get; set; }
+    }
+
+    public CompositionOpenGlSwapchain(ICompositionGlContext context, CompositionDrawingSurface surface)
+    {
+        _context = context;
         _surface = surface;
-        _texture = externalObjects.CreateImage(KnownPlatformGraphicsExternalImageHandleTypes.D3D11TextureGlobalSharedHandle,
-            size, PlatformGraphicsExternalImageFormat.R8G8B8A8UNorm);
     }
-    public async ValueTask DisposeAsync()
+
+    private Entry? CleanupAndFindNextEntry(PixelSize size)
     {
-        // The texture is already sent to the compositor, so we need to wait for its attempts to use the texture
-        // before destroying it
-        if (_imported != null)
+        Entry? firstFound = null;
+        var foundMultiple = false;
+
+        for (var c = _entries.Count - 1; c > -1; c--)
         {
-            // No need to wait for import / LastPresent since calls are serialized on the compositor side anyway
-            try
+            var entry = _entries[c];
+            var ready = entry.Texture.IsReadyForDraw;
+            var matches = entry.Texture.Size == size;
+            var broken = entry.LastPresent is { IsCompleted: true, Status: not TaskStatus.RanToCompletion };
+            if (broken || (!matches && ready))
             {
-                await _imported.DisposeAsync();
+                entry.Texture.DisposeAsync();
+                _entries.RemoveAt(c);
             }
-            catch
+
+            if (matches && ready)
             {
-                // Ignore
-            }
-        }
-        _texture.Dispose();
-    }
-
-    public int TextureId => _texture.TextureId;
-    public int InternalFormat => _texture.InternalFormat;
-    public PixelSize Size => new(_texture.Properties.Width, _texture.Properties.Height);
-    public Task? LastPresent => _lastPresent;
-    public void BeginDraw() => _texture.AcquireKeyedMutex(0);
-
-    public void Present()
-    {
-        _texture.ReleaseKeyedMutex(1);
-        _imported ??= _interop.ImportImage(_texture.GetHandle(), _texture.Properties);
-        _lastPresent = _surface.UpdateWithKeyedMutexAsync(_imported, 1, 0);
-    }
-}
-
-internal class CompositionOpenGlSwapChainImage : IGlSwapchainImage
-{
-    private readonly ICompositionGpuInterop _interop;
-    private readonly CompositionDrawingSurface _target;
-    private readonly ICompositionImportableOpenGlSharedTexture _texture;
-    private ICompositionImportedGpuImage? _imported;
-
-    public CompositionOpenGlSwapChainImage(
-        IGlContext context,
-        IOpenGlTextureSharingRenderInterfaceContextFeature sharingFeature,
-        PixelSize size,
-        ICompositionGpuInterop interop,
-        CompositionDrawingSurface target)
-    {
-        _interop = interop;
-        _target = target;
-        _texture = sharingFeature.CreateSharedTextureForComposition(context, size);
-    }
-
-    
-    public async ValueTask DisposeAsync()
-    {
-        // The texture is already sent to the compositor, so we need to wait for its attempts to use the texture
-        // before destroying it
-        if (_imported != null)
-        {
-            // No need to wait for import / LastPresent since calls are serialized on the compositor side anyway
-            try
-            {
-                await _imported.DisposeAsync();
-            }
-            catch
-            {
-                // Ignore
+                if (firstFound == null)
+                    firstFound = entry;
+                else
+                    foundMultiple = true;
             }
         }
 
-        _texture.Dispose();
+        // We are making sure that there was at least one texture of the same size in flight
+        // Otherwise we might encounter UI thread lockups
+        return foundMultiple ? firstFound : null;
     }
 
-    public int TextureId => _texture.TextureId;
-    public int InternalFormat => _texture.InternalFormat;
-    public PixelSize Size => _texture.Size;
-    public Task? LastPresent { get; private set; }
-    public void BeginDraw()
+    public Lease BeginDraw(PixelSize size, out CompositionGlTextureInfo texture)
     {
-        // No-op for texture sharing
+        var entry = CleanupAndFindNextEntry(size);
+        if (entry == null)
+        {
+            entry = new Entry { Texture = _context.CreateTexture(_surface, size) };
+            _entries.Add(entry);
+        }
+
+        var lease = entry.Texture.BeginDraw();
+        texture = lease.Texture;
+        return new Lease(entry, lease);
     }
 
-    public void Present()
+    /// <summary>
+    /// Presents the frame on <see cref="Dispose"/>, unless it was discarded via <see cref="Discard"/>.
+    /// </summary>
+    public sealed class Lease : IDisposable
     {
-        _imported ??= _interop.ImportImage(_texture);
-        LastPresent = _target.UpdateAsync(_imported);
+        private readonly Entry _entry;
+        private ICompositionGlTextureLease? _lease;
+
+        internal Lease(Entry entry, ICompositionGlTextureLease lease)
+        {
+            _entry = entry;
+            _lease = lease;
+        }
+
+        public void Discard()
+        {
+            var lease = _lease;
+            _lease = null;
+            lease?.Dispose();
+        }
+
+        public void Dispose()
+        {
+            var lease = _lease;
+            _lease = null;
+            if (lease != null)
+                _entry.LastPresent = lease.PresentAsync();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Snapshot, since awaiting the disposal can pump the dispatcher
+        foreach (var entry in _entries.ToArray())
+            await entry.Texture.DisposeAsync();
+        _entries.Clear();
     }
 }

--- a/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
+++ b/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Logging;
 using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
 using Avalonia.VisualTree;
-using Avalonia.Platform;
 using System.ComponentModel;
 
 namespace Avalonia.OpenGL.Controls
@@ -35,6 +33,7 @@ namespace Avalonia.OpenGL.Controls
         private Task<bool>? _initialization;
         private OpenGlControlBaseResources? _resources;
         private Compositor? _compositor;
+        private int _generation;
 
         [MemberNotNullWhen(true, nameof(_resources))]
         private bool IsInitializedSuccessfully => _initialization is { Status: TaskStatus.RanToCompletion, Result: true };
@@ -54,6 +53,7 @@ namespace Avalonia.OpenGL.Controls
 
         private void DoCleanup()
         {
+            _generation++;
             if (IsInitializedSuccessfully)
             {
                 try
@@ -94,51 +94,6 @@ namespace Avalonia.OpenGL.Controls
             RequestNextFrameRendering();
         }
 
-        [MemberNotNullWhen(true, nameof(_resources))]
-        private bool EnsureInitializedCore(
-            ICompositionGpuInterop interop,
-            IOpenGlTextureSharingRenderInterfaceContextFeature? contextSharingFeature)
-        {
-            var surface = _compositor!.CreateDrawingSurface();
-
-            IGlContext? ctx = null;
-            try
-            {
-                if (contextSharingFeature?.CanCreateSharedContext == true)
-                    _resources = OpenGlControlBaseResources.TryCreate(surface, interop, contextSharingFeature);
-
-                if(_resources == null)
-                {
-                    var contextFactory = AvaloniaLocator.Current.GetRequiredService<IPlatformGraphicsOpenGlContextFactory>();
-                    ctx = contextFactory.CreateContext(null);
-                    if (ctx.TryGetFeature<IGlContextExternalObjectsFeature>(out var externalObjects))
-                        _resources = OpenGlControlBaseResources.TryCreate(ctx, surface, interop, externalObjects);
-                }
-                
-                if(_resources == null)
-                {
-                    Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log("OpenGlControlBase",
-                        "Unable to initialize OpenGL: current platform does not support multithreaded context sharing and shared memory");
-                    ctx?.Dispose();
-                    return false;
-                }
-            }
-            catch (Exception e)
-            {
-                Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log("OpenGlControlBase",
-                    "Unable to initialize OpenGL: {exception}", e);
-                ctx?.Dispose();
-                return false;
-            }
-            
-            _visual = _compositor.CreateSurfaceVisual();
-            _visual.Size = new Vector(Bounds.Width, Bounds.Height);
-            _visual.Surface = _resources.Surface;
-            ElementComposition.SetElementChildVisual(this, _visual);
-            return true;
-
-        }
-
         /// <inheritdoc/>
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
@@ -155,6 +110,7 @@ namespace Avalonia.OpenGL.Controls
         {
             _initialization = null;
             _resources?.DisposeAsync();
+            _resources = null;
             OnOpenGlLost();
         }
 
@@ -170,7 +126,7 @@ namespace Avalonia.OpenGL.Controls
                     return false;
                 }
 
-                if (_resources.Context.IsLost)
+                if (_resources.IsLost)
                     ContextLost();
                 else 
                     return true;
@@ -217,31 +173,47 @@ namespace Avalonia.OpenGL.Controls
                     "Unable to obtain Compositor instance");
                 return false;
             }
-            
-            var gpuInteropTask = _compositor.TryGetCompositionGpuInterop();
 
-            var contextSharingFeature =
-                (IOpenGlTextureSharingRenderInterfaceContextFeature?)
-                await _compositor.TryGetRenderInterfaceFeature(
-                    typeof(IOpenGlTextureSharingRenderInterfaceContextFeature));
-            var interop = await gpuInteropTask;
-
-            if (interop == null)
+            var generation = _generation;
+            var context = await _compositor.TryCreateCompatibleGlContextAsync();
+            if (context == null)
             {
                 Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log("OpenGlControlBase",
-                    "Compositor backend doesn't support GPU interop");
+                    "Unable to initialize OpenGL: current platform doesn't support OpenGL interop with the compositor");
                 return false;
             }
 
-            if (!EnsureInitializedCore(interop, contextSharingFeature))
+            if (generation != _generation)
             {
+                // The control was detached while we were awaiting
+                await context.DisposeAsync();
+                return false;
+            }
+
+            var surface = _compositor.CreateDrawingSurface();
+            try
+            {
+                _resources = new OpenGlControlBaseResources(context, surface);
+            }
+            catch (Exception e)
+            {
+                Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log("OpenGlControlBase",
+                    "Unable to initialize OpenGL: {exception}", e);
+                surface.Dispose();
+                await context.DisposeAsync();
+                // The failure might be transient, allow the next invalidation to retry
                 DoCleanup();
                 return false;
             }
 
+            _visual = _compositor.CreateSurfaceVisual();
+            _visual.Size = new Vector(Bounds.Width, Bounds.Height);
+            _visual.Surface = _resources.Surface;
+            ElementComposition.SetElementChildVisual(this, _visual);
+
             using (_resources.Context.MakeCurrent())
                 OnOpenGlInit(_resources.Context.GlInterface);
-            
+
             return true;
         }
 

--- a/src/Avalonia.OpenGL/Controls/OpenGlControlResources.cs
+++ b/src/Avalonia.OpenGL/Controls/OpenGlControlResources.cs
@@ -1,74 +1,31 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Logging;
-using Avalonia.Platform;
 using Avalonia.Reactive;
 using Avalonia.Rendering.Composition;
 using static Avalonia.OpenGL.GlConsts;
 namespace Avalonia.OpenGL.Controls;
 
-internal class OpenGlControlBaseResources : IAsyncDisposable
+internal sealed class OpenGlControlBaseResources : IAsyncDisposable
 {
     private int _depthBuffer;
     public int Fbo { get; private set; }
     private PixelSize _depthBufferSize;
     public CompositionDrawingSurface Surface { get; }
     private readonly CompositionOpenGlSwapchain _swapchain;
-    public IGlContext Context { get; private set; }
+    private readonly ICompositionGlContext _compositionContext;
 
-    public static OpenGlControlBaseResources? TryCreate(CompositionDrawingSurface surface,
-        ICompositionGpuInterop interop,
-        IOpenGlTextureSharingRenderInterfaceContextFeature feature)
+    public IGlContext Context => _compositionContext.GlContext;
+
+    public bool IsLost => !_compositionContext.IsValidForInterop;
+
+    public OpenGlControlBaseResources(ICompositionGlContext context, CompositionDrawingSurface surface)
     {
-        IGlContext? context;
-        try
-        {
-            context = feature.CreateSharedContext();
-        }
-        catch (Exception e)
-        {
-            Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log("OpenGlControlBase",
-                "Unable to initialize OpenGL: unable to create additional OpenGL context: {exception}", e);
-            return null;
-        }
-
-        if (context == null)
-        {
-            Logger.TryGet(LogEventLevel.Error, "OpenGL")?.Log("OpenGlControlBase",
-                "Unable to initialize OpenGL: unable to create additional OpenGL context.");
-            return null;
-        }
-
-        return new OpenGlControlBaseResources(context, surface, interop, feature, null);
-    }
-
-    public static OpenGlControlBaseResources? TryCreate(IGlContext context, CompositionDrawingSurface surface,
-        ICompositionGpuInterop interop, IGlContextExternalObjectsFeature externalObjects)
-    {
-        if (!interop.SupportedImageHandleTypes.Contains(KnownPlatformGraphicsExternalImageHandleTypes
-                .D3D11TextureGlobalSharedHandle)
-            || !externalObjects.SupportedExportableExternalImageTypes.Contains(
-                KnownPlatformGraphicsExternalImageHandleTypes.D3D11TextureGlobalSharedHandle))
-            return null;
-        return new OpenGlControlBaseResources(context, surface, interop, null, externalObjects);
-    }
-    
-    private OpenGlControlBaseResources(IGlContext context,
-        CompositionDrawingSurface surface,
-        ICompositionGpuInterop interop,
-        IOpenGlTextureSharingRenderInterfaceContextFeature? feature,
-        IGlContextExternalObjectsFeature? externalObjects
-        )
-    {
-        Context = context;
+        _compositionContext = context;
         Surface = surface;
-        using (context.MakeCurrent())
-            Fbo = context.GlInterface.GenFramebuffer();
-        _swapchain =
-            feature != null ?
-                new CompositionOpenGlSwapchain(context, interop, Surface, feature) :
-                new CompositionOpenGlSwapchain(context, interop, Surface, externalObjects);
+        using (Context.MakeCurrent())
+            Fbo = Context.GlInterface.GenFramebuffer();
+        _swapchain = new CompositionOpenGlSwapchain(context, surface);
     }
 
     private void UpdateDepthRenderbuffer(PixelSize size)
@@ -89,20 +46,20 @@ internal class OpenGlControlBaseResources : IAsyncDisposable
         gl.BindRenderbuffer(GL_RENDERBUFFER, oldRenderBuffer);
         _depthBufferSize = size;
     }
-    
+
     public IDisposable BeginDraw(PixelSize size)
     {
         var restoreContext = Context.EnsureCurrent();
-        IDisposable? imagePresent = null;
+        CompositionOpenGlSwapchain.Lease? lease = null;
         var success = false;
         try
         {
             var gl = Context.GlInterface;
-            Context.GlInterface.BindFramebuffer(GL_FRAMEBUFFER, Fbo);
+            gl.BindFramebuffer(GL_FRAMEBUFFER, Fbo);
             UpdateDepthRenderbuffer(size);
 
-            imagePresent = _swapchain.BeginDraw(size, out var texture);
-            gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture.TextureId, 0);
+            lease = _swapchain.BeginDraw(size, out var texture);
+            gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, texture.Target, texture.TextureId, 0);
 
             var status = gl.CheckFramebufferStatus(GL_FRAMEBUFFER);
             if (status != GL_FRAMEBUFFER_COMPLETE)
@@ -118,8 +75,13 @@ internal class OpenGlControlBaseResources : IAsyncDisposable
             {
                 try
                 {
-                    Context.GlInterface.Flush();
-                    imagePresent.Dispose();
+                    // The texture should be unbound from user framebuffers before it's presented.
+                    // User code could have bound another framebuffer, so rebind ours first
+                    var glDone = Context.GlInterface;
+                    glDone.BindFramebuffer(GL_FRAMEBUFFER, Fbo);
+                    glDone.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                        texture.Target, 0, 0);
+                    lease.Dispose();
                 }
                 finally
                 {
@@ -131,15 +93,22 @@ internal class OpenGlControlBaseResources : IAsyncDisposable
         {
             if (!success)
             {
-                imagePresent?.Dispose();
-                restoreContext.Dispose();
+                try
+                {
+                    // The frame wasn't rendered, so it shouldn't reach the surface
+                    lease?.Discard();
+                }
+                finally
+                {
+                    restoreContext.Dispose();
+                }
             }
         }
     }
 
     public async ValueTask DisposeAsync()
     {
-        if (Context is { IsLost: false })
+        if (!IsLost)
         {
             try
             {
@@ -153,19 +122,16 @@ internal class OpenGlControlBaseResources : IAsyncDisposable
                         gl.DeleteRenderbuffer(_depthBuffer);
                     _depthBuffer = 0;
                 }
-
             }
             catch
             {
                 //
             }
-
-            Surface.Dispose();
-           
-            await _swapchain.DisposeAsync();
-            Context.Dispose();
-
-            Context = null!;
         }
+
+        Surface.Dispose();
+
+        await _swapchain.DisposeAsync();
+        await _compositionContext.DisposeAsync();
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Composition/CompositorControllerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Composition/CompositorControllerTests.cs
@@ -16,7 +16,7 @@ public class CompositorControllerTests
     public void Controller_Compositor_Shares_Server_And_Commits_Via_Posted_Job()
     {
         using var s = new CompositorTestServices();
-        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+        var controller = s.Compositor.CreateCompositorController(Dispatcher.UIThread);
         Assert.Same(s.Compositor.Server, controller.Compositor.Server);
 
         var batch = controller.Compositor.RequestCompositionBatchCommitAsync();
@@ -29,7 +29,7 @@ public class CompositorControllerTests
     public void Manual_Commit_Submits_Synchronously_And_Scheduled_Job_Becomes_Noop()
     {
         using var s = new CompositorTestServices();
-        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+        var controller = s.Compositor.CreateCompositorController(Dispatcher.UIThread);
         var compositor = controller.Compositor;
         var commitCount = 0;
         compositor.AfterCommit += () => commitCount++;
@@ -52,7 +52,7 @@ public class CompositorControllerTests
     public void Manual_Commit_Of_Empty_Batch_Provides_A_Render_Thread_Fence()
     {
         using var s = new CompositorTestServices();
-        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+        var controller = s.Compositor.CreateCompositorController(Dispatcher.UIThread);
 
         var batch = controller.Commit();
         Assert.False(batch.Processed.IsCompleted);
@@ -64,7 +64,7 @@ public class CompositorControllerTests
     public void Commit_Requested_While_A_Batch_Is_In_Flight_Is_Deferred_Until_It_Is_Processed()
     {
         using var s = new CompositorTestServices();
-        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+        var controller = s.Compositor.CreateCompositorController(Dispatcher.UIThread);
         var compositor = controller.Compositor;
         var commitCount = 0;
         compositor.AfterCommit += () => commitCount++;
@@ -102,7 +102,7 @@ public class CompositorControllerTests
             try
             {
                 var dispatcher = Dispatcher.CurrentDispatcher;
-                var controller = new CompositorController(s.Compositor, dispatcher);
+                var controller = s.Compositor.CreateCompositorController(dispatcher);
                 batch = controller.Compositor.RequestCompositionBatchCommitAsync();
                 dispatcher.InvokeShutdown();
             }
@@ -125,7 +125,7 @@ public class CompositorControllerTests
     public void Proxy_Surface_Shares_Server_Object_And_Belongs_To_Target_Compositor()
     {
         using var s = new CompositorTestServices();
-        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+        var controller = s.Compositor.CreateCompositorController(Dispatcher.UIThread);
         var surface = s.Compositor.CreateDrawingSurface();
 
         var proxy = surface.CreateProxyForCompositor(controller.Compositor);
@@ -141,7 +141,7 @@ public class CompositorControllerTests
     public void Proxy_Creation_Validates_Surface_State_And_Server_Affinity()
     {
         using var s = new CompositorTestServices();
-        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+        var controller = s.Compositor.CreateCompositorController(Dispatcher.UIThread);
         var surface = s.Compositor.CreateDrawingSurface();
 
         Assert.Throws<InvalidOperationException>(() => surface.CreateProxyForCompositor(s.Compositor));
@@ -160,7 +160,7 @@ public class CompositorControllerTests
     public void Imported_Objects_From_A_Different_Compositor_Are_Rejected()
     {
         using var s = new CompositorTestServices();
-        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+        var controller = s.Compositor.CreateCompositorController(Dispatcher.UIThread);
         var surface = s.Compositor.CreateDrawingSurface();
         var proxy = surface.CreateProxyForCompositor(controller.Compositor);
 

--- a/tests/Avalonia.Base.UnitTests/Composition/CompositorControllerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Composition/CompositorControllerTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Threading;
+using Avalonia.Rendering;
+using Avalonia.Rendering.Composition;
+using Avalonia.Rendering.Composition.Server;
+using Avalonia.Rendering.Composition.Transport;
+using Avalonia.Threading;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Composition;
+
+public class CompositorControllerTests
+{
+    [Fact]
+    public void Controller_Compositor_Shares_Server_And_Commits_Via_Posted_Job()
+    {
+        using var s = new CompositorTestServices();
+        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+        Assert.Same(s.Compositor.Server, controller.Compositor.Server);
+
+        var batch = controller.Compositor.RequestCompositionBatchCommitAsync();
+        Assert.False(batch.Processed.IsCompleted);
+        s.RunJobs();
+        Assert.True(batch.Processed.IsCompleted);
+    }
+
+    [Fact]
+    public void Manual_Commit_Submits_Synchronously_And_Scheduled_Job_Becomes_Noop()
+    {
+        using var s = new CompositorTestServices();
+        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+        var compositor = controller.Compositor;
+        var commitCount = 0;
+        compositor.AfterCommit += () => commitCount++;
+
+        var batch = compositor.RequestCompositionBatchCommitAsync();
+        Assert.Same(batch, controller.Commit());
+        Assert.False(compositor.HasPendingCommit);
+        Assert.Equal(1, commitCount);
+
+        // The batch is already submitted, so a render pass processes it without pumping the dispatcher
+        s.Timer.TriggerTick();
+        Assert.True(batch.Processed.IsCompleted);
+
+        // The still-scheduled commit job must not submit an empty batch
+        s.RunJobs();
+        Assert.Equal(1, commitCount);
+    }
+
+    [Fact]
+    public void Manual_Commit_Of_Empty_Batch_Provides_A_Render_Thread_Fence()
+    {
+        using var s = new CompositorTestServices();
+        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+
+        var batch = controller.Commit();
+        Assert.False(batch.Processed.IsCompleted);
+        s.Timer.TriggerTick();
+        Assert.True(batch.Processed.IsCompleted);
+    }
+
+    [Fact]
+    public void Commit_Requested_While_A_Batch_Is_In_Flight_Is_Deferred_Until_It_Is_Processed()
+    {
+        using var s = new CompositorTestServices();
+        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+        var compositor = controller.Compositor;
+        var commitCount = 0;
+        compositor.AfterCommit += () => commitCount++;
+
+        var batch1 = compositor.RequestCompositionBatchCommitAsync();
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(1, commitCount);
+        Assert.False(batch1.Processed.IsCompleted);
+
+        var batch2 = compositor.RequestCompositionBatchCommitAsync();
+        Assert.NotSame(batch1, batch2);
+        // The second batch is not committed while the first one is still in flight
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(1, commitCount);
+
+        s.Timer.TriggerTick();
+        Assert.True(batch1.Processed.IsCompleted);
+        Assert.False(batch2.Processed.IsCompleted);
+
+        // Processing the first batch re-triggers the commit request
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(2, commitCount);
+        s.Timer.TriggerTick();
+        Assert.True(batch2.Processed.IsCompleted);
+    }
+
+    [Fact]
+    public void Dispatcher_Shutdown_Flushes_The_Pending_Commit()
+    {
+        using var s = new CompositorTestServices();
+        CompositionBatch? batch = null;
+        Exception? error = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                var dispatcher = Dispatcher.CurrentDispatcher;
+                var controller = new CompositorController(s.Compositor, dispatcher);
+                batch = controller.Compositor.RequestCompositionBatchCommitAsync();
+                dispatcher.InvokeShutdown();
+            }
+            catch (Exception e)
+            {
+                error = e;
+            }
+        });
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(30)));
+        Assert.Null(error);
+
+        // The batch was submitted by the shutdown flush without the worker dispatcher ever being pumped
+        Assert.False(batch!.Processed.IsCompleted);
+        s.Timer.TriggerTick();
+        Assert.True(batch.Processed.IsCompleted);
+    }
+
+    [Fact]
+    public void Proxy_Surface_Shares_Server_Object_And_Belongs_To_Target_Compositor()
+    {
+        using var s = new CompositorTestServices();
+        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+        var surface = s.Compositor.CreateDrawingSurface();
+
+        var proxy = surface.CreateProxyForCompositor(controller.Compositor);
+        Assert.Same(surface.Server, proxy.Server);
+        Assert.Same(controller.Compositor, proxy.Compositor);
+
+        proxy.Dispose();
+        surface.Dispose();
+        s.RunJobs();
+    }
+
+    [Fact]
+    public void Proxy_Creation_Validates_Surface_State_And_Server_Affinity()
+    {
+        using var s = new CompositorTestServices();
+        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+        var surface = s.Compositor.CreateDrawingSurface();
+
+        Assert.Throws<InvalidOperationException>(() => surface.CreateProxyForCompositor(s.Compositor));
+
+        var foreignCompositor = new Compositor(RenderLoop.FromTimer(new CompositorTestServices.ManualRenderTimer()), null, true,
+            new DispatcherCompositorScheduler(), true, Dispatcher.UIThread);
+        Assert.Throws<InvalidOperationException>(() => surface.CreateProxyForCompositor(foreignCompositor));
+        surface.Dispose();
+
+        var disposedSurface = s.Compositor.CreateDrawingSurface();
+        disposedSurface.Dispose();
+        Assert.Throws<ObjectDisposedException>(() => disposedSurface.CreateProxyForCompositor(controller.Compositor));
+    }
+
+    [Fact]
+    public void Imported_Objects_From_A_Different_Compositor_Are_Rejected()
+    {
+        using var s = new CompositorTestServices();
+        var controller = new CompositorController(s.Compositor, Dispatcher.UIThread);
+        var surface = s.Compositor.CreateDrawingSurface();
+        var proxy = surface.CreateProxyForCompositor(controller.Compositor);
+
+        var foreignImage = new CompositionImportedGpuImage(s.Compositor, null!, null!, () => null!, null);
+        // The ownership check throws synchronously, before any server job is scheduled
+        Assert.Throws<InvalidOperationException>(() => { _ = proxy.UpdateAsync(foreignImage); });
+
+        proxy.Dispose();
+        surface.Dispose();
+        s.RunJobs();
+    }
+
+    [Fact]
+    public void Server_Surface_Is_Released_When_The_Last_Reference_Is_Disposed()
+    {
+        using var s = new CompositorTestServices();
+        var server = new ServerCompositionDrawingSurface(s.Compositor.Server);
+
+        server.AddRef();
+        server.Dispose();
+        // Not released yet, adding a reference is still valid
+        server.AddRef();
+        server.Dispose();
+        server.Dispose();
+        Assert.Throws<ObjectDisposedException>(() => server.AddRef());
+        // A failed AddRef must not resurrect the surface
+        Assert.Throws<ObjectDisposedException>(() => server.AddRef());
+    }
+}

--- a/tests/Avalonia.RenderTests/Composition/OpenGlCompositionInteropTests.cs
+++ b/tests/Avalonia.RenderTests/Composition/OpenGlCompositionInteropTests.cs
@@ -1,5 +1,6 @@
 #if AVALONIA_SKIA
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Media;
@@ -329,6 +330,125 @@ public class OpenGlCompositionInteropTests : TestBase
         Assert.False(texture.IsReadyForDraw);
         Assert.Throws<ObjectDisposedException>(() => texture.BeginDraw());
         surface.Dispose();
+    }
+
+    [Fact]
+    public void Worker_Thread_Renders_Through_Proxy_Surface()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        var host = new Border { Width = 100, Height = 100, Background = Brushes.Black };
+        using var scaffolding = new CompositorScaffolding(host, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+        var surface = scaffolding.Compositor.CreateDrawingSurface();
+        AttachSurfaceVisual(scaffolding, host, surface, new Size(100, 100));
+
+        using var controllerCreated = new SemaphoreSlim(0);
+        using var proxyCreated = new SemaphoreSlim(0);
+        using var redPresented = new SemaphoreSlim(0);
+        using var originalDisposed = new SemaphoreSlim(0);
+        using var bluePresented = new SemaphoreSlim(0);
+        using var cleanupApproved = new SemaphoreSlim(0);
+        using var workerDone = new SemaphoreSlim(0);
+        CompositorController? controller = null;
+        CompositionDrawingSurface? proxy = null;
+        Exception? workerException = null;
+
+        var timeout = TimeSpan.FromSeconds(30);
+        var worker = new Thread(() =>
+        {
+            try
+            {
+                var dispatcher = Dispatcher.CurrentDispatcher;
+                // Awaits below have to resume on this thread, normally this is provided by the dispatcher loop
+                SynchronizationContext.SetSynchronizationContext(
+                    new AvaloniaSynchronizationContext(dispatcher, DispatcherPriority.Normal));
+                controller = new CompositorController(scaffolding.Compositor, dispatcher);
+                controllerCreated.Release();
+                Assert.True(proxyCreated.Wait(timeout));
+
+                void PumpUntil(Task task)
+                {
+                    for (var c = 0; c < 10000 && !task.IsCompleted; c++)
+                    {
+                        dispatcher.RunJobs();
+                        Thread.Sleep(1);
+                    }
+                    Assert.True(task.IsCompleted, "The task hasn't been completed after pumping the worker loop");
+                    task.GetAwaiter().GetResult();
+                }
+
+                var contextTask = controller.Compositor.TryCreateCompatibleGlContextAsync().AsTask();
+                PumpUntil(contextTask);
+                var context = contextTask.Result;
+                Assert.NotNull(context);
+
+                var texture = context.CreateTexture(proxy!, new PixelSize(100, 100));
+                ClearTexture(context, texture, 1, 0, 0, 1, out var present);
+                PumpUntil(present);
+                redPresented.Release();
+
+                Assert.True(originalDisposed.Wait(timeout));
+                // The original surface is disposed, but the proxy must keep the server-side surface alive
+                ClearTexture(context, texture, 0, 0, 1, 1, out present);
+                PumpUntil(present);
+                bluePresented.Release();
+
+                Assert.True(cleanupApproved.Wait(timeout));
+                PumpUntil(texture.DisposeAsync().AsTask());
+                proxy!.Dispose();
+                PumpUntil(context.DisposeAsync().AsTask());
+                // Deterministically submit the batch with the proxy dispose job
+                PumpUntil(controller.Commit().Processed);
+            }
+            catch (Exception e)
+            {
+                Volatile.Write(ref workerException, e);
+            }
+            finally
+            {
+                workerDone.Release();
+            }
+        }) { IsBackground = true };
+
+        void WaitWhilePumping(SemaphoreSlim semaphore)
+        {
+            for (var c = 0; c < 10000; c++)
+            {
+                if (semaphore.Wait(0))
+                    return;
+                if (Volatile.Read(ref workerException) != null)
+                    break;
+                scaffolding.Pump();
+                Thread.Sleep(1);
+            }
+            // Let the worker wind down before the scaffolding is torn down under it
+            worker.Join(TimeSpan.FromSeconds(5));
+            Assert.Fail($"Timed out waiting for the worker thread, worker exception: {Volatile.Read(ref workerException)}");
+        }
+
+        worker.Start();
+        Assert.True(controllerCreated.Wait(timeout));
+        proxy = surface.CreateProxyForCompositor(controller!.Compositor);
+        proxyCreated.Release();
+
+        WaitWhilePumping(redPresented);
+        Assert.Equal(((byte)255, (byte)0, (byte)0, (byte)255), scaffolding.GetPixel(50, 50));
+
+        surface.Dispose();
+        scaffolding.Pump();
+        originalDisposed.Release();
+
+        WaitWhilePumping(bluePresented);
+        Assert.Equal(((byte)0, (byte)0, (byte)255, (byte)255), scaffolding.GetPixel(50, 50));
+        cleanupApproved.Release();
+
+        WaitWhilePumping(workerDone);
+        worker.Join();
+        Assert.Null(workerException);
+
+        // With the last reference disposed the server-side surface content is released
+        scaffolding.Pump();
+        Assert.Equal(((byte)0, (byte)0, (byte)0, (byte)255), scaffolding.GetPixel(50, 50));
     }
 
     private class ClearColorGlControl : OpenGlControlBase

--- a/tests/Avalonia.RenderTests/Composition/OpenGlCompositionInteropTests.cs
+++ b/tests/Avalonia.RenderTests/Composition/OpenGlCompositionInteropTests.cs
@@ -362,7 +362,7 @@ public class OpenGlCompositionInteropTests : TestBase
                 // Awaits below have to resume on this thread, normally this is provided by the dispatcher loop
                 SynchronizationContext.SetSynchronizationContext(
                     new AvaloniaSynchronizationContext(dispatcher, DispatcherPriority.Normal));
-                controller = new CompositorController(scaffolding.Compositor, dispatcher);
+                controller = scaffolding.Compositor.CreateCompositorController(dispatcher);
                 controllerCreated.Release();
                 Assert.True(proxyCreated.Wait(timeout));
 

--- a/tests/Avalonia.RenderTests/Composition/OpenGlCompositionInteropTests.cs
+++ b/tests/Avalonia.RenderTests/Composition/OpenGlCompositionInteropTests.cs
@@ -1,0 +1,373 @@
+#if AVALONIA_SKIA
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.OpenGL;
+using Avalonia.OpenGL.Controls;
+using Avalonia.Platform;
+using Avalonia.Platform.Surfaces;
+using Avalonia.Rendering;
+using Avalonia.Rendering.Composition;
+using Avalonia.Threading;
+using Avalonia.UnitTests;
+using Xunit;
+using static Avalonia.OpenGL.GlConsts;
+
+namespace Avalonia.Skia.RenderTests;
+
+public class OpenGlCompositionInteropTests : TestBase
+{
+    public OpenGlCompositionInteropTests()
+        : base(@"Composition\OpenGlInterop")
+    {
+    }
+
+    private sealed unsafe class CompositorScaffolding : IDisposable
+    {
+        private readonly IPlatformGraphics _gpu;
+        public ManualRenderTimer Timer { get; } = new();
+        public Compositor Compositor { get; }
+        public TestRenderRoot Root { get; }
+        public CompositingRenderer Renderer { get; }
+        public IWriteableBitmapImpl Bitmap { get; }
+
+        public CompositorScaffolding(Control content, IPlatformGraphics gpu, PixelSize pixelSize)
+        {
+            _gpu = gpu;
+            var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
+            Bitmap = factory.CreateWriteableBitmap(pixelSize, new Vector(96, 96), PixelFormats.Rgba8888,
+                factory.DefaultAlphaFormat);
+            Compositor = new Compositor(RenderLoop.FromTimer(Timer), gpu, true,
+                new DispatcherCompositorScheduler(), true, Dispatcher.UIThread);
+            IPlatformRenderSurface surface = gpu is Avalonia.OpenGL.Egl.EglPlatformGraphics
+                ? new FboReadbackGlPlatformSurface(Bitmap, 1)
+                : new VulkanReadbackPlatformSurface(Bitmap, 1);
+            Root = new TestRenderRoot(1, null!);
+            Renderer = new CompositingRenderer(Root, Compositor, () => new[] { surface });
+            // TestRenderRoot sizes itself from the child, so the content must have explicit dimensions
+            Root.Initialize(Renderer, content);
+            Renderer.Start();
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        public void Pump()
+        {
+            Dispatcher.UIThread.RunJobs();
+            Timer.TriggerTick();
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        public T WaitFor<T>(ValueTask<T> task) => WaitFor(task.AsTask());
+
+        public void WaitFor(ValueTask task) => WaitFor(task.AsTask());
+
+        public T WaitFor<T>(Task<T> task)
+        {
+            WaitFor((Task)task);
+            return task.GetAwaiter().GetResult();
+        }
+
+        public void WaitFor(Task task)
+        {
+            for (var c = 0; c < 1000 && !task.IsCompleted; c++)
+            {
+                Pump();
+                if (!task.IsCompleted)
+                    // Parts of the commit chain hop through the thread pool, give them a chance to run
+                    System.Threading.Thread.Sleep(1);
+            }
+            Assert.True(task.IsCompleted, "The task hasn't been completed after pumping the event loop");
+            task.GetAwaiter().GetResult();
+        }
+
+        public ICompositionGlContext CreateGlContext(CompositionGlContextOptions? options = null)
+        {
+            var context = WaitFor(Compositor.TryCreateCompatibleGlContextAsync(options));
+            Assert.NotNull(context);
+            return context;
+        }
+
+        public (byte R, byte G, byte B, byte A) GetPixel(int x, int y)
+        {
+            Renderer.Paint(new Rect(0, 0, Bitmap.PixelSize.Width, Bitmap.PixelSize.Height), false);
+            using var fb = Bitmap.Lock();
+            var px = (byte*)fb.Address + fb.RowBytes * y + x * 4;
+            return (px[0], px[1], px[2], px[3]);
+        }
+
+        public void Dispose()
+        {
+            Root.Child = null;
+            Dispatcher.UIThread.RunJobs();
+            Renderer.Dispose();
+            // Compositors are created per test, so their backend contexts have to be
+            // disposed deterministically instead of piling up until finalization
+            var renderInterface = Compositor.Server.RenderInterface;
+            using (renderInterface.EnsureCurrent())
+                Compositor.Server.ResetAllGpuResources();
+            if (!_gpu.UsesSharedContext)
+                renderInterface.GpuContext?.Dispose();
+            Bitmap.Dispose();
+        }
+    }
+
+    private static ICompositionGlTexture ClearTexture(ICompositionGlContext context, ICompositionGlTexture texture,
+        float r, float g, float b, float a, out Task present)
+    {
+        using (context.GlContext.MakeCurrent())
+        {
+            var gl = context.GlContext.GlInterface;
+            var fbo = gl.GenFramebuffer();
+            using (var lease = texture.BeginDraw())
+            {
+                var info = lease.Texture;
+                gl.BindFramebuffer(GL_FRAMEBUFFER, fbo);
+                gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, info.Target, info.TextureId, 0);
+                gl.ClearColor(r, g, b, a);
+                gl.Clear(GL_COLOR_BUFFER_BIT);
+                gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, info.Target, 0, 0);
+                gl.BindFramebuffer(GL_FRAMEBUFFER, 0);
+                present = lease.PresentAsync();
+            }
+
+            gl.DeleteFramebuffer(fbo);
+        }
+
+        return texture;
+    }
+
+    private static Exception? RunOnOtherThread(Action action)
+    {
+        // A dedicated thread instead of Task.Run, since waiting for a task can inline it on the current thread
+        Exception? exception = null;
+        var thread = new System.Threading.Thread(() => exception = Record.Exception(action));
+        thread.Start();
+        thread.Join();
+        return exception;
+    }
+
+    private static CompositionSurfaceVisual AttachSurfaceVisual(CompositorScaffolding scaffolding, Control host,
+        CompositionDrawingSurface surface, Size size)
+    {
+        var visual = scaffolding.Compositor.CreateSurfaceVisual();
+        visual.Size = new Vector(size.Width, size.Height);
+        visual.Surface = surface;
+        ElementComposition.SetElementChildVisual(host, visual);
+        Dispatcher.UIThread.RunJobs();
+        return visual;
+    }
+
+    [Fact]
+    public void Can_Create_Compatible_Context_With_Gl_Compositor()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        using var scaffolding = new CompositorScaffolding(new Border { Width = 100, Height = 100 }, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+
+        var context = scaffolding.CreateGlContext();
+        Assert.Same(scaffolding.Compositor, context.Compositor);
+        Assert.NotNull(context.GlContext);
+        Assert.True(context.IsValidForInterop);
+        var version = context.GlContext.Version;
+        scaffolding.WaitFor(context.DisposeAsync());
+        Assert.False(context.IsValidForInterop);
+
+        // GlProfiles preference is plumbed through
+        var context2 = scaffolding.CreateGlContext(new CompositionGlContextOptions { GlProfiles = new[] { version } });
+        Assert.Equal(version, context2.GlContext.Version);
+        scaffolding.WaitFor(context2.DisposeAsync());
+    }
+
+    [Fact]
+    public void Context_Creation_Returns_Null_With_Vulkan_Compositor()
+    {
+        if (!MesaSoftwareRenderer.VulkanEnabled)
+            return;
+        using var scaffolding = new CompositorScaffolding(new Border { Width = 100, Height = 100 }, MesaSoftwareRenderer.Vulkan, new PixelSize(100, 100));
+
+        // lavapipe Vulkan backend has no OpenGL sharing feature and no D3D11 shared memory support
+        var context = scaffolding.WaitFor(scaffolding.Compositor.TryCreateCompatibleGlContextAsync());
+        Assert.Null(context);
+    }
+
+    [Fact]
+    public void Presented_Texture_Is_Composited()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        var host = new Border { Width = 100, Height = 100, Background = Brushes.Black };
+        using var scaffolding = new CompositorScaffolding(host, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+        var context = scaffolding.CreateGlContext();
+        var surface = scaffolding.Compositor.CreateDrawingSurface();
+        AttachSurfaceVisual(scaffolding, host, surface, new Size(100, 100));
+
+        var texture = context.CreateTexture(surface, new PixelSize(100, 100));
+        Assert.True(texture.IsReadyForDraw);
+        ClearTexture(context, texture, 1, 0, 0, 1, out var present);
+
+        scaffolding.WaitFor(present);
+        Assert.True(texture.IsReadyForDraw);
+        Assert.Equal(((byte)255, (byte)0, (byte)0, (byte)255), scaffolding.GetPixel(50, 50));
+
+        // The texture is reusable, present another frame
+        ClearTexture(context, texture, 0, 0, 1, 1, out present);
+        scaffolding.WaitFor(present);
+        Assert.Equal(((byte)0, (byte)0, (byte)255, (byte)255), scaffolding.GetPixel(50, 50));
+
+        scaffolding.WaitFor(texture.DisposeAsync());
+        surface.Dispose();
+        scaffolding.WaitFor(context.DisposeAsync());
+    }
+
+    [Fact]
+    public void Lease_State_Machine_Is_Enforced()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        using var scaffolding = new CompositorScaffolding(new Border { Width = 100, Height = 100 }, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+        var context = scaffolding.CreateGlContext();
+        var surface = scaffolding.Compositor.CreateDrawingSurface();
+
+        var texture = context.CreateTexture(surface, new PixelSize(64, 64));
+
+        // Draw session is exclusive
+        var lease = texture.BeginDraw();
+        Assert.False(texture.IsReadyForDraw);
+        Assert.NotEqual(0, lease.Texture.TextureId);
+        Assert.Throws<InvalidOperationException>(() => texture.BeginDraw());
+
+        // Dispose without present discards the frame and makes the texture immediately reusable
+        lease.Dispose();
+        Assert.True(texture.IsReadyForDraw);
+        Assert.Throws<ObjectDisposedException>(() => lease.Texture);
+
+        // While a present is pending the texture is busy. Commits are only processed when the event
+        // loop is pumped, so the present can't have been completed at this point.
+        ClearTexture(context, texture, 1, 1, 1, 1, out var present);
+        Assert.False(present.IsCompleted);
+        Assert.False(texture.IsReadyForDraw);
+        Assert.Throws<InvalidOperationException>(() => texture.BeginDraw());
+
+        scaffolding.WaitFor(present);
+        Assert.True(texture.IsReadyForDraw);
+
+        // Present is terminal for the lease
+        var lease2 = texture.BeginDraw();
+        var present2 = lease2.PresentAsync();
+        Assert.IsType<ObjectDisposedException>(Record.Exception(() => { _ = lease2.PresentAsync(); }));
+        Assert.Throws<ObjectDisposedException>(() => lease2.Texture);
+        lease2.Dispose(); // no-op after present
+        scaffolding.WaitFor(present2);
+
+        scaffolding.WaitFor(texture.DisposeAsync());
+        Assert.Throws<ObjectDisposedException>(() => texture.BeginDraw());
+        surface.Dispose();
+        scaffolding.WaitFor(context.DisposeAsync());
+    }
+
+    [Fact]
+    public void Entry_Points_Verify_Compositor_Thread_Access()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        using var scaffolding = new CompositorScaffolding(new Border { Width = 100, Height = 100 }, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+        var context = scaffolding.CreateGlContext();
+        var surface = scaffolding.Compositor.CreateDrawingSurface();
+        var texture = context.CreateTexture(surface, new PixelSize(64, 64));
+
+        Assert.IsType<InvalidOperationException>(
+            RunOnOtherThread(() => context.CreateTexture(surface, new PixelSize(64, 64))),
+            exactMatch: false);
+        Assert.IsType<InvalidOperationException>(
+            RunOnOtherThread(() => texture.BeginDraw()),
+            exactMatch: false);
+
+        scaffolding.WaitFor(texture.DisposeAsync());
+        surface.Dispose();
+        scaffolding.WaitFor(context.DisposeAsync());
+    }
+
+    [Fact]
+    public void Create_Texture_Validates_Arguments()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        using var scaffolding = new CompositorScaffolding(new Border { Width = 100, Height = 100 }, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+        var context = scaffolding.CreateGlContext();
+        var surface = scaffolding.Compositor.CreateDrawingSurface();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => context.CreateTexture(surface, new PixelSize(0, 0)));
+
+        // A surface from a different compositor is rejected.
+        // This compositor has no GPU backend and no started renderer, so there is nothing to dispose deterministically.
+        var foreignCompositor = new Compositor(RenderLoop.FromTimer(new ManualRenderTimer()), null, true,
+            new DispatcherCompositorScheduler(), true, Dispatcher.UIThread);
+        var foreignSurface = foreignCompositor.CreateDrawingSurface();
+        Assert.Throws<InvalidOperationException>(() => context.CreateTexture(foreignSurface, new PixelSize(64, 64)));
+        foreignSurface.Dispose();
+
+        surface.Dispose();
+        scaffolding.WaitFor(context.DisposeAsync());
+    }
+
+    [Fact]
+    public void Disposing_Context_Disposes_Textures()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        using var scaffolding = new CompositorScaffolding(new Border { Width = 100, Height = 100 }, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+        var context = scaffolding.CreateGlContext();
+        var surface = scaffolding.Compositor.CreateDrawingSurface();
+
+        var texture = context.CreateTexture(surface, new PixelSize(64, 64));
+        ClearTexture(context, texture, 1, 0, 1, 1, out var present);
+        scaffolding.WaitFor(present);
+
+        scaffolding.WaitFor(context.DisposeAsync());
+        Assert.False(context.IsValidForInterop);
+        Assert.False(texture.IsReadyForDraw);
+        Assert.Throws<ObjectDisposedException>(() => texture.BeginDraw());
+        surface.Dispose();
+    }
+
+    private class ClearColorGlControl : OpenGlControlBase
+    {
+        public int RenderCount;
+
+        protected override void OnOpenGlRender(GlInterface gl, int fb)
+        {
+            RenderCount++;
+            gl.ClearColor(0, 1, 0, 1);
+            gl.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        }
+    }
+
+    [Fact]
+    public void OpenGlControlBase_Renders_Through_Composition_Interop()
+    {
+        if (!MesaSoftwareRenderer.GlEnabled)
+            return;
+        var control = new ClearColorGlControl { Width = 100, Height = 100 };
+        using var scaffolding = new CompositorScaffolding(control, MesaSoftwareRenderer.Gl, new PixelSize(100, 100));
+
+        // The control initializes asynchronously after being attached
+        (byte, byte, byte, byte) pixel = default;
+        for (var c = 0; c < 100; c++)
+        {
+            scaffolding.Pump();
+            pixel = scaffolding.GetPixel(50, 50);
+            if (pixel == ((byte)0, (byte)255, (byte)0, (byte)255))
+                break;
+        }
+
+        Assert.Equal(((byte)0, (byte)255, (byte)0, (byte)255), pixel);
+        Assert.True(control.RenderCount > 0);
+
+        // Detach triggers the cleanup path
+        scaffolding.Root.Child = null;
+        for (var c = 0; c < 10; c++)
+            scaffolding.Pump();
+    }
+}
+#endif


### PR DESCRIPTION
This is a part of gradual move towards supporting more things on non-UI threads. Eventually we want to have some kind of headless UI there for various purposes or HostVisual/VisualTarget-like APIs.

For now this change enables limited access to `Compositor` APIs:

1) Compositor and CompositionDrawingSurface can be imported to non-UI thread. This is done by sharing render-thread side objects and having new proxies to use their own commit cadence bound to non-UI-thread Dispatcher.
2) Since Compositor is technically a fully-functional one API-wise, it's possible to use GPU general interop APIs and OpenGL-specific interop APIs to draw things to CompositionDrawingSurface that was initially created on UI thread and imported to non-UI one

This is somewhat similar to OffscreenCanvas in web tech.

Creating a new compositor proxy returns `CompositorController` ([WinRT naming](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.composition.core.compositorcontroller?view=windows-app-sdk-1.1)) bound to specified dispatcher that allows to control commit cadence manually. If commits aren't done explicitly they are scheduled via normal-ish means via bound dispatcher.

For now this does _not_ involve MediaContext machinery, so it's not yet suitable for driving normal visuals and their rendering.


This builds on top of https://github.com/AvaloniaUI/Avalonia/pull/21853 to have something to test with


```diff
namespace Avalonia.Rendering.Composition
{       
    public partial class Compositor
    {   
+       /// <summary>
+       /// Creates a compositor attached to the same server-side compositor as this one, but bound to a
+       /// different dispatcher and driven by the returned <see cref="CompositorController"/> instead of
+       /// the framework's scheduler
+       /// </summary>
+       /// <param name="dispatcher">
+       /// The dispatcher the new compositor is bound to, the dispatcher of the current thread by default
+       /// </param>
+       public CompositorController CreateCompositorController(Dispatcher? dispatcher = null);
    }

    public sealed partial class CompositionDrawingSurface
    {
+       /// <summary>
+       /// Creates a proxy surface sharing the server-side surface with this one, but bound to
+       /// <paramref name="compositor"/> and usable from that compositor's thread
+       /// </summary>
+       /// <remarks>
+       /// This method can only be called from the thread of the compositor this surface belongs to.
+       /// The server-side surface is kept alive until this surface and all of its proxies are disposed,
+       /// so the returned proxy must be disposed too.
+       /// The target compositor must share the server-side compositor with this surface's compositor,
+       /// see <see cref="CompositorController"/>.
+       /// </remarks>
+       /// <param name="compositor">The compositor the proxy is created for</param>
+       /// <returns>A proxy surface bound to <paramref name="compositor"/></returns>
+       /// <exception cref="ObjectDisposedException">This surface is already disposed</exception>
+       /// <exception cref="InvalidOperationException">
+       /// The target compositor is the compositor of this surface or doesn't share its server-side compositor
+       /// </exception>
+       public CompositionDrawingSurface CreateProxyForCompositor(Compositor compositor);
    }   

+   /// <summary>
+   /// Provides a <see cref="Compositor"/> that is attached to the same render thread as an
+   /// existing compositor, but is bound to a different dispatcher and is not driven by the framework's scheduler.
+   /// </summary>
+   /// <remarks>
+   /// Created via <see cref="Compositor.CreateCompositorController"/>.
+   /// The controlled compositor is intended for feeding composition surfaces from non-UI threads,
+   /// see <see cref="CompositionDrawingSurface.CreateProxyForCompositor"/>.
+   /// Batches are committed either explicitly via <see cref="Commit"/> or by a job posted to the compositor's
+   /// dispatcher, so the dispatcher's thread is expected to run a dispatcher loop. The loop also installs the
+   /// synchronization context that keeps continuations of awaited composition APIs on the compositor's thread;
+   /// without it those continuations resume on the thread pool.
+   /// All <see cref="Compositor"/> APIs are bound to the dispatcher's thread.
+   /// Composition objects created for the compositor, including surface proxies, should be disposed before
+   /// the dispatcher is shut down: jobs posted to a shut down dispatcher are discarded, so cleanup requested
+   /// afterwards never reaches the render thread.
+   /// </remarks>
+   public sealed class CompositorController
+   {   
+       /// <summary>
+       /// The compositor managed by this controller
+       /// </summary>
+       public Compositor Compositor { get; }
+       
+       /// <summary>
+       /// Synchronously serializes pending changes and submits them to the render thread.
+       /// Can only be called on the compositor's dispatcher thread.
+       /// </summary>
+       /// <returns>
+       /// The submitted batch. Note that this method returns once the batch is submitted, without waiting for it
+       /// to be applied, use <see cref="CompositionBatch.Processed"/> or <see cref="CompositionBatch.Rendered"/>
+       /// for synchronization with the render thread.
+       /// </returns>
+       /// <exception cref="InvalidOperationException">The method is called on a wrong thread</exception>
+       public CompositionBatch Commit();
+   }
} 
```