### PR TITLE
Add pen/touch to headless platform

### DIFF
--- a/src/Headless/Avalonia.Headless/HeadlessWindowExtensions.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
@@ -81,7 +82,7 @@ public static class HeadlessWindowExtensions
     /// Simulates a mouse down on the headless window/toplevel.
     /// </summary>
     /// <remarks>
-    /// In the headless platform, there is a single mouse pointer. There are no helper methods for touch or pen input.
+    /// In the headless platform, there is a single mouse pointer. For touch input use the TouchBegin method, for pen input use the PenBegin method.
     /// </remarks>
     public static void MouseDown(this TopLevel topLevel, Point point, MouseButton button,
         RawInputModifiers modifiers = RawInputModifiers.None) =>
@@ -107,6 +108,111 @@ public static class HeadlessWindowExtensions
     public static void MouseWheel(this TopLevel topLevel, Point point, Vector delta,
         RawInputModifiers modifiers = RawInputModifiers.None) =>
         RunJobsOnImpl(topLevel, w => w.MouseWheel(point, delta, modifiers));
+
+    /// <summary>
+    /// Simulates a touch contact being pressed on the headless window/toplevel.
+    /// </summary>
+    /// <returns>
+    /// A touch pointer to pass to <see cref="TouchMove"/> and <see cref="TouchEnd"/>.
+    /// Disposing the pointer cancels the contact if it is still pressed.
+    /// </returns>
+    /// <remarks>
+    /// To simulate multi-touch, keep several returned touch pointers pressed at the same time.
+    /// </remarks>
+    public static IHeadlessTouchPointer TouchBegin(this TopLevel topLevel, Point point,
+        RawInputModifiers modifiers = RawInputModifiers.None)
+    {
+        var touchPointId = Interlocked.Increment(ref s_nextTouchPointId);
+        RunJobsOnImpl(topLevel, w => w.Touch(point, touchPointId, RawPointerEventType.TouchBegin, modifiers));
+        return new HeadlessTouchPointer(topLevel, touchPointId, point);
+    }
+
+    /// <summary>
+    /// Simulates a touch contact being moved on the headless window/toplevel.
+    /// </summary>
+    /// <param name="topLevel">The target headless top level. Must be the one the touch pointer was created on.</param>
+    /// <param name="touchPointer">The touch pointer returned from <see cref="TouchBegin"/>.</param>
+    /// <param name="point">The new contact position.</param>
+    /// <param name="modifiers">The optional key modifiers.</param>
+    public static void TouchMove(this TopLevel topLevel, IHeadlessTouchPointer touchPointer, Point point,
+        RawInputModifiers modifiers = RawInputModifiers.None) =>
+        GetTouchPointer(topLevel, touchPointer).Move(point, modifiers);
+
+    /// <summary>
+    /// Simulates a touch contact being released on the headless window/toplevel.
+    /// </summary>
+    /// <param name="topLevel">The target headless top level. Must be the one the touch pointer was created on.</param>
+    /// <param name="touchPointer">The touch pointer returned from <see cref="TouchBegin"/>.</param>
+    /// <param name="point">The position at which the contact is released.</param>
+    /// <param name="modifiers">The optional key modifiers.</param>
+    public static void TouchEnd(this TopLevel topLevel, IHeadlessTouchPointer touchPointer, Point point,
+        RawInputModifiers modifiers = RawInputModifiers.None) =>
+        GetTouchPointer(topLevel, touchPointer).End(point, modifiers);
+
+    /// <summary>
+    /// Simulates a pen entering the headless window/toplevel.
+    /// The pen initially hovers over the toplevel without touching it.
+    /// </summary>
+    /// <param name="topLevel">The target headless top level.</param>
+    /// <param name="point">The pen position.</param>
+    /// <param name="modifiers">The optional key modifiers.</param>
+    /// <returns>
+    /// A pen pointer to pass to <see cref="PenDown"/>, <see cref="PenMove"/> and <see cref="PenUp"/>.
+    /// Each returned pointer represents a separate pen device.
+    /// Disposing the pointer makes the pen leave the toplevel, cancelling the contact if the tip is still pressed.
+    /// </returns>
+    public static IHeadlessPenPointer PenBegin(this TopLevel topLevel, Point point,
+        RawInputModifiers modifiers = RawInputModifiers.None)
+    {
+        var penPointer = new HeadlessPenPointer(topLevel);
+        penPointer.Move(point, 0f, 0f, 0f, 0f, modifiers);
+        return penPointer;
+    }
+
+    /// <summary>
+    /// Simulates a pen tip being pressed on the headless window/toplevel.
+    /// </summary>
+    /// <param name="topLevel">The target headless top level. Must be the one the pen pointer was created on.</param>
+    /// <param name="penPointer">The pen pointer returned from <see cref="PenBegin"/>.</param>
+    /// <param name="point">The pen position.</param>
+    /// <param name="pressure">The pen pressure, in the 0..1 range.</param>
+    /// <param name="xTilt">The pen tilt along the X axis, in the -90..90 degrees range.</param>
+    /// <param name="yTilt">The pen tilt along the Y axis, in the -90..90 degrees range.</param>
+    /// <param name="twist">The pen rotation around its own axis, in the 0..359 degrees range.</param>
+    /// <param name="modifiers">The optional key modifiers.</param>
+    public static void PenDown(this TopLevel topLevel, IHeadlessPenPointer penPointer, Point point,
+        float pressure = 0.5f, float xTilt = 0f, float yTilt = 0f, float twist = 0f,
+        RawInputModifiers modifiers = RawInputModifiers.None) =>
+        GetPenPointer(topLevel, penPointer).Down(point, pressure, xTilt, yTilt, twist, modifiers);
+
+    /// <summary>
+    /// Simulates a pen being moved over the headless window/toplevel, either hovering or with the tip pressed.
+    /// </summary>
+    /// <inheritdoc cref="PenDown" path="/param"/>
+    public static void PenMove(this TopLevel topLevel, IHeadlessPenPointer penPointer, Point point,
+        float pressure = 0.5f, float xTilt = 0f, float yTilt = 0f, float twist = 0f,
+        RawInputModifiers modifiers = RawInputModifiers.None) =>
+        GetPenPointer(topLevel, penPointer).Move(point, pressure, xTilt, yTilt, twist, modifiers);
+
+    /// <summary>
+    /// Simulates a pen tip being released on the headless window/toplevel.
+    /// The pen keeps hovering over the toplevel afterwards.
+    /// </summary>
+    /// <inheritdoc cref="PenDown" path="/param"/>
+    public static void PenUp(this TopLevel topLevel, IHeadlessPenPointer penPointer, Point point,
+        float pressure = 0f, float xTilt = 0f, float yTilt = 0f, float twist = 0f,
+        RawInputModifiers modifiers = RawInputModifiers.None) =>
+        GetPenPointer(topLevel, penPointer).Up(point, pressure, xTilt, yTilt, twist, modifiers);
+
+    private static RawPointerPoint CreatePenPoint(Point point, float pressure, float xTilt, float yTilt, float twist) =>
+        new()
+        {
+            Position = point,
+            Pressure = pressure,
+            XTilt = xTilt,
+            YTilt = yTilt,
+            Twist = twist
+        };
 
     /// <summary>
     /// Simulates a drag and drop target event on the headless window/toplevel. This event simulates a user moving files from another app to the current app.
