### PR TITLE
Ensure that ActualThemeVariant always has a proper value

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaView.cs
+++ b/src/Android/Avalonia.Android/AvaloniaView.cs
@@ -137,11 +137,8 @@ namespace Avalonia.Android
         private void SendConfigurationChanged(Configuration? newConfig)
         {
             _view.InsetsManager?.SetDefaultSystemLightMode(!(newConfig?.UiMode.HasFlag(UiMode.NightYes) ?? false));
-            if (Context is { } context && newConfig is { } config)
+            if (Context is not null && newConfig is not null)
             {
-                var settings =
-                    AvaloniaLocator.Current.GetRequiredService<IPlatformSettings>() as AndroidPlatformSettings;
-                settings?.OnViewConfigurationChanged(context, config);
                 ((AndroidScreens)_view.TryGetFeature<IScreenImpl>()!).OnChanged();
             }
         }

--- a/src/Android/Avalonia.Android/Platform/AndroidPlatformSettings.cs
+++ b/src/Android/Avalonia.Android/Platform/AndroidPlatformSettings.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Android.Platform;
 // TODO: ideally should be created per view/activity.
 internal class AndroidPlatformSettings : DefaultPlatformSettings
 {
-    private PlatformColorValues _latestValues;
+    private PlatformColorValues _colorValues;
     private TimeSpan _holdWaitDuration = TimeSpan.FromMilliseconds(300);
     private TimeSpan _doubleTapTime = TimeSpan.FromMilliseconds(500);
     private Size _doubleTapSize = new Size(16,16);
@@ -20,16 +20,16 @@ internal class AndroidPlatformSettings : DefaultPlatformSettings
 
     public AndroidPlatformSettings()
     {
-        _latestValues = base.GetColorValues();
+        _colorValues = base.GetColorValues();
         if (global::Android.App.Application.Context is { } context)
         {
-            GetInputConfigValues(context);
+            UpdateInputConfigValues(context);
         }
     }
 
     public override PlatformColorValues GetColorValues()
     {
-        return _latestValues;
+        return _colorValues;
     }
 
     public override TimeSpan GetDoubleTapTime(PointerType type)
@@ -51,48 +51,66 @@ internal class AndroidPlatformSettings : DefaultPlatformSettings
 
     internal void OnViewConfigurationChanged(Context context, Configuration configuration)
     {
-        if (context.Resources is null)
-        {
-            return;
-        }
+        UpdateInputConfigValues(context);
+        UpdateColorValues(context, configuration);
+    }
 
-        PlatformThemeVariant systemTheme = (configuration.UiMode & UiMode.NightMask) switch
+    private void UpdateColorValues(Context context, Configuration configuration)
+    {
+        var oldColorValues = _colorValues;
+        var colorValues = GetColorValuesFromContext(context, configuration);
+
+        if (oldColorValues != colorValues)
+        {
+            _colorValues = colorValues;
+            OnColorValuesChanged(colorValues);
+        }
+    }
+
+    private static PlatformColorValues GetColorValuesFromContext(Context context, Configuration configuration)
+    {
+        var systemTheme = (configuration.UiMode & UiMode.NightMask) switch
         {
             UiMode.NightYes => PlatformThemeVariant.Dark,
             UiMode.NightNo => PlatformThemeVariant.Light,
             _ => throw new ArgumentOutOfRangeException()
         };
 
+        var contrastPreference = IsHighContrast(context);
+
         if (OperatingSystem.IsAndroidVersionAtLeast(31))
         {
-            // See https://developer.android.com/reference/android/R.color
-            var accent1 = context.Resources.GetColor(17170494, context.Theme); // Resource.Color.SystemAccent1500
-            var accent2 = context.Resources.GetColor(17170507, context.Theme); // Resource.Color.SystemAccent2500
-            var accent3 = context.Resources.GetColor(17170520, context.Theme); // Resource.Color.SystemAccent3500
-
-            _latestValues = new PlatformColorValues
+            if (context.Resources is { } resources)
             {
-                ThemeVariant = systemTheme,
-                ContrastPreference = IsHighContrast(context),
-                AccentColor1 = new Color(accent1.A, accent1.R, accent1.G, accent1.B),
-                AccentColor2 = new Color(accent2.A, accent2.R, accent2.G, accent2.B),
-                AccentColor3 = new Color(accent3.A, accent3.R, accent3.G, accent3.B),
-            };
+                // See https://developer.android.com/reference/android/R.color
+                var accent1 = resources.GetColor(17170494, context.Theme); // Resource.Color.SystemAccent1500
+                var accent2 = resources.GetColor(17170507, context.Theme); // Resource.Color.SystemAccent2500
+                var accent3 = resources.GetColor(17170520, context.Theme); // Resource.Color.SystemAccent3500
+
+                return new PlatformColorValues
+                {
+                    ThemeVariant = systemTheme,
+                    ContrastPreference = contrastPreference,
+                    AccentColor1 = new Color(accent1.A, accent1.R, accent1.G, accent1.B),
+                    AccentColor2 = new Color(accent2.A, accent2.R, accent2.G, accent2.B),
+                    AccentColor3 = new Color(accent3.A, accent3.R, accent3.G, accent3.B),
+                };
+            }
         }
         else if (OperatingSystem.IsAndroidVersionAtLeast(23))
         {
             // See https://developer.android.com/reference/android/R.attr
-            var array = context.Theme?.ObtainStyledAttributes(new[] { 16843829 }); // Resource.Attribute.ColorAccent
+            var array = context.Theme?.ObtainStyledAttributes([16843829]); // Resource.Attribute.ColorAccent
             if (array is not null)
             {
                 try
                 {
                     var accent = array.GetColor(0, 0);
 
-                    _latestValues = new PlatformColorValues
+                    return new PlatformColorValues
                     {
                         ThemeVariant = systemTheme,
-                        ContrastPreference = IsHighContrast(context),
+                        ContrastPreference = contrastPreference,
                         AccentColor1 = new Color(accent.A, accent.R, accent.G, accent.B)
                     };
                 }
@@ -102,17 +120,15 @@ internal class AndroidPlatformSettings : DefaultPlatformSettings
                 }
             }
         }
-        else
+
+        return new PlatformColorValues
         {
-            _latestValues = _latestValues with { ThemeVariant = systemTheme };
-        }
-
-        GetInputConfigValues(context);
-
-        OnColorValuesChanged(_latestValues);
+            ThemeVariant = systemTheme,
+            ContrastPreference = contrastPreference
+        };
     }
 
-    private void GetInputConfigValues(Context context)
+    private void UpdateInputConfigValues(Context context)
     {
         _holdWaitDuration = TimeSpan.FromMilliseconds(ViewConfiguration.LongPressTimeout);
 

--- a/src/Android/Avalonia.Android/Platform/AndroidPlatformSettings.cs
+++ b/src/Android/Avalonia.Android/Platform/AndroidPlatformSettings.cs
@@ -168,7 +168,6 @@ internal class AndroidPlatformSettings : DefaultPlatformSettings
             // The context might still have the old values at this point because they haven't been processed yet.
             // Postpone the update 100ms arbitrarily. Not an ideal solution, but sufficient.
             var timer = new DispatcherTimer(TimeSpan.FromMilliseconds(100), DispatcherPriority.Normal, Dispatcher.UIThread);
-            timer.Start();
 
             timer.Tick += (_, _) =>
             {
@@ -176,6 +175,8 @@ internal class AndroidPlatformSettings : DefaultPlatformSettings
                 settings.UpdateInputConfigValues(context);
                 settings.UpdateColorValues(context);
             };
+
+            timer.Start();
         }
     }
 }

