### PR TITLE
fix(TextBox): Initialize command states in constructor

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -431,6 +431,7 @@ namespace Avalonia.Controls
             _undoRedoHelper = new UndoRedoHelper<UndoRedoState>(this);
             _selectedTextChangesMadeSinceLastUndoSnapshot = 0;
             _hasDoneSnapshotOnce = false;
+            UpdateCommandStates();
             UpdatePseudoclasses();
         }
 

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -1550,6 +1550,19 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Empty_TextBox_Initializes_Clipboard_Command_States()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox();
+
+                Assert.False(tb.CanCopy);
+                Assert.False(tb.CanCut);
+                Assert.True(tb.CanPaste);
+            }
+        }
+
+        [Fact]
         public void Command_States_Update_When_ReadOnly_And_PasswordChar_Change()
         {
             using (UnitTestApplication.Start(Services))


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Initializes `TextBox` clipboard command states during construction.


## What is the current behavior?
Paste is disabled before an editable `TextBox` receives focus.


## What is the updated/expected behavior with this PR?
Paste is enabled immediately for editable `TextBox` controls.


## How was the solution implemented (if it's not obvious)?
Calls `UpdateCommandStates()` in the constructor and adds a regression test.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Fixes #21858 

