### PR TITLE
Only raise OnColorValuesChanged when colors actually change

### DIFF
--- a/src/Avalonia.FreeDesktop/DBusPlatformSettings.cs
+++ b/src/Avalonia.FreeDesktop/DBusPlatformSettings.cs
@@ -34,8 +34,9 @@ namespace Avalonia.FreeDesktop
             {
                 _themeVariant = await TryGetThemeVariantAsync(settings);
                 _accentColor = await TryGetAccentColorAsync(settings);
+                var oldValues = _lastColorValues;
                 _lastColorValues = BuildPlatformColorValues();
-                if (_lastColorValues is not null)
+                if (_lastColorValues is not null && oldValues != _lastColorValues)
                     Dispatcher.UIThread.Post(() => OnColorValuesChanged(_lastColorValues));
             }
         }

--- a/src/Avalonia.Native/NativePlatformSettings.cs
+++ b/src/Avalonia.Native/NativePlatformSettings.cs
@@ -8,6 +8,7 @@ namespace Avalonia.Native;
 internal class NativePlatformSettings : DefaultPlatformSettings
 {
     private readonly IAvnPlatformSettings _platformSettings;
+    private PlatformColorValues? _lastColorValues;
 
     public NativePlatformSettings(IAvnPlatformSettings platformSettings)
     {
@@ -29,7 +30,7 @@ internal class NativePlatformSettings : DefaultPlatformSettings
 
         if (color > 0)
         {
-            return new PlatformColorValues
+            return _lastColorValues = new PlatformColorValues
             {
                 ThemeVariant = theme,
                 ContrastPreference = contrast,
@@ -38,7 +39,7 @@ internal class NativePlatformSettings : DefaultPlatformSettings
         }
         else
         {
-            return new PlatformColorValues
+            return _lastColorValues = new PlatformColorValues
             {
                 ThemeVariant = theme,
                 ContrastPreference = contrast
@@ -48,7 +49,13 @@ internal class NativePlatformSettings : DefaultPlatformSettings
 
     public void OnColorValuesChanged()
     {
-        OnColorValuesChanged(GetColorValues());
+        var oldColors = _lastColorValues;
+        var newColors = GetColorValues();
+
+        if (oldColors != newColors)
+        {
+            OnColorValuesChanged(newColors);
+        }
     }
 
     private class ColorsChangeCallback : NativeCallbackBase, IAvnActionCallback

--- a/src/Windows/Avalonia.Win32/Win32PlatformSettings.cs
+++ b/src/Windows/Avalonia.Win32/Win32PlatformSettings.cs
@@ -11,6 +11,7 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
     private static readonly Lazy<bool> s_uiSettingsSupported = new(() =>
         WinRTApiInformation.IsTypePresent("Windows.UI.ViewManagement.UISettings")
         && WinRTApiInformation.IsTypePresent("Windows.UI.ViewManagement.AccessibilitySettings"));
+    private PlatformColorValues? _lastColorValues;
 
     public override Size GetTapSize(PointerType type)
     {
@@ -31,7 +32,7 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
     }
 
     public override TimeSpan GetDoubleTapTime(PointerType type) => TimeSpan.FromMilliseconds(GetDoubleClickTime());
-    
+
     public override PlatformColorValues GetColorValues()
     {
         if (!s_uiSettingsSupported.Value)
@@ -52,7 +53,7 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
             // - Night sky - High Contrast #2
             // Only "Desert" one can be considered a "light" preference. 
             using var highContrastScheme = new HStringInterop(accessibilitySettings.HighContrastScheme);
-            return new PlatformColorValues
+            return _lastColorValues = new PlatformColorValues
             {
                 ThemeVariant = highContrastScheme.Value?.Contains("White") == true ?
                     PlatformThemeVariant.Light :
@@ -65,19 +66,25 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
         else
         {
             var background = uiSettings.GetColorValue(UIColorType.Background).ToAvalonia();
-            return new PlatformColorValues
+            return _lastColorValues = new PlatformColorValues
             {
                 ThemeVariant = background.R + background.G + background.B < (255 * 3 - background.R - background.G - background.B) ?
                     PlatformThemeVariant.Dark :
                     PlatformThemeVariant.Light,
                 ContrastPreference = ColorContrastPreference.NoPreference,
                 AccentColor1 = accent
-            };   
+            };
         }
     }
-    
+
     internal void OnColorValuesChanged()
     {
-        OnColorValuesChanged(GetColorValues());
+        var oldColors = _lastColorValues;
+        var newColors = GetColorValues();
+
+        if (oldColors != newColors)
+        {
+            OnColorValuesChanged(newColors);
+        }
     }
 }

--- a/src/iOS/Avalonia.iOS/PlatformSettings.cs
+++ b/src/iOS/Avalonia.iOS/PlatformSettings.cs
@@ -64,6 +64,6 @@ internal class PlatformSettings : DefaultPlatformSettings
 
     internal void OnColorValuesChanged()
     {
-        OnColorValuesChanged(GetColorValues());
+        TraitCollectionDidChange();
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes an issue where `PlatformSettings.OnColorValuesChanged` is raised anytime a window or toplevel is created. This can cause long initialization of toplevel especially when custom theme managers are implemented and many toplevels exist.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/21897