### PR TITLE
Fix NSTextInputClient range handling and null dereference issues

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnTextInputMethod.mm
+++ b/native/Avalonia.Native/src/OSX/AvnTextInputMethod.mm
@@ -32,7 +32,10 @@ void AvnTextInputMethod::Reset() {
 }
 
 void AvnTextInputMethod::SetSurroundingText(char* text, int start, int end) {
-    [_inputMethodDelegate setText:[NSString stringWithUTF8String:text]];
+    // stringWithUTF8String: throws on a null pointer and returns nil for invalid UTF-8.
+    NSString* surroundingText = text != nullptr ? [NSString stringWithUTF8String:text] : nil;
+
+    [_inputMethodDelegate setText:surroundingText != nil ? surroundingText : @""];
     [_inputMethodDelegate setSelection: start:end];
 }
 

--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -747,25 +747,48 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
     return (AvnInputModifiers)rv;
 }
 
+// Clamps a range so that it can never be used to index outside of _text.
+// Ranges reaching us from AppKit or from the managed side are not guaranteed to be valid.
+- (NSRange)clampRangeToText:(NSRange)range
+{
+    if (range.location == NSNotFound)
+        return NSMakeRange(NSNotFound, 0);
+
+    NSUInteger length = _text.length;
+
+    if (range.location > length)
+        return NSMakeRange(length, 0);
+
+    // Avoids the overflow of location + length that a plain bounds check would have.
+    return NSMakeRange(range.location, MIN(range.length, length - range.location));
+}
+
 - (BOOL)hasMarkedText
 {
-    return _markedRange.length > 0;
+    return _markedRange.location != NSNotFound && _markedRange.length > 0;
 }
 
 - (NSRange)markedRange
 {
-    return _markedRange;
+    // From the docs: returns {NSNotFound, 0} if there is no marked range.
+    if (![self hasMarkedText])
+        return NSMakeRange(NSNotFound, 0);
+
+    // The preedit isn't necessarily part of the surrounding text we got from the managed side,
+    // so only the location is clamped here. An overlong length is handled by
+    // attributedSubstringForProposedRange:actualRange:, as the docs require.
+    return NSMakeRange(MIN(_markedRange.location, _text.length), _markedRange.length);
 }
 
 - (NSRange)selectedRange
 {
-    return _selectedRange;
+    return [self clampRangeToText:_selectedRange];
 }
 
 - (void)setMarkedText:(id)string selectedRange:(NSRange)selectedRange replacementRange:(NSRange)replacementRange
 {
     NSString* markedText;
-        
+
     if([string isKindOfClass:[NSAttributedString class]])
     {
         markedText = [string string];
@@ -774,35 +797,47 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
     {
         markedText = (NSString*) string;
     }
-    
+
+    if (markedText == nil)
+    {
+        markedText = @"";
+    }
+
     auto parent = _parent.tryGet();
 
     // Delete any replaced range
-    if (replacementRange.location != NSNotFound && parent != nullptr && parent->InputMethod->IsActive())
+    auto finalReplacementRange = [self clampRangeToText:replacementRange];
+
+    if (finalReplacementRange.location != NSNotFound && parent != nullptr && parent->InputMethod->IsActive())
     {
-        parent->InputMethod->Client->SelectInSurroundingText((int)replacementRange.location, (int)(replacementRange.location + replacementRange.length));
+        parent->InputMethod->Client->SelectInSurroundingText((int)finalReplacementRange.location, (int)(finalReplacementRange.location + finalReplacementRange.length));
         uint64_t timestamp = static_cast<uint64_t>([NSDate timeIntervalSinceReferenceDate] * 1000);
         parent->TopLevelEvents->RawKeyEvent(KeyDown, timestamp, AvnInputModifiersNone, AvnKeyBack, AvnPhysicalKeyNone, "\b");
         parent->TopLevelEvents->RawKeyEvent(KeyUp, timestamp, AvnInputModifiersNone, AvnKeyBack, AvnPhysicalKeyNone, "\b");
     }
-    
-    _markedRange = NSMakeRange(_selectedRange.location, [markedText length]);
+
+    auto markedLocation = [self selectedRange].location;
+
+    _markedRange = NSMakeRange(markedLocation == NSNotFound ? 0 : markedLocation, [markedText length]);
 
     if (parent != nullptr && parent->InputMethod->IsActive())
     {
-        parent->InputMethod->Client->SetPreeditText((char*)[markedText UTF8String]);
+        const char* utf8MarkedText = [markedText UTF8String];
+        parent->InputMethod->Client->SetPreeditText((char*)(utf8MarkedText != nullptr ? utf8MarkedText : ""));
     }
 }
 
 - (void)unmarkText
 {
     auto parent = _parent.tryGet();
-    if(parent->InputMethod->IsActive()){
+    if(parent != nullptr && parent->InputMethod->IsActive()){
         parent->InputMethod->Client->SetPreeditText(nullptr);
     }
-    
-    _markedRange = NSMakeRange(_selectedRange.location, 0);
-    
+
+    auto selectionLocation = [self selectedRange].location;
+
+    _markedRange = NSMakeRange(selectionLocation == NSNotFound ? 0 : selectionLocation, 0);
+
     if([self inputContext]) {
         [[self inputContext] discardMarkedText];
     }
@@ -815,20 +850,27 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
 
 - (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)range actualRange:(NSRangePointer)actualRange
 {
-    if(actualRange){
-        range = *actualRange;
-    }
-
     // From the docs: an implementation of this method should be prepared for aRange to be out of bounds.
     // In this case, you should return the intersection of the document's range and aRange.
     // If the location of aRange is completely outside of the document's range, return nil.
-    auto finalRange = NSIntersectionRange(range, NSMakeRange(0, _text.length));
-    
+    // actualRange is an out parameter: it is uninitialized on entry and must only be written to.
+    NSRange docRange = NSMakeRange(0, _text.length);
+    NSRange finalRange = NSIntersectionRange(range, docRange);
+
     if (finalRange.length == 0)
+    {
+        if (actualRange) {
+            *actualRange = NSMakeRange(NSNotFound, 0);
+        }
+
         return nil;
-    
-    NSAttributedString* subString = [_text attributedSubstringFromRange:finalRange];
-    return subString;
+    }
+
+    if (actualRange) {
+        *actualRange = finalRange;
+    }
+
+    return [_text attributedSubstringFromRange:finalRange];
 }
 
 - (void)insertText:(id)string replacementRange:(NSRange)replacementRange
@@ -848,19 +890,28 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
     {
         text = (NSString*) string;
     }
-    
-    if (replacementRange.location != NSNotFound &&
+
+    if (text == nil)
+    {
+        text = @"";
+    }
+
+    auto finalReplacementRange = [self clampRangeToText:replacementRange];
+
+    if (finalReplacementRange.location != NSNotFound &&
         ![self hasMarkedText] &&
         parent->InputMethod->IsActive())
     {
-        parent->InputMethod->Client->SelectInSurroundingText((int)replacementRange.location, (int)(replacementRange.location + replacementRange.length));
+        parent->InputMethod->Client->SelectInSurroundingText((int)finalReplacementRange.location, (int)(finalReplacementRange.location + finalReplacementRange.length));
     }
-    
+
     [self unmarkText];
-        
+
     uint64_t timestamp = static_cast<uint64_t>([NSDate timeIntervalSinceReferenceDate] * 1000);
-        
-    parent->TopLevelEvents->RawTextInputEvent(timestamp, [text UTF8String]);
+
+    const char* utf8Text = [text UTF8String];
+
+    parent->TopLevelEvents->RawTextInputEvent(timestamp, utf8Text != nullptr ? utf8Text : "");
 }
 
 - (NSUInteger)characterIndexForPoint:(NSPoint)point
@@ -870,11 +921,17 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
 
 - (NSRect)firstRectForCharacterRange:(NSRange)range actualRange:(NSRangePointer)actualRange
 {
+    // actualRange is an out parameter: it is uninitialized on entry and must only be written to.
+    // We only ever report a single rect, so the requested range is echoed back clamped to the document.
+    if (actualRange) {
+        *actualRange = [self clampRangeToText:range];
+    }
+
     auto parent = _parent.tryGet();
-    if(!parent->InputMethod->IsActive()){
+    if(parent == nullptr || !parent->InputMethod->IsActive()){
         return NSZeroRect;
     }
-    
+
     return _cursorRect;
 }
 
@@ -1028,11 +1085,31 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
 }
 
 - (void) setText:(NSString *)text{
-    [[_text mutableString] setString:text];
+    [[_text mutableString] setString:text != nil ? text : @""];
+
+    // The document changed, so the stored ranges can now point outside of it.
+    _selectedRange = [self clampRangeToText:_selectedRange];
+
+    if (_markedRange.location != NSNotFound)
+    {
+        _markedRange = NSMakeRange(MIN(_markedRange.location, _text.length), _markedRange.length);
+    }
 }
 
 - (void) setSelection:(int)start :(int)end{
-    _selectedRange = NSMakeRange(start, end - start);
+    if (end < start)
+    {
+        auto temp = start;
+        start = end;
+        end = temp;
+    }
+
+    auto length = (int)_text.length;
+
+    start = MAX(0, MIN(start, length));
+    end = MAX(start, MIN(end, length));
+
+    _selectedRange = NSMakeRange((NSUInteger)start, (NSUInteger)(end - start));
 }
 
 - (void) setCursorRect:(AvnRect)rect{


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Fixes range handling in the macOS `NSTextInputClient` implementation (`AvnView`), so that out parameters are written as the protocol requires and no range handed to AppKit can point outside the document.

## What is the current behavior?

`attributedSubstringForProposedRange:actualRange:` reads `*actualRange` on entry and uses it as the proposed range. `actualRange` is an out parameter and is uninitialized on entry, so the substring comes from an arbitrary range instead of the one AppKit asked for. The method also never writes the out parameter, and neither does `firstRectForCharacterRange:actualRange:`.

Separately, ranges crossing the boundary are never clamped: a stale or reversed managed selection produces a range past the end of the document, which AppKit feeds straight back into the substring call. `markedRange` also returns `{selectionLocation, 0}` with no marked text where the docs specify `{NSNotFound, 0}`.

Anything that queries surrounding text gets wrong or empty context: IME candidate windows, the emoji panel, press-and-hold accents, dictation. Worst case is an out-of-bounds index into the text or a null dereference of the parent.

## What is the updated/expected behavior with this PR?

No uncaught exception 'NSRangeException', reason: 'NSConcreteMutableAttributedString attributedSubstringFromRange:: Out of bounds' when attributedSubstringForProposedRange on macOS 27 beta

## How was the solution implemented (if it's not obvious)?

One `clampRangeToText:` helper handles every range crossing the boundary. It preserves `NSNotFound`, moves an out-of-range location to the end of the document, and truncates length via `length - location` so the `location + length` overflow of a plain bounds check cannot happen. `setSelection::` additionally swaps reversed pairs, and `setText:` re-clamps the stored ranges after the document changes.

`attributedSubstringForProposedRange:actualRange:` now intersects the requested range with the document and writes the result, or `{NSNotFound, 0}` plus nil when the intersection is empty. `firstRectForCharacterRange:actualRange:` echoes the clamped request, since only one rect is ever reported. `markedRange` clamps the location only: the preedit is not necessarily part of the managed surrounding text, and the docs put an overlong length on the substring call.

Nil strings and nil `UTF8String` results are no longer passed across the COM boundary, and `SetSurroundingText` no longer calls `stringWithUTF8String:` on a null pointer, which throws.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

Objective-C++ backend code with no test harness in the repo, verified by hand on macOS. No public API change.

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues