### PR TITLE
Fix Loaded event processing after a handler throws

### DIFF
--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -93,7 +93,7 @@ namespace Avalonia.Controls
 
         private static bool _isLoadedProcessing = false;
         private static readonly HashSet<Control> _loadedQueue = new HashSet<Control>();
-        private static readonly HashSet<Control> _loadedProcessingQueue = new HashSet<Control>();
+        private static readonly Queue<Control> _loadedProcessingQueue = new Queue<Control>();
 
         private LoadState _loadState = LoadState.Unloaded;
         private DataTemplates? _dataTemplates;
@@ -244,29 +244,38 @@ namespace Avalonia.Controls
         {
             // Copy the loaded queue for processing
             // There was a possibility of the "Collection was modified; enumeration operation may not execute."
-            // exception when only a single hash set was used. This could happen when new controls are added
-            // within the Loaded callback/event itself. To fix this, two hash sets are used and while one is
+            // exception when only a single collection was used. This could happen when new controls are added
+            // within the Loaded callback/event itself. To fix this, two collections are used and while one is
             // being processed the other accepts adding new controls to process next.
-            _loadedProcessingQueue.Clear();
             foreach (Control control in _loadedQueue)
             {
-                _loadedProcessingQueue.Add(control);
+                _loadedProcessingQueue.Enqueue(control);
             }
             _loadedQueue.Clear();
 
-            foreach (Control control in _loadedProcessingQueue)
+            try
             {
-                control.OnLoadedCore();
+                while (_loadedProcessingQueue.Count > 0)
+                {
+                    _loadedProcessingQueue.Dequeue().OnLoadedCore();
+                }
             }
-
-            _loadedProcessingQueue.Clear();
-            _isLoadedProcessing = false;
-
-            // Restart if any controls were added to the queue while processing
-            if (_loadedQueue.Count > 0)
+            finally
             {
-                _isLoadedProcessing = true;
-                Dispatcher.UIThread.Post(loadedProcessingAction!, DispatcherPriority.Loaded);
+                // An exception from OnLoadedCore (a Loaded handler or override) propagates to the
+                // dispatcher as usual, but the processing machinery must recover: controls left
+                // unprocessed are requeued and a new dispatcher job is posted for them, so a single
+                // faulty handler cannot stop Loaded from ever being raised again (see #18742).
+                _loadedQueue.UnionWith(_loadedProcessingQueue);
+                _loadedProcessingQueue.Clear();
+                _isLoadedProcessing = false;
+
+                // Restart if any controls were added to the queue while processing
+                if (_loadedQueue.Count > 0)
+                {
+                    _isLoadedProcessing = true;
+                    Dispatcher.UIThread.Post(loadedProcessingAction!, DispatcherPriority.Loaded);
+                }
             }
         };
 

--- a/tests/Avalonia.Controls.UnitTests/LoadedTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/LoadedTests.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Platform;
+﻿using System;
+using Avalonia.Platform;
 using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Moq;
@@ -70,6 +71,70 @@ public class LoadedTests : ScopedTestBase
             Assert.Equal(1, loadedCount);
             Assert.Equal(1, unloadedCount);
             Assert.False(target.IsLoaded);