--- a/src/Android/Avalonia.Android/Platform/AndroidPlatformSettings.cs
+++ b/src/Android/Avalonia.Android/Platform/AndroidPlatformSettings.cs
@@ -3,13 +3,14 @@ using Android.Content;
 using Android.Content.Res;
 using Android.Provider;
 using Android.Views;
+using AndroidX.Core.Content;
 using Avalonia.Input;
 using Avalonia.Platform;
+using Avalonia.Threading;
 using Color = Avalonia.Media.Color;
 
 namespace Avalonia.Android.Platform;
 
-// TODO: ideally should be created per view/activity.
 internal class AndroidPlatformSettings : DefaultPlatformSettings
 {
     private PlatformColorValues _colorValues;
@@ -20,11 +21,19 @@ internal class AndroidPlatformSettings : DefaultPlatformSettings
 
     public AndroidPlatformSettings()
     {
-        _colorValues = base.GetColorValues();
         if (global::Android.App.Application.Context is { } context)
         {
             UpdateInputConfigValues(context);
+            _colorValues = GetColorValuesFromContext(context);
+
+            ContextCompat.RegisterReceiver(
+                context,
+                new ConfigurationChangedReceiver(this),
+                new IntentFilter(Intent.ActionConfigurationChanged),
+                ContextCompat.ReceiverNotExported);
         }
+        else
+            _colorValues = base.GetColorValues();
     }
 
     public override PlatformColorValues GetColorValues()
@@ -49,16 +58,10 @@ internal class AndroidPlatformSettings : DefaultPlatformSettings
 
     public override TimeSpan HoldWaitDuration => _holdWaitDuration;
 
-    internal void OnViewConfigurationChanged(Context context, Configuration configuration)
-    {
-        UpdateInputConfigValues(context);
-        UpdateColorValues(context, configuration);
-    }
-
-    private void UpdateColorValues(Context context, Configuration configuration)
+    private void UpdateColorValues(Context context)
     {
         var oldColorValues = _colorValues;
-        var colorValues = GetColorValuesFromContext(context, configuration);
+        var colorValues = GetColorValuesFromContext(context);
 
         if (oldColorValues != colorValues)
         {
@@ -67,15 +70,10 @@ internal class AndroidPlatformSettings : DefaultPlatformSettings
         }
     }
 
-    private static PlatformColorValues GetColorValuesFromContext(Context context, Configuration configuration)
+    private static PlatformColorValues GetColorValuesFromContext(Context context)
     {
-        var systemTheme = (configuration.UiMode & UiMode.NightMask) switch
-        {
-            UiMode.NightYes => PlatformThemeVariant.Dark,
-            UiMode.NightNo => PlatformThemeVariant.Light,
-            _ => throw new ArgumentOutOfRangeException()
-        };
-
+        var uiMode = context.Resources?.Configuration?.UiMode & UiMode.NightMask ?? UiMode.NightNo;
+        var systemTheme = uiMode == UiMode.NightYes ? PlatformThemeVariant.Dark : PlatformThemeVariant.Light;
         var contrastPreference = IsHighContrast(context);
 
         if (OperatingSystem.IsAndroidVersionAtLeast(31))
@@ -157,6 +155,27 @@ internal class AndroidPlatformSettings : DefaultPlatformSettings
         catch
         {
             return ColorContrastPreference.NoPreference;
+        }
+    }
+
+    private sealed class ConfigurationChangedReceiver(AndroidPlatformSettings settings) : BroadcastReceiver
+    {
+        public override void OnReceive(Context? context, Intent? intent)
+        {
+            if (context is null)
+                return;
+
+            // The context might still have the old values at this point because they haven't been processed yet.
+            // Postpone the update 100ms arbitrarily. Not an ideal solution, but sufficient.
+            var timer = new DispatcherTimer(TimeSpan.FromMilliseconds(100), DispatcherPriority.Normal, Dispatcher.UIThread);
+            timer.Start();
+
+            timer.Tick += (_, _) =>
+            {
+                timer.Stop();
+                settings.UpdateInputConfigValues(context);
+                settings.UpdateColorValues(context);
+            };
         }
     }
 }

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -254,14 +254,6 @@ namespace Avalonia.Android.Platform.SkiaPlatform
                 themeVariant == PlatformThemeVariant.Light ? AppCompatDelegate.ModeNightNo : AppCompatDelegate.ModeNightYes;
 
             AppCompatDelegate.DefaultNightMode = nightMode;
-
-            if (nightMode == AppCompatDelegate.ModeNightFollowSystem && _view?.Context is { } context
-                && context.Resources?.Configuration is { } config)
-            {
-                var settings =
-                    AvaloniaLocator.Current.GetRequiredService<IPlatformSettings>() as AndroidPlatformSettings;
-                settings?.OnViewConfigurationChanged(context, config);
-            }
         }
 
         public AcrylicPlatformCompensationLevels AcrylicCompensationLevels => new(1, 1, 1);

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -30,6 +30,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 {
     class TopLevelImpl : ITopLevelImpl, EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfoWithWaitPolicy
     {
+        private readonly Context _context;
         private readonly AndroidKeyboardEventsHelper<TopLevelImpl> _keyboardHelper;
         private readonly AndroidMotionEventsHelper _pointerHelper;
         private readonly AndroidInputMethod<AvaloniaView> _textInputMethod;
@@ -51,6 +52,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
                 throw new ArgumentException("AvaloniaView.Context must not be null");
             }
 
+            _context = context;
             _view = new SurfaceViewImpl(context, this, placeOnTop);
             _textInputMethod = new AndroidInputMethod<AvaloniaView>(avaloniaView);
             _keyboardHelper = new AndroidKeyboardEventsHelper<TopLevelImpl>(this);
@@ -245,15 +247,16 @@ namespace Avalonia.Android.Platform.SkiaPlatform
                 };
             }
 
-            // Sets the default app NightMode to AppCompatDelegate.ModeNightFollowSystem when themeVariant is null. This
-            // allows app to follow the current OS night mode. Using either ModeNightNo or ModeNightYes will force the app
-            // to use one night mode, ignoring the system's configuration and preventing us from detecting system theme changes
-            // in View.OnConfigurationChanged. In this case, only Activity.OnConfigurationChanged is called when system theme is
-            // changed, but we don't have access to that method if the toplevel view is embedded in a custom activity
-            var nightMode = themeVariant == null ? AppCompatDelegate.ModeNightFollowSystem :
-                themeVariant == PlatformThemeVariant.Light ? AppCompatDelegate.ModeNightNo : AppCompatDelegate.ModeNightYes;
+            if (_context is AppCompatActivity activity)
+            {
+                var nightMode = themeVariant == PlatformThemeVariant.Dark ?
+                    AppCompatDelegate.ModeNightYes :
+                    AppCompatDelegate.ModeNightNo;
 
-            AppCompatDelegate.DefaultNightMode = nightMode;
+                // Don't use AppCompatDelegate.DefaultNightMode: doing so will force the app to use one night mode,
+                // ignoring the system's configuration and preventing us from detecting system theme changes.
+                activity.Delegate.SetLocalNightMode(nightMode);
+            }
         }
 
         public AcrylicPlatformCompensationLevels AcrylicCompensationLevels => new(1, 1, 1);

