### PR TITLE
Open a submenu when its parent menu item is clicked on macOS

### DIFF
--- a/native/Avalonia.Native/src/OSX/menu.mm
+++ b/native/Avalonia.Native/src/OSX/menu.mm
@@ -101,20 +101,29 @@ NSMenuItem* AvnAppMenuItem::GetNative()
 HRESULT AvnAppMenuItem::SetSubMenu (IAvnMenu* menu)
 {
     START_COM_CALL;
-    
+
     @autoreleasepool
     {
         if(menu != nullptr)
         {
             auto nsMenu = dynamic_cast<AvnAppMenu*>(menu)->GetNative();
-            
+
             [_native setSubmenu: nsMenu];
+
+            // Parity with -[NSMenu setSubmenu:forItem:]: without submenuAction: a click is dispatched to
+            // didSelectItem: and dismisses the menu instead of opening the submenu.
+            [_native setTarget: nil];
+            [_native setAction: @selector(submenuAction:)];
         }
         else
         {
             [_native setSubmenu: nullptr];
+
+            // The item is reused, so put its own action back.
+            [_native setTarget: _native];
+            [_native setAction: @selector(didSelectItem:)];
         }
-        
+
         return S_OK;
     }
 }


### PR DESCRIPTION
## What does the pull request do?
 On macOS, a menu item that has a submenu did not open it when the user clicked it. This PR fixes that. See #21886. 


## What is the current behavior?
Clicking such an item closes the whole menu, and the submenu never opens. Hovering over the item works fine. This happens in tray icon menus, window menus and the application menu.


## What is the updated/expected behavior with this PR?
Clicking the item opens its submenu, and the menu stays open, like in other macOS apps. Normal items still raise `Click` and run their `Command`.

How to test: add a tray icon with a menu that contains an item with a nested `NativeMenu`, then click that item. 


## How was the solution implemented (if it's not obvious)?
`AvnAppMenuItem::SetSubMenu` attaches the submenu with `-[NSMenuItem setSubmenu:]`. That method does not set `submenuAction:` on the item, but `-[NSMenu setSubmenu:forItem:]` does. So the item kept Avalonia's own `didSelectItem:` action, and AppKit called it on click: this raised `Click` and closed the menu. Now the item gets `submenuAction:` together with the submenu, the same way AppKit does it.

The `else` branch sets `didSelectItem:` back when the submenu is removed. `SetSubMenu(null)` is called on the same `NSMenuItem` (see `IAvnMenuItem.Update` and `Deinitialize`). Without this, the item would keep `submenuAction:` with no submenu and would stop reacting to clicks.

I tested the change with a locally built `libAvalonia.Native.OSX.dylib`, with menus written both in C# and in XAML, for a tray icon menu and for a window menu.

I did not add a test. The Objective-C code has no unit tests, and all tray icon tests in `tests/Avalonia.IntegrationTests.Appium/TrayIconTests.cs` are marked `Skip = "Flaky test"`, so a new Appium test would not run in CI either. I can add one if you prefer.


## Checklist
- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
No API changes.

## Fixed issues
Fixes #21886
