### PR TITLE
fix(LinuxFramebuffer): free native DRM resources after enumeration

### DIFF
--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
@@ -93,26 +93,35 @@ namespace Avalonia.LinuxFramebuffer.Output
             if (res == null)
                 throw new Win32Exception("drmModeGetResources failed");
 
-            var crtcs = new drmModeCrtc[res->count_crtcs];
-            for (var c = 0; c < res->count_crtcs; c++)
+            try
             {
-                var crtc = drmModeGetCrtc(fd, res->crtcs[c]);
-                crtcs[c] = *crtc;
-                drmModeFreeCrtc(crtc);
-            }
+                var crtcs = new drmModeCrtc[res->count_crtcs];
+                for (var c = 0; c < res->count_crtcs; c++)
+                {
+                    var crtc = drmModeGetCrtc(fd, res->crtcs[c]);
+                    crtcs[c] = *crtc;
+                    drmModeFreeCrtc(crtc);
+                }
 
-            for (var c = 0; c < res->count_encoders; c++)
-            {
-                var enc = drmModeGetEncoder(fd, res->encoders[c]);
-                Encoders[res->encoders[c]] = new DrmEncoder(*enc, crtcs);
-                drmModeFreeEncoder(enc);
-            }
+                for (var c = 0; c < res->count_encoders; c++)
+                {
+                    var enc = drmModeGetEncoder(fd, res->encoders[c]);
+                    Encoders[res->encoders[c]] = new DrmEncoder(*enc, crtcs);
+                    drmModeFreeEncoder(enc);
+                }
 
-            for (var c = 0; c < res->count_connectors; c++)
+                for (var c = 0; c < res->count_connectors; c++)
+                {
+                    var conn = connectorsForceProbe ?
+                        drmModeGetConnector(fd, res->connectors[c]) :
+                        drmModeGetConnectorCurrent(fd, res->connectors[c]);
+                    Connectors.Add(new DrmConnector(conn));
+                    drmModeFreeConnector(conn);
+                }
+            }
+            finally
             {
-                var conn = connectorsForceProbe ? drmModeGetConnector(fd, res->connectors[c]) : drmModeGetConnectorCurrent(fd, res->connectors[c]);
-                Connectors.Add(new DrmConnector(conn));
-                drmModeFreeConnector(conn);
+                drmModeFreeResources(res);
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Releases the native `drmModeRes` returned by `drmModeGetResources` after its data has been copied into managed objects.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

`DrmResources` does not call `drmModeFreeResources`, causing a native memory leak each time DRM resources are queried.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

The native DRM resource structure is always released after it has been processed.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

None.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

None.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

None.