--- a/src/Avalonia.Base/StyledElement.cs
+++ b/src/Avalonia.Base/StyledElement.cs
@@ -612,13 +612,6 @@ namespace Avalonia
             {
                 OnControlThemeChanged();
             }
-            else if (change.Property == ThemeVariant.RequestedThemeVariantProperty)
-            {
-                if (change.GetNewValue<ThemeVariant>() is {} themeVariant && themeVariant != ThemeVariant.Default)
-                    SetValue(ThemeVariant.ActualThemeVariantProperty, themeVariant);
-                else
-                    ClearValue(ThemeVariant.ActualThemeVariantProperty);
-            }
             else if (change.Property == ThemeVariant.ActualThemeVariantProperty)
             {
                 ActualThemeVariantChanged?.Invoke(this, EventArgs.Empty);

--- a/src/Avalonia.Base/Styling/IThemeVariantRoot.cs
+++ b/src/Avalonia.Base/Styling/IThemeVariantRoot.cs
@@ -1,0 +1,12 @@
+namespace Avalonia.Styling;
+
+/// <summary>
+/// Implemented by objects which resolve a <see cref="ThemeVariant.Default"/> requested theme variant from the platform.
+/// </summary>
+internal interface IThemeVariantRoot
+{
+    /// <summary>
+    /// Gets whether this object currently acts as a theme variant root (it has no parent).
+    /// </summary>
+    bool IsThemeVariantRoot { get; }
+}

--- a/src/Avalonia.Base/Styling/ThemeVariant.cs
+++ b/src/Avalonia.Base/Styling/ThemeVariant.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Text;
+using Avalonia.Logging;
 using Avalonia.Platform;
 
 namespace Avalonia.Styling;
@@ -45,7 +45,12 @@ public sealed record ThemeVariant
     internal static readonly StyledProperty<ThemeVariant?> RequestedThemeVariantProperty =
         AvaloniaProperty.Register<StyledElement, ThemeVariant?>(
             "RequestedThemeVariant", defaultValue: Default);
-    
+
+    static ThemeVariant()
+    {
+        RequestedThemeVariantProperty.Changed.AddClassHandler<AvaloniaObject>((x, _) => UpdateActualThemeVariant(x));
+    }
+
     /// <summary>
     /// Creates a new instance of the <see cref="ThemeVariant"/>
     /// </summary>
@@ -78,6 +83,42 @@ public sealed record ThemeVariant
     /// Reference to a theme variant which should be used, if resource wasn't found for the requested variant.
     /// </summary>
     public ThemeVariant? InheritVariant { get; }
+
+    internal static void UpdateActualThemeVariant(AvaloniaObject target)
+    {
+        var requested = target.GetValue(RequestedThemeVariantProperty) ?? Default;
+
+        if (requested != Default)
+        {
+            target.SetValue(ActualThemeVariantProperty, requested);
+            return;
+        }
+
+        if (target is IThemeVariantRoot { IsThemeVariantRoot: true })
+        {
+            var actual = GetPlatformThemeVariant();
+
+            Logger.TryGet(LogEventLevel.Debug, LogArea.Platform)
+                ?.Log(target, "Requested Default theme variant, used {ActualThemeVariant} platform variant", actual);
+
+            target.SetValue(ActualThemeVariantProperty, actual);
+        }
+        else
+        {
+            Logger.TryGet(LogEventLevel.Debug, LogArea.Platform)
+                ?.Log(target, "Requested Default theme variant, inheriting from parent");
+
+            target.ClearValue(ActualThemeVariantProperty);
+        }
+    }
+
+    private static ThemeVariant GetPlatformThemeVariant()
+    {
+        var variant = AvaloniaLocator.Current.GetService<IPlatformSettings>()?.GetColorValues().ThemeVariant ??
+                      PlatformThemeVariant.Light;
+
+        return (ThemeVariant)variant;
+    }
 
     public override string ToString()
     {

--- a/src/Avalonia.Controls/Application.cs
+++ b/src/Avalonia.Controls/Application.cs
@@ -30,7 +30,7 @@ namespace Avalonia
     /// method.
     /// - Tracks the lifetime of the application.
     /// </remarks>
-    public class Application : AvaloniaObject, IDataContextProvider, IGlobalDataTemplates, IGlobalStyles, IThemeVariantHost, IResourceHost, IOptionalFeatureProvider
+    public class Application : AvaloniaObject, IDataContextProvider, IGlobalDataTemplates, IGlobalStyles, IThemeVariantHost, IThemeVariantRoot, IResourceHost, IOptionalFeatureProvider
     {
         /// <summary>
         /// The application-global data templates.
@@ -96,6 +96,8 @@ namespace Avalonia
         [System.Diagnostics.CodeAnalysis.SuppressMessage("AvaloniaProperty", "AVP1031", Justification = "This property is supposed to be a styled readonly property.")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("AvaloniaProperty", "AVP1030", Justification = "False positive.")]
         public ThemeVariant ActualThemeVariant => GetValue(ActualThemeVariantProperty);
+
+        bool IThemeVariantRoot.IsThemeVariantRoot => true;
 
         /// <summary>
         /// Gets the current instance of the <see cref="Application"/> class.
@@ -250,11 +252,7 @@ namespace Avalonia
             AvaloniaSynchronizationContext.InstallIfNeeded();
             InputManager = new InputManager();
 
-            if (PlatformSettings is { } settings)
-            {
-                settings.ColorValuesChanged += OnColorValuesChanged;
-                OnColorValuesChanged(settings, settings.GetColorValues());
-            }
+            InitializeThemeVariant();
 
             AvaloniaLocator.CurrentMutable
                 .Bind<IAccessKeyHandler>().ToTransient<AccessKeyHandler>()
@@ -328,21 +326,7 @@ namespace Avalonia
         {
             base.OnPropertyChanged(change);
 
-            if (change.Property == RequestedThemeVariantProperty)
-            {
-                if (change.GetNewValue<ThemeVariant>() is { } themeVariant)
-                {
-                    if (themeVariant == ThemeVariant.Default)
-                    {
-                        ClearValue(ActualThemeVariantProperty);
-                    }
-                    else
-                    {
-                        SetValue(ActualThemeVariantProperty, themeVariant);
-                    }
-                }
-            }
-            else if (change.Property == ActualThemeVariantProperty)
+            if (change.Property == ActualThemeVariantProperty)
             {
                 ActualThemeVariantChanged?.Invoke(this, EventArgs.Empty);
             }
@@ -350,8 +334,13 @@ namespace Avalonia
 
         private void OnColorValuesChanged(object? sender, PlatformColorValues e)
         {
-            if ((RequestedThemeVariant ?? ThemeVariant.Default) == ThemeVariant.Default)
-                SetValue(ActualThemeVariantProperty, (ThemeVariant)e.ThemeVariant);
+            ThemeVariant.UpdateActualThemeVariant(this);
+        }
+
+        internal void InitializeThemeVariant()
+        {
+            PlatformSettings?.ColorValuesChanged += OnColorValuesChanged;
+            ThemeVariant.UpdateActualThemeVariant(this);
         }
     }
 }

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -42,7 +42,8 @@ namespace Avalonia.Controls
     public abstract class TopLevel : ContentControl,
         ICloseable,
         IStyleHost,
-        ILogicalRoot
+        ILogicalRoot,
+        IThemeVariantRoot
     {
         /// <summary>
         /// Defines the <see cref="ClientSize"/> property.
@@ -248,19 +249,19 @@ namespace Avalonia.Controls
                 _globalStyles.GlobalStylesAdded += ((IStyleHost)this).StylesAdded;
                 _globalStyles.GlobalStylesRemoved += ((IStyleHost)this).StylesRemoved;
             }
+
             if (_applicationThemeHost is { })
             {
                 SetValue(ActualThemeVariantProperty, _applicationThemeHost.ActualThemeVariant, BindingPriority.Template);
                 _applicationThemeHost.ActualThemeVariantChanged += GlobalActualThemeVariantChanged;
             }
+            else
+            {
+                ThemeVariant.UpdateActualThemeVariant(this);
+            }
+
             CreatePlatformImplBinding(ActualThemeVariantProperty, variant =>
             {
-                if(_applicationThemeHost is AvaloniaObject element)
-                {
-                    if (element.GetValue(ThemeVariantScope.RequestedThemeVariantProperty) is { } requestedThemeVariant)
-                        variant = requestedThemeVariant == ThemeVariant.Default ? ThemeVariant.Default : variant;
-                }
-                variant ??= ThemeVariant.Default;
                 PlatformImpl?.SetFrameThemeVariant((PlatformThemeVariant?)variant);
             });
 
@@ -399,6 +400,8 @@ namespace Avalonia.Controls
             get => GetValue(RequestedThemeVariantProperty);
             set => SetValue(RequestedThemeVariantProperty, value);
         }
+
+        bool IThemeVariantRoot.IsThemeVariantRoot => _applicationThemeHost is null;
 
         /// <summary>
         /// Occurs when physical Back Button is pressed or a back navigation has been requested.

--- a/src/Avalonia.FreeDesktop/DBusPlatformSettings.cs
+++ b/src/Avalonia.FreeDesktop/DBusPlatformSettings.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Avalonia.Media;
 using Avalonia.Platform;
-using Avalonia.Threading;
 using Tmds.DBus.Protocol;
 using Avalonia.FreeDesktop.DBus;
 
@@ -12,12 +10,14 @@ namespace Avalonia.FreeDesktop
     {
         private readonly Settings? _settings;
 
-        private PlatformColorValues? _lastColorValues;
+        private PlatformColorValues _colorValues;
         private PlatformThemeVariant? _themeVariant;
         private Color? _accentColor;
 
         public DBusPlatformSettings()
         {
+            _colorValues = base.GetColorValues();
+
             if (DBusHelper.DefaultConnection is not { } conn)
                 return;
 
@@ -26,7 +26,7 @@ namespace Avalonia.FreeDesktop
             _ = TryGetInitialValuesAsync();
         }
 
-        public override PlatformColorValues GetColorValues() => _lastColorValues ?? base.GetColorValues();
+        public override PlatformColorValues GetColorValues() => _colorValues;
 
         private async Task TryGetInitialValuesAsync()
         {
@@ -34,15 +34,26 @@ namespace Avalonia.FreeDesktop
             {
                 _themeVariant = await TryGetThemeVariantAsync(settings);
                 _accentColor = await TryGetAccentColorAsync(settings);
-                _lastColorValues = BuildPlatformColorValues();
-                if (_lastColorValues is not null)
-                    Dispatcher.UIThread.Post(() => OnColorValuesChanged(_lastColorValues));
+                UpdateColorValues();
             }
         }
 
-        internal void OnRequestDefaultThemeVariant()
+        private static async Task<PlatformColorValues> GetUncachedColorValuesAsync(Settings settings)
         {
-            _ = TryGetInitialValuesAsync();
+            var nullableThemeVariant = await TryGetThemeVariantAsync(settings);
+            var nullableAccentColor = await TryGetAccentColorAsync(settings);
+
+            return (nullableThemeVariant, nullableAccentColor) switch
+            {
+                ({ } themeVariant, { } accentColor)
+                    => new PlatformColorValues { ThemeVariant = themeVariant, AccentColor1 = accentColor },
+                ({ } themeVariant, null)
+                    => new PlatformColorValues { ThemeVariant = themeVariant },
+                (null, { } accentColor)
+                    => new PlatformColorValues { AccentColor1 = accentColor },
+                (null, null)
+                    => new PlatformColorValues { ThemeVariant = PlatformThemeVariant.Light }
+            };
         }
 
         private static async Task<PlatformThemeVariant?> TryGetThemeVariantAsync(Settings settings)
@@ -82,32 +93,48 @@ namespace Avalonia.FreeDesktop
             }
         }
 
