### PR TITLE
Report disposed WaylandEglWsiSurface render target

### DIFF
--- a/src/Avalonia.Wayland/Server/Transient/Rendering/WaylandEglWsiSurface.cs
+++ b/src/Avalonia.Wayland/Server/Transient/Rendering/WaylandEglWsiSurface.cs
@@ -37,16 +37,27 @@ internal sealed class WaylandEglWsiSurface : EglGlPlatformSurfaceBase, IPlatform
         private IntPtr _eglWindow;
         private EglSurface? _eglSurface;
         private PixelSize _currentSize;
+        private bool _disposed;
 
         public RenderTarget(WSurface surface, EglContext context) : base(context)
         {
             _surface = surface;
+            _surface.RegisterRenderTarget(this);
         }
-        
+
         protected override bool SkipWaits => true;
 
-        public override PlatformRenderTargetState State =>
-            IsCorrupted ? PlatformRenderTargetState.Corrupted : _surface.State;
+        public override PlatformRenderTargetState State
+        {
+            get
+            {
+                if (_disposed)
+                    return PlatformRenderTargetState.Disposed;
+                if (IsCorrupted)
+                    return PlatformRenderTargetState.Corrupted;
+                return _surface.State;
+            }
+        }
 
         public override IGlPlatformSurfaceRenderingSession BeginDrawCore(IRenderTarget.RenderTargetSceneInfo sceneInfo)
         {
@@ -89,6 +100,11 @@ internal sealed class WaylandEglWsiSurface : EglGlPlatformSurfaceBase, IPlatform
 
         public override void Dispose()
         {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _surface.UnregisterRenderTarget(this);
             _eglSurface?.Dispose();
             _eglSurface = null;
             if (_eglWindow != IntPtr.Zero)


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that `WaylandEglWsiSurface.RenderTarget` correctly reports its disposal to its parent surface, allowing it to be recreated, for example if the window is hidden then shown again.

Only the WSI EGL path (the default on Wayland) was affected, the DMA-BUF one was already doing the right thing.

## What is the current behavior?
The render target isn't re-created and the window stays invisible.

## What is the updated/expected behavior with this PR?
The render target is properly re-created.

## Fixed issues
- Fixes #21775
