### PR TITLE
CompositionBrush corrections

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Brushes/CompositionBrush.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Brushes/CompositionBrush.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Avalonia.Rendering.Composition;
 using Avalonia.Rendering.Composition.Server;
 using Avalonia.Rendering.Composition.Transport;
@@ -42,10 +43,47 @@ partial class CompositionConicGradientBrush : IConicGradientBrush
 
 public abstract partial class CompositionGradientBrush : CompositionBrush, IGradientBrush
 {
+    private List<IGradientStop> _gradientStops = [];
+    private GradientSpreadMethod _spreadMethod;
+
     internal new ServerCompositionGradientBrush Server { get; }
-    public List<IGradientStop> GradientStops { get; set; } = [];
+
+    /// <summary>
+    /// The gradient stops. Mutations of the list itself are not tracked - assign
+    /// the property to ship in-place edits made after a commit. Stops created via
+    /// <see cref="Compositor.CreateGradientStop(double, Media.Color)"/> stay live
+    /// on the server and animate individually; other stops are snapshotted at
+    /// serialization time.
+    /// </summary>
+    public List<IGradientStop> GradientStops
+    {
+        get => _gradientStops;
+        set
+        {
+            if (ReferenceEquals(_gradientStops, value))
+                return;
+            _gradientStops = value;
+            RegisterForSerialization();
+        }
+    }
+
     IReadOnlyList<IGradientStop> IGradientBrush.GradientStops => GradientStops;
-    public GradientSpreadMethod SpreadMethod { get; set; }
+
+    /// <summary>
+    /// How the gradient repeats outside the stop range.
+    /// </summary>
+    public GradientSpreadMethod SpreadMethod
+    {
+        get => _spreadMethod;
+        set
+        {
+            if (_spreadMethod == value)
+                return;
+            _spreadMethod = value;
+            RegisterForSerialization();
+        }
+    }
+
     partial void OnRootChanged();
     partial void OnRootChanging();
 
@@ -63,7 +101,10 @@ public abstract partial class CompositionGradientBrush : CompositionBrush, IGrad
             if (stop is CompositionGradientStop comp)
                 writer.WriteObject(comp.Server);
             else
-                writer.WriteObject(stop);
+                // A mutable UI-thread stop must not cross to the render thread
+                // by reference; ship its current values instead.
+                writer.WriteObject(stop as ImmutableGradientStop
+                    ?? new ImmutableGradientStop(stop.Offset, stop.Color));
         }
     }
 }

--- a/src/Avalonia.Base/Rendering/Composition/Drawing/ServerResourceHelperExtensions.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/ServerResourceHelperExtensions.cs
@@ -20,7 +20,14 @@ static class ServerResourceHelperExtensions
         if (brush is ICompositionRenderResource<IBrush> resource)
             return resource.GetForCompositor(compositor);
         if (brush is CompositionBrush compositionBrush)
+        {
+            // The server object belongs to its own compositor's render loop;
+            // handing it to another compositor would share one resource across
+            // two render threads.
+            if (compositionBrush.Compositor != compositor)
+                ThrowForeignCompositor(compositionBrush);
             return compositionBrush.Server;
+        }
         ThrowNotCompatible(brush);
         return null;
     }
@@ -42,6 +49,10 @@ static class ServerResourceHelperExtensions
     [MethodImpl(MethodImplOptions.NoInlining), DoesNotReturn]
     static void ThrowNotCompatible(object o) =>
         throw new InvalidOperationException(o.GetType() + " is not compatible with composition");
