### PR TITLE
Ignore child margins when positioning a popup (redux)

### DIFF
--- a/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
+++ b/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
@@ -26,6 +26,7 @@ namespace Avalonia.Controls.Primitives
         private Point _lastRequestedPosition;
         private PopupPositionRequest? _popupPositionRequest;
         private Size _popupSize;
+        private Thickness _childMargin;
         private bool _needsUpdate;
 
         static OverlayPopupHost()
@@ -102,9 +103,23 @@ namespace Avalonia.Controls.Primitives
         /// <inheritdoc />
         protected override Size ArrangeOverride(Size finalSize)
         {
+            var reposition = false;
+
+            var newMargin = Presenter?.Child?.Margin ?? default;
+            if (newMargin != _childMargin)
+            {
+                _childMargin = newMargin;
+                reposition = true;
+            }
+
             if (_popupSize != finalSize)
             {
                 _popupSize = finalSize;
+                reposition = true;
+            }
+
+            if (reposition)
+            {
                 _needsUpdate = true;
                 UpdatePosition();
             }
@@ -116,7 +131,7 @@ namespace Avalonia.Controls.Primitives
             if (_needsUpdate && _popupPositionRequest is not null)
             {
                 _needsUpdate = false;
-                _positioner.Update(TopLevel.GetTopLevel(_overlayLayer)!, _popupPositionRequest, _popupSize, FlowDirection);
+                _positioner.Update(TopLevel.GetTopLevel(_overlayLayer)!, _popupPositionRequest, _popupSize, _childMargin, FlowDirection);
             }
         }
 

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/CustomPopupPlacement.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/CustomPopupPlacement.cs
@@ -8,9 +8,10 @@ public record CustomPopupPlacement
     private PopupGravity _gravity;
     private PopupAnchor _anchor;
 
-    internal CustomPopupPlacement(Size popupSize, Visual target)
+    internal CustomPopupPlacement(Size popupSize, Thickness deflate, Visual target)
     {
         PopupSize = popupSize;
+        Deflate = deflate;
         Target = target;
     }
 
@@ -18,6 +19,12 @@ public record CustomPopupPlacement
     /// The <see cref="Size"/> of the <see cref="Popup"/> control.
     /// </summary>
     public Size PopupSize { get; }
+
+    /// <summary>
+    /// Gets or sets how far to deflate <see cref="PopupSize"/> when positioning the popup.
+    /// </summary>
+    /// <inheritdoc cref="PopupPositionerParameters.Deflate"/>
+    public Thickness Deflate { get; }
 
     /// <summary>
     /// Placement target of the popup.

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
@@ -78,6 +78,15 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
         public Size Size { get; set; }
 
         /// <summary>
+        /// Gets or sets how far to deflate <see cref="Size"/> when positioning the popup.
+        /// </summary>
+        /// <remarks>
+        /// This is normally set to the margin of the popup's child. This allows out-of-bounds effects 
+        /// like drop shadows to be drawn without affecting the final position of the child.
+        /// </remarks>
+        public Thickness Deflate { get; set; }
+
+        /// <summary>
         /// Specifies the anchor rectangle within the parent that the popup will be placed relative
         /// to, in device-independent pixels.
         /// </summary>
@@ -452,6 +461,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             TopLevel topLevel,
             PopupPositionRequest positionRequest,
             Size popupSize,
+            Thickness deflate,
             FlowDirection flowDirection)
         {
             if (popupSize == default)
@@ -459,20 +469,14 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
                 return;
             }
 
-            var parameters = BuildParameters(topLevel, positionRequest, popupSize, flowDirection);
-            positioner.Update(parameters);
-        }
+            var positionerParameters = new PopupPositionerParameters
+            {
+                Offset = positionRequest.Offset,
+                Size = popupSize,
+                Deflate = deflate,
+                ConstraintAdjustment = positionRequest.ConstraintAdjustment
+            };
 
