### PR TITLE
DiagnosticTextRenderer: Make numbers monospace (big perf win)

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Server/DiagnosticTextRenderer.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/DiagnosticTextRenderer.cs
@@ -11,22 +11,15 @@ namespace Avalonia.Rendering.Composition.Server
         private const char FirstChar = (char)32;
         private const char LastChar = (char)126;
 
+        private double maxCharGlyphWidth = 0.0;
+        private double maxCharGlyphHeight = 0.0;
+        private double maxNumberCharGlyphWidth = 0.0;
+
         private readonly GlyphRun[] _runs = new GlyphRun[LastChar - FirstChar + 1];
 
         public double GetMaxHeight()
         {
-            var maxHeight = 0.0;
-
-            for (var c = FirstChar; c <= LastChar; c++)
-            {
-                var height = _runs[c - FirstChar].Bounds.Height;
-                if (height > maxHeight)
-                {
-                    maxHeight = height;
-                }
-            }
-
-            return maxHeight;
+            return maxCharGlyphHeight;
         }
 
         public DiagnosticTextRenderer(GlyphTypeface glyphTypeface, double fontRenderingEmSize)
@@ -38,23 +31,41 @@ namespace Avalonia.Rendering.Composition.Server
                 chars[index] = c;
                 var glyph = glyphTypeface.CharacterToGlyphMap[c];
                 _runs[index] = new GlyphRun(glyphTypeface, fontRenderingEmSize, chars.AsMemory(index, 1), new[] { glyph });
+
+                // Calculate max character width and height
+                if (_runs[index].Bounds.Width > maxCharGlyphWidth)
+                {
+                    maxCharGlyphWidth = _runs[index].Bounds.Width;
+                }
+                if (_runs[index].Bounds.Height > maxCharGlyphHeight)
+                {
+                    maxCharGlyphHeight = _runs[index].Bounds.Height;
+                }
+            }
+
+            // Calculate the fixed cell width for digits (0-9)
+            for (var c = '0'; c <= '9'; c++)
+            {
+                var index = c - FirstChar;
+                if (_runs[index].Bounds.Width > maxNumberCharGlyphWidth)
+                {
+                    maxNumberCharGlyphWidth = _runs[index].Bounds.Width;
+                }
             }
         }
 
         public Size MeasureAsciiText(ReadOnlySpan<char> text)
         {
             var width = 0.0;
-            var height = 0.0;
 
             foreach (var c in text)
             {
                 var effectiveChar = c is >= FirstChar and <= LastChar ? c : ' ';
                 var run = _runs[effectiveChar - FirstChar];
-                width += run.Bounds.Width;
-                height = Math.Max(height, run.Bounds.Height);
+                width += (c >= '0' && c <= '9')? maxNumberCharGlyphWidth : run.Bounds.Width;
             }
 
-            return new Size(width, height);
+            return new Size(width, maxCharGlyphHeight);
         }
 
         public void DrawAsciiText(ImmediateDrawingContext context, ReadOnlySpan<char> text, IImmutableBrush foreground)
@@ -64,10 +75,16 @@ namespace Avalonia.Rendering.Composition.Server
             foreach (var c in text)
             {
                 var effectiveChar = c is >= FirstChar and <= LastChar ? c : ' ';
+                var charIsNumber = c >= '0' && c <= '9';
                 var run = _runs[effectiveChar - FirstChar];
-                using (context.PushPreTransform(Matrix.CreateTranslation(offset, 0.0)))
+
+                // Center any number character inside a fixed-width cell
+                var centeringOffset = charIsNumber? (maxCharGlyphWidth - run.Bounds.Width) / 2.0 : 0.0;
+
+                using (context.PushPreTransform(Matrix.CreateTranslation(offset + centeringOffset, 0.0)))
                     context.PlatformImpl.DrawGlyphRun(foreground, run.PlatformImpl.Item);
-                offset += run.Bounds.Width;
+
+                offset += charIsNumber? maxNumberCharGlyphWidth : run.Bounds.Width;
             }
 
         }


### PR DESCRIPTION
## What does the pull request do?
This makes the numbers rendered by DiagnosticTextRenderer monospace.

For reasons I admittedly don't entirely understand, this is a *massive* performance win on embedded.  On the target device (Rockchip PX30 SOC with 4x Cortex-a35, Arm Mali-G31 GPU, and 800x640 display; custom OS build using Buildroot; Mesa's Panfrost driver for rendering) using the Linux embedded DRM target with a NativeAOT build, running the RenderDemo app, on the "Spring Animation" page, FPS goes from the 30-40 range to the 90-100 range.  (Vsync was commented out for testing and the default 60FPS limit was changed to 500, in order to get a proper measurement of performance differences.)

(I'm aware that particular setup is considered tier 3, but I'd be surprised if the performance issue didn't also affect the Raspberry Pi; and regardless, not having the rapidly changing number make the text jump around is a nice usability improvement.)

## What is the current behavior?
Currently, the numbers jump around a good bit (unless presumably you happen to already be using a monospace font), and performance on a low0power embedded device is very low with the FPS display open.

## What is the updated/expected behavior with this PR?
Numbers no longer jump around, and FPS is significantly improved on embedded devices.

## How was the solution implemented (if it's not obvious)?
Had Gemini help with removing various FPS throttles (vsync, etc) to get raw performance data.  Noticed that the animation looked a lot smoother when the FPS overlay was closed, so experimented with changes until coming across this fix.

## Checklist

- [ ] Added unit tests (if possible)?  N/A
- [ ] Added XML documentation to any related classes?  N/A
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation  N/A

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
No issue filed

Assisted-by: Gemini 3.1 Pro