+        private void UpdateColorValues()
+        {
+            var oldColorValues = _colorValues;
+            var colorValues = BuildPlatformColorValues(_themeVariant, _accentColor);
+
+            if (oldColorValues != colorValues)
+            {
+                _colorValues = colorValues;
+                OnColorValuesChanged(colorValues);
+            }
+        }
+
         private void SettingsChangedHandler((string Namespace, string Key, VariantValue Value) tuple)
         {
             switch (tuple)
             {
                 case ("org.freedesktop.appearance", "color-scheme", var colorScheme):
                     _themeVariant = ToColorScheme(colorScheme.GetUInt32());
-                    _lastColorValues = BuildPlatformColorValues();
-                    OnColorValuesChanged(_lastColorValues!);
+                    UpdateColorValues();
                     break;
                 case ("org.freedesktop.appearance", "accent-color", var accentColor):
                     _accentColor = ToAccentColor(accentColor);
-                    _lastColorValues = BuildPlatformColorValues();
-                    OnColorValuesChanged(_lastColorValues!);
+                    UpdateColorValues();
                     break;
             }
         }
 
-        private PlatformColorValues? BuildPlatformColorValues()
+        private static PlatformColorValues BuildPlatformColorValues(
+            PlatformThemeVariant? nullableThemeVariant,
+            Color? nullableAccentColor)
         {
-            if (_themeVariant is { } themeVariant && _accentColor is { } accentColor)
-                return new PlatformColorValues { ThemeVariant = themeVariant, AccentColor1 = accentColor };
-            if (_themeVariant is { } themeVariant1)
-                return new PlatformColorValues { ThemeVariant = themeVariant1 };
-            if (_accentColor is { } accentColor1)
-                return new PlatformColorValues { AccentColor1 = accentColor1 };
-            return null;
+            return (nullableThemeVariant, nullableAccentColor) switch
+            {
+                ({ } themeVariant, { } accentColor)
+                    => new PlatformColorValues { ThemeVariant = themeVariant, AccentColor1 = accentColor },
+                ({ } themeVariant, null)
+                    => new PlatformColorValues { ThemeVariant = themeVariant },
+                (null, { } accentColor)
+                    => new PlatformColorValues { AccentColor1 = accentColor },
+                (null, null)
+                    => new PlatformColorValues { ThemeVariant = PlatformThemeVariant.Light }
+            };
         }
 
         private static PlatformThemeVariant ToColorScheme(uint value)

