### PR TITLE
[Android] Fix multiline TextBox caret staying on previous line after autocorrect + Enter

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Input/AvaloniaInputConnection.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AvaloniaInputConnection.cs
@@ -311,7 +311,7 @@ namespace Avalonia.Android.Platform.Input
 
         public bool SendKeyEvent(KeyEvent? e)
         {
-            _inputMethod.View.DispatchKeyEvent(e);
+            QueueCommand(new KeyEventCommand(e));
 
             return true;
         }

--- a/src/Android/Avalonia.Android/Platform/Input/EditCommand.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/EditCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Android.Views;
 using Avalonia.Input.TextInput;
 
 namespace Avalonia.Android.Platform.Input
@@ -175,6 +176,21 @@ namespace Avalonia.Android.Platform.Input
         public override void Apply(TextEditBuffer buffer)
         {
             buffer.Composition = default;
+        }
+    }
+
+    internal class KeyEventCommand : EditCommand
+    {
+        private readonly KeyEvent? _keyEvent;
+
+        public KeyEventCommand(KeyEvent? keyEvent)
+        {
+            _keyEvent = keyEvent;
+        }
+
+        public override void Apply(TextEditBuffer buffer)
+        {
+            buffer.DispatchKeyEvent(_keyEvent);
         }
     }
 }

--- a/src/Android/Avalonia.Android/Platform/Input/TextEditBuffer.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/TextEditBuffer.cs
@@ -131,5 +131,11 @@ namespace Avalonia.Android.Platform.Input
                 Composition = null;
             }
         }
+
+
+        internal void DispatchKeyEvent(KeyEvent? keyEvent)
+        {
+            _textInputMethod?.View.DispatchKeyEvent(keyEvent);
+        }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Fixes incorrect Enter-key behavior on Android when a soft-keyboard autocorrect
suggestion is committed in a multiline `TextBox`. See #21895.

## What is the current behavior?

In a multiline `TextBox` (`AcceptsReturn="True"`, `TextInputOptions.Multiline="True"`,
`TextWrapping="Wrap"`), typing a word that triggers an autocorrect suggestion and
then pressing Enter commits the autocorrect and inserts a line break, but the caret
stays on the *previous* line instead of moving to the new line.

Root cause: on Android the composing/autocorrect text is written as live text while
only a composition *region* (start/end indices) is tracked. IME edit operations
(`commitText`, `finishComposingText`) are **queued** and flushed on `EndBatchEdit`,
but `AvaloniaInputConnection.SendKeyEvent` dispatched the key **immediately, bypassing
the queue**. When the soft keyboard batches "commit autocorrect + press Enter", the
newline is inserted before the queued commit flushes; the commit then applies with
stale pre-newline composition indices and resets the caret to the end of the
committed word — i.e. before the `\r\n`.

## What is the updated/expected behavior with this PR?

The autocorrect is committed first, then the newline is inserted, leaving the caret
at the start of the new line.

To test: on an Android device/emulator with a suggestion-capable keyboard (e.g.
Gboard), use a multiline `TextBox`:
```xml
<TextBox AcceptsReturn="True" TextWrapping="Wrap" Width="200" Height="125"
         TextInputOptions.Multiline="True" />
```
Type a word that shows an autocorrect suggestion, then press Enter — the suggestion
is accepted, a line break is inserted, and the caret is on the new line.

https://github.com/user-attachments/assets/64b6288d-c4f9-4445-baf6-3f8131352733

## How was the solution implemented (if it's not obvious)?
`SendKeyEvent` now routes the key event through the same command queue as the other
IME edit operations, via a new `KeyEventCommand`, so key events apply in FIFO order
with the queued edits. This honors Android's `InputConnection` batch-edit ordering
contract (calls within a batch apply in order). Outside a batch edit the key is still
dispatched immediately, preserving existing timing.

- `AvaloniaInputConnection.SendKeyEvent` — queue the key event instead of dispatching synchronously.
- `EditCommand.KeyEventCommand` — new command that dispatches the key event on apply.
- `TextEditBuffer.DispatchKeyEvent` — small helper reusing the existing `View.DispatchKeyEvent` route already used by `Remove`/`Replace`.

Hardware key input is unaffected — it flows through `AvaloniaView.DispatchKeyEvent` /
`AndroidKeyboardEventsHelper`, not through the InputConnection.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21895