### PR TITLE
Fix ServerCompositionDrawingSurface orphaning GPU snapshots when an update is processed after Dispose

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionDrawingSurface.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionDrawingSurface.cs
@@ -9,6 +9,7 @@ internal class ServerCompositionDrawingSurface : ServerCompositionSurface, IDisp
 {
     private IRef<IBitmapImpl>? _bitmap;
     private IPlatformRenderInterfaceContext? _createdWithContext;
+    private bool _disposed;
     public override IRef<IBitmapImpl>? Bitmap
     {
         get
@@ -41,6 +42,17 @@ internal class ServerCompositionDrawingSurface : ServerCompositionSurface, IDisp
 
     void Update(IBitmapImpl newImage, IPlatformRenderInterfaceContext context)
     {
+        if (_disposed)
+        {
+            // Batches are processed with disposals before server jobs, so an update job
+            // can be processed after this surface was disposed in the same batch.
+            // Dispose the snapshot here on the render thread (context is current)
+            // instead of orphaning it: an orphaned ref is only ever released by the
+            // Ref<T> critical finalizer, which then performs GPU work on the finalizer
+            // thread and races the render loop (#21865).
+            newImage.Dispose();
+            return;
+        }
         _bitmap?.Dispose();
         _bitmap = RefCountable.Create(newImage);
         _createdWithContext = context;
@@ -92,5 +104,7 @@ internal class ServerCompositionDrawingSurface : ServerCompositionSurface, IDisp
     public void Dispose()
     {
         _bitmap?.Dispose();
+        _bitmap = null;
+        _disposed = true;
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Composition/CompositionDrawingSurfaceTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Composition/CompositionDrawingSurfaceTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Avalonia.Rendering.Composition;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Composition;
+
+public class CompositionDrawingSurfaceTests : ScopedTestBase
+{
+    private class TrackingBitmapImpl : IBitmapImpl
+    {
+        public bool IsDisposed { get; private set; }
+        public Vector Dpi => new(96, 96);
+        public PixelSize PixelSize => new(1, 1);
+        public int Version => 1;
+        public void Save(Stream stream, BitmapEncoderOptions options) => throw new NotSupportedException();
+        public void Dispose() => IsDisposed = true;
+    }
+
+    private class FakeImportedImage : IPlatformRenderInterfaceImportedImage
+    {
+        public TrackingBitmapImpl LastSnapshot { get; private set; } = null!;
+
+        private IBitmapImpl Snapshot() => LastSnapshot = new TrackingBitmapImpl();
+
+        public IBitmapImpl SnapshotWithKeyedMutex(uint acquireIndex, uint releaseIndex) => Snapshot();
+        public IBitmapImpl SnapshotWithSemaphores(
+            IPlatformRenderInterfaceImportedSemaphore waitForSemaphore,
+            IPlatformRenderInterfaceImportedSemaphore signalSemaphore) => Snapshot();
+        public IBitmapImpl SnapshotWithTimelineSemaphores(
+            IPlatformRenderInterfaceImportedSemaphore waitForSemaphore, ulong waitForValue,
+            IPlatformRenderInterfaceImportedSemaphore signalSemaphore, ulong signalValue) => Snapshot();
+        public IBitmapImpl SnapshotWithAutomaticSync() => Snapshot();
+        public void Dispose()
+        {
+        }
+    }
+
+    private class FakeExternalObjectsFeature : IExternalObjectsRenderInterfaceContextFeature
+    {
+        public FakeImportedImage Image { get; } = new();
+
+        public IReadOnlyList<string> SupportedImageHandleTypes => new[] { "Fake" };
+        public IReadOnlyList<string> SupportedSemaphoreTypes => Array.Empty<string>();
+        public byte[]? DeviceUuid => null;
+        public byte[]? DeviceLuid => null;
+
+        public IPlatformRenderInterfaceImportedImage ImportImage(IPlatformHandle handle,
+            PlatformGraphicsExternalImageProperties properties) => Image;
+
+        public IPlatformRenderInterfaceImportedImage ImportImage(ICompositionImportableSharedGpuContextImage image) =>
+            Image;
+
+        public IPlatformRenderInterfaceImportedSemaphore ImportSemaphore(IPlatformHandle handle) =>
+            throw new NotSupportedException();
+
+        public CompositionGpuImportedImageSynchronizationCapabilities GetSynchronizationCapabilities(
+            string imageHandleType) => CompositionGpuImportedImageSynchronizationCapabilities.Automatic;
+    }
+
+    [Fact]
+    public async Task Update_Processed_After_Dispose_Should_Dispose_Snapshot_Instead_Of_Orphaning_It()
+    {
+        // A commit batch is processed on the render thread in serialization order:
+        // the dispose list is written (and therefore processed) BEFORE queued server
+        // jobs. This means the perfectly legal user-code order
+        //     surface.UpdateAsync(image); surface.Dispose();
+        // executes on the render thread as Dispose() -> UpdateWithAutomaticSync().
+        // Without a disposed-guard, the update stores a fresh snapshot into the
+        // already-disposed surface. Nothing ever disposes that ref again, so the
+        // GPU-backed snapshot is left to the RefCountable.Ref<T> critical finalizer,
+        // which performs GPU work (context MakeCurrent + native SKImage dispose) on
+        // the finalizer thread and races the compositor render loop. See #21865.
+        using var services = new CompositorTestServices();
+        var compositor = services.Compositor;
+
+        var feature = new FakeExternalObjectsFeature();
+        var interop = new CompositionInterop(compositor, feature);
+        var imported = interop.ImportImage(
+            new PlatformHandle(new IntPtr(1), "Fake"),
+            new PlatformGraphicsExternalImageProperties { Width = 1, Height = 1 });
+
+        services.RunJobs();
+        Assert.True(((CompositionImportedGpuImage)imported).ImportCompleted.IsCompletedSuccessfully);
+
+        var surface = compositor.CreateDrawingSurface();
+
+        var update = surface.UpdateAsync(imported);
+        surface.Dispose();
+
+        services.RunJobs();
+        await update;
+
+        var snapshot = feature.Image.LastSnapshot;
+        Assert.NotNull(snapshot);
+        Assert.True(snapshot.IsDisposed,
+            "The snapshot taken by an update processed after the surface was disposed " +
+            "must be disposed on the render thread instead of being orphaned to the finalizer.");
+    }
+
+    [Fact]
+    public async Task Update_Before_Dispose_In_Separate_Batches_Should_Dispose_Snapshot_With_The_Surface()
+    {
+        // Baseline: when the update is processed in an earlier batch than the dispose,
+        // the surface's Dispose() releases the stored snapshot. This already works and
+        // must keep working with the disposed-guard in place.
+        using var services = new CompositorTestServices();
+        var compositor = services.Compositor;
+
+        var feature = new FakeExternalObjectsFeature();
+        var interop = new CompositionInterop(compositor, feature);
+        var imported = interop.ImportImage(
+            new PlatformHandle(new IntPtr(1), "Fake"),
+            new PlatformGraphicsExternalImageProperties { Width = 1, Height = 1 });
+
+        services.RunJobs();
+
+        var surface = compositor.CreateDrawingSurface();
+
+        var update = surface.UpdateAsync(imported);
+        services.RunJobs();
+        await update;
+
+        var snapshot = feature.Image.LastSnapshot;
+        Assert.NotNull(snapshot);
+        Assert.False(snapshot.IsDisposed);
+
+        surface.Dispose();
+        services.RunJobs();
+
+        Assert.True(snapshot.IsDisposed);
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Fixes `ServerCompositionDrawingSurface` orphaning GPU-backed snapshots when an update job is processed after the surface's disposal, which is the root cause of the native AV inside `sk_canvas_flush` reported in #21865.

## What is the root cause?

A commit batch is serialized (and therefore processed on the render thread) with the dispose list **before** queued server jobs. So the perfectly legal user-code order:

```csharp
surface.UpdateAsync(image); // e.g. a swapchain present
surface.Dispose();
```

executes on the render thread as `Dispose()` → `UpdateWithKeyedMutex/…()`. `Update()` has no disposed state, so it stores a **fresh snapshot ref into the already-disposed surface**. Nothing ever disposes that ref again. The GPU-backed `ImmutableBitmap` inside it is then released by the `RefCountable.Ref<T>` critical finalizer, whose dispose callback performs GPU work (`EglContext.MakeCurrent()` + native `SKImage` dispose) **on the .NET finalizer thread**, racing the compositor render loop mid-`Blit`/`sk_canvas_flush`.

This is not theoretical: in a production crash dump attached to #21865 (details in a follow-up comment there), the finalizer thread was captured exactly in `RefCountable.Ref<T>.Finalize() → ImmutableBitmap.Dispose() → GlSkiaImportedImage.<TakeSnapshot>b__0 → EglContext.MakeCurrent()` while the render thread died in `SurfaceRenderTarget.Blit → sk_canvas_flush`.

## What is the fix?

`ServerCompositionDrawingSurface` gets a `_disposed` flag. An `Update` processed after `Dispose` now disposes the fresh snapshot immediately on the render thread — where the GPU context is current — instead of orphaning it to the finalizer.

Per the contributing guide, the first commit adds the failing test (fails on current `main`: the snapshot is orphaned undisposed), the second commit fixes it. The test exercises the real commit/batch pipeline via `CompositorTestServices` with a fake external-objects feature, so the dispose-before-jobs ordering is demonstrated end-to-end, headlessly.

## Field validation

We ship a desktop app whose users hit this crash across a wide range of GPUs (RTX 4070 12GB through 128MB-VRAM Intel iGPUs — dumps for two distinct libSkiaSharp fault sites are attached to #21865). We have been running this exact fix (backported to 11.3.18) in our production build since 2026-07-28.

## Checklist

- [x] Added unit tests (failing-test-first commit structure)
- [x] Considered breaking changes: none — behavior only changes for updates processed after disposal, which previously leaked
- Fixed issues: root cause of #21865 (the companion consumer-side leak in HelixToolkit is being fixed separately in helix-toolkit)
