### PR TITLE
Avalonia.Native: Support manually copied dylib on non-OSX platfroms

### DIFF
--- a/src/Avalonia.Native/Avalonia.Native.csproj
+++ b/src/Avalonia.Native/Avalonia.Native.csproj
@@ -1,17 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackAvaloniaNative Condition="'$(PackAvaloniaNative)' == ''">$([MSBuild]::IsOSPlatform(OSX))</PackAvaloniaNative>
-    <IsPackable>$(PackAvaloniaNative)</IsPackable>
-    <IsPackable Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'True'">true</IsPackable>
-    <IsPackable Condition="'$(ForcePackAvaloniaNative)' == 'True'">True</IsPackable>
     <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseMicroComGeneratorRoslyn>true</UseMicroComGeneratorRoslyn>
+
+    <!-- Include libAvaloniaNative.dylib, only if we are on macOS host or dylib was manually copied -->
+    <AvaloniaNativeDylibPath>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)../../Build/Products/Release/libAvalonia.Native.OSX.dylib))</AvaloniaNativeDylibPath>
+    <IncludeAvaloniaDylib Condition="'$(IncludeAvaloniaDylib)' == '' AND Exists($(AvaloniaNativeDylibPath))">true</IncludeAvaloniaDylib>
+    <IncludeAvaloniaDylib Condition="'$(IncludeAvaloniaDylib)' == ''">$([MSBuild]::IsOSPlatform(OSX))</IncludeAvaloniaDylib>
+
+    <!-- It only makes sense to pack Avalonia.Native, if it includes dylib, of if it was enforced -->
+    <IsPackable>$(IncludeAvaloniaDylib)</IsPackable>
+    <IsPackable Condition="'$(ForcePackAvaloniaNative)' == 'True'">True</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(PackAvaloniaNative)' == 'true'">
-    <Content Include="../../Build/Products/Release/libAvalonia.Native.OSX.dylib">
+  <ItemGroup Condition="'$(IncludeAvaloniaDylib)' == 'true'">
+    <Content Include="$(AvaloniaNativeDylibPath)">
       <Link>libAvaloniaNative.dylib</Link>
       <PackagePath>runtimes/osx/native/libAvaloniaNative.dylib</PackagePath>
       <Pack>true</Pack>


### PR DESCRIPTION
## What does the pull request do?

Before this PR it wasn't possible to compile any project or local nuget packages with full macOS backend.
Because to get full macOS backend, we need to compile `dylib` native package, which isn't possible on Windows or Linux (not with standard tooling at least).

But nothing should prevent developer from getting fully functioning backend for dev-testing. If they can copy dylib from their macOS machine, or from the latest nightly/stable build.

This PR changes Avalonia.Native dylib inclusion logic a little:
- `libAvaloniaNative.dylib` is always included on macOS (as always), but now is also included on any platform if this file already exists
- `IsPackable` now also respects pre-existence of `libAvaloniaNative.dylib`, allowing packaging of functioning nupkg without `ForcePackAvaloniaNative`.

-------

Use case: I sometimes build macOS-only applications on Windows machine (mostly when testing Parcel cross-packaging). And I need to have a functioning Avalonia.Native backend when building local packages.