### PR TITLE
fix(focus): infinite loop in tab stop search with TabNavigation=Once

### DIFF
--- a/src/Avalonia.Base/Input/FocusManager.cs
+++ b/src/Avalonia.Base/Input/FocusManager.cs
@@ -665,7 +665,7 @@ namespace Avalonia.Input
                     if (IsValidTabStopSearchCandidate(parent) && parent is InputElement p && KeyboardNavigation.GetTabNavigation(p) == KeyboardNavigationMode.Once)
                     {
                         current = parent;
-                        parent = FocusHelpers.GetFocusParent(focused);
+                        parent = FocusHelpers.GetFocusParent(current);
                         if (parent == null)
                             break;
                     }
@@ -765,7 +765,7 @@ namespace Avalonia.Input
                         else
                         {
                             current = parent;
-                            parent = FocusHelpers.GetFocusParent(focused);
+                            parent = FocusHelpers.GetFocusParent(current);
                             if (parent == null)
                                 break;
                         }
@@ -803,7 +803,7 @@ namespace Avalonia.Input
                             else
                             {
                                 current = parent;
-                                parent = FocusHelpers.GetFocusParent(focused);
+                                parent = FocusHelpers.GetFocusParent(current);
                                 if (parent == null)
                                     break;
                             }

--- a/src/Avalonia.Base/Input/FocusManager.cs
+++ b/src/Avalonia.Base/Input/FocusManager.cs
@@ -928,7 +928,11 @@ namespace Avalonia.Input
                         }
                         else
                         {
-                            if (compareIndexResult < 0 || (((foundCurrent || currentPassed) || compareCurrentForPreviousElement) && compareIndexResult == 0))
+                            // A candidate with an equal tab index is "previous" only while the walk has not
+                            // passed the focused element yet; candidates from a nested container scan
+                            // (compareCurrentForPreviousElement) already enforced the ordering themselves.
+                            // Matches WinUI: (((!bFoundCurrent && !bCurrentPassed) || bCurrentCompare) && ...)
+                            if (compareIndexResult < 0 || (((!foundCurrent && !currentPassed) || compareCurrentForPreviousElement) && compareIndexResult == 0))
                             {
                                 if (newTabStop != null)
                                 {

--- a/src/Avalonia.Base/Input/FocusManager.cs
+++ b/src/Avalonia.Base/Input/FocusManager.cs
@@ -752,7 +752,10 @@ namespace Avalonia.Input
                 {
                     if (IsValidTabStopSearchCandidate(current) && current is InputElement c && KeyboardNavigation.GetTabNavigation(c) == KeyboardNavigationMode.Cycle)
                     {
-                        newTabStop = GetFirstFocusableElement(current, current);
+                        // Wrapping backwards inside a Cycle scope lands on the LAST focusable
+                        // element, mirroring the forward wrap (last -> first).
+                        // Matches WinUI: GetLastFocusableElement(pCurrent, pCurrent).
+                        newTabStop = GetLastFocusableElement(current, current);
                         break;
                     }
 

--- a/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
@@ -913,6 +913,87 @@ namespace Avalonia.Base.UnitTests.Input
         }
 
         [Fact]
+        public void Can_Get_Next_Element_Out_Of_Container_With_TabNavigation_Once()
+        {
+            using (UnitTestApplication.Start(TestServices.RealFocus))
+            {
+                var inside = new Button { Focusable = true, Content = "inside" };
+                var after = new Button { Focusable = true, Content = "after" };
+
+                // The focused element has to sit at least one level below the Once container:
+                // GetFocusParent(focused) must resolve to something *deeper* than that container,
+                // otherwise the reset below happens to land on the correct node and the walk
+                // terminates by accident.
+                var once = new StackPanel
+                {
+                    [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Once,
+                    Children =
+                    {
+                        new StackPanel { Children = { inside } }
+                    }
+                };
+                var root = new TestRoot
+                {
+                    Child = new StackPanel
+                    {
+                        Children = { once, after }
+                    }
+                };
+
+                var focusManager = FocusManager.GetFocusManager(inside);
+                Assert.NotNull(focusManager);
+                inside.Focus();
+
+                // Before the fix this call never returned: on every Once hit the parent walk was
+                // reset to the focused element's parent, so it oscillated between the same two
+                // nodes forever and burned 100% CPU on the UI thread.
+                var next = focusManager.FindNextElement(NavigationDirection.Next);
+
+                Assert.Equal(after, next);
+            }
+        }
+
+        [Fact]
+        public void Can_Get_Previous_Element_Out_Of_Container_With_TabNavigation_Once()
+        {
+            using (UnitTestApplication.Start(TestServices.RealFocus))
+            {
+                var before = new Button { Name = "before", Focusable = true, Content = "before" };
+                var inside = new Button { Name = "inside", Focusable = true, Content = "inside" };
+
+                // Same shape as the Next case. The Once container itself must stay unfocusable,
+                // otherwise GetPreviousTabStop returns it before reaching the faulty branch.
+                var once = new StackPanel
+                {
+                    [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Once,
+                    Children =
+                    {
+                        new StackPanel { Children = { inside } }
+                    }
+                };
+                var root = new TestRoot
+                {
+                    Child = new StackPanel
+                    {
+                        Children = { before, once }
+                    }
+                };
+
+                var focusManager = FocusManager.GetFocusManager(inside);
+                Assert.NotNull(focusManager);
+                inside.Focus();
+
+                // Before the fix this call never returned either. Which element *should* come
+                // back here is a separate question - the Once container's cycle fallback
+                // currently hands back the focused element itself - so this test only locks
+                // down that the parent walk terminates at all.
+                var previous = focusManager.FindNextElement(NavigationDirection.Previous);
+
+                Assert.NotNull(previous);
+            }
+        }
+
+        [Fact]
         public void Can_Get_Next_Element_With_FocusedElement_Option()
         {
             using (UnitTestApplication.Start(TestServices.RealFocus))

--- a/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
@@ -983,13 +983,47 @@ namespace Avalonia.Base.UnitTests.Input
                 Assert.NotNull(focusManager);
                 inside.Focus();
 
-                // Before the fix this call never returned either. Which element *should* come
-                // back here is a separate question - the Once container's cycle fallback
-                // currently hands back the focused element itself - so this test only locks
-                // down that the parent walk terminates at all.
+                // Before the fixes this call never returned. The walk must leave the Once
+                // container and land on the element preceding it.
                 var previous = focusManager.FindNextElement(NavigationDirection.Previous);
 
-                Assert.NotNull(previous);
+                Assert.Equal(before, previous);
+            }
+        }
+
+        [Fact]
+        public void Can_Get_Previous_Element()
+        {
+            using (UnitTestApplication.Start(TestServices.RealFocus))
+            {
+                var target1 = new Button { Focusable = true, Content = "1" };
+                var target2 = new Button { Focusable = true, Content = "2" };
+                var target3 = new Button { Focusable = true, Content = "3" };
+                var target4 = new Button { Focusable = true, Content = "4" };
+                var container = new StackPanel
+                {
+                    Children =
+                    {
+                        target1,
+                        target2,
+                        target3,
+                        target4
+                    }
+                };
+                var root = new TestRoot
+                {
+                    Child = container
+                };
+
+                var focusManager = FocusManager.GetFocusManager(container);
+                Assert.NotNull(focusManager);
+                target3.Focus();
+
+                // Must return the closest preceding sibling: not target1 (which merely comes
+                // first) and not target4 (which comes after the focused element).
+                var previous = focusManager.FindNextElement(NavigationDirection.Previous);
+
+                Assert.Equal(target2, previous);
             }
         }
 

--- a/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
@@ -1028,6 +1028,42 @@ namespace Avalonia.Base.UnitTests.Input
         }
 
         [Fact]
+        public void Previous_Wraps_To_Last_Element_In_Cycle_Container()
+        {
+            using (UnitTestApplication.Start(TestServices.RealFocus))
+            {
+                var target1 = new Button { Focusable = true, Content = "1" };
+                var target2 = new Button { Focusable = true, Content = "2" };
+                var target3 = new Button { Focusable = true, Content = "3" };
+                var cycle = new StackPanel
+                {
+                    [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Cycle,
+                    Children =
+                    {
+                        target1,
+                        target2,
+                        target3
+                    }
+                };
+                var root = new TestRoot
+                {
+                    Child = cycle
+                };
+
+                var focusManager = FocusManager.GetFocusManager(target1);
+                Assert.NotNull(focusManager);
+                target1.Focus();
+
+                // Wrapping backwards inside a Cycle scope must land on the last focusable
+                // element, mirroring the forward wrap (last -> first). It used to take the
+                // FIRST element - the focused element itself - making Previous a no-op.
+                var previous = focusManager.FindNextElement(NavigationDirection.Previous);
+
+                Assert.Equal(target3, previous);
+            }
+        }
+
+        [Fact]
         public void Can_Get_Next_Element_With_FocusedElement_Option()
         {
             using (UnitTestApplication.Start(TestServices.RealFocus))


### PR DESCRIPTION
`FocusManager.FindNextElement(Next|Previous)` and `TryMoveFocus(Next|Previous)` never return when the focused element sits inside a container with `KeyboardNavigationMode.Once`. The calling thread spins at 100% CPU forever; in a desktop app that means a hard hang of the UI thread requiring the process to be killed.

## Root cause

The upward walk in `GetNextTabStop` / `GetPreviousTabStop` advances at the end of each iteration with `parent = GetFocusParent(parent)`. But when the walk reaches a container whose `TabNavigation` is `Once` (or `None`, in one branch), the code resets `parent` from `focused` instead of from `current`:

```csharp
current = parent;
parent = FocusHelpers.GetFocusParent(focused);   // focused is a loop invariant
```

`focused` never changes, so `parent` drops back down to the focused element's immediate parent. The next iteration walks up to the same container again and takes the same branch, so the walk oscillates between two nodes indefinitely. None of the three loop exit conditions (`parent != null`, `!parentIsRootVisual`, `newTabStop == null`) can ever be satisfied.

The correct form already exists a few lines below in `GetNextTabStop`, in the structurally identical `KeyboardNavigationMode.None` branch:

```csharp
current = pIE;
parent = FocusHelpers.GetFocusParent(current);   // walks up, converges
```

This changes the three remaining occurrences to match it: one in `GetNextTabStop`, two in `GetPreviousTabStop`. The two loop initializers outside the `while` (`FocusManager.cs:647` and `:748`) correctly keep using `focused` and are left alone.

## Reproducing it

The focused element has to be nested **at least one level below** the `Once` container. When it is a direct child, `GetFocusParent(focused)` happens to return that same container and the walk terminates by accident - which is likely why this went unnoticed for so long.

Minimal shape (used by both new tests):

```
StackPanel
├── StackPanel [TabNavigation=Once]
│   └── StackPanel
│       └── Button   <- focused
└── Button           <- expected result for Next
```

Found in a production app: FluentAvalonia's `ContentDialog` calls `FindNextElement(NavigationDirection.Next, ...)` from its `Loaded` handler to pick an initial focus target. With focus sitting on a nested `NavigationView` item - the `Once` container comes from the NavigationView template - opening any dialog hung the app permanently.

## Scope

Only the programmatic focus APIs go through this code. Pressing Tab is unaffected: `KeyboardNavigationHandler` uses the separate, WPF-derived implementation in `Navigation/TabNavigation.cs`, which handles `Once` correctly by passing the container itself as the new starting point.

## Verification

- Two regression tests added to `InputElement_Focus`, covering both directions.
- Confirmed they actually catch the bug: with the `FocusManager.cs` change reverted, the Next test ran for 90s using 89.5s of CPU and the Previous test for 60s using 59.6s before being killed. With the fix both return immediately.
- Full `Avalonia.Base.UnitTests` suite: 2996 tests, 0 failed (2984 passed, 12 skipped).

## Not addressed here

The `Once` branches are asymmetric: `GetPreviousTabStop` returns the container when it is focusable (`if (FocusHelpers.IsFocusable(parent)) newTabStop = parent;`), `GetNextTabStop` has no such check. Separately, in the Previous direction this shape ends up returning the focused element itself via the cycle fallback in `GetTabStopCandidateElement`, rather than the element preceding the container. Both look like genuine issues, but they are behavioural questions independent of the hang, so the Previous test only asserts that the call terminates. Happy to follow up in a separate PR if you would like them fixed.

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