@@ -172,5 +278,145 @@ public static class HeadlessWindowExtensions
             IHeadlessWindow headless => headless,
             _ => throw new InvalidOperationException("TopLevel must be a headless window.")
         };
+    }
+
+    private static long s_nextTouchPointId;
+
+    private static HeadlessTouchPointer GetTouchPointer(TopLevel topLevel, IHeadlessTouchPointer touchPointer)
+    {
+        if (touchPointer is not HeadlessTouchPointer headlessTouchPointer)
+            throw new ArgumentException("The touch pointer was not created by TouchBegin.", nameof(touchPointer));
+        if (headlessTouchPointer.TopLevel != topLevel)
+            throw new ArgumentException("The touch pointer belongs to a different toplevel.", nameof(touchPointer));
+        return headlessTouchPointer;
+    }
+
+    private static HeadlessPenPointer GetPenPointer(TopLevel topLevel, IHeadlessPenPointer penPointer)
+    {
+        if (penPointer is not HeadlessPenPointer headlessPenPointer)
+            throw new ArgumentException("The pen pointer was not created by PenBegin.", nameof(penPointer));
+        if (headlessPenPointer.TopLevel != topLevel)
+            throw new ArgumentException("The pen pointer belongs to a different toplevel.", nameof(penPointer));
+        return headlessPenPointer;
+    }
+
+    private sealed class HeadlessTouchPointer : IHeadlessTouchPointer
+    {
+        private readonly long _touchPointId;
+        private Point _position;
+        private bool _pressed = true;
+
+        public HeadlessTouchPointer(TopLevel topLevel, long touchPointId, Point position)
+        {
+            TopLevel = topLevel;
+            _touchPointId = touchPointId;
+            _position = position;
+        }
+
+        public TopLevel TopLevel { get; }
+
+        public void Move(Point point, RawInputModifiers modifiers)
+        {
+            ThrowIfReleased();
+            RunJobsOnImpl(TopLevel, w => w.Touch(point, _touchPointId, RawPointerEventType.TouchUpdate, modifiers));
+            _position = point;
+        }
+
+        public void End(Point point, RawInputModifiers modifiers)
+        {
+            ThrowIfReleased();
+            _pressed = false;
+            RunJobsOnImpl(TopLevel, w => w.Touch(point, _touchPointId, RawPointerEventType.TouchEnd, modifiers));
+        }
+
+        public void Dispose()
+        {
+            if (!_pressed)
+                return;
+            _pressed = false;
+
+            // The toplevel might have been closed already, cancelling all of its touch pointers.
+            if (TopLevel.PlatformImpl is IHeadlessWindow)
+                RunJobsOnImpl(TopLevel, w => w.Touch(_position, _touchPointId, RawPointerEventType.TouchCancel, RawInputModifiers.None));
+        }
+
+        private void ThrowIfReleased()
+        {
+            if (!_pressed)
+                throw new InvalidOperationException("The touch pointer has already been released.");
+        }
+    }
+
+    private sealed class HeadlessPenPointer : IHeadlessPenPointer
+    {
+        private readonly PenDevice _penDevice = new();
+        private Point _position;
+        private bool _pressed;
+        private bool _disposed;
+
+        public HeadlessPenPointer(TopLevel topLevel)
+        {
+            TopLevel = topLevel;
+        }
+
+        public TopLevel TopLevel { get; }
+
+        public void Down(Point point, float pressure, float xTilt, float yTilt, float twist, RawInputModifiers modifiers)
+        {
+            ThrowIfDisposed();
+            if (_pressed)
+                throw new InvalidOperationException("The pen tip is already pressed.");
+            _pressed = true;
+            Send(point, pressure, xTilt, yTilt, twist, RawPointerEventType.LeftButtonDown, modifiers);
+        }
+
+        public void Move(Point point, float pressure, float xTilt, float yTilt, float twist, RawInputModifiers modifiers)
+        {
+            ThrowIfDisposed();
+            Send(point, pressure, xTilt, yTilt, twist, RawPointerEventType.Move, modifiers);
+        }
+
+        public void Up(Point point, float pressure, float xTilt, float yTilt, float twist, RawInputModifiers modifiers)
+        {
+            ThrowIfDisposed();
+            if (!_pressed)
+                throw new InvalidOperationException("The pen tip is not pressed.");
+            _pressed = false;
+            Send(point, pressure, xTilt, yTilt, twist, RawPointerEventType.LeftButtonUp, modifiers);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+
+            // The toplevel might have been closed already, releasing all of its pointers.
+            if (TopLevel.PlatformImpl is IHeadlessWindow)
+            {
+                if (_pressed)
+                    RunJobsOnImpl(TopLevel, w => w.Pen(_penDevice, CreatePenPoint(_position, 0f, 0f, 0f, 0f),
+                        RawPointerEventType.CancelCapture, RawInputModifiers.None));
+                RunJobsOnImpl(TopLevel, w => w.Pen(_penDevice, CreatePenPoint(_position, 0f, 0f, 0f, 0f),
+                    RawPointerEventType.LeaveWindow, RawInputModifiers.None));
+            }
+
+            _pressed = false;
+            _penDevice.Dispose();
+        }
+
+        private void Send(Point point, float pressure, float xTilt, float yTilt, float twist,
+            RawPointerEventType type, RawInputModifiers modifiers)
+        {
+            RunJobsOnImpl(TopLevel, w => w.Pen(_penDevice, CreatePenPoint(point, pressure, xTilt, yTilt, twist),
+                type, modifiers));
+            _position = point;
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(IHeadlessPenPointer));
+        }
     }
 }