-        private static PopupPositionerParameters BuildParameters(
-            TopLevel topLevel,
-            PopupPositionRequest positionRequest,
-            Size popupSize,
-            FlowDirection flowDirection)
-        {
-            PopupPositionerParameters positionerParameters = default;
-            positionerParameters.Offset = positionRequest.Offset;
-            positionerParameters.Size = popupSize;
-            positionerParameters.ConstraintAdjustment = positionRequest.ConstraintAdjustment;
             if (positionRequest.Placement == PlacementMode.Pointer)
             {
                 // We need a better way for tracking the last pointer position
@@ -492,6 +496,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
 
                 var customPlacementParameters = new CustomPopupPlacement(
                     popupSize,
+                    deflate,
                     positionRequest.Target)
                 {
                     AnchorRectangle = positionerParameters.AnchorRectangle,
@@ -562,7 +567,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
                 }
             }
 
-            return positionerParameters;
+            positioner.Update(positionerParameters);
         }
 
         private static Rect CalculateAnchorRect(TopLevel topLevel, PopupPositionRequest positionRequest)

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
@@ -84,7 +84,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
         public void Update(PopupPositionerParameters parameters)
         {
             var rect = Calculate(
-                parameters.Size * _popup.Scaling,
+                parameters.Size.Deflate(parameters.Deflate) * _popup.Scaling,
                 new Rect(
                     parameters.AnchorRectangle.TopLeft * _popup.Scaling,
                     parameters.AnchorRectangle.Size * _popup.Scaling),
@@ -92,14 +92,16 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
                 parameters.Gravity,
                 parameters.ConstraintAdjustment,
                 parameters.Offset * _popup.Scaling);
-           
+
+            rect = rect.Inflate(parameters.Deflate * _popup.Scaling);
+
             _popup.MoveAndResize(
                 rect.Position,
                 rect.Size / _popup.Scaling);
         }
 
         
-        private Rect Calculate(Size translatedSize, 
+        private Rect Calculate(Size translatedSize,
             Rect anchorRect, PopupAnchor anchor, PopupGravity gravity,
             PopupPositionerConstraintAdjustment constraintAdjustment, Point offset)
         {

--- a/src/Avalonia.Controls/Primitives/PopupRoot.cs
+++ b/src/Avalonia.Controls/Primitives/PopupRoot.cs
@@ -31,6 +31,7 @@ namespace Avalonia.Controls.Primitives
 
         private PopupPositionRequest? _popupPositionRequest;
         private Size _popupSize;
+        private Thickness _childMargin;
         private bool _needsUpdate;
 
         /// <summary>
@@ -38,14 +39,14 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         static PopupRoot()
         {
-            BackgroundProperty.OverrideDefaultValue(typeof(PopupRoot), Brushes.White);            
+            BackgroundProperty.OverrideDefaultValue(typeof(PopupRoot), Brushes.White);
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PopupRoot"/> class.
         /// </summary>
         public PopupRoot(TopLevel parent, IPopupImpl impl)
-            : this(parent, impl,null)
+            : this(parent, impl, null)
         {
         }
 
@@ -67,7 +68,7 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Gets the platform-specific window implementation.
         /// </summary>
-        public new IPopupImpl? PlatformImpl => (IPopupImpl?)base.PlatformImpl;               
+        public new IPopupImpl? PlatformImpl => (IPopupImpl?)base.PlatformImpl;
 
         /// <summary>
         /// Gets or sets a transform that will be applied to the popup.
@@ -133,7 +134,7 @@ namespace Avalonia.Controls.Primitives
             {
                 _needsUpdate = false;
                 PlatformImpl?.PopupPositioner?
-                    .Update(ParentTopLevel, _popupPositionRequest, _popupSize, FlowDirection);
+                    .Update(ParentTopLevel, _popupPositionRequest, _popupSize, _childMargin, FlowDirection);
             }
         }
 
@@ -149,7 +150,7 @@ namespace Avalonia.Controls.Primitives
         public void TakeFocus() => PlatformImpl?.TakeFocus();
 
         Visual IPopupHost.HostedVisualTreeRoot => this;
-        
+
         protected override Size MeasureOverride(Size availableSize)
         {
             var maxAutoSize = PlatformImpl?.MaxAutoSizeHint ?? Size.Infinity;
@@ -192,9 +193,23 @@ namespace Avalonia.Controls.Primitives
 
         private protected sealed override Size ArrangeSetBounds(Size size)
         {
+            var reposition = false;
+
+            var newMargin = Presenter?.Child?.Margin ?? default;
+            if (newMargin != _childMargin)
+            {
+                _childMargin = newMargin;
+                reposition = true;
+            }
+
             if (_popupSize != size)
             {
                 _popupSize = size;
+                reposition = true;
+            }
+
+            if (reposition)
+            {
                 _needsUpdate = true;
                 UpdatePosition();
             }

--- a/src/Avalonia.Wayland/Server/Persistent/WSurface.cs
+++ b/src/Avalonia.Wayland/Server/Persistent/WSurface.cs
@@ -821,6 +821,11 @@ class WXdgPopup : WXdgShellSurface, IWXdgPopup
         var hadPrevious = _positioner.HasValue;
         _positioner = positioner;
 
+        // The popup child's margin (Deflate) must be carved out of the surface's window geometry
+        // so the compositor positions and constrains against the child content.
+        if (positioner.Deflate != default)
+            SetShadowExtents(positioner.Deflate);
+
         if (!hadPrevious)
         {
             // First positioner — attempt to attach now (may still defer
@@ -915,9 +920,12 @@ class WXdgPopup : WXdgShellSurface, IWXdgPopup
 
         var positioner = Globals.XdgWmBase.CreatePositioner();
 
-        // Size: protocol requires positive integers.
-        var width = Math.Max(1, (int)Math.Ceiling(p.Size.Width));
-        var height = Math.Max(1, (int)Math.Ceiling(p.Size.Height));
+        // Size corresponds to the popup's window geometry (see the
+        // xdg_positioner.set_size contract), which excludes the child margin.
+        // The protocol requires positive integers.
+        var geometrySize = p.Size.Deflate(p.Deflate);
+        var width = Math.Max(1, (int)Math.Ceiling(geometrySize.Width));
+        var height = Math.Max(1, (int)Math.Ceiling(geometrySize.Height));
         positioner.SetSize(width, height);
 
         // The anchor rect is given in the parent's *buffer-relative* logical

--- a/src/Avalonia.Wayland/Server/Persistent/XdgPopupPositionerParams.cs
+++ b/src/Avalonia.Wayland/Server/Persistent/XdgPopupPositionerParams.cs
@@ -16,6 +16,7 @@ namespace Avalonia.Wayland.Server.Persistent;
 /// to the wayland buffer-vs-geometry distinction.
 /// </summary>
 /// <param name="Size">The size of the popup, in logical surface-local coordinates. Both width and height must be positive.</param>
+/// <param name="Deflate">The popup child's margin, in logical pixels, excluded from the surface's window geometry.</param>
 /// <param name="AnchorRect">The anchor rectangle in the parent's <b>buffer-relative</b> logical coordinates (true top-left, includes shadow).</param>
 /// <param name="Anchor">The edge/corner of the anchor rect that the popup is anchored to. Uses the NWayland-provided wire enum directly — Avalonia's bitfield <see cref="Avalonia.Controls.Primitives.PopupPositioning.PopupAnchor"/> must be translated explicitly UI-side.</param>
 /// <param name="Gravity">The direction the popup expands from the anchor point. Uses the NWayland-provided wire enum directly — same translation note as <paramref name="Anchor"/>.</param>
@@ -24,6 +25,7 @@ namespace Avalonia.Wayland.Server.Persistent;
 [DefinitelyNotARecord]
 internal readonly partial struct XdgPopupPositionerParams(
     Size Size,
+    Thickness Deflate,
     Rect AnchorRect,
     XdgPositioner.AnchorEnum Anchor,
     XdgPositioner.GravityEnum Gravity,

--- a/src/Avalonia.Wayland/WaylandConversionExtensions.cs
+++ b/src/Avalonia.Wayland/WaylandConversionExtensions.cs
@@ -29,6 +29,7 @@ internal static class WaylandConversionExtensions
     public static XdgPopupPositionerParams ToWayland(this PopupPositionerParameters parameters) =>
         new(
             Size: parameters.Size,
+            Deflate: parameters.Deflate,
             AnchorRect: parameters.AnchorRectangle,
             Anchor: parameters.Anchor.ToWayland(),
             Gravity: parameters.Gravity.ToWayland(),

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -1126,6 +1126,65 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void Child_Margin_Should_Not_Affect_Popup_Position()
+        {
+            using var services = CreateServices();
+
+            var placementTarget = new Panel
+            {
+                Width = 10,
+                Height = 10,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            var popupChild = new Border
+            {
+                Width = 10,
+                Height = 10,
+            };
+
+            var popup = new Popup
+            {
+                PlacementTarget = placementTarget,
+                Placement = PlacementMode.BottomEdgeAlignedLeft,
+                Child = popupChild,
+            };
+            ((ISetLogicalParent)popup).SetParent(popup.PlacementTarget);
+
+            var window = PreparedWindow(placementTarget);
+            window.Show();
+            popup.Open();
+            Dispatcher.UIThread.RunJobs();
+
+            Point GetPopupPosition()
+            {
+                if (UsePopupHost)
+                {
+                    return Assert.IsAssignableFrom<OverlayPopupHost>(popup.Host).TranslatePoint(default, window)!.Value;
+                }
+                else
+                {
+                    var impl = Assert.IsAssignableFrom<PopupRoot>(popup.Host).PlatformImpl;
+                    return impl.Position.ToPoint(impl.RenderScaling);
+                }
+            }
+
+            var initialPosition = GetPopupPosition();
+
+            const int ChildMarginLength = 20;
+
+            popupChild.Margin = new(ChildMarginLength);
+
+            // The popup's bounds will now include the child's margin, but the positioning system should have substracted this
+            // to keep the child's bounds stable. Thus the popup as a whole should have moved upwards and to the left.
+            var expected = initialPosition - new Point(ChildMarginLength, ChildMarginLength);
+            
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal(expected, GetPopupPosition());
+        }
+
+        [Fact]
         public void Events_Should_Be_Routed_To_Popup_Parent()
         {
             using (CreateServices())

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -1155,7 +1155,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             var window = PreparedWindow(placementTarget);
             window.Show();
             popup.Open();
-            Dispatcher.UIThread.RunJobs();
+            Dispatcher.UIThread.RunJobs(null, TestContext.Current.CancellationToken);
 
             Point GetPopupPosition()
             {
@@ -1166,6 +1166,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 else
                 {
                     var impl = Assert.IsAssignableFrom<PopupRoot>(popup.Host).PlatformImpl;
+                    Assert.NotNull(impl);
                     return impl.Position.ToPoint(impl.RenderScaling);
                 }
             }
@@ -1180,7 +1181,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             // to keep the child's bounds stable. Thus the popup as a whole should have moved upwards and to the left.
             var expected = initialPosition - new Point(ChildMarginLength, ChildMarginLength);
             
-            Dispatcher.UIThread.RunJobs();
+            Dispatcher.UIThread.RunJobs(null, TestContext.Current.CancellationToken);
             Assert.Equal(expected, GetPopupPosition());
         }
 


### PR DESCRIPTION
## What does the pull request do?
This PR continues #18827, ignoring the margins of a popup's child when positioning the popup.
Please see that PR for details.

All commits from #18827 are included, but this PR also adds Wayland support by carving out the necessary geometry using `SetWindowGeometry`. The existing method `SetShadowExtents` is reused to do so. I hesitated to rename it, but decided against it in the end.

Tested on Windows, X11 and Wayland.

## Fixed issues
- Fixes #18810
