### PR TITLE
Implement a copy-on-write list for VisualChildren/LogicalChildren

### DIFF
--- a/src/Avalonia.Base/Collections/AvaloniaList.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaList.cs
@@ -49,7 +49,7 @@ namespace Avalonia.Collections
     /// </remarks>
     public class AvaloniaList<T> : IAvaloniaList<T>, IList, INotifyCollectionChangedDebug
     {
-        private readonly List<T> _inner;
+        private List<T> _inner;
         private NotifyCollectionChangedEventHandler? _collectionChanged;
 
         /// <summary>
@@ -144,6 +144,16 @@ namespace Avalonia.Collections
 
         internal IAvaloniaListItemValidator<T>? Validator { get; set; }
 
+        private protected List<T> Inner
+        {
+            get => _inner;
+            set => _inner = value;
+        }
+
+        private protected virtual void OnMutating()
+        {
+        }
+
         /// <inheritdoc/>
         bool IList.IsFixedSize => false;
 
@@ -182,6 +192,7 @@ namespace Avalonia.Collections
 
                 if (!EqualityComparer<T>.Default.Equals(old, value))
                 {
+                    OnMutating();
                     _inner[index] = value;
 
                     if (_collectionChanged != null)
@@ -224,6 +235,9 @@ namespace Avalonia.Collections
         public virtual void Add(T item)
         {
             Validator?.Validate(item);
+
+            OnMutating();
+
             int index = _inner.Count;
             _inner.Add(item);
             NotifyAdd(item, index);
@@ -242,6 +256,8 @@ namespace Avalonia.Collections
         {
             if (Count > 0)
             {
+                OnMutating();
+
                 if (_collectionChanged != null)
                 {
                     var e = ResetBehavior == ResetBehavior.Reset ?
@@ -331,6 +347,9 @@ namespace Avalonia.Collections
         public virtual void Insert(int index, T item)
         {
             Validator?.Validate(item);
+
+            OnMutating();
+
             _inner.Insert(index, item);
             NotifyAdd(item, index);
         }
@@ -351,6 +370,8 @@ namespace Avalonia.Collections
             {
                 if (list.Count > 0)
                 {
+                    OnMutating();
+
                     if (list is ICollection<T> collection)
                     {
                         if (hasValidation)
@@ -395,6 +416,8 @@ namespace Avalonia.Collections
                 {
                     if (en.MoveNext())
                     {
+                        OnMutating();
+
                         // Avoid allocating list for collection notification if there is no event subscriptions.
                         List<T>? notificationItems = willRaiseCollectionChanged ?
                             new List<T>() :
@@ -438,6 +461,9 @@ namespace Avalonia.Collections
         public void Move(int oldIndex, int newIndex)
         {
             var item = this[oldIndex];
+
+            OnMutating();
+
             _inner.RemoveAt(oldIndex);
             _inner.Insert(newIndex, item);
 
@@ -462,6 +488,9 @@ namespace Avalonia.Collections
         {
             var items = _inner.GetRange(oldIndex, count);
             var modifiedNewIndex = newIndex;
+
+            OnMutating();
+
             _inner.RemoveRange(oldIndex, count);
 
             if (newIndex > oldIndex)
@@ -515,6 +544,7 @@ namespace Avalonia.Collections
 
             if (index != -1)
             {
+                OnMutating();
                 _inner.RemoveAt(index);
                 NotifyRemove(item , index);
                 return true;
@@ -558,6 +588,7 @@ namespace Avalonia.Collections
         public virtual void RemoveAt(int index)
         {
             T item = _inner[index];
+            OnMutating();
             _inner.RemoveAt(index);
             NotifyRemove(item , index);
         }
@@ -572,6 +603,7 @@ namespace Avalonia.Collections
             if (count > 0)
             {
                 var list = _inner.GetRange(index, count);
+                OnMutating();
                 _inner.RemoveRange(index, count);
                 NotifyRemove(list, index);
             }

--- a/src/Avalonia.Base/Input/FocusHelpers.cs
+++ b/src/Avalonia.Base/Input/FocusHelpers.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Input
             // TODO: add control overrides to return custom focus list from control
             if (parent is Visual visual)
             {
-                return visual.VisualChildren.OfType<IInputElement>();
+                return visual.TypedVisualChildren.OfType<IInputElement>();
             }
 
             return Array.Empty<IInputElement>();

--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -1044,17 +1044,12 @@ namespace Avalonia.Input
         {
             IsEffectivelyEnabled = IsEnabledCore && (parent?.IsEffectivelyEnabled ?? true);
 
-            // PERF-SENSITIVE: This is called on entire hierarchy and using foreach or LINQ
+            // PERF-SENSITIVE: This is called on entire hierarchy and using LINQ
             // will cause extra allocations and overhead.
 
-            var children = VisualChildren;
-
-            // ReSharper disable once ForCanBeConvertedToForeach
-            for (int i = 0; i < children.Count; ++i)
+            foreach (var child in TypedVisualChildren)
             {
-                var child = children[i] as InputElement;
-
-                child?.UpdateIsEffectivelyEnabled(this);
+                (child as InputElement)?.UpdateIsEffectivelyEnabled(this);
             }
         }
 

--- a/src/Avalonia.Base/Input/KeyboardDevice.cs
+++ b/src/Avalonia.Base/Input/KeyboardDevice.cs
@@ -46,7 +46,7 @@ namespace Avalonia.Input
         {
             if (element is Visual v)
             {
-                foreach (var visual in v.VisualChildren)
+                foreach (var visual in v.TypedVisualChildren)
                 {
                     if (visual is IInputElement el && el.IsKeyboardFocusWithin)
                     {
@@ -112,7 +112,7 @@ namespace Avalonia.Input
         {
             if (element is Visual v)
             {
-                foreach (var visual in v.VisualChildren)
+                foreach (var visual in v.TypedVisualChildren)
                 {
                     if (visual is IInputElement el && el.IsKeyboardFocusWithin)
                     {

--- a/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
+++ b/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
@@ -169,7 +169,7 @@ namespace Avalonia.Input
         {
             if (element is Visual v)
             {
-                foreach (var el in v.VisualChildren)
+                foreach (var el in v.TypedVisualChildren)
                 {
                     if (el is IInputElement { IsPointerOver: true } child)
                     {

--- a/src/Avalonia.Base/Layout/LayoutHelper.cs
+++ b/src/Avalonia.Base/Layout/LayoutHelper.cs
@@ -120,13 +120,8 @@ namespace Avalonia.Layout
                     targetLayoutable.InvalidateMeasure();
                 }
 
-                var visualChildren = target.VisualChildren;
-                var visualChildrenCount = visualChildren.Count;
-
-                for (int i = 0; i < visualChildrenCount; i++)
+                foreach (var child in target.TypedVisualChildren)
                 {
-                    Visual child = visualChildren[i];
-
                     InnerInvalidateMeasure(child);
                 }
             }

--- a/src/Avalonia.Base/Layout/Layoutable.cs
+++ b/src/Avalonia.Base/Layout/Layoutable.cs
@@ -635,13 +635,8 @@ namespace Avalonia.Layout
             double width = 0;
             double height = 0;
 
-            var visualChildren = VisualChildren;
-            var visualCount = visualChildren.Count;
-
-            for (var i = 0; i < visualCount; i++)
+            foreach (var visual in TypedVisualChildren)
             {
-                Visual visual = visualChildren[i];
-
                 if (visual is Layoutable layoutable)
                 {
                     layoutable.Measure(availableSize);
@@ -761,13 +756,8 @@ namespace Avalonia.Layout
         {
             var arrangeRect = new Rect(finalSize);
 
-            var visualChildren = VisualChildren;
-            var visualCount = visualChildren.Count;
-
-            for (var i = 0; i < visualCount; i++)
+            foreach (var visual in TypedVisualChildren)
             {
-                Visual visual = visualChildren[i];
-
                 if (visual is Layoutable layoutable)
                 {
                     layoutable.Arrange(arrangeRect);
@@ -857,11 +847,9 @@ namespace Avalonia.Layout
                     // property then we can piggy-pack on that; for the moment we do this manually.
                     if (this.GetLayoutRoot() is {} layoutRoot)
                     {
-                        var count = VisualChildren.Count;
-
-                        for (var i = 0; i < count; ++i)
+                        foreach (var child in TypedVisualChildren)
                         {
-                            (VisualChildren[i] as Layoutable)?.AncestorBecameVisible(layoutRoot.LayoutManager);
+                            (child as Layoutable)?.AncestorBecameVisible(layoutRoot.LayoutManager);
                         }
                     }
                 }
@@ -904,11 +892,9 @@ namespace Avalonia.Layout
                 InvalidateVisual();
             }
 
-            var count = VisualChildren.Count;
-
-            for (var i = 0; i < count; ++i)
+            foreach (var child in TypedVisualChildren)
             {
-                (VisualChildren[i] as Layoutable)?.AncestorBecameVisible(layoutManager);
+                (child as Layoutable)?.AncestorBecameVisible(layoutManager);
             }
         }
 

--- a/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
@@ -75,8 +75,8 @@ internal class ImmediateRenderer
             }
 
             IEnumerable<Visual> childrenEnumerable = visual.HasNonUniformZIndexChildren
-                ? visual.VisualChildren.OrderBy(x => x, ZIndexComparer.Instance)
-                : visual.VisualChildren;
+                ? visual.TypedVisualChildren.OrderBy(x => x, ZIndexComparer.Instance)
+                : visual.TypedVisualChildren;
 
             if (visual.ClipToBounds)
             {

--- a/src/Avalonia.Base/StyledElement.cs
+++ b/src/Avalonia.Base/StyledElement.cs
@@ -14,6 +14,7 @@ using Avalonia.Logging;
 using Avalonia.LogicalTree;
 using Avalonia.PropertyStore;
 using Avalonia.Styling;
+using Avalonia.Utilities;
 
 namespace Avalonia
 {
@@ -81,7 +82,7 @@ namespace Avalonia
         private string? _name;
         private Classes? _classes;
         private ILogicalRoot? _logicalRoot;
-        private AvaloniaList<ILogical>? _logicalChildren;
+        private SafeEnumerableAvaloniaList<ILogical>? _logicalChildren;
         private IResourceDictionary? _resources;
         private Styles? _styles;
         private bool _stylesApplied;
@@ -259,15 +260,15 @@ namespace Avalonia
         }
 
         /// <summary>
-        /// Gets the styled element's logical children.
+        /// Gets the styled element's logical children, strongly-typed, to avoid interface calls and enumerator boxing.
         /// </summary>
-        protected internal IAvaloniaList<ILogical> LogicalChildren
+        internal SafeEnumerableAvaloniaList<ILogical> TypedLogicalChildren
         {
             get
             {
                 if (_logicalChildren == null)
                 {
-                    var list = new AvaloniaList<ILogical>
+                    var list = new SafeEnumerableAvaloniaList<ILogical>
                     {
                         ResetBehavior = ResetBehavior.Remove,
                         Validator = this
@@ -279,6 +280,11 @@ namespace Avalonia
                 return _logicalChildren;
             }
         }
+
+        /// <summary>
+        /// Gets the styled element's logical children.
+        /// </summary>
+        protected internal IAvaloniaList<ILogical> LogicalChildren => TypedLogicalChildren;
 
         /// <summary>
         /// Gets the <see cref="Classes"/> collection in a form that allows adding and removing
@@ -320,7 +326,7 @@ namespace Avalonia
         /// <summary>
         /// Gets the styled element's logical children.
         /// </summary>
-        IAvaloniaReadOnlyList<ILogical> ILogical.LogicalChildren => LogicalChildren;
+        IAvaloniaReadOnlyList<ILogical> ILogical.LogicalChildren => TypedLogicalChildren;
 
         /// <inheritdoc/>
         bool IResourceNode.HasResources => (_resources?.HasResources ?? false) ||
@@ -541,17 +547,10 @@ namespace Avalonia
         /// <param name="e">The change token.</param>
         internal virtual void NotifyChildResourcesChanged(ResourcesChangedEventArgs e)
         {
-            if (_logicalChildren is object)
+            if (_logicalChildren is not null)
             {
-                var count = _logicalChildren.Count;
-
-                if (count > 0)
-                {
-                    for (var i = 0; i < count; ++i)
-                    {
-                        _logicalChildren[i].NotifyResourcesChanged(e);
-                    }
-                }
+                foreach (var child in _logicalChildren)
+                    child.NotifyResourcesChanged(e);
             }
         }
 
@@ -712,12 +711,9 @@ namespace Avalonia
                     element._dataContextUpdating = true;
                     element.OnDataContextBeginUpdate();
 
-                    var logicalChildren = element.LogicalChildren;
-                    var logicalChildrenCount = logicalChildren.Count;
-
-                    for (var i = 0; i < logicalChildrenCount; i++)
+                    foreach (var child in element.TypedLogicalChildren)
                     {
-                        if (element.LogicalChildren[i] is StyledElement s &&
+                        if (child is StyledElement s &&
                             s.InheritanceParent == element &&
                             !s.IsSet(DataContextProperty))
                         {
@@ -871,12 +867,9 @@ namespace Avalonia
                 AttachedToLogicalTree?.Invoke(this, e);
             }
 
-            var logicalChildren = LogicalChildren;
-            var logicalChildrenCount = logicalChildren.Count;
-
-            for (var i = 0; i < logicalChildrenCount; i++)
+            foreach (var logicalChild in TypedLogicalChildren)
             {
-                if (logicalChildren[i] is StyledElement child && child._logicalRoot != e.Root) // child may already have been attached within an event handler
+                if (logicalChild is StyledElement child && child._logicalRoot != e.Root) // child may already have been attached within an event handler
                 {
                     child.OnAttachedToLogicalTreeCore(e);
                 }
@@ -892,12 +885,9 @@ namespace Avalonia
                 OnDetachedFromLogicalTree(e);
                 DetachedFromLogicalTree?.Invoke(this, e);
 
-                var logicalChildren = LogicalChildren;
-                var logicalChildrenCount = logicalChildren.Count;
-
-                for (var i = 0; i < logicalChildrenCount; i++)
+                foreach (var logicalChild in TypedLogicalChildren)
                 {
-                    if (logicalChildren[i] is StyledElement child)
+                    if (logicalChild is StyledElement child)
                     {
                         child.OnDetachedFromLogicalTreeCore(e);
                     }
@@ -959,12 +949,8 @@ namespace Avalonia
 
             if (_logicalChildren is not null)
             {
-                var childCount = _logicalChildren.Count;
-
-                for (var i = 0; i < childCount; ++i)
-                {
-                    (_logicalChildren[i] as StyledElement)?.DetachStyles(styles);
-                }
+                foreach (var child in _logicalChildren)
+                    (child as StyledElement)?.DetachStyles(styles);
             }
         }
 

--- a/src/Avalonia.Base/StyledElement.cs
+++ b/src/Avalonia.Base/StyledElement.cs
@@ -93,6 +93,10 @@ namespace Avalonia
         private ControlTheme? _implicitTheme;
         private ResourcesChangedEventArgs _lastResourcesChangedEventArgs;
 
+        // True when this element has been removed from a logical children collection and not added back since:
+        // This flag avoids a costly quadratic LogicalChildren.Contains call in OnAttachedToLogicalTreeCore.
+        private bool _removedFromLogicalParent;
+
         /// <summary>
         /// Initializes static members of the <see cref="StyledElement"/> class.
         /// </summary>
@@ -869,7 +873,10 @@ namespace Avalonia
 
             foreach (var logicalChild in TypedLogicalChildren)
             {
-                if (logicalChild is StyledElement child && child._logicalRoot != e.Root) // child may already have been attached within an event handler
+                // An event handler may have modified the children while we're enumerating a snapshot of the collection.
+                if (logicalChild is StyledElement child &&
+                    child._logicalRoot != e.Root &&
+                    (child.Parent is not null || !child._removedFromLogicalParent))
                 {
                     child.OnAttachedToLogicalTreeCore(e);
                 }
@@ -917,7 +924,12 @@ namespace Avalonia
             for (var i = 0; i < count; i++)
             {
                 var logical = (ILogical) children[i]!;
-                
+
+                if (logical is StyledElement styledElement)
+                {
+                    styledElement._removedFromLogicalParent = false;
+                }
+
                 if (logical.LogicalParent is null)
                 {
                     ((ISetLogicalParent)logical).SetParent(this);
@@ -932,7 +944,12 @@ namespace Avalonia
             for (var i = 0; i < count; i++)
             {
                 var logical = (ILogical) children[i]!;
-                
+
+                if (logical is StyledElement styledElement)
+                {
+                    styledElement._removedFromLogicalParent = true;
+                }
+
                 if (logical.LogicalParent == this)
                 {
                     ((ISetLogicalParent)logical).SetParent(null);

--- a/src/Avalonia.Base/Utilities/SafeEnumerableAvaloniaList.cs
+++ b/src/Avalonia.Base/Utilities/SafeEnumerableAvaloniaList.cs
@@ -1,0 +1,80 @@
+using System.Collections;
+using System.Collections.Generic;
+using Avalonia.Collections;
+
+namespace Avalonia.Utilities;
+
+/// <summary>
+/// An <see cref="AvaloniaList{T}"/> which can be mutated while it's being enumerated.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When the list is mutated while one or more enumerations are in progress, the inner list is first copied and the
+/// mutation is applied to the copy: active enumerators continue iterating over the snapshot taken when they were created.
+/// Mutations made while no enumerator is active are applied in place, at no extra cost.
+/// </para>
+/// <para>
+/// Warning! Enumerating an instance statically typed as <see cref="AvaloniaList{T}"/> uses the base,
+/// non-snapshotting enumerator: expose instances of this type as <see cref="SafeEnumerableAvaloniaList{T}"/> or
+/// <see cref="IAvaloniaList{T}"/>.
+/// </para>
+/// </remarks>
+internal sealed class SafeEnumerableAvaloniaList<T> : AvaloniaList<T>, IEnumerable<T>
+{
+    private int _generation;
+    private int _enumCount;
+
+    /// <summary>
+    /// For unit tests only!
+    /// </summary>
+    internal List<T> InnerForTests => Inner;
+
+    private protected override void OnMutating()
+    {
+        if (_enumCount > 0)
+        {
+            Inner = new List<T>(Inner);
+            ++_generation;
+            _enumCount = 0;
+        }
+    }
+
+    public new Enumerator GetEnumerator() => new(this);
+
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public new struct Enumerator : IEnumerator<T>
+    {
+        private readonly SafeEnumerableAvaloniaList<T> _owner;
+        private readonly int _generation;
+        private List<T>.Enumerator _innerEnumerator;
+
+        internal Enumerator(SafeEnumerableAvaloniaList<T> owner)
+        {
+            _owner = owner;
+            _generation = owner._generation;
+            ++owner._enumCount;
+            _innerEnumerator = owner.Inner.GetEnumerator();
+        }
+
+        public bool MoveNext()
+            => _innerEnumerator.MoveNext();
+
+        public T Current
+            => _innerEnumerator.Current;
+
+        object? IEnumerator.Current
+            => Current;
+
+        void IEnumerator.Reset()
+            => ((IEnumerator)_innerEnumerator).Reset();
+
+        public void Dispose()
+        {
+            if (_generation == _owner._generation)
+                --_owner._enumCount;
+        }
+    }
+}

--- a/src/Avalonia.Base/Visual.Composition.cs
+++ b/src/Avalonia.Base/Visual.Composition.cs
@@ -45,7 +45,7 @@ public partial class Visual
         if(CompositionVisual == null)
             return;
         var compositionChildren = CompositionVisual.Children;
-        var visualChildren = (AvaloniaList<Visual>)VisualChildren;
+        var visualChildren = TypedVisualChildren;
         
         PooledList<(Visual visual, int index)>? sortedChildren = null;
         if (HasNonUniformZIndexChildren && visualChildren.Count > 1)

--- a/src/Avalonia.Base/Visual.cs
+++ b/src/Avalonia.Base/Visual.cs
@@ -561,7 +561,9 @@ namespace Avalonia
 
             foreach (var child in TypedVisualChildren)
             {
-                if (child.PresentationSource != e.PresentationSource) // child may already have been attached within an event handler
+                // An event handler may have modified the children: skip a child which has already been attached, or
+                // which has been removed from this visual (we're enumerating a snapshot of the collection).
+                if (child.PresentationSource != e.PresentationSource && child.VisualParent == this)
                 {
                     child.OnAttachedToVisualTreeCore(e);
                 }
@@ -596,7 +598,12 @@ namespace Avalonia
 
             foreach (var child in TypedVisualChildren)
             {
-                child.OnDetachedFromVisualTreeCore(e);
+                // A child removed within an event handler has already been detached by the removal itself:
+                // don't detach it a second time (we're enumerating a snapshot of the collection).
+                if (child.PresentationSource is not null)
+                {
+                    child.OnDetachedFromVisualTreeCore(e);
+                }
             }
         }
 

--- a/src/Avalonia.Base/Visual.cs
+++ b/src/Avalonia.Base/Visual.cs
@@ -159,11 +159,11 @@ namespace Avalonia
             // Disable transitions until we're added to the visual tree.
             DisableTransitions();
 
-            var visualChildren = new AvaloniaList<Visual>();
+            var visualChildren = new SafeEnumerableAvaloniaList<Visual>();
             visualChildren.ResetBehavior = ResetBehavior.Remove;
             visualChildren.Validator = this;
             visualChildren.CollectionChanged += VisualChildrenChanged;
-            VisualChildren = visualChildren;
+            TypedVisualChildren = visualChildren;
         }
 
         /// <summary>
@@ -228,15 +228,11 @@ namespace Avalonia
             IsEffectivelyVisible = isEffectivelyVisible;
             IsEffectivelyVisibleChanged?.Invoke(this, EventArgs.Empty);
 
-            // PERF-SENSITIVE: This is called on entire hierarchy and using foreach or LINQ
+            // PERF-SENSITIVE: This is called on entire hierarchy and using LINQ
             // will cause extra allocations and overhead.
 
-            var children = VisualChildren;
-
-            // ReSharper disable once ForCanBeConvertedToForeach
-            for (int i = 0; i < children.Count; ++i)
+            foreach (var child in TypedVisualChildren)
             {
-                var child = children[i];
                 child.UpdateIsEffectivelyVisible(isEffectivelyVisible);
             }
         }
@@ -338,9 +334,11 @@ namespace Avalonia
         }
 
         /// <summary>
-        /// Gets the control's child visuals.
+        /// /// Gets the control's child visuals, strongly-typed, to avoid interface calls and enumerator boxing.
         /// </summary>
-        protected internal IAvaloniaList<Visual> VisualChildren { get; }
+        internal SafeEnumerableAvaloniaList<Visual> TypedVisualChildren { get; }
+
+        protected internal IAvaloniaList<Visual> VisualChildren => TypedVisualChildren;
 
         /// <summary>
         /// Gets the root of the visual tree, if the control is attached to a visual tree.
@@ -512,7 +510,7 @@ namespace Avalonia
             {
                 InvalidateMirrorTransform();
 
-                foreach (var child in VisualChildren)
+                foreach (var child in TypedVisualChildren)
                 {
                     child.InvalidateMirrorTransform();
                 }
@@ -561,12 +559,9 @@ namespace Avalonia
                     _visualParent.HasNonUniformZIndexChildren = true;
             }
 
-            var visualChildren = VisualChildren;
-            var visualChildrenCount = visualChildren.Count;
-
-            for (var i = 0; i < visualChildrenCount; i++)
+            foreach (var child in TypedVisualChildren)
             {
-                if (visualChildren[i] is { } child && child.PresentationSource != e.PresentationSource) // child may already have been attached within an event handler
+                if (child.PresentationSource != e.PresentationSource) // child may already have been attached within an event handler
                 {
                     child.OnAttachedToVisualTreeCore(e);
                 }
@@ -599,15 +594,9 @@ namespace Avalonia
             
             PresentationSource = null;
 
-            var visualChildren = VisualChildren;
-            var visualChildrenCount = visualChildren.Count;
-
-            for (var i = 0; i < visualChildrenCount; i++)
+            foreach (var child in TypedVisualChildren)
             {
-                if (visualChildren[i] is { } child)
-                {
-                    child.OnDetachedFromVisualTreeCore(e);
-                }
+                child.OnDetachedFromVisualTreeCore(e);
             }
         }
 
@@ -777,12 +766,11 @@ namespace Avalonia
         {
             base.OnTemplatedParentControlThemeChanged();
 
-            var count = VisualChildren.Count;
             var templatedParent = TemplatedParent;
 
-            for (var i = 0; i < count; ++i)
+            foreach (var visualChild in TypedVisualChildren)
             {
-                if (VisualChildren[i] is StyledElement child &&
+                if (visualChild is StyledElement child &&
                     child.TemplatedParent == templatedParent)
                 {
                     child.OnTemplatedParentControlThemeChanged();

--- a/src/Avalonia.Base/VisualTree/VisualExtensions.cs
+++ b/src/Avalonia.Base/VisualTree/VisualExtensions.cs
@@ -391,7 +391,7 @@ namespace Avalonia.VisualTree
         /// <returns>The visual children.</returns>
         public static IEnumerable<Visual> GetVisualChildren(this Visual visual)
         {
-            return visual.VisualChildren;
+            return visual.TypedVisualChildren;
         }
 
         /// <summary>
@@ -401,7 +401,7 @@ namespace Avalonia.VisualTree
         /// <returns>The visual's ancestors.</returns>
         public static IEnumerable<Visual> GetVisualDescendants(this Visual visual)
         {
-            foreach (Visual child in visual.VisualChildren)
+            foreach (Visual child in visual.TypedVisualChildren)
             {
                 yield return child;
 
@@ -517,13 +517,8 @@ namespace Avalonia.VisualTree
 
         private static T? FindDescendantOfTypeCore<T>(Visual visual, Predicate<T>? predicate) where T : class
         {
-            var visualChildren = visual.VisualChildren;
-            var visualChildrenCount = visualChildren.Count;
-
-            for (var i = 0; i < visualChildrenCount; i++)
+            foreach (var child in visual.TypedVisualChildren)
             {
-                Visual child = visualChildren[i];
-
                 if (child is T result)
                 {
                     if (predicate == null || predicate(result))

--- a/tests/Avalonia.Base.UnitTests/Styling/StyledElementTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/StyledElementTests.cs
@@ -230,6 +230,87 @@ namespace Avalonia.Base.UnitTests.Styling
         }
 
         [Fact]
+        public void LogicalChildren_Can_Be_Added_During_AttachedToLogicalTree()
+        {
+            var root = new TestRoot();
+            var parent = new StyledElement();
+            var child1 = new StyledElement();
+            var child2 = new StyledElement();
+
+            parent.LogicalChildren.Add(child1);
+
+            child1.AttachedToLogicalTree += (_, _) => parent.LogicalChildren.Add(child2);
+
+            root.LogicalChildren.Add(parent);
+
+            Assert.Equal([child1, child2], parent.LogicalChildren);
+            Assert.True(((ILogical)child1).IsAttachedToLogicalTree);
+            Assert.True(((ILogical)child2).IsAttachedToLogicalTree);
+        }
+
+        [Fact]
+        public void LogicalChildren_Can_Be_Removed_During_AttachedToLogicalTree()
+        {
+            var root = new TestRoot();
+            var parent = new StyledElement();
+            var child1 = new StyledElement();
+            var child2 = new StyledElement();
+
+            parent.LogicalChildren.AddRange([child1, child2]);
+
+            child1.AttachedToLogicalTree += (_, _) => parent.LogicalChildren.Remove(child2);
+
+            root.LogicalChildren.Add(parent);
+
+            Assert.Equal([child1], parent.LogicalChildren);
+            Assert.True(((ILogical)child1).IsAttachedToLogicalTree);
+            Assert.False(((ILogical)child2).IsAttachedToLogicalTree);
+        }
+
+        [Fact]
+        public void LogicalChildren_Can_Be_Added_During_DetachedFromLogicalTree()
+        {
+            var root = new TestRoot();
+            var parent = new StyledElement();
+            var child1 = new StyledElement();
+            var child2 = new StyledElement();
+
+            parent.LogicalChildren.Add(child1);
+            root.LogicalChildren.Add(parent);
+
+            child1.DetachedFromLogicalTree += (_, _) => parent.LogicalChildren.Add(child2);
+
+            root.LogicalChildren.Remove(parent);
+
+            Assert.Equal([child1, child2], parent.LogicalChildren);
+            Assert.False(((ILogical)child1).IsAttachedToLogicalTree);
+            Assert.False(((ILogical)child2).IsAttachedToLogicalTree);
+        }
+
+        [Fact]
+        public void LogicalChildren_Can_Be_Removed_During_DetachedFromLogicalTree()
+        {
+            var root = new TestRoot();
+            var parent = new StyledElement();
+            var child1 = new StyledElement();
+            var child2 = new StyledElement();
+            var child2Detached = 0;
+
+            parent.LogicalChildren.AddRange([child1, child2]);
+            root.LogicalChildren.Add(parent);
+
+            child1.DetachedFromLogicalTree += (_, _) => parent.LogicalChildren.Remove(child2);
+            child2.DetachedFromLogicalTree += (_, _) => ++child2Detached;
+
+            root.LogicalChildren.Remove(parent);
+
+            Assert.Equal([child1], parent.LogicalChildren);
+            Assert.False(((ILogical)child1).IsAttachedToLogicalTree);
+            Assert.False(((ILogical)child2).IsAttachedToLogicalTree);
+            Assert.Equal(1, child2Detached);
+        }
+
+        [Fact]
         public void Parent_Should_Be_Null_When_DetachedFromLogicalTree_Called()
         {
             var target = new TestControl();

--- a/tests/Avalonia.Base.UnitTests/Utilities/SafeEnumerableAvaloniaListTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Utilities/SafeEnumerableAvaloniaListTests.cs
@@ -1,0 +1,212 @@
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using Avalonia.Utilities;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Utilities;
+
+public class SafeEnumerableAvaloniaListTests
+{
+    [Fact]
+    public void List_Is_Not_Copied_Outside_Enumeration()
+    {
+        var target = new SafeEnumerableAvaloniaList<string>();
+        var inner = target.InnerForTests;
+
+        target.Add("foo");
+        target.Add("bar");
+        target.Remove("foo");
+        target.Insert(0, "baz");
+        target[0] = "qux";
+        target.Move(0, 1);
+        target.Clear();
+
+        Assert.Same(inner, target.InnerForTests);
+    }
+
+    [Fact]
+    public void List_Is_Copied_When_Mutated_During_Enumeration()
+    {
+        var target = new SafeEnumerableAvaloniaList<string>();
+        var inner = target.InnerForTests;
+
+        target.Add("foo");
+
+        foreach (var item in target)
+        {
+            Assert.Same(inner, target.InnerForTests);
+            target.Add("bar");
+            Assert.NotSame(inner, target.InnerForTests);
+            Assert.Equal("foo", item);
+        }
+
+        Assert.Equal(["foo", "bar"], target);
+    }
+
+    [Fact]
+    public void Enumerator_Iterates_Snapshot_Taken_At_Creation()
+    {
+        var target = new SafeEnumerableAvaloniaList<string> { "foo", "bar", "baz" };
+        var seen = new List<string>();
+
+        foreach (var item in target)
+        {
+            seen.Add(item);
+            target.Remove(item);
+        }
+
+        Assert.Equal(["foo", "bar", "baz"], seen);
+        Assert.Empty(target);
+    }
+
+    [Fact]
+    public void List_Is_Not_Copied_After_Enumeration()
+    {
+        var target = new SafeEnumerableAvaloniaList<string>();
+        var inner = target.InnerForTests;
+
+        target.Add("foo");
+
+        foreach (var item in target)
+        {
+            target.Add("bar");
+            Assert.NotSame(inner, target.InnerForTests);
+            inner = target.InnerForTests;
+            Assert.Equal("foo", item);
+        }
+
+        target.Add("baz");
+        Assert.Same(inner, target.InnerForTests);
+    }
+
+    [Fact]
+    public void List_Is_Copied_Only_Once_During_Enumeration()
+    {
+        var target = new SafeEnumerableAvaloniaList<string>();
+        var inner = target.InnerForTests;
+
+        target.Add("foo");
+
+        foreach (var item in target)
+        {
+            target.Add("bar");
+            Assert.NotSame(inner, target.InnerForTests);
+            inner = target.InnerForTests;
+            target.Add("baz");
+            Assert.Same(inner, target.InnerForTests);
+        }
+    }
+
+    [Fact]
+    public void List_Is_Copied_During_Nested_Enumerations()
+    {
+        var target = new SafeEnumerableAvaloniaList<string>();
+        var initialInner = target.InnerForTests;
+        var firstItems = new List<string>();
+        var secondItems = new List<string>();
+
+        target.Add("foo");
+
+        foreach (var i in target)
+        {
+            target.Add("bar");
+
+            var firstInner = target.InnerForTests;
+            Assert.NotSame(initialInner, firstInner);
+
+            foreach (var j in target)
+            {
+                target.Add("baz");
+
+                var secondInner = target.InnerForTests;
+                Assert.NotSame(firstInner, secondInner);
+
+                secondItems.Add(j);
+            }
+
+            firstItems.Add(i);
+        }
+
+        Assert.Equal(["foo"], firstItems);
+        Assert.Equal(["foo", "bar"], secondItems);
+        Assert.Equal(["foo", "bar", "baz", "baz"], target);
+
+        var finalInner = target.InnerForTests;
+        target.Add("final");
+        Assert.Same(finalInner, target.InnerForTests);
+    }
+
+    [Fact]
+    public void Enumeration_Through_Interface_Is_Safe()
+    {
+        var target = new SafeEnumerableAvaloniaList<string> { "foo", "bar" };
+        var seen = new List<string>();
+
+        foreach (var item in (IEnumerable<string>)target)
+        {
+            seen.Add(item);
+            target.Add("baz");
+        }
+
+        Assert.Equal(["foo", "bar"], seen);
+        Assert.Equal(["foo", "bar", "baz", "baz"], target);
+    }
+
+    [Fact]
+    public void CollectionChanged_Is_Raised_For_Mutations_After_Copy()
+    {
+        var target = new SafeEnumerableAvaloniaList<string> { "foo" };
+        var events = new List<NotifyCollectionChangedEventArgs>();
+
+        target.CollectionChanged += (_, e) => events.Add(e);
+
+        foreach (var item in target)
+        {
+            target.Add("bar");
+        }
+
+        target.Add("baz");
+
+        Assert.Equal(2, events.Count);
+        Assert.All(events, e => Assert.Equal(NotifyCollectionChangedAction.Add, e.Action));
+        Assert.Equal("bar", events[0].NewItems!.Cast<string>().Single());
+        Assert.Equal("baz", events[1].NewItems!.Cast<string>().Single());
+    }
+
+    [Fact]
+    public void PropertyChanged_Is_Raised_For_Count_After_Copy()
+    {
+        var target = new SafeEnumerableAvaloniaList<string> { "foo" };
+        var countChanged = 0;
+
+        target.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(target.Count))
+                ++countChanged;
+        };
+
+        foreach (var i in target)
+            target.Add("bar");
+
+        target.Add("baz");
+
+        Assert.Equal(2, countChanged);
+    }
+
+    [Fact]
+    public void Validator_Is_Invoked_After_Copy()
+    {
+        var target = new SafeEnumerableAvaloniaList<string> { "foo" };
+        var validated = new List<string>();
+
+        target.Validate = validated.Add;
+
+        foreach (var item in target)
+            target.Add("bar");
+
+        target.Add("baz");
+
+        Assert.Equal(["bar", "baz"], validated);
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/VisualTests.cs
+++ b/tests/Avalonia.Base.UnitTests/VisualTests.cs
@@ -128,6 +128,87 @@ namespace Avalonia.Base.UnitTests
         }
 
         [Fact]
+        public void VisualChildren_Can_Be_Added_During_AttachedToVisualTree()
+        {
+            var root = new TestRoot();
+            var parent = new TestVisual();
+            var child1 = new TestVisual();
+            var child2 = new TestVisual();
+
+            parent.AddChild(child1);
+
+            child1.AttachedToVisualTree += (_, _) => parent.AddChild(child2);
+
+            root.VisualChildren.Add(parent);
+
+            Assert.Equal([child1, child2], parent.VisualChildren);
+            Assert.True(child1.IsAttachedToVisualTree());
+            Assert.True(child2.IsAttachedToVisualTree());
+        }
+
+        [Fact]
+        public void VisualChildren_Can_Be_Removed_During_AttachedToVisualTree()
+        {
+            var root = new TestRoot();
+            var parent = new TestVisual();
+            var child1 = new TestVisual();
+            var child2 = new TestVisual();
+
+            parent.AddChildren([child1, child2]);
+
+            child1.AttachedToVisualTree += (_, _) => parent.RemoveChild(child2);
+
+            root.VisualChildren.Add(parent);
+
+            Assert.Equal([child1], parent.VisualChildren);
+            Assert.True(child1.IsAttachedToVisualTree());
+            Assert.False(child2.IsAttachedToVisualTree());
+        }
+
+        [Fact]
+        public void VisualChildren_Can_Be_Added_During_DetachedFromVisualTree()
+        {
+            var root = new TestRoot();
+            var parent = new TestVisual();
+            var child1 = new TestVisual();
+            var child2 = new TestVisual();
+
+            parent.AddChild(child1);
+            root.VisualChildren.Add(parent);
+
+            child1.DetachedFromVisualTree += (_, _) => parent.AddChild(child2);
+
+            root.VisualChildren.Remove(parent);
+
+            Assert.Equal([child1, child2], parent.VisualChildren);
+            Assert.False(child1.IsAttachedToVisualTree());
+            Assert.False(child2.IsAttachedToVisualTree());
+        }
+
+        [Fact]
+        public void VisualChildren_Can_Be_Removed_During_DetachedFromVisualTree()
+        {
+            var root = new TestRoot();
+            var parent = new TestVisual();
+            var child1 = new TestVisual();
+            var child2 = new TestVisual();
+            var child2Detached = 0;
+
+            parent.AddChildren([child1, child2]);
+            root.VisualChildren.Add(parent);
+
+            child1.DetachedFromVisualTree += (_, _) => parent.RemoveChild(child2);
+            child2.DetachedFromVisualTree += (_, _) => ++child2Detached;
+
+            root.VisualChildren.Remove(parent);
+
+            Assert.Equal([child1], parent.VisualChildren);
+            Assert.False(child1.IsAttachedToVisualTree());
+            Assert.False(child2.IsAttachedToVisualTree());
+            Assert.Equal(1, child2Detached);
+        }
+
+        [Fact]
         public void Root_Should_Return_Self_As_VisualRoot()
         {
             var root = new TestRoot();


### PR DESCRIPTION
## What does the pull request do?
This PR implements a copy-on-write list used for `VisualChildren` and `LogicalChildren`.

When a change occurs while the list is being iterated, for example in `OnAttachedToLogicalTree/OnDetachedFromLogicalTree`, the iteration continues on the original list, avoiding exceptions.

Unlike previous solutions such as #13498 and #20028, this has no extra indirection or allocations (in the standard case, when no copy is involved) compared to a standard `AvaloniaList<T>`.

The new class, `SafeEnumerableAvaloniaList<T>`, directly inherits from `AvaloniaList<T>` and simply swaps its inner `List<T>` when necessary. It also provides a new, safe enumerator that hides the one from `AvaloniaList<T>`. This means that casting the `SafeEnumerableAvaloniaList<T>` to `AvaloniaList<T>` won't use the safe enumerator. In practice, I think this is an acceptable compromise. First, it's unlikely to happen. Second, we only want to guard the attach/detach paths that we have complete control over.

The list alone isn't enough though, as it just removes the actual exception, but some code paths weren't ready to handle mutation correctly, throwing further down. This PR also includes necessary changes and tests to ensure that everything works as expected.

Unit tests have been added.

Existing benchmarks related to control creation and iteration in standard cases show no measurable change. The new `AvaloniaList<T>.OnMutating()` call is effectively always de-virtualized: the `VisualChildren/LogicalChildren` fields have been strongly typed to ensure the JIT sees the actual type.

## Fixed issues
 - Fixes #14437
 - Fixes #13497
 - Closes #17236
 - Supersedes #20028