--- a/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -22,6 +22,7 @@ namespace Avalonia.Headless
         private readonly IKeyboardDevice _keyboard;
         private readonly IScreenImpl _screen;
         private readonly Stopwatch _st = Stopwatch.StartNew();
+        private readonly TouchDevice _touchDevice = new();
         private WriteableBitmap? _lastRenderedFrame;
         private readonly object _sync = new object();
         private readonly AvaloniaHeadlessPlatformOptions _options;
@@ -62,6 +63,7 @@ namespace Avalonia.Headless
         {
             _popupParent?._openPopups.Remove(this);
             Closed?.Invoke();
+            _touchDevice.Dispose();
             _lastRenderedFrame?.Dispose();
             _lastRenderedFrame = null;
         }
@@ -373,6 +375,18 @@ namespace Avalonia.Headless
         {
             Input?.Invoke(new RawMouseWheelEventArgs(MouseDevice, Timestamp, InputRoot!,
                 point, delta, modifiers));
+        }
+
+        void IHeadlessWindow.Touch(Point point, long touchPointId, RawPointerEventType type, RawInputModifiers modifiers)
+        {
+            Input?.Invoke(new RawTouchEventArgs(_touchDevice, Timestamp, InputRoot!,
+                type, point, modifiers, touchPointId));
+        }
+
+        void IHeadlessWindow.Pen(PenDevice device, RawPointerPoint point, RawPointerEventType type, RawInputModifiers modifiers)
+        {
+            Input?.Invoke(new RawPointerEventArgs(device, Timestamp, InputRoot!,
+                type, point, modifiers));
         }
 
         void IHeadlessWindow.DragDrop(Point point, RawDragEventType type, IDataTransfer data, DragDropEffects effects, RawInputModifiers modifiers)

