### PR TITLE
Fix TreeViewItem.BringIntoView

### DIFF
--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -198,12 +198,23 @@ namespace Avalonia.Controls
 
                     if (m.HasValue)
                     {
-                        var bounds = new Rect(_header.Bounds.Size);
+                        var bounds = new Rect(GetHeaderTargetSize(_header));
                         var rect = bounds.TransformToAABB(m.Value);
                         e.TargetRect = rect;
                     }
                 }
             }
+        }
+
+        private static Size GetHeaderTargetSize(Control header)
+        {
+            // Use the DesiredWidth, not Bounds.Width: the latter is stretched to the full width of the tree view's extent,
+            // preventing scrolling, whereas the desired size is what the header actually needs.
+            var margin = header.Margin;
+            var desiredWidth = header.DesiredSize.Width - margin.Left - margin.Right;
+            var boundsSize = header.Bounds.Size;
+
+            return boundsSize.WithWidth(Math.Clamp(desiredWidth, 0.0, boundsSize.Width));
         }
 
         /// <inheritdoc/>

--- a/tests/Avalonia.Controls.UnitTests/TreeViewBringIntoViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TreeViewBringIntoViewTests.cs
@@ -1,0 +1,122 @@
+using System.Linq;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Themes.Simple;
+using Avalonia.UnitTests;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests;
+
+public class TreeViewBringIntoViewTests : ScopedTestBase
+{
+    [Fact]
+    public void BringIntoView_Should_Scroll_Back_To_Item_Scrolled_Off_To_The_Left()
+    {
+        using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+        var (root, treeView) = CreateTarget([CreateHeader(100), CreateHeader(500), CreateHeader(900)]);
+
+        root.LayoutManager.ExecuteInitialLayoutPass();
+
+        var scrollViewer = GetScrollViewer(treeView);
+
+        scrollViewer.Offset = new Vector(scrollViewer.Extent.Width - scrollViewer.Viewport.Width, 0);
+        root.LayoutManager.ExecuteLayoutPass();
+
+        var startOffset = scrollViewer.Offset.X;
+        Assert.True(startOffset > 0);
+
+        // The first item is narrow and now completely off to the left:
+        // bringing it into view must scroll back so that its header becomes visible.
+        var item = Assert.IsType<TreeViewItem>(treeView.ContainerFromIndex(0));
+        item.BringIntoView();
+        root.LayoutManager.ExecuteLayoutPass();
+
+        Assert.True(scrollViewer.Offset.X < 30);
+    }
+
+    [Fact]
+    public void BringIntoView_Should_Not_Scroll_When_Item_Is_Already_Visible()
+    {
+        using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+        var (root, treeView) = CreateTarget([CreateHeader(100), CreateHeader(500), CreateHeader(900)]);
+
+        root.LayoutManager.ExecuteInitialLayoutPass();
+
+        var scrollViewer = GetScrollViewer(treeView);
+        Assert.Equal(0, scrollViewer.Offset.X);
+
+        var item = Assert.IsType<TreeViewItem>(treeView.ContainerFromIndex(0));
+        item.BringIntoView();
+        root.LayoutManager.ExecuteLayoutPass();
+
+        Assert.Equal(0, scrollViewer.Offset.X);
+    }
+
+    [Fact]
+    public void BringIntoView_Should_Reveal_A_Nested_Item()
+    {
+        using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+        // A narrow item nested three levels deep, under wide ancestors that make the tree scroll.
+        var nestedHeader = CreateHeader(100);
+        var nestedItem = new TreeViewItem { Header = nestedHeader };
+        var item = nestedItem;
+
+        for (var i = 0; i < 3; i++)
+        {
+            item = new TreeViewItem
+            {
+                Header = CreateHeader(900),
+                IsExpanded = true,
+                ItemsSource = new[] { item }
+            };
+        }
+
+        var (root, treeView) = CreateTarget([item]);
+
+        root.LayoutManager.ExecuteInitialLayoutPass();
+
+        var scrollViewer = GetScrollViewer(treeView);
+
+        scrollViewer.Offset = new Vector(scrollViewer.Extent.Width - scrollViewer.Viewport.Width, 0);
+        root.LayoutManager.ExecuteLayoutPass();
+        Assert.True(scrollViewer.Offset.X > 0);
+
+        nestedItem.BringIntoView();
+        root.LayoutManager.ExecuteLayoutPass();
+
+        var headerBounds = new Rect(nestedHeader.Bounds.Size).TransformToAABB(nestedHeader.TransformToVisual(scrollViewer)!.Value);
+
+        Assert.True(headerBounds.Left >= -0.5 && headerBounds.Right <= scrollViewer.Viewport.Width + 0.5);
+    }
+
+    private static Border CreateHeader(double width) => new()
+    {
+        Width = width,
+        Height = 20,
+        HorizontalAlignment = HorizontalAlignment.Left,
+        Background = Brushes.Red
+    };
+
+    private static (TestRoot Root, TreeView TreeView) CreateTarget(Control[] headers)
+    {
+        var treeView = new TreeView
+        {
+            Width = 400,
+            Height = 200,
+            ItemsSource = headers
+        };
+
+        var root = new TestRoot { Width = 400, Height = 200 };
+        root.Resources.MergedDictionaries.Add(new SimpleTheme());
+        root.Child = treeView;
+
+        return (root, treeView);
+    }
+
+    private static ScrollViewer GetScrollViewer(TreeView treeView)
+        => treeView.GetVisualDescendants().OfType<ScrollViewer>().Single();
+}


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that when a `TreeViewItem` is brought into view, it is appropriately scrolled horizontally:
 - If the item is already completely visible, nothing moves.
 - If the item is partly visible, it is horizontally scrolled to.

## How was the solution implemented (if it's not obvious)?
This is an alternative to #20531. Instead of changing the horizontal alignment and breaking existing controls, we now bring into view the _measured_ width of the header (which is what it needs), rather than the _arranged_ size (which corresponds to the largest item in the view).

## Fixed issues
 - Fixes #15335
 - Fixes #20530
 - Supersedes #20531