### PR TITLE
Add regression test for AlwaysSelected removal of virtualized selected item

### DIFF
--- a/tests/Avalonia.Controls.UnitTests/ListBoxVirtualizationIssueTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxVirtualizationIssueTests.cs
@@ -36,6 +36,62 @@ public class ListBoxVirtualizationIssueTests : ScopedTestBase
         }
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Removing_Virtualized_Selected_Item_With_AlwaysSelected_Removes_Correct_Item(bool autoScrollToSelectedItem)
+    {
+        // Issue #16169: with SelectionMode=AlwaysSelected, the selected item's container is the
+        // TabOnceActiveElement, so the panel retains it when it is virtualized away. Removing the
+        // item then left the retained container mapped to index 0, so the wrong item visually
+        // disappeared and the removed item stayed shown and selected.
+        using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+        {
+            var items = new ObservableCollection<int>(Enumerable.Range(0, 100));
+            var target = new ListBox
+            {
+                Template = new FuncControlTemplate(CreateListBoxTemplate),
+                ItemsSource = items,
+                ItemTemplate = new FuncDataTemplate<int>((_, _) => new TextBlock { Height = 50 }),
+                ItemsPanel = new FuncTemplate<Panel?>(() => new VirtualizingStackPanel()),
+                SelectionMode = SelectionMode.AlwaysSelected,
+                AutoScrollToSelectedItem = autoScrollToSelectedItem,
+            };
+
+            Prepare(target);
+            target.UpdateLayout();
+
+            Assert.Equal(0, target.SelectedIndex);
+            Assert.Equal(0, target.SelectedItem);
+
+            // Scroll to the end so that the selected item's container is virtualized away.
+            target.ScrollIntoView(99);
+            target.UpdateLayout();
+
+            items.RemoveAt(0);
+            target.UpdateLayout();
+
+            // Selection must have moved to the next item.
+            Assert.Equal(0, target.SelectedIndex);
+            Assert.Equal(1, target.SelectedItem);
+
+            // Scroll back to the start: the removed item must be gone and the new first item
+            // must be shown and selected.
+            target.ScrollIntoView(0);
+            target.UpdateLayout();
+
+            var firstContainer = Assert.IsType<ListBoxItem>(target.ContainerFromIndex(0));
+            Assert.Equal(1, firstContainer.Content);
+            Assert.True(firstContainer.IsSelected);
+
+            // Every realized container must display the item at its own index.
+            foreach (var container in target.GetRealizedContainers().Cast<ListBoxItem>())
+            {
+                Assert.Equal(items[target.IndexFromContainer(container)], container.Content);
+            }
+        }
+    }
+
     [Fact]
     public void Replaced_ItemsSource_Should_Not_Show_Old_Selected_Item_When_Scrolled_Back()
     {


### PR DESCRIPTION
## What does the pull request do?

Adds a regression test for #16169 (ListBox with `SelectionMode=AlwaysSelected`: removing the selected item while its container is virtualized away removed the wrong item visually and kept the removed item selected).

While reproducing the issue it turned out the underlying bug was already fixed on `main` by the ghost-item fixes #20700 and #20784: `VirtualizingStackPanel.UpdateSpecialElementsOnItemsChanged` now recycles the retained focused/anchor container when its item is removed. No existing test covered the `AlwaysSelected` scenario from the issue, so this PR pins it with a test so the issue can be closed.

## What is the current behavior?

On current `main` the behavior is already correct. Before #20700/#20784 (verified by running this test at commit d22683f4eb, the parent of #20700's merge commit, where it fails):

1. With `AlwaysSelected`, the selected item's container is the `TabOnceActiveElement`, so `VirtualizingStackPanel` retained it as its focused element when scrolled out of view.
2. Removing that item did not recycle the retained container or adjust its stale index, so index 0 stayed mapped to the removed item's container.
3. After scrolling back to the top, `ContainerFromIndex(0)` returned the removed item's container: the removed item was still shown and selected, and the next item appeared to have been removed instead.

## What is the updated/expected behavior with this PR?

`ListBoxVirtualizationIssueTests.Removing_Virtualized_Selected_Item_With_AlwaysSelected_Removes_Correct_Item` (theory, `AutoScrollToSelectedItem` true/false) asserts that after removing the virtualized selected item:

- `SelectedIndex`/`SelectedItem` move to the next item,
- the container at index 0 shows the next item and is selected,
- every realized container displays the item at its own index.

## How was the solution implemented (if it's not obvious)?

Test only, no product code change. Validation:

- `dotnet run --project tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj -p:AvsSkipBuildingLegacyTargetFrameworks=True -- --filter-class "*ListBoxVirtualizationIssueTests*"` — 8 passed (6 existing + 2 new).
- Same test run at pre-fix commit d22683f4eb — both theory cases fail with `Expected: 1, Actual: 0` for the content of the container at index 0 (the removed item still shown), confirming the test pins the issue.
- Regression sweep: `--filter-class "*VirtualizingStackPanelTests*"` (130 passed), `"*SelectingItemsControlTests*"` (537 passed), `"*ListBoxTests*"` (74 passed).

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #16169
