### PR TITLE
Fix vector geometry anti-aliasing regression by making stencil buffers opt-in

### DIFF
--- a/src/Skia/Avalonia.Skia/Gpu/Metal/SkiaMetalGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/Metal/SkiaMetalGpu.cs
@@ -17,7 +17,7 @@ internal class SkiaMetalGpu : ISkiaGpu
 
     public SkiaMetalGpu(IMetalDevice device, long? maxResourceBytes, bool? useStencilBuffers = null)
     {
-        var avoidStencilBuffers = useStencilBuffers == false;
+        var avoidStencilBuffers = SkiaOptions.ShouldAvoidStencilBuffers(useStencilBuffers);
         _context = GRContext.CreateMetal(
                        new GRMtlBackendContext { DeviceHandle = device.Device, QueueHandle = device.CommandQueue, },
                        new GRContextOptions { AvoidStencilBuffers = avoidStencilBuffers })

--- a/src/Skia/Avalonia.Skia/Gpu/OpenGl/GlSkiaGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/OpenGl/GlSkiaGpu.cs
@@ -40,7 +40,7 @@ namespace Avalonia.Skia
                 
                 using(iface)
                 {
-                    var avoidStencilBuffers = useStencilBuffers == false;
+                    var avoidStencilBuffers = SkiaOptions.ShouldAvoidStencilBuffers(useStencilBuffers);
                     _grContext = GRContext.CreateGl(iface, new GRContextOptions { AvoidStencilBuffers = avoidStencilBuffers });
                     if (maxResourceBytes.HasValue)
                     {

--- a/src/Skia/Avalonia.Skia/Gpu/Vulkan/VulkanSkiaGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/Vulkan/VulkanSkiaGpu.cs
@@ -48,7 +48,7 @@ internal class VulkanSkiaGpu : ISkiaGpu
                 GetProcedureAddress = GetProcAddressWrapper
             };
 
-            var avoidStencilBuffers = useStencilBuffers == false;
+            var avoidStencilBuffers = SkiaOptions.ShouldAvoidStencilBuffers(useStencilBuffers);
             
             GrContext = GRContext.CreateVulkan(ctx, new GRContextOptions { AvoidStencilBuffers = avoidStencilBuffers }) ??
                          throw new VulkanException("Unable to create GrContext from IVulkanDevice");

--- a/src/Skia/Avalonia.Skia/SkiaOptions.cs
+++ b/src/Skia/Avalonia.Skia/SkiaOptions.cs
@@ -26,9 +26,17 @@ namespace Avalonia
         public bool UseOpacitySaveLayer { get; set; } = false;
         
         /// <summary>
-        /// Gets whether stencil buffers can be used for various draw operations, improving performance.
-        /// If null (the default), Avalonia chooses whether to enable stencil buffers depending on the platform.
+        /// Gets whether stencil buffers can be used for various draw operations, improving clipping performance.
+        /// Enabling them lets Skia pick multisample-based path rendering, which quantizes edge coverage and
+        /// visibly degrades anti-aliasing of vector geometry, so they are disabled unless explicitly requested.
         /// </summary>
         public bool? UseStencilBuffers { get; set; }
+
+        /// <summary>
+        /// Maps <see cref="UseStencilBuffers"/> onto Skia's inverted <c>GRContextOptions.AvoidStencilBuffers</c>.
+        /// Only an explicit <c>true</c> opts in: stencil buffers trade geometry anti-aliasing quality for
+        /// clipping speed (see issue #21760), so they must never be enabled implicitly.
+        /// </summary>
+        internal static bool ShouldAvoidStencilBuffers(bool? useStencilBuffers) => useStencilBuffers == false;
     }
 }