--- a/src/Avalonia.FreeDesktop/DBusPlatformSettings.cs
+++ b/src/Avalonia.FreeDesktop/DBusPlatformSettings.cs
@@ -38,24 +38,6 @@ namespace Avalonia.FreeDesktop
             }
         }
 
-        private static async Task<PlatformColorValues> GetUncachedColorValuesAsync(Settings settings)
-        {
-            var nullableThemeVariant = await TryGetThemeVariantAsync(settings);
-            var nullableAccentColor = await TryGetAccentColorAsync(settings);
-
-            return (nullableThemeVariant, nullableAccentColor) switch
-            {
-                ({ } themeVariant, { } accentColor)
-                    => new PlatformColorValues { ThemeVariant = themeVariant, AccentColor1 = accentColor },
-                ({ } themeVariant, null)
-                    => new PlatformColorValues { ThemeVariant = themeVariant },
-                (null, { } accentColor)
-                    => new PlatformColorValues { AccentColor1 = accentColor },
-                (null, null)
-                    => new PlatformColorValues { ThemeVariant = PlatformThemeVariant.Light }
-            };
-        }
-
         private static async Task<PlatformThemeVariant?> TryGetThemeVariantAsync(Settings settings)
         {
             try

--- a/src/Avalonia.Native/NativePlatformSettings.cs
+++ b/src/Avalonia.Native/NativePlatformSettings.cs
@@ -8,6 +8,7 @@ namespace Avalonia.Native;
 internal class NativePlatformSettings : DefaultPlatformSettings
 {
     private readonly IAvnPlatformSettings _platformSettings;
+    private PlatformColorValues? _colorValues;
 
     public NativePlatformSettings(IAvnPlatformSettings platformSettings)
     {
@@ -16,6 +17,9 @@ internal class NativePlatformSettings : DefaultPlatformSettings
     }
 
     public override PlatformColorValues GetColorValues()
+        => _colorValues ??= GetUncachedColorValues();
+
+    private PlatformColorValues GetUncachedColorValues()
     {
         var (theme, contrast) = _platformSettings.PlatformTheme switch
         {
@@ -48,7 +52,14 @@ internal class NativePlatformSettings : DefaultPlatformSettings
 
     public void OnColorValuesChanged()
     {
-        OnColorValuesChanged(GetColorValues());
+        var oldColorValues = _colorValues;
+        var colorValues = GetUncachedColorValues();
+
+        if (oldColorValues != colorValues)
+        {
+            _colorValues = colorValues;
+            OnColorValuesChanged(colorValues);
+        }
     }
 
     private class ColorsChangeCallback : NativeCallbackBase, IAvnActionCallback

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -71,12 +71,6 @@ namespace Avalonia.Native
         public override void SetFrameThemeVariant(PlatformThemeVariant? themeVariant)
         {
             var settings = AvaloniaLocator.Current.GetService<IPlatformSettings>();
-
-            if (themeVariant is null && settings is NativePlatformSettings typedSettings)
-            {
-                typedSettings.OnColorValuesChanged();
-            }
-
             themeVariant ??= settings?.GetColorValues().ThemeVariant ?? PlatformThemeVariant.Light;
             Native?.SetFrameThemeVariant((AvnPlatformThemeVariant)themeVariant);
         }

--- a/src/Avalonia.Wayland/WindowImplBase.cs
+++ b/src/Avalonia.Wayland/WindowImplBase.cs
@@ -78,12 +78,8 @@ internal abstract partial class WindowBaseImpl : IWindowBaseImpl
     public AcrylicPlatformCompensationLevels AcrylicCompensationLevels { get; } = default;
     public void SetTransparencyLevelHint(IReadOnlyList<WindowTransparencyLevel> transparencyLevels) { }
 
-    public async void SetFrameThemeVariant(PlatformThemeVariant? themeVariant)
+    public void SetFrameThemeVariant(PlatformThemeVariant? themeVariant)
     {
-        if (themeVariant == null && AvaloniaLocator.Current.GetService<IPlatformSettings>() is DBusPlatformSettings platformSettings)
-        {
-            platformSettings.OnRequestDefaultThemeVariant();
-        }
     }
 
     public Action? Closed { get; set; }

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -1710,12 +1710,8 @@ namespace Avalonia.X11
         public WindowTransparencyLevel TransparencyLevel =>
             _transparencyHelper?.CurrentLevel ?? WindowTransparencyLevel.None;
 
-        public async void SetFrameThemeVariant(PlatformThemeVariant? themeVariant)
+        public void SetFrameThemeVariant(PlatformThemeVariant? themeVariant)
         {
-            if (themeVariant == null && AvaloniaLocator.Current.GetService<IPlatformSettings>() is DBusPlatformSettings platformSettings)
-            {
-                platformSettings.OnRequestDefaultThemeVariant();
-            }
         }
 
         public AcrylicPlatformCompensationLevels AcrylicCompensationLevels { get; } = new AcrylicPlatformCompensationLevels(1, 0.8, 0.8);

--- a/src/Browser/Avalonia.Browser/BrowserPlatformSettings.cs
+++ b/src/Browser/Avalonia.Browser/BrowserPlatformSettings.cs
@@ -9,6 +9,7 @@ internal class BrowserPlatformSettings : DefaultPlatformSettings
     private bool _isDarkMode;
     private bool _isHighContrast;
     private bool _isInitialized;
+    private PlatformColorValues? _colorValues;
 
     public override event EventHandler<PlatformColorValues>? ColorValuesChanged
     {
@@ -22,25 +23,27 @@ internal class BrowserPlatformSettings : DefaultPlatformSettings
 
     public override PlatformColorValues GetColorValues()
     {
-        EnsureBackend();
-
-        return base.GetColorValues() with
+        if (_colorValues is null)
         {
-            ThemeVariant = _isDarkMode ? PlatformThemeVariant.Dark : PlatformThemeVariant.Light,
-            ContrastPreference = _isHighContrast ? ColorContrastPreference.High : ColorContrastPreference.NoPreference
-        };
+            EnsureBackend();
+            _colorValues = BuildPlatformColorValues(_isDarkMode, _isHighContrast);
+        }
+
+        return _colorValues;
     }
+
+    private static PlatformColorValues BuildPlatformColorValues(bool isDarkMode, bool isHighContrast)
+        => new()
+        {
+            ThemeVariant = isDarkMode ? PlatformThemeVariant.Dark : PlatformThemeVariant.Light,
+            ContrastPreference = isHighContrast ? ColorContrastPreference.High : ColorContrastPreference.NoPreference
+        };
 
     public void OnValuesChanged(bool isDarkMode, bool isHighContrast)
     {
         _isDarkMode = isDarkMode;
         _isHighContrast = isHighContrast;
-        OnColorValuesChanged(GetColorValues());
-    }
-
-    public void OnValuesChanged()
-    {
-        OnColorValuesChanged(GetColorValues());
+        UpdateColorValues();
     }
     
     private void EnsureBackend()
@@ -55,6 +58,18 @@ internal class BrowserPlatformSettings : DefaultPlatformSettings
                 _isDarkMode = values[0] > 0;
                 _isHighContrast = values[1] > 0;
             }
+        }
+    }
+
+    private void UpdateColorValues()
+    {
+        var oldColorValues = _colorValues;
+        var colorValues = BuildPlatformColorValues(_isDarkMode, _isHighContrast);
+
+        if (oldColorValues != colorValues)
+        {
+            _colorValues = colorValues;
+            OnColorValuesChanged(colorValues);
         }
     }
 }

