### PR TITLE
fix(input): fix AccessKeyHandler when no descendant control has focus

### DIFF
--- a/src/Avalonia.Base/Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Base/Input/AccessKeyHandler.cs
@@ -176,9 +176,9 @@ namespace Avalonia.Input
         /// <param name="e">The event args.</param>
         protected virtual void OnPreviewKeyDown(object? sender, KeyEventArgs e)
         {
-            // if the owner (IInputRoot) does not have the keyboard focus, ignore all keyboard events
+            // if the event did not originate from within the owner (IInputRoot), ignore all keyboard events
             // KeyboardDevice.IsKeyboardFocusWithin in case of a PopupRoot seems to only work once, so we created our own
-            var isFocusWithinOwner = IsFocusWithinOwner(_owner!);
+            var isFocusWithinOwner = IsFocusWithinOwner(_owner!, e.Source as IInputElement);
             if (!isFocusWithinOwner)
                 return;
 
@@ -226,9 +226,9 @@ namespace Avalonia.Input
         /// <param name="e">The event args.</param>
         protected virtual void OnKeyDown(object? sender, KeyEventArgs e)
         {
-            // if the owner (IInputRoot) does not have the keyboard focus, ignore all keyboard events
+            // if the event did not originate from within the owner (IInputRoot), ignore all keyboard events
             // KeyboardDevice.IsKeyboardFocusWithin in case of a PopupRoot seems to only work once, so we created our own
-            var isFocusWithinOwner = IsFocusWithinOwner(_owner!);
+            var isFocusWithinOwner = IsFocusWithinOwner(_owner!, e.Source as IInputElement);
             if (!isFocusWithinOwner)
                 return;
 
@@ -450,18 +450,18 @@ namespace Avalonia.Input
         }
 
         /// <summary>
-        /// Checks if the focused element is a descendent of the owner.
+        /// Checks if the event's source is the owner itself, or a descendant of it.
         /// </summary>
         /// <param name="owner">The owner to check.</param>
+        /// <param name="source">The source of the key event, representing the effective focused element.</param>
         /// <returns>If focused element is decendant of owner <c>true</c>, otherwise <c>false</c>. </returns>
-        private static bool IsFocusWithinOwner(IInputElement owner)
+        private static bool IsFocusWithinOwner(IInputElement owner, IInputElement? source)
         {
-            var focusedElement = KeyboardDevice.Instance?.FocusedElement;
-            if (focusedElement is not InputElement inputElement)
-                return false;
-
-            var isAncestorOf = owner is Visual root && root.IsVisualAncestorOf(inputElement);
-            return isAncestorOf;
+            if (source is not Visual sourceVisual)
+                    return false;
+            
+            return ReferenceEquals(sourceVisual, owner) ||
+                       (owner is Visual root && root.IsVisualAncestorOf(sourceVisual));
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Base/Input/AccessKeyHandler.cs
@@ -454,14 +454,13 @@ namespace Avalonia.Input
         /// </summary>
         /// <param name="owner">The owner to check.</param>
         /// <param name="source">The source of the key event, representing the effective focused element.</param>
-        /// <returns>If focused element is decendant of owner <c>true</c>, otherwise <c>false</c>. </returns>
-        private static bool IsFocusWithinOwner(IInputElement owner, IInputElement? source)
+        /// <returns>If <paramref name="source"/> is <paramref name="owner"/> or a descendant of it, <c>true</c>, otherwise <c>false</c>.</returns>
+        private static bool IsFocusWithinOwner(InputElement owner, IInputElement? source)
         {
-            if (source is not Visual sourceVisual)
-                    return false;
+            if (source is not Visual sourceVisual) 
+                return false;
             
-            return ReferenceEquals(sourceVisual, owner) ||
-                       (owner is Visual root && root.IsVisualAncestorOf(sourceVisual));
+            return ReferenceEquals(sourceVisual, owner) || owner.IsVisualAncestorOf(sourceVisual);
         }
 
         /// <summary>

--- a/tests/Avalonia.Base.UnitTests/Input/AccessKeyHandlerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/AccessKeyHandlerTests.cs
@@ -131,11 +131,9 @@ namespace Avalonia.Base.UnitTests.Input
             KeyUp(root, Key.A, "a", KeyModifiers.Alt);
             KeyUp(root, Key.LeftAlt);
 
-            // Alt+A's KeyDown is now correctly matched and marked Handled by
-            // AccessKeyHandler.OnKeyDown (Bubble), so it no longer reaches a plain
-            // (non-handledEventsToo) KeyDown subscriber. The corresponding KeyUp is
-            // unaffected: AccessKeyHandler only reacts to KeyUp for the Alt key itself
-            // (OnPreviewKeyUp), not for arbitrary registered access keys.
+            // AccessKeyHandler marks the Alt+A KeyDown as Handled once it matches a registered
+            // access key, so a plain KeyDown subscriber doesn't see it. KeyUp is unaffected: only
+            // KeyUp for the Alt key itself is handled, not arbitrary registered access keys.
             Assert.Equal(new[]
             {
                 "KeyDown LeftAlt",
@@ -351,6 +349,29 @@ namespace Avalonia.Base.UnitTests.Input
 
                 KeyUp(root, Key.LeftAlt);
                 Assert.Equal(1, menu.TimesOpenCalled);
+            }
+        }
+        
+        [Fact]
+        public void Should_Raise_AccessKey_When_Focus_Is_On_Descendant()
+        {
+            using (UnitTestApplication.Start(TestServices.RealFocus))
+            {
+                var button = new Button();
+                var root = new TestRoot(button);
+                var target = new AccessKeyHandler();
+                var raised = 0;
+
+                KeyboardDevice.Instance?.SetFocusedElement(button, NavigationMethod.Unspecified, KeyModifiers.None);
+
+                target.SetOwner(root);
+                target.Register("A", button);
+                button.AddHandler(AccessKeyHandler.AccessKeyEvent, (s, e) => ++raised);
+
+                KeyDown(button, Key.LeftAlt);
+                KeyDown(button, Key.A, "a", KeyModifiers.Alt);
+
+                Assert.Equal(1, raised);
             }
         }
 

--- a/tests/Avalonia.Base.UnitTests/Input/AccessKeyHandlerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/AccessKeyHandlerTests.cs
@@ -131,11 +131,14 @@ namespace Avalonia.Base.UnitTests.Input
             KeyUp(root, Key.A, "a", KeyModifiers.Alt);
             KeyUp(root, Key.LeftAlt);
 
-            // This differs from WPF which doesn't raise the `A` key event, but matches UWP.
+            // Alt+A's KeyDown is now correctly matched and marked Handled by
+            // AccessKeyHandler.OnKeyDown (Bubble), so it no longer reaches a plain
+            // (non-handledEventsToo) KeyDown subscriber. The corresponding KeyUp is
+            // unaffected: AccessKeyHandler only reacts to KeyUp for the Alt key itself
+            // (OnPreviewKeyUp), not for arbitrary registered access keys.
             Assert.Equal(new[]
             {
                 "KeyDown LeftAlt",
-                "KeyDown A",
                 "KeyUp A",
                 "KeyUp LeftAlt",
             }, events);
@@ -278,6 +281,74 @@ namespace Avalonia.Base.UnitTests.Input
                 KeyDown(root, Key.LeftAlt);
                 Assert.Equal(0, menu.TimesOpenCalled);
                 
+                KeyUp(root, Key.LeftAlt);
+                Assert.Equal(1, menu.TimesOpenCalled);
+            }
+        }
+
+        [Fact]
+        public void Should_Raise_AccessKey_When_Nothing_Is_Focused()
+        {
+            using (UnitTestApplication.Start(TestServices.RealFocus))
+            {
+                var button = new Button();
+                var root = new TestRoot(button);
+                var target = new AccessKeyHandler();
+                var raised = 0;
+
+                Assert.Null(KeyboardDevice.Instance?.FocusedElement);
+
+                target.SetOwner(root);
+                target.Register("A", button);
+                button.AddHandler(AccessKeyHandler.AccessKeyEvent, (s, e) => ++raised);
+
+                KeyDown(root, Key.LeftAlt);
+                KeyDown(root, Key.A, "a", KeyModifiers.Alt);
+
+                Assert.Equal(1, raised);
+            }
+        }
+
+        [Fact]
+        public void Should_Raise_AccessKey_When_Owner_Itself_Is_Focused()
+        {
+            using (UnitTestApplication.Start(TestServices.RealFocus))
+            {
+                var button = new Button();
+                var root = new TestRoot(button);
+                var target = new AccessKeyHandler();
+                var raised = 0;
+
+                KeyboardDevice.Instance?.SetFocusedElement(root, NavigationMethod.Unspecified, KeyModifiers.None);
+
+                target.SetOwner(root);
+                target.Register("A", button);
+                button.AddHandler(AccessKeyHandler.AccessKeyEvent, (s, e) => ++raised);
+
+                KeyDown(root, Key.LeftAlt);
+                KeyDown(root, Key.A, "a", KeyModifiers.Alt);
+
+                Assert.Equal(1, raised);
+            }
+        }
+
+        [Fact]
+        public void Should_Open_MainMenu_On_Alt_KeyUp_When_Nothing_Is_Focused()
+        {
+            using (UnitTestApplication.Start(TestServices.RealFocus))
+            {
+                var target = new AccessKeyHandler();
+                var menu = new FakeMenu();
+                var root = new TestRoot(menu);
+
+                Assert.Null(KeyboardDevice.Instance?.FocusedElement);
+
+                target.SetOwner(root);
+                target.MainMenu = menu;
+
+                KeyDown(root, Key.LeftAlt);
+                Assert.Equal(0, menu.TimesOpenCalled);
+
                 KeyUp(root, Key.LeftAlt);
                 Assert.Equal(1, menu.TimesOpenCalled);
             }


### PR DESCRIPTION
## What does the pull request do?
Fixes `AccessKeyHandler` so that Alt/mnemonic access keys work correctly even when no
descendant control has claimed keyboard focus yet — most notably right after a `Window`
is opened, before the user has pressed Tab or clicked anything.

## What is the current behavior?
`AccessKeyHandler.OnPreviewKeyDown` / `OnKeyDown` guard their logic behind
`IsFocusWithinOwner(_owner)`, which re-queries `KeyboardDevice.Instance.FocusedElement`
directly:

- Right after startup, `KeyboardDevice.Instance.FocusedElement` is `null` (nothing has
  claimed focus yet), so the pattern match `focusedElement is not InputElement` fails
  and `IsFocusWithinOwner` returns `false` immediately.
- Even once something does assign the owner/`TopLevel` itself as the focused element,
  `Visual.IsVisualAncestorOf` is a strict, non-reflexive ancestor check
  (`x.IsVisualAncestorOf(x)` is always `false`), so `IsFocusWithinOwner` still returns
  `false` when `FocusedElement == owner`.

In both cases `OnPreviewKeyDown`/`OnKeyDown` return early, so pressing Alt does nothing:
no access key underlines, no menu opening, no F10.

Meanwhile `KeyboardDevice.ProcessRawEvent` already resolves the *effective* focused
element as `FocusedElement ?? e.Root.FocusRoot` and uses that both as the routing target
and as `KeyEventArgs.Source` — so the event does correctly reach `AccessKeyHandler`'s
handlers on `_owner`, it's only the internal guard that re-derives a different (and
incomplete) answer from scratch.

## What is the updated/expected behavior with this PR?
Access keys (Alt + underline display, Alt+letter, F10/menu opening) work immediately
after a window opens, without requiring a prior Tab press or mouse click. Tests have
been added.

## How was the solution implemented (if it's not obvious)?
`IsFocusWithinOwner` now takes the routed event's `Source` (already resolved by
`KeyboardDevice.ProcessRawEvent` using the same `FocusedElement ?? e.Root.FocusRoot`
fallback) instead of independently re-reading `KeyboardDevice.Instance.FocusedElement`.
This avoids duplicating focus-resolution logic and fixes both underlying issues at once:

- `Source` is never `null` for a real key event, so the "nothing focused yet" case is
  handled correctly.
- The check now also accepts `ReferenceEquals(source, owner)`, fixing the
  `IsVisualAncestorOf` non-reflexivity issue for the case where the owner itself holds
  focus.

The shared `KeyDown`/`KeyUp` test helpers in `AccessKeyHandlerTests` have been updated to
populate `Source` the same way production code does
(`KeyboardDevice.Instance?.FocusedElement ?? target`), since they previously never set it.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None. `IsFocusWithinOwner` is a `private` method; its signature change is not observable
from outside `AccessKeyHandler`.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #21806