--- a/src/Headless/Avalonia.Headless/IHeadlessPenPointer.cs
+++ b/src/Headless/Avalonia.Headless/IHeadlessPenPointer.cs
@@ -1,0 +1,18 @@
+using System;
+using Avalonia.Metadata;
+
+namespace Avalonia.Headless;
+
+/// <summary>
+/// Represents a pen/stylus device simulated on a headless window/toplevel.
+/// Use <see cref="HeadlessWindowExtensions.PenDown"/>, <see cref="HeadlessWindowExtensions.PenMove"/>
+/// and <see cref="HeadlessWindowExtensions.PenUp"/> to drive the pen.
+/// </summary>
+/// <remarks>
+/// Each pen pointer represents a separate pen device.
+/// Disposing the pen pointer makes the pen leave the toplevel, cancelling the contact if the tip is still pressed.
+/// </remarks>
+[NotClientImplementable]
+public interface IHeadlessPenPointer : IDisposable
+{
+}

--- a/src/Headless/Avalonia.Headless/IHeadlessTouchPointer.cs
+++ b/src/Headless/Avalonia.Headless/IHeadlessTouchPointer.cs
@@ -1,0 +1,16 @@
+using System;
+using Avalonia.Metadata;
+
+namespace Avalonia.Headless;
+
+/// <summary>
+/// Represents an active touch contact simulated on a headless window/toplevel.
+/// Use <see cref="HeadlessWindowExtensions.TouchMove"/> and <see cref="HeadlessWindowExtensions.TouchEnd"/> to drive the contact.
+/// </summary>
+/// <remarks>
+/// Disposing the touch pointer cancels the contact if it hasn't been released with <see cref="HeadlessWindowExtensions.TouchEnd"/> yet.
+/// </remarks>
+[NotClientImplementable]
+public interface IHeadlessTouchPointer : IDisposable
+{
+}