--- a/src/Browser/Avalonia.Browser/BrowserTopLevelImpl.cs
+++ b/src/Browser/Avalonia.Browser/BrowserTopLevelImpl.cs
@@ -146,11 +146,6 @@ namespace Avalonia.Browser
 
         public void SetFrameThemeVariant(PlatformThemeVariant? themeVariant)
         {
-            // not in the standard, but we potentially can use "apple-mobile-web-app-status-bar-style" for iOS and "theme-color" for android.
-            if (themeVariant == null && AvaloniaLocator.Current.GetService<IPlatformSettings>() is BrowserPlatformSettings platformSettings)
-            {
-                platformSettings.OnValuesChanged();
-            }
         }
 
         public AcrylicPlatformCompensationLevels AcrylicCompensationLevels { get; }

--- a/src/Windows/Avalonia.Win32/Win32PlatformSettings.cs
+++ b/src/Windows/Avalonia.Win32/Win32PlatformSettings.cs
@@ -12,6 +12,8 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
         WinRTApiInformation.IsTypePresent("Windows.UI.ViewManagement.UISettings")
         && WinRTApiInformation.IsTypePresent("Windows.UI.ViewManagement.AccessibilitySettings"));
 
+    private PlatformColorValues? _colorValues;
+
     public override Size GetTapSize(PointerType type)
     {
         return type switch
@@ -33,10 +35,16 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
     public override TimeSpan GetDoubleTapTime(PointerType type) => TimeSpan.FromMilliseconds(GetDoubleClickTime());
     
     public override PlatformColorValues GetColorValues()
+        => _colorValues ??= GetUncachedColorValues();
+
+    private PlatformColorValues GetUncachedColorValues()
     {
         if (!s_uiSettingsSupported.Value)
         {
-            return base.GetColorValues();
+            return new PlatformColorValues
+            {
+                ThemeVariant = PlatformThemeVariant.Light
+            };
         }
 
         var uiSettings = NativeWinRTMethods.CreateInstance<IUISettings3>("Windows.UI.ViewManagement.UISettings");
@@ -50,7 +58,7 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
             // - Desert - High Contrast White
             // - Dusk - High Contrast #1
             // - Night sky - High Contrast #2
-            // Only "Desert" one can be considered a "light" preference. 
+            // Only "Desert" one can be considered a "light" preference.
             using var highContrastScheme = new HStringInterop(accessibilitySettings.HighContrastScheme);
             return new PlatformColorValues
             {
@@ -72,12 +80,19 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
                     PlatformThemeVariant.Light,
                 ContrastPreference = ColorContrastPreference.NoPreference,
                 AccentColor1 = accent
-            };   
+            };
         }
     }
-    
+
     internal void OnColorValuesChanged()
     {
-        OnColorValuesChanged(GetColorValues());
+        var oldColorValues = _colorValues;
+        var colorValues = GetUncachedColorValues();
+
+        if (oldColorValues != colorValues)
+        {
+            _colorValues = colorValues;
+            OnColorValuesChanged(colorValues);
+        }
     }
 }

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -964,8 +964,6 @@ namespace Avalonia.Win32
                     SetTransparencyMica();
                 }
             }
-
-            (Win32Platform.Instance.PlatformSettings as Win32PlatformSettings)?.OnColorValuesChanged();
         }
 
         protected virtual IntPtr CreateWindowOverride(ushort atom)

