### PR TITLE
fix(LinuxFramebuffer): select a KMS-capable DRM card automatically

### DIFF
--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 using static Avalonia.LinuxFramebuffer.NativeUnsafeMethods;
 using static Avalonia.LinuxFramebuffer.Output.LibDrm;
 
@@ -149,23 +148,36 @@ namespace Avalonia.LinuxFramebuffer.Output
 
     public unsafe class DrmCard : IDisposable
     {
-        public int Fd { get; private set; }
+        public int Fd { get; private set; } = -1;
         public DrmCard(string? path = null)
         {
             if (path == null)
             {
-                var files = Directory.GetFiles("/dev/dri/");
-
-                foreach (var file in files)
+                var files = new SortedDictionary<int, string>();
+                foreach (var file in Directory.GetFiles("/dev/dri/", "card*"))
                 {
-                    var match = Regex.Match(file, "card[0-9]+");
+                    if (int.TryParse(Path.GetFileName(file).AsSpan(4), out var cardNumber))
+                        files[cardNumber] = file;
+                }
 
-                    if (match.Success)
+                foreach (var file in files.Values)
+                {
+                    var fd = open(file, 2, 0);
+                    if (fd == -1)
+                        continue;
+
+                    var resources = drmModeGetResources(fd);
+                    if (resources != null && resources->count_crtcs > 0 && resources->count_encoders > 0 &&
+                        resources->count_connectors > 0)
                     {
-                        Fd = open(file, 2, 0);
-                        if (Fd != -1)
-                            break;
+                        drmModeFreeResources(resources);
+                        Fd = fd;
+                        break;
                     }
+
+                    if (resources != null)
+                        drmModeFreeResources(resources);
+                    close(fd);
                 }
 
                 if (Fd == -1)
@@ -187,6 +199,8 @@ namespace Avalonia.LinuxFramebuffer.Output
         public DrmResources GetResources(bool connectorsForceProbe = false) => new DrmResources(Fd, connectorsForceProbe);
         public void Dispose()
         {
+            if (Fd == -1)
+                return;
             close(Fd);
             Fd = -1;
         }

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using static Avalonia.LinuxFramebuffer.NativeUnsafeMethods;
@@ -156,7 +157,8 @@ namespace Avalonia.LinuxFramebuffer.Output
                 var files = new SortedDictionary<int, string>();
                 foreach (var file in Directory.GetFiles("/dev/dri/", "card*"))
                 {
-                    if (int.TryParse(Path.GetFileName(file).AsSpan(4), out var cardNumber))
+                    if (int.TryParse(Path.GetFileName(file).AsSpan(4), NumberStyles.None, CultureInfo.InvariantCulture,
+                            out var cardNumber))
                         files[cardNumber] = file;
                 }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Improves automatic DRM card detection.

Avalonia documentation states:

```csharp
// Avalonia auto-detects the output card.
// To specify one explicitly: card: "/dev/dri/card1"
return builder.StartLinuxDrm(args, card: null, options: new DrmOutputOptions
```
However, the previous detection simply opened the first DRM card returned by the file system.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

When no card path is specified, Avalonia opens the first matching /dev/dri/cardN, even if it does not expose usable KMS resources.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Avalonia checks DRM cards in numeric order and selects the first card exposing KMS resources with at least one CRTC, encoder, and connector.
Unsuitable cards are closed and skipped.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Card names are validated and sorted numerically. Each candidate is opened and checked with `drmModeGetResources`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

None.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

None.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

None.