--- a/src/Headless/Avalonia.Headless/IHeadlessWindow.cs
+++ b/src/Headless/Avalonia.Headless/IHeadlessWindow.cs
@@ -17,6 +17,8 @@ namespace Avalonia.Headless
         void MouseMove(Point point, RawInputModifiers modifiers = RawInputModifiers.None);
         void MouseUp(Point point, MouseButton button, RawInputModifiers modifiers = RawInputModifiers.None);
         void MouseWheel(Point point, Vector delta, RawInputModifiers modifiers = RawInputModifiers.None);
+        void Touch(Point point, long touchPointId, RawPointerEventType type, RawInputModifiers modifiers = RawInputModifiers.None);
+        void Pen(PenDevice device, RawPointerPoint point, RawPointerEventType type, RawInputModifiers modifiers = RawInputModifiers.None);
         void DragDrop(Point point, RawDragEventType type, IDataTransfer data, DragDropEffects effects, RawInputModifiers modifiers = RawInputModifiers.None);
         void SetRenderScaling(double scaling);
         IReadOnlyList<TopLevel> GetOpenPopups();

--- a/tests/Avalonia.Headless.UnitTests/InputTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/InputTests.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Avalonia.Threading;
 
 namespace Avalonia.Headless.UnitTests;
@@ -101,6 +103,195 @@ public class InputTests
         _window.MouseUp(translatePoint.Value, MouseButton.Left, RawInputModifiers.None);
 
         AssertHelper.Equal(1, clickCount);
