### PR TITLE
Expand security policy with response expectations and scope

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,5 @@
 # Security Policy
+Avalonia is free and open-source software published by AvaloniaUI OÜ. The framework is made publicly available at no charge and is not placed on the market within the meaning of the EU Cyber Resilience Act (Regulation (EU) 2024/2847). AvaloniaUI OÜ acts as the project's open-source software steward and maintains this cybersecurity policy in that capacity, in line with Article 24 of that Regulation.
 
 ## Reporting a Vulnerability
 
@@ -23,13 +24,23 @@ Alternatively, you may report security vulnerabilities by emailing security@aval
 
 ### What to Expect
 
-- We will acknowledge your report within **2 business days**.
-- We will confirm whether we consider it a vulnerability and give you a remediation timeline within **10 business days**.
+- We aim to acknowledge your report within **2 business days**.
+- We aim to confirm whether we consider it a vulnerability and to share a remediation timeline within **10 business days**.
 - We will keep you informed of progress and coordinate the disclosure date with you.
 - We will credit you in the published advisory unless you ask us not to.
 
+These timescales are the targets we work to for the open-source project; they are not contractual commitments. Organisations that require contractually binding response and remediation times can obtain them under a commercial agreement.
+
 Please note that Avalonia does not operate a bug bounty programme.
+
+## Versions Receiving Security Fixes
+| Version | Security fixes |
+|---|---|
+| 11.x and older | Not provided |
+| 12.x (current stable) | Provided |
+ 
+Security fixes for the versions listed above are published openly and free of charge. Access to Avalonia's open-source releases, updates and security fixes is never conditional on payment.
 
 ## Scope
 
-This policy covers the Avalonia framework packages published from this repository only.
+This policy covers the Avalonia framework packages published from this repository (`Avalonia` and the `Avalonia.*` platform and integration packages).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ Please note that Avalonia does not operate a bug bounty programme.
 | 11.x and older | Not provided |
 | 12.x (current stable) | Provided |
  
-Security fixes for the versions listed above are published openly and free of charge. Access to Avalonia's open-source releases, updates and security fixes is never conditional on payment.
+Security fixes are delivered at the head of the current stable series. If a vulnerability affects earlier 12.x releases, we fix it in a new release of the latest version, and the remediation path is to upgrade to that release. Security fixes for the current series are published openly and free of charge. Access to Avalonia's open-source releases, updates and security fixes is never conditional on payment.
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,17 +30,6 @@ Alternatively, you may report security vulnerabilities by emailing security@aval
 
 Please note that Avalonia does not operate a bug bounty programme.
 
-## Supported Versions
-
-| Version | Supported |
-|---|---|
-| 12.x (current stable) | Yes |
-| 11.x and older | No |
-
-Security updates are provided free of charge for supported versions.
-
 ## Scope
 
-This policy covers the Avalonia framework packages published from this repository (`Avalonia` and the `Avalonia.*` platform and integration packages).
-
-For security issues in other Avalonia products — including Avalonia Accelerate components and Avalonia XPF — use the affected repository's security page if you have access to it, or email security@avaloniaui.net.
+This policy covers the Avalonia framework packages published from this repository only.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,5 +21,26 @@ https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/
 ### Reporting via Email 
 Alternatively, you may report security vulnerabilities by emailing security@avaloniaui.net.
 
-### Misc 
+### What to Expect
+
+- We will acknowledge your report within **2 business days**.
+- We will confirm whether we consider it a vulnerability and give you a remediation timeline within **10 business days**.
+- We will keep you informed of progress and coordinate the disclosure date with you.
+- We will credit you in the published advisory unless you ask us not to.
+
 Please note that Avalonia does not operate a bug bounty programme.
+
+## Supported Versions
+
+| Version | Supported |
+|---|---|
+| 12.x (current stable) | Yes |
+| 11.x and older | No |
+
+Security updates are provided free of charge for supported versions.
+
+## Scope
+
+This policy covers the Avalonia framework packages published from this repository (`Avalonia` and the `Avalonia.*` platform and integration packages).
+
+For security issues in other Avalonia products — including Avalonia Accelerate components and Avalonia XPF — use the affected repository's security page if you have access to it, or email security@avaloniaui.net.


### PR DESCRIPTION
## What

Expands SECURITY.md with two additions (existing reporting instructions are unchanged):

- **What to Expect** — response commitments aligned with the org-wide security policy: acknowledge within 2 business days, remediation timeline within 10 business days, coordinated disclosure, credit for reporters.
- **Scope** — this policy covers the framework packages published from this repository only.

## Why

Part of the coordinated vulnerability disclosure rollout (AvaloniaUI/CustomerPortal#377), alongside the org-wide default policy (AvaloniaUI/.github#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)