--- a/src/Skia/Avalonia.Skia/SkiaOptions.cs
+++ b/src/Skia/Avalonia.Skia/SkiaOptions.cs
@@ -37,6 +37,6 @@ namespace Avalonia
         /// Only an explicit <c>true</c> opts in: stencil buffers trade geometry anti-aliasing quality for
         /// clipping speed (see issue #21760), so they must never be enabled implicitly.
         /// </summary>
-        internal static bool ShouldAvoidStencilBuffers(bool? useStencilBuffers) => useStencilBuffers == false;
+        internal static bool ShouldAvoidStencilBuffers(bool? useStencilBuffers) => useStencilBuffers != true;
     }
 }

--- a/tests/Avalonia.Skia.UnitTests/SkiaOptionsTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/SkiaOptionsTests.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+namespace Avalonia.Skia.UnitTests
+{
+    public class SkiaOptionsTests
+    {
+        // Stencil buffers let Skia choose multisample-based path rendering, which quantizes edge
+        // coverage and visibly degraded vector geometry anti-aliasing on GPU backends in 12.1.0.
+        // They are a performance opt-in, so anything other than an explicit `true` must avoid them.
+        [Theory]
+        [InlineData(null, true)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        public void Stencil_Buffers_Are_Avoided_Unless_Explicitly_Enabled(bool? useStencilBuffers, bool expected)
+        {
+            Assert.Equal(expected, SkiaOptions.ShouldAvoidStencilBuffers(useStencilBuffers));
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Restores the pre-12.1 default for Skia's `AvoidStencilBuffers`, fixing the vector-geometry
anti-aliasing regression in #21760. The `SkiaOptions.UseStencilBuffers` option from #21586 is kept
as an explicit opt-in.

## What is the current behavior?

On GPU backends, stroked `Path` / `StreamGeometry` shapes rasterize with softer, rougher edges on
12.1.0 than on 12.0.5. Small icons are worst affected. Text is byte-identical; software/headless
rendering is unaffected.

## What is the updated/expected behavior with this PR?

Only an explicit `true` enables stencil buffers. `null` (the default) and `false` both avoid them,
restoring 12.0.5 rasterization. Apps that want the clipping speedup opt in:

```csharp
AppBuilder.Configure<App>()
    .With(new SkiaOptions { UseStencilBuffers = true });
```

## How was the solution implemented (if it's not obvious)?

#21586 replaced the hardcoded `AvoidStencilBuffers = true` with `useStencilBuffers == false`.
`UseStencilBuffers` defaults to `null`, and `null == false` is `false`, so stencil buffers became
enabled by default on every GPU backend. Skia then selects multisample-based path rendering over
analytic coverage, quantizing edge coverage to the sample count instead of a smooth 8-bit ramp.
That accounts for each symptom above: glyphs come from the mask atlas rather than the path
renderer, and `GRContextOptions` only reaches `GRContext`, never the CPU rasterizer.

Nothing else in `12.0.5..12.1.0` affects GPU rasterization: SkiaSharp is pinned at 3.119.4 at both
tags, and #21682 changes compositor serialization, not `DrawingContextImpl` / `GeometryImpl`.

The default was duplicated across the GL, Metal and Vulkan backends, so one change flipped it in
three places. It is now single-sourced in `SkiaOptions.ShouldAvoidStencilBuffers` and covered by a
test. The XML doc described a per-platform default that was never implemented; it is corrected too.

Commits are split so the test can be seen failing before the fix.

### Verification

`tests/Avalonia.Skia.UnitTests` on macOS (arm64, .NET 10): 436 total, 427 passed, 9 skipped
(pre-existing Windows-font cases), 0 failed. The new test fails on the first commit and passes on
the second.

**Not visually verified** — the regression reproduces on Windows GPU and I only have macOS.
Existing render tests can't cover it either: they rasterize on the CPU and never construct a
`GRContext`.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

No API changes. Apps on 12.1.x implicitly getting stencil-accelerated clipping lose that speedup
unless they set `UseStencilBuffers = true`. This restores the 12.0.5 default.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21760