+    }
+
+#if NUNIT
+    [AvaloniaTest]
+#elif XUNIT
+    [AvaloniaFact]
+#endif
+    public void Touch_Contact_Raises_Touch_Pointer_Events()
+    {
+        var pressedCount = 0;
+        var movedCount = 0;
+        var releasedCount = 0;
+        PointerType pressedPointerType = default;
+
+        var border = new Border { Background = Brushes.Red };
+        border.PointerPressed += (_, e) =>
+        {
+            pressedCount++;
+            pressedPointerType = e.Pointer.Type;
+        };
+        border.PointerMoved += (_, _) => movedCount++;
+        border.PointerReleased += (_, _) => releasedCount++;
+
+        _window.Content = border;
+        _window.Show();
+
+        var touch = _window.TouchBegin(new Point(50, 50));
+        _window.TouchMove(touch, new Point(60, 60));
+        _window.TouchEnd(touch, new Point(60, 60));
+
+        AssertHelper.Equal(1, pressedCount);
+        AssertHelper.Equal(1, movedCount);
+        AssertHelper.Equal(1, releasedCount);
+        AssertHelper.Equal(PointerType.Touch, pressedPointerType);
+    }
+
+#if NUNIT
+    [AvaloniaTest]
+#elif XUNIT
+    [AvaloniaFact]
+#endif
+    public void Multiple_Touch_Contacts_Are_Distinct_Pointers()
+    {
+        var pointerIds = new HashSet<int>();
+
+        var border = new Border { Background = Brushes.Red };
+        border.PointerPressed += (_, e) => pointerIds.Add(e.Pointer.Id);
+
+        _window.Content = border;
+        _window.Show();
+
+        var touch1 = _window.TouchBegin(new Point(30, 30));
+        var touch2 = _window.TouchBegin(new Point(70, 70));
+        _window.TouchEnd(touch1, new Point(30, 30));
+        _window.TouchEnd(touch2, new Point(70, 70));
+
+        AssertHelper.Equal(2, pointerIds.Count);
+    }
+
+#if NUNIT
+    [AvaloniaTest]
+#elif XUNIT
+    [AvaloniaFact]
+#endif
+    public void Disposing_Touch_Pointer_Cancels_Contact()
+    {
+        var captureLostCount = 0;
+        var releasedCount = 0;
+
+        var border = new Border { Background = Brushes.Red };
+        border.PointerCaptureLost += (_, _) => captureLostCount++;
+        border.PointerReleased += (_, _) => releasedCount++;
+
+        _window.Content = border;
+        _window.Show();
+
+        using (_window.TouchBegin(new Point(50, 50)))
+        {
+        }
+
+        AssertHelper.Equal(1, captureLostCount);
+        AssertHelper.Equal(0, releasedCount);
+    }
+
+#if NUNIT
+    [AvaloniaTest]
+#elif XUNIT
+    [AvaloniaFact]
+#endif
+    public void Pen_Input_Reports_Pen_Type_And_Pressure()
+    {
+        PointerType pressedPointerType = default;
+        float pressure = 0f;
+        var releasedCount = 0;
+
+        var border = new Border { Background = Brushes.Red };
+        border.PointerPressed += (_, e) =>
+        {
+            pressedPointerType = e.Pointer.Type;
+            pressure = e.GetCurrentPoint(border).Properties.Pressure;
+        };
+        border.PointerReleased += (_, _) => releasedCount++;
+
+        _window.Content = border;
+        _window.Show();
+
+        using var pen = _window.PenBegin(new Point(40, 40));
+        _window.PenDown(pen, new Point(50, 50), pressure: 0.75f);
+        _window.PenMove(pen, new Point(60, 60), pressure: 0.75f);
+        _window.PenUp(pen, new Point(60, 60));
+
+        AssertHelper.Equal(PointerType.Pen, pressedPointerType);
+        AssertHelper.Equal(0.75f, pressure);
+        AssertHelper.Equal(1, releasedCount);
+    }
+
+#if NUNIT
+    [AvaloniaTest]
+#elif XUNIT
+    [AvaloniaFact]
+#endif
+    public void Pen_Hovers_Before_And_After_Press()
+    {
+        var movedCount = 0;
+        var pressedCount = 0;
+
+        var border = new Border { Background = Brushes.Red };
+        border.PointerMoved += (_, _) => movedCount++;
+        border.PointerPressed += (_, _) => pressedCount++;
+
+        _window.Content = border;
+        _window.Show();
+
+        using var pen = _window.PenBegin(new Point(50, 50));
+        _window.PenMove(pen, new Point(60, 60), pressure: 0f);
+
+        AssertHelper.Equal(2, movedCount);
+        AssertHelper.Equal(0, pressedCount);
+    }
+
+#if NUNIT
+    [AvaloniaTest]
+#elif XUNIT
+    [AvaloniaFact]
+#endif
+    public void Multiple_Pens_Are_Distinct_Pointers()
+    {
+        var pointerIds = new HashSet<int>();
+
+        var border = new Border { Background = Brushes.Red };
+        border.PointerPressed += (_, e) => pointerIds.Add(e.Pointer.Id);
+
+        _window.Content = border;
+        _window.Show();
+
+        using var pen1 = _window.PenBegin(new Point(30, 30));
+        using var pen2 = _window.PenBegin(new Point(70, 70));
+        _window.PenDown(pen1, new Point(30, 30));
+        _window.PenDown(pen2, new Point(70, 70));
+        _window.PenUp(pen1, new Point(30, 30));
+        _window.PenUp(pen2, new Point(70, 70));
+
+        AssertHelper.Equal(2, pointerIds.Count);
+    }
+
+#if NUNIT
+    [AvaloniaTest]
+#elif XUNIT
+    [AvaloniaFact]
+#endif
+    public void Disposing_Pressed_Pen_Pointer_Cancels_Contact()
+    {
+        var captureLostCount = 0;
+        var releasedCount = 0;
+
+        var border = new Border { Background = Brushes.Red };
+        border.PointerCaptureLost += (_, _) => captureLostCount++;
+        border.PointerReleased += (_, _) => releasedCount++;
+
+        _window.Content = border;
+        _window.Show();
+
+        using (var pen = _window.PenBegin(new Point(50, 50)))
+        {
+            _window.PenDown(pen, new Point(50, 50));
+        }
+
+        AssertHelper.Equal(1, captureLostCount);
+        AssertHelper.Equal(0, releasedCount);
     }
 
 #if NUNIT


### PR DESCRIPTION
It was previously limited to mouse. The API mostly mirrors the mouse one with exception for touch move/end - they consume an opaque point interface returned by touch-begin. This is needed because touch contacts are ephemeral, stateful and many.