+
+    [MethodImpl(MethodImplOptions.NoInlining), DoesNotReturn]
+    static void ThrowForeignCompositor(CompositionObject o) =>
+        throw new InvalidOperationException(o.GetType() + " belongs to a different compositor");
     
     public static ITransform? GetServer(this ITransform? transform, Compositor? compositor)
     {

--- a/tests/Avalonia.Base.UnitTests/Composition/CompositionBrushTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Composition/CompositionBrushTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using Avalonia.Rendering;
+using Avalonia.Rendering.Composition;
+using Avalonia.Rendering.Composition.Drawing;
+using Avalonia.Threading;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Composition;
+
+public class CompositionBrushTests : ScopedTestBase
+{
+    [Fact]
+    public void Replacing_The_Gradient_Stop_List_After_A_Commit_Should_Reach_The_Server()
+    {
+        using var services = new CompositorTestServices();
+        var compositor = services.Compositor;
+
+        var brush = compositor.CreateLinearGradientBrush();
+        brush.GradientStops.Add(compositor.CreateGradientStop(0, Colors.Red));
+        services.RunJobs();
+
+        Assert.Single(brush.Server.GradientStops);
+
+        brush.GradientStops = new List<IGradientStop>
+        {
+            compositor.CreateGradientStop(0, Colors.Red),
+            compositor.CreateGradientStop(1, Colors.Blue),
+        };
+        services.RunJobs();
+
+        Assert.Equal(2, brush.Server.GradientStops.Count);
+    }
+
+    [Fact]
+    public void Changing_SpreadMethod_After_A_Commit_Should_Reach_The_Server()
+    {
+        using var services = new CompositorTestServices();
+        var compositor = services.Compositor;
+
+        var brush = compositor.CreateLinearGradientBrush();
+        brush.GradientStops.Add(compositor.CreateGradientStop(0, Colors.Red));
+        services.RunJobs();
+
+        Assert.Equal(GradientSpreadMethod.Pad, brush.Server.SpreadMethod);
+
+        brush.SpreadMethod = GradientSpreadMethod.Repeat;
+        services.RunJobs();
+
+        Assert.Equal(GradientSpreadMethod.Repeat, brush.Server.SpreadMethod);
+    }
+
+    [Fact]
+    public void Mutable_Gradient_Stops_Should_Be_Snapshotted_For_The_Server()
+    {
+        using var services = new CompositorTestServices();
+        var compositor = services.Compositor;
+
+        var mutableStop = new GradientStop(Colors.Red, 0);
+        var brush = compositor.CreateLinearGradientBrush();
+        brush.GradientStops.Add(mutableStop);
+        services.RunJobs();
+
+        // The render thread reads the server list at replay time, so a mutable
+        // UI-thread stop must not cross the batch by reference.
+        var serverStop = Assert.Single(brush.Server.GradientStops);
+        Assert.NotSame(mutableStop, serverStop);
+        Assert.Equal(Colors.Red, serverStop.Color);
+        Assert.Equal(0, serverStop.Offset);
+    }
+
+    [Fact]
+    public void Using_A_Composition_Brush_With_A_Foreign_Compositor_Should_Throw()
+    {
+        using var services = new CompositorTestServices();
+
+        var brush = services.Compositor.CreateSolidColorBrush(Colors.Red);
+
+        var foreign = new Compositor(RenderLoop.FromTimer(services.Timer), null,
+            true, new DispatcherCompositorScheduler(), true, Dispatcher.UIThread);
+
+        // A composition brush's server object belongs to its own compositor's
+        // render loop; handing it to another compositor's stream would let two
+        // render threads race over one resource.
+        Assert.Throws<InvalidOperationException>(() => brush.GetServer(foreign));
+
+        // A transient context without a compositor keeps the client brush and
+        // draws its static values, so no affinity applies there.
+        Assert.Same(brush, brush.GetServer(null));
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Fixes three defects in `CompositionGradientBrush`, all introduced with the composition brush feature: property writes that never reached the render thread, mutable gradient stops crossing the thread boundary by reference, and a composition brush from one compositor being accepted by another.

## What is the updated/expected behavior with this PR?

Assigning `GradientStops` or `SpreadMethod` after the brush has been committed now takes effect:

```csharp
var brush = compositor.CreateLinearGradientBrush();
brush.GradientStops = [stopA, stopB];    // registers for serialization
brush.SpreadMethod = GradientSpreadMethod.Reflect;   // registers for serialization
```

Both were auto-properties, so a write after the first commit updated the client object and nothing else - the render thread kept painting the values from the initial serialization.

A plain `GradientStop` in that list is now snapshotted at serialization time instead of being handed to the render thread by reference. `CompositionGradientStop` instances are unchanged: they stay live on the server and animate individually.

Using a `CompositionBrush` with a compositor other than its own now throws `InvalidOperationException` instead of silently sharing one server object across two render loops:

```csharp
// throws: the brush belongs to a different compositor
otherCompositor.CreateSolidColorBrush(...) /* used in a drawing on this compositor */
```

Mutating the returned `GradientStops` list in place is still not tracked - that is documented on the property, and assigning the property is the way to ship in-place edits.

### How to test

`CompositionBrushTests` in `Avalonia.Base.UnitTests` covers all three: a stop-list replacement and a spread-method change both reaching the server, a mutable stop being snapshotted rather than shared, and the foreign-compositor throw. The first commit adds them failing; the second makes them pass.

## How was the solution implemented (if it's not obvious)?

`GradientStops` and `SpreadMethod` became backed properties that call `RegisterForSerialization()` on change, which is what every other composition property already did. `SerializeChangesCore` writes an `ImmutableGradientStop` copy for any stop that is not a `CompositionGradientStop`, so only server-owned or immutable data crosses the boundary. `ServerResourceHelperExtensions.GetServer` compares `CompositionBrush.Compositor` against the target compositor and throws when they differ, next to the existing not-compatible throw.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None to the API surface. One behavioral change worth flagging: passing a `CompositionBrush` to a different compositor used to be accepted and now throws. Code relying on that produced undefined cross-thread behavior, so the throw is the fix rather than a regression, but it turns a silent bug into an exception.

## Obsoletions / Deprecations

None.

## Fixed issues

<!-- Link the issue(s) for the composition gradient brush change tracking here. -->