--- a/src/iOS/Avalonia.iOS/AvaloniaView.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaView.cs
@@ -256,11 +256,6 @@ namespace Avalonia.iOS
 
             public void SetFrameThemeVariant(PlatformThemeVariant? themeVariant)
             {
-                if (themeVariant is null && AvaloniaLocator.Current.GetService<IPlatformSettings>() is PlatformSettings settings)
-                {
-                    settings.OnColorValuesChanged();
-                }
-
 #if !TVOS
                 // TODO adjust status bar depending on full screen mode.
                 if ((OperatingSystem.IsIOSVersionAtLeast(13)

--- a/src/iOS/Avalonia.iOS/PlatformSettings.cs
+++ b/src/iOS/Avalonia.iOS/PlatformSettings.cs
@@ -8,9 +8,12 @@ namespace Avalonia.iOS;
 // TODO: ideally should be created per view/activity.
 internal class PlatformSettings : DefaultPlatformSettings
 {
-    private PlatformColorValues? _lastColorValues;
+    private PlatformColorValues? _colorValues;
 
     public override PlatformColorValues GetColorValues()
+        => _colorValues ??= GetUncachedColorValues();
+
+    private static PlatformColorValues GetUncachedColorValues()
     {
         var themeVariant = UITraitCollection.CurrentTraitCollection.UserInterfaceStyle == UIUserInterfaceStyle.Dark ?
             PlatformThemeVariant.Dark :
@@ -32,7 +35,7 @@ internal class PlatformSettings : DefaultPlatformSettings
             tintColor.GetRGBA(out var red, out var green, out var blue, out var alpha);
             if (red != 0 && green != 0 && blue != 0 && alpha != 0)
             {
-                return _lastColorValues = new PlatformColorValues
+                return new PlatformColorValues
                 {
                     ThemeVariant = themeVariant,
                     ContrastPreference = contrastPreference,
@@ -45,25 +48,22 @@ internal class PlatformSettings : DefaultPlatformSettings
             }
         }
 
-        return _lastColorValues = new PlatformColorValues
+        return new PlatformColorValues
         {
-            ThemeVariant = themeVariant, ContrastPreference = contrastPreference
+            ThemeVariant = themeVariant,
+            ContrastPreference = contrastPreference
         };
     }
 
     public void TraitCollectionDidChange()
     {
-        var oldColorValues = _lastColorValues;
-        var colorValues = GetColorValues();
+        var oldColorValues = _colorValues;
+        var colorValues = GetUncachedColorValues();
 
         if (oldColorValues != colorValues)
         {
+            _colorValues = colorValues;
             OnColorValuesChanged(colorValues);
         }
-    }
-
-    internal void OnColorValuesChanged()
-    {
-        OnColorValuesChanged(GetColorValues());
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/ThemeVariantTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ThemeVariantTests.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using Avalonia.Platform;
+using Avalonia.Styling;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests;
+
+public class ThemeVariantTests : ScopedTestBase
+{
+    [Fact]
+    public void Application_ActualThemeVariant_Falls_Back_To_Light_Without_Platform_Settings()
+    {
+        var application = new Application();
+        application.InitializeThemeVariant();
+
+        Assert.Equal(ThemeVariant.Light, application.ActualThemeVariant);
+    }
+
+    [Theory]
+    [InlineData(PlatformThemeVariant.Light)]
+    [InlineData(PlatformThemeVariant.Dark)]
+    public void Application_ActualThemeVariant_Is_Initialized_From_Platform_Settings(
+        PlatformThemeVariant platformThemeVariant)
+    {
+        using var app = StartApplication(new TestPlatformSettings(platformThemeVariant));
+
+        Assert.Equal((ThemeVariant)platformThemeVariant, Application.Current!.ActualThemeVariant);
+    }
+
+    [Fact]
+    public void Application_ActualThemeVariant_Follows_Platform_Settings_Changes()
+    {
+        var platformSettings = new TestPlatformSettings(PlatformThemeVariant.Light);
+        using var app = StartApplication(platformSettings);
+        var application = Application.Current!;
+
+        var raised = 0;
+        application.ActualThemeVariantChanged += (_, _) => ++raised;
+
+        platformSettings.ThemeVariant = PlatformThemeVariant.Dark;
+
+        Assert.Equal(ThemeVariant.Dark, application.ActualThemeVariant);
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public void Application_RequestedThemeVariant_Overrides_Platform_Settings()
+    {
+        var platformSettings = new TestPlatformSettings(PlatformThemeVariant.Light);
+        using var app = StartApplication(platformSettings);
+        var application = Application.Current!;
+
+        application.RequestedThemeVariant = ThemeVariant.Dark;
+
+        Assert.Equal(ThemeVariant.Dark, application.ActualThemeVariant);
+
+        platformSettings.ThemeVariant = PlatformThemeVariant.Light;
+        Assert.Equal(ThemeVariant.Dark, application.ActualThemeVariant);
+    }
+
+    [Fact]
+    public void Application_ActualThemeVariant_Reverts_To_Platform_Settings_When_Requesting_Default()
+    {
+        var platformSettings = new TestPlatformSettings(PlatformThemeVariant.Dark);
+        using var app = StartApplication(platformSettings);
+        var application = Application.Current!;
+
+        application.RequestedThemeVariant = ThemeVariant.Light;
+        Assert.Equal(ThemeVariant.Light, application.ActualThemeVariant);
+
+        application.RequestedThemeVariant = ThemeVariant.Default;
+        Assert.Equal(ThemeVariant.Dark, application.ActualThemeVariant);
+    }
+
+    [Fact]
+    public void Application_ActualThemeVariant_Reverts_To_Platform_Settings_When_Requesting_Null()
+    {
+        var platformSettings = new TestPlatformSettings(PlatformThemeVariant.Dark);
+        using var app = StartApplication(platformSettings);
+        var application = Application.Current!;
+
+        application.RequestedThemeVariant = ThemeVariant.Light;
+        Assert.Equal(ThemeVariant.Light, application.ActualThemeVariant);
+
+        application.RequestedThemeVariant = null;
+        Assert.Equal(ThemeVariant.Dark, application.ActualThemeVariant);
+    }
+
+    [Fact]
+    public void Application_Custom_ThemeVariant_Is_Used_As_Is()
+    {
+        var custom = new ThemeVariant("Custom", ThemeVariant.Dark);
+        using var app = StartApplication(new TestPlatformSettings(PlatformThemeVariant.Light));
+        var application = Application.Current!;
+
+        application.RequestedThemeVariant = custom;
+
+        Assert.Equal(custom, application.ActualThemeVariant);
+    }
+
+    [Fact]
+    public void TopLevel_ActualThemeVariant_Is_Initialized_From_Application()
+    {
+        using var app = StartApplication(new TestPlatformSettings(PlatformThemeVariant.Light));
+
+        BindApplicationAsThemeVariantHost();
+        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+
+        var window = new Window();
+
+        Assert.Equal(ThemeVariant.Dark, window.ActualThemeVariant);
+    }
+
+    [Fact]
+    public void TopLevel_ActualThemeVariant_Is_Initialized_From_Platform_Settings_Without_ThemeVariantHost()
+    {
+        using var app = StartApplication(new TestPlatformSettings(PlatformThemeVariant.Dark));
+
+        var window = new Window();
+
+        Assert.Equal(ThemeVariant.Dark, window.ActualThemeVariant);
+    }
+
+    [Fact]
+    public void TopLevel_ActualThemeVariant_Follows_Application()
+    {
+        var platformSettings = new TestPlatformSettings(PlatformThemeVariant.Light);
+        using var app = StartApplication(platformSettings);
+        var application = Application.Current!;
+
+        BindApplicationAsThemeVariantHost();
+
+        var window = new Window();
+        Assert.Equal(ThemeVariant.Light, window.ActualThemeVariant);
+
+        application.RequestedThemeVariant = ThemeVariant.Dark;
+        Assert.Equal(ThemeVariant.Dark, window.ActualThemeVariant);
+
+        application.RequestedThemeVariant = ThemeVariant.Default;
+        Assert.Equal(ThemeVariant.Light, window.ActualThemeVariant);
+
+        platformSettings.ThemeVariant = PlatformThemeVariant.Dark;
+        Assert.Equal(ThemeVariant.Dark, window.ActualThemeVariant);
+    }
+
+    [Fact]
+    public void TopLevel_RequestedThemeVariant_Overrides_Application_And_Is_Sent_To_Platform_Impl()
+    {
+        using var app = StartApplication(new TestPlatformSettings(PlatformThemeVariant.Dark));
+
+        BindApplicationAsThemeVariantHost();
+
+        var window = new Window { RequestedThemeVariant = ThemeVariant.Light };
+
+        Assert.Equal(ThemeVariant.Dark, Application.Current!.ActualThemeVariant);
+        Assert.Equal(ThemeVariant.Light, window.ActualThemeVariant);
+    }
+
+    [Fact]
+    public void TopLevel_ActualThemeVariant_Is_Inherited_By_Children()
+    {
+        using var app = StartApplication(new TestPlatformSettings(PlatformThemeVariant.Dark));
+
+        BindApplicationAsThemeVariantHost();
+
+        var child = new Border();
+        var scope = new ThemeVariantScope { Child = child };
+        var window = new Window { Content = scope };
+        window.Show();
+
+        Assert.Equal(ThemeVariant.Dark, scope.ActualThemeVariant);
+        Assert.Equal(ThemeVariant.Dark, child.ActualThemeVariant);
+
+        scope.RequestedThemeVariant = ThemeVariant.Light;
+
+        Assert.Equal(ThemeVariant.Dark, window.ActualThemeVariant);
+        Assert.Equal(ThemeVariant.Light, scope.ActualThemeVariant);
+        Assert.Equal(ThemeVariant.Light, child.ActualThemeVariant);
+    }
+
+    [Fact]
+    public void ThemeVariantScope_Requesting_Default_Reinherits_From_Parent()
+    {
+        using var app = StartApplication(new TestPlatformSettings(PlatformThemeVariant.Light));
+
+        BindApplicationAsThemeVariantHost();
+        Application.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+
+        var child = new Border();
+        var scope = new ThemeVariantScope { Child = child };
+        var window = new Window { Content = scope };
+        window.Show();
+
+        scope.RequestedThemeVariant = ThemeVariant.Light;
+        Assert.Equal(ThemeVariant.Light, scope.ActualThemeVariant);
+        Assert.Equal(ThemeVariant.Light, child.ActualThemeVariant);
+
+        scope.RequestedThemeVariant = ThemeVariant.Default;
+        Assert.Equal(ThemeVariant.Dark, scope.ActualThemeVariant);
+        Assert.Equal(ThemeVariant.Dark, child.ActualThemeVariant);
+    }
+
+    private static IDisposable StartApplication(TestPlatformSettings platformSettings)
+        => UnitTestApplication.Start(TestServices.StyledWindow.With(
+            platformSettings: platformSettings,
+            windowingPlatform: new MockWindowingPlatform()));
+
+    private static void BindApplicationAsThemeVariantHost()
+        => AvaloniaLocator.CurrentMutable.Bind<IThemeVariantHost>().ToConstant(Application.Current!);
+}

--- a/tests/Avalonia.UnitTests/TestPlatformSettings.cs
+++ b/tests/Avalonia.UnitTests/TestPlatformSettings.cs
@@ -1,0 +1,23 @@
+using Avalonia.Platform;
+
+namespace Avalonia.UnitTests;
+
+public class TestPlatformSettings(PlatformThemeVariant themeVariant)
+    : DefaultPlatformSettings
+{
+    private PlatformColorValues _colorValues = new() { ThemeVariant = themeVariant };
+
+    public override PlatformColorValues GetColorValues() => _colorValues;
+
+    public PlatformThemeVariant ThemeVariant
+    {
+        get => _colorValues.ThemeVariant;
+        set => SetColorValues(_colorValues with { ThemeVariant = value });
+    }
+
+    public void SetColorValues(PlatformColorValues colorValues)
+    {
+        _colorValues = colorValues;
+        OnColorValuesChanged(colorValues);
+    }
+}

--- a/tests/Avalonia.UnitTests/TestServices.cs
+++ b/tests/Avalonia.UnitTests/TestServices.cs
@@ -77,6 +77,7 @@ namespace Avalonia.UnitTests
             Func<IMouseDevice?>? mouseDevice = null,
             IRuntimePlatform? platform = null,
             IPlatformRenderInterface? renderInterface = null,
+            IPlatformSettings? platformSettings = null,
             ICursorFactory? standardCursorFactory = null,
             Func<IStyle>? theme = null,
             IFontManagerImpl? fontManagerImpl = null,
@@ -94,6 +95,7 @@ namespace Avalonia.UnitTests
             MouseDevice = mouseDevice;
             Platform = platform;
             RenderInterface = renderInterface;
+            PlatformSettings = platformSettings;
             FontManagerImpl = fontManagerImpl;
             TextShaperImpl = textShaperImpl;
             StandardCursorFactory = standardCursorFactory;
@@ -111,6 +113,7 @@ namespace Avalonia.UnitTests
         public Func<IMouseDevice?>? MouseDevice { get; }
         public IRuntimePlatform? Platform { get; }
         public IPlatformRenderInterface? RenderInterface { get; }
+        public IPlatformSettings? PlatformSettings { get; }
         public IFontManagerImpl? FontManagerImpl { get; }
         public ITextShaperImpl? TextShaperImpl { get; }
         public ICursorFactory? StandardCursorFactory { get; }
@@ -128,6 +131,7 @@ namespace Avalonia.UnitTests
             Func<IMouseDevice?>? mouseDevice = null,
             IRuntimePlatform? platform = null,
             IPlatformRenderInterface? renderInterface = null,
+            IPlatformSettings? platformSettings = null,
             IRenderTimer? renderLoop = null,
             IScheduler? scheduler = null,
             ICursorFactory? standardCursorFactory = null,
@@ -147,6 +151,7 @@ namespace Avalonia.UnitTests
                 mouseDevice: mouseDevice ?? MouseDevice,
                 platform: platform ?? Platform,
                 renderInterface: renderInterface ?? RenderInterface,
+                platformSettings: platformSettings ?? PlatformSettings,
                 fontManagerImpl: fontManagerImpl ?? FontManagerImpl,
                 textShaperImpl: textShaperImpl ?? TextShaperImpl,
                 standardCursorFactory: standardCursorFactory ?? StandardCursorFactory,

--- a/tests/Avalonia.UnitTests/UnitTestApplication.cs
+++ b/tests/Avalonia.UnitTests/UnitTestApplication.cs
@@ -88,9 +88,11 @@ namespace Avalonia.UnitTests
                 .Bind<ICursorFactory?>().ToConstant(Services.StandardCursorFactory)
                 .Bind<IWindowingPlatform?>().ToConstant(Services.WindowingPlatform)
                 .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>()
-                .Bind<IPlatformSettings>().ToSingleton<DefaultPlatformSettings>()
+                .Bind<IPlatformSettings>().ToConstant(Services.PlatformSettings ?? new DefaultPlatformSettings())
                 .Bind<IAccessKeyHandler?>().ToFunc(Services.AccessKeyHandler ?? (() => null));
-            
+
+            InitializeThemeVariant();
+
             // This is a hack to make tests work, we need to refactor the way font manager is registered
             // See https://github.com/AvaloniaUI/Avalonia/issues/10081
             AvaloniaLocator.CurrentMutable.Bind<FontManager>().ToConstant((FontManager)null!);


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that `ActualThemeVariant` always has a proper value (typically `Light/Dark`).
Currently, there are cases where `ActualThemeVariant` gets set to null.

It was actually implemented in #16340 but caused several other problems. First, the fact that `ActualThemeVariant` could have an invalid value prevented the theme from propagating correctly. This led to workarounds like have to raise `PlatformSettings.ColorValuesChanged` to properly propagate the theme, even though the system settings didn't really change. Which caused in turn performance issues such as #21897.

Instead, this PR sets `ActualThemeVariant` properly again on `Application/TopLevel/ThemeVariantScope` whenever the `RequestedThemeVariant` or the system settings change.

Doing so actually regressed #16340 on Android though, as a non-null `ThemeVariant` is now again always passed to `ITopLevelImpl.SetFrameThemeVariant()`, causing the app to force a default mode, preventing system changes from happening (as documented). Instead, a local night mode is now set, and a custom receiver listens to configuration changes.

Unit tests have been added for non-platform code (verifying `ActualThemeVariant`).
Windows, macOS, Android, iOS, X11, Wayland and Browser have all been modified and re-tested.


## Fixed issues
 - Fixes #21897
 - Supersedes #16340
 - Supersedes #21921