+        }
+    }
+
+    [Fact]
+    public void Loaded_Exception_Does_Not_Prevent_Other_Controls_From_Loading()
+    {
+        // Some other tests are populating the queue and are not resetting the dispatcher, so we need to purge it
+        Control.ResetLoadedQueueForUnitTests();
+        using (UnitTestApplication.Start(TestServices.StyledWindow))
+        {
+            var window = new Window();
+            window.Show();
+            Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded, TestContext.Current.CancellationToken);
+
+            // Batch 1: a control whose Loaded handler throws, plus siblings queued in the same batch.
+            var throwing = new Button();
+            throwing.Loaded += (_, _) => throw new InvalidOperationException("Loaded handler failure");
+
+            var sibling1 = new Button();
+            var sibling2 = new Button();
+            int sibling1LoadedCount = 0, sibling2LoadedCount = 0;
+            sibling1.Loaded += (_, _) => sibling1LoadedCount++;
+            sibling2.Loaded += (_, _) => sibling2LoadedCount++;
+
+            window.Content = new StackPanel { Children = { sibling1, throwing, sibling2 } };
+
+            // The exception must surface (propagate to the dispatcher), not be swallowed.
+            PumpLoadedJobs(swallowedExceptionsAllowed: 1);
+
+            // Both siblings from the same batch must still have been loaded.
+            Assert.True(sibling1.IsLoaded);
+            Assert.True(sibling2.IsLoaded);
+            Assert.Equal(1, sibling1LoadedCount);
+            Assert.Equal(1, sibling2LoadedCount);
+
+            // Batch 2: controls loaded afterwards must still receive Loaded.
+            var later = new Button();
+            int laterLoadedCount = 0;
+            later.Loaded += (_, _) => laterLoadedCount++;
+            ((StackPanel)window.Content!).Children.Add(later);
+
+            PumpLoadedJobs(swallowedExceptionsAllowed: 0);
+
+            Assert.True(later.IsLoaded);
+            Assert.Equal(1, laterLoadedCount);
+        }
+    }
+
+    private static void PumpLoadedJobs(int swallowedExceptionsAllowed)
+    {
+        // A throwing Loaded handler propagates its exception out of the dispatcher job.
+        // Keep pumping so that any rescheduled loaded-processing jobs also run, but fail
+        // if more exceptions escape than the single expected one.
+        for (var i = 0; i <= swallowedExceptionsAllowed; i++)
+        {
+            try
+            {
+                Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded, TestContext.Current.CancellationToken);
+                return;
+            }
+            catch (InvalidOperationException) when (i < swallowedExceptionsAllowed)
+            {
+                // Expected exception from the throwing Loaded handler; continue pumping.
+            }
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?

Makes the `Loaded` event processing machinery recover when a `Loaded` handler (or `OnLoaded` override) throws, so a single faulty handler can no longer permanently stop `Loaded` from being raised for every control in the application.

## What is the current behavior?

`Control.loadedProcessingAction` iterates the pending controls with no exception handling. If any control's `Loaded` handler throws:

- the static `_isLoadedProcessing` flag stays `true` forever, and since `ScheduleOnLoadedCore` only posts a dispatcher job when that flag is `false`, no control created afterwards — app-wide — ever receives `Loaded`;
- the remaining controls in the same batch are skipped;
- the stuck static processing queue retains control references (leak).

## What is the updated/expected behavior with this PR?

The exception still propagates to the dispatcher as an unhandled exception (matching WPF semantics — it is not swallowed), but the machinery recovers: the controls queued after the faulty one receive `Loaded` on a re-posted dispatcher job, and controls loaded later work normally.

The new unit test `LoadedTests.Loaded_Exception_Does_Not_Prevent_Other_Controls_From_Loading` covers both cases (siblings in the same batch and a control loaded in a later batch). The first commit contains the failing test only, the second the fix.

## How was the solution implemented (if it's not obvious)?

The `_loadedProcessingQueue` snapshot is now a `Queue<Control>` drained with `Dequeue` before invoking `OnLoadedCore` (which must not run twice for the same control), so on an exception the queue holds exactly the unprocessed remainder. A `finally` block restores the invariant that `_isLoadedProcessing` is `true` only while a job is scheduled or running: it merges the remainder back into `_loadedQueue`, clears the processing queue, resets the flag and posts a new dispatcher job if work remains.

`try`/`finally` was chosen over catching per control so the exception surfaces unchanged instead of being swallowed or aggregated.

## Risks

Low. The change is confined to the static loaded-queue processing in `Control`; scheduling, deduplication and the detach failsafe are unchanged. Order of processing within a batch is now the queue's insertion order instead of `HashSet` enumeration order, which was never guaranteed.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes? Not applicable: no public API changed.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation. Not applicable: no user-facing API changed.

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Validation

- `dotnet build tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -p:AvsSkipBuildingLegacyTargetFrameworks=True` — 0 errors.
- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj --no-build -f net10.0 -- --filter-class Avalonia.Controls.UnitTests.LoadedTests` — the new test fails on the test-only commit (the sibling queued after the throwing control never loads), and all 4 `LoadedTests` pass with the fix.

## Fixed issues

Fixes #18742
