### PR TITLE
Enable picking `.app`-packages as a folder on macOS

### DIFF
--- a/native/Avalonia.Native/src/OSX/StorageProvider.mm
+++ b/native/Avalonia.Native/src/OSX/StorageProvider.mm
@@ -192,6 +192,7 @@ public:
             panel.canChooseDirectories = true;
             panel.canCreateDirectories = true;
             panel.canChooseFiles = false;
+            panel.treatsFilePackagesAsDirectories = true;
             
             if(title != nullptr)
             {


### PR DESCRIPTION
The native `NSOpenPanel` folder picker does not let you pick file packages like `Application.app`-bundles by default.
Since the file picker does not return these bundles either, picking these bundles is currently impossible.

## What does the pull request do?

Currently, neither the file picker, nor the folder picker, lets you pick `Application.app`-bundles.
This was reported for file pickers in #18080, with the response that bundles should be picked using the folder picker https://github.com/AvaloniaUI/Avalonia/issues/18080#issuecomment-2626300133.

However, the folder picker _does not let you_ pick bundles, because macOS generally wants you to think of these as a single file:
> A package is any directory that the Finder presents to the user as if it were a single file.
https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/AboutBundles/AboutBundles.html

By enabling `treatsFilePackagesAsDirectories` users can select a bundle and pick it as a folder, and also select the contents of that package.

<img width="512" alt="Application bundle selectable in folder picker, and its children visible" src="https://github.com/user-attachments/assets/586b4eb9-2b89-4561-a823-ac288837ab05" />

Note that this not only lets you pick the bundle, but also folders _inside_ the bundle. This was previously not possible.

## What is the current behavior?

The file picker without a filter lets you select application bundles, but when you confirm you get an empty result.

The folder picker does not let you select application bundles, they are greyed out:
<img width="512" alt="Picture before this change, showing the application bundle greyed out in the folder picker" src="https://github.com/user-attachments/assets/1faf2b83-eda5-44a8-bf5f-466a80dbae4f" />

## What is the updated/expected behavior with this PR?

1. File packages (like Application bundles) are selectable (main goal)
2. Contents of file packages are also visible, and selectable. Only in the folder picker, file picker is unchanged.

Test using

```sh
./build.sh CompileNative
dotnet run --project samples/ControlCatalog.Desktop/
```
then open the folder picker in the `Dialogs` tab. Try opening an application in `/Applications`.

## Checklist

- [ ] Added unit tests (if possible)?
Not possible as far as I can tell. Also, I've seen no integration test for the file pickers either, so I didn't add any tests.
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

Code-wise, none. Functionality-wise: contents of file packages (`.app`-Bundles, `.rtfd`-Documents, `.photolibrary`) are now visible, they weren't before.
`OpenFolderPickerAsync` can now return folders inside packages, like `Foo.app/Contents/Resources`.

## Fixed issues
Doesn't exactly fix #18080 (as that one is about file pickers), but it lets you work around it by opening a folder instead.

## Possible alternatives

Configure whether the folder picker and the file picker allow descending into file packages, configurable as an app-wide option in `MacOSPlatformOptions`.

Or return the `.app` folder path from the file picker instead, as it did before Avalonia 11.2 I think.