### PR TITLE
Disconnect template descendants hosted inside Viewbox when the template changes

### DIFF
--- a/src/Avalonia.Controls/Viewbox.cs
+++ b/src/Avalonia.Controls/Viewbox.cs
@@ -113,6 +113,20 @@ namespace Avalonia.Controls
 
                 InvalidateMeasure();
             }
+            else if (change.Property == TemplatedParentProperty)
+            {
+                // TemplatedControl teardown walks the visual tree via GetTemplateDescendants,
+                // which stops at visuals whose TemplatedParent is null. The container must carry
+                // the Viewbox's TemplatedParent so teardown can reach template descendants hosted
+                // inside it (e.g. a ContentPresenter) and disconnect them. Null is not forwarded:
+                // teardown clears the Viewbox's TemplatedParent while iterating, and forwarding it
+                // would prune the walk before it reaches the container's subtree; the walk clears
+                // the container's own TemplatedParent instead.
+                if (change.NewValue is AvaloniaObject templatedParent)
+                {
+                    _containerVisual.TemplatedParent = templatedParent;
+                }
+            }
         }
 
         /// <inheritdoc />

--- a/src/Avalonia.Controls/Viewbox.cs
+++ b/src/Avalonia.Controls/Viewbox.cs
@@ -115,13 +115,8 @@ namespace Avalonia.Controls
             }
             else if (change.Property == TemplatedParentProperty)
             {
-                // TemplatedControl teardown walks the visual tree via GetTemplateDescendants,
-                // which stops at visuals whose TemplatedParent is null. The container must carry
-                // the Viewbox's TemplatedParent so teardown can reach template descendants hosted
-                // inside it (e.g. a ContentPresenter) and disconnect them. Null is not forwarded:
-                // teardown clears the Viewbox's TemplatedParent while iterating, and forwarding it
-                // would prune the walk before it reaches the container's subtree; the walk clears
-                // the container's own TemplatedParent instead.
+                // Update _containerVisual.TemplateParent, otherwise its descendants aren't reachable
+                // during the template's teardown and incorrectly stay attached to the visual tree.
                 if (change.NewValue is AvaloniaObject templatedParent)
                 {
                     _containerVisual.TemplatedParent = templatedParent;

--- a/tests/Avalonia.Controls.UnitTests/ViewboxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ViewboxTests.cs
@@ -1,8 +1,11 @@
+using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Shapes;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.UnitTests;
+using Avalonia.VisualTree;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
@@ -228,6 +231,58 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal("foo", target.Child.DataContext);
         }
       
+        [Fact]
+        public void Content_Presented_In_Viewbox_Should_Be_Reparented_When_Template_Changes()
+        {
+            // Issue #9551: a template containing Viewbox > ContentPresenter presenting a control
+            // that outlives the template. Swapping the template must disconnect the presented
+            // control so the new template's presenter can adopt it.
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            static FuncControlTemplate CreateTemplate()
+            {
+                return new FuncControlTemplate<TestTemplatedControl>((_, _) => new Viewbox
+                {
+                    Child = new ContentPresenter
+                    {
+                        [~ContentPresenter.ContentProperty] = new TemplateBinding(TestTemplatedControl.MyControlProperty),
+                    },
+                });
+            }
+
+            var child = new Canvas();
+            var target = new TestTemplatedControl
+            {
+                MyControl = child,
+                Template = CreateTemplate(),
+            };
+
+            var root = new TestRoot(target);
+            root.ExecuteInitialLayoutPass();
+
+            var oldPresenter = Assert.IsType<ContentPresenter>(child.GetVisualParent());
+
+            target.Template = CreateTemplate();
+            target.ApplyTemplate();
+            root.LayoutManager.ExecuteLayoutPass();
+
+            var newPresenter = Assert.IsType<ContentPresenter>(child.GetVisualParent());
+            Assert.NotSame(oldPresenter, newPresenter);
+            Assert.Same(root, child.GetVisualRoot());
+        }
+
+        private class TestTemplatedControl : Avalonia.Controls.Primitives.TemplatedControl
+        {
+            public static readonly StyledProperty<Control?> MyControlProperty =
+                AvaloniaProperty.Register<TestTemplatedControl, Control?>(nameof(MyControl));
+
+            public Control? MyControl
+            {
+                get => GetValue(MyControlProperty);
+                set => SetValue(MyControlProperty, value);
+            }
+        }
+
         private static bool TryGetScale(Viewbox viewbox, out Vector scale)
         {
             if (viewbox.InternalTransform is null)


### PR DESCRIPTION
## What does the pull request do?

Fixes #9551: when a `ControlTemplate`/`ControlTheme` contains `Viewbox > ContentPresenter` presenting a control that outlives the template (e.g. FluentAvalonia's `NavigationView` presenting an `IconElement`), swapping the control's `Theme`/`Template` throws `InvalidOperationException: "The control already has a visual parent"`. Removing the `Viewbox` from the template makes the same scenario work.

## What is the current behavior?

`Viewbox` hosts its `Child` inside an internal `ViewboxContainer` visual, which is a visual child but not a logical child of the `Viewbox`. Template teardown in `TemplatedControl.ApplyTemplate` disconnects old template descendants via `GetTemplateDescendants`, a visual-tree walk that stops recursing at any visual whose `TemplatedParent` is null. `ViewboxContainer` never had a `TemplatedParent`, so the walk stopped at it and any template descendants hosted inside the `Viewbox` (such as a `ContentPresenter`) never had their `TemplatedParent` cleared.

As a result, the old `ContentPresenter`'s `{TemplateBinding}` stayed live, it kept the presented control as its visual child, and when the new template's presenter tried to adopt that control it threw "The control already has a visual parent". The stale template bindings also kept the discarded template subtree subscribed to the templated parent.

## What is the updated/expected behavior with this PR?

Swapping the theme/template of a control whose template contains `Viewbox > ContentPresenter` no longer throws; the presented control is disconnected from the old presenter and re-parented into the new template. To test, run the repro from #9551 and click the window to swap templates.

## How was the solution implemented (if it's not obvious)?

`Viewbox` now forwards its `TemplatedParent` to the internal `ViewboxContainer`, restoring the invariant `GetTemplateDescendants` relies on: every template descendant is reachable through visuals whose `TemplatedParent` is non-null. Null is deliberately not forwarded — teardown clears the Viewbox's `TemplatedParent` while lazily iterating the descendants, and forwarding null at that point would prune the walk before it reaches the container's subtree; the walk clears the container's own `TemplatedParent` itself instead.

Validation (macOS arm64, net10.0):

- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -p:AvsSkipBuildingLegacyTargetFrameworks=True -- --filter-class Avalonia.Controls.UnitTests.ViewboxTests` — new test `Content_Presented_In_Viewbox_Should_Be_Reparented_When_Template_Changes` fails before the fix with the issue's exact exception and passes after; 16/16 passed.
- Same command with `--filter-class` for `TemplatedControlTests`, `ContentControlTests`, `ContentPresenterTests_InTemplate`, `ContentPresenterTests_Standalone`, `ContentPresenterTests_Layout`, `ContentPresenterTests_Unrooted` — 113/113 passed.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None. The only observable side effect is that `GetTemplateDescendants`/`GetTemplateChildren` now also enumerate the internal `ViewboxContainer` for templates containing a `Viewbox`.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #9551
