### PR TITLE
fix: wrong escaping on xdg-open (linux)

### DIFF
--- a/src/Avalonia.Base/Platform/Storage/FileIO/BclLauncher.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/BclLauncher.cs
@@ -45,8 +45,16 @@ internal class BclLauncher : ILauncher
             {
                 // If no associated application/json MimeType is found xdg-open opens return error
                 // but it tries to open it anyway using the console editor (nano, vim, other..)
-                var args = EscapeForShell(urlOrFile);
-                ShellExecRaw($"xdg-open \\\"{args}\\\"", waitForExit: false);
+                var info = new ProcessStartInfo
+                {
+                    FileName = "xdg-open",
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                };
+                // Using ArgumentList.Add() avoid escaping! 
+                // This is similar to the following code for macos.
+                info.ArgumentList.Add(urlOrFile);
+                using var process = Process.Start(info);
                 return true;
             }
             else if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
@@ -74,31 +82,6 @@ internal class BclLauncher : ILauncher
             Logger.TryGet(LogEventLevel.Error, nameof(BclLauncher))?
                 .Log(null, "Exception during BclLauncher.Exec: {Error}", ex);
             return false;
-        }
-    }
-    
-    private static string EscapeForShell(string input) => Regex
-        .Replace(input, "(?=[`~!#&*()|;'<>])", "\\")
-        .Replace("\"", "\\\\\\\"");
-    
-    private static void ShellExecRaw(string cmd, bool waitForExit = true)
-    {
-        using (var process = Process.Start(
-                   new ProcessStartInfo
-                   {
-                       FileName = "/bin/sh",
-                       Arguments = $"-c \"{cmd}\"",
-                       RedirectStandardOutput = true,
-                       UseShellExecute = false,
-                       CreateNoWindow = true,
-                       WindowStyle = ProcessWindowStyle.Hidden
-                   }
-               ))
-        {
-            if (waitForExit)
-            {
-                process?.WaitForExit();
-            }
         }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

This PR resolves the issue described in #20230.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

(Based on what I encountered) An unnecessary `\` is added before the `#` character, causing the attempt to open a directory containing `#` to fail.

More detailed information can be found here: https://github.com/AvaloniaUI/Avalonia/issues/20230#issue-3703205766

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

The URI (file path, URL, etc.) is passed directly as an argument to `xdg-open`, allowing directories containing `#` to be opened successfully.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

(This is likely quite straightforward, but for the sake of clarity:)

Just like the macOS implementation, the arguments are passed directly to `xdg-open` (i.e., without any escaping).

Furthermore, the reason I didn't use the fix described in the additional information for Issue #20230 is that writing the code in a format similar to that for macOS eliminates the need for additional functions and avoids calling /bin/sh, which is of unclear necessity.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

None

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

None

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #20230


<details>
<summary>The Japanese original text before machine translation</summary>

## What does the pull request do?

#20230 の問題を解決するものです。

## What is the current behavior?

（私が直面した範囲では）`#` の前に不必要な `\` が追加され、`#`を含むディレクトリを開くことに失敗します。

こちらのほうがより詳細な情報があると思います : https://github.com/AvaloniaUI/Avalonia/issues/20230#issue-3703205766

## What is the updated/expected behavior with this PR?

そのまま xdg-open の引数に URI (ファイルパスや URLなど) が送られ、正常に `#` を含むディレクトリを開くことが出来ること。

## How was the solution implemented (if it's not obvious)?

(かなり愚直でわかりやすいと思いますが一応)

macos 向けのコードのように、引数をそのまま（つまり一切のエスケープ無しで） xdg-open の引数に渡るようにしています。

また、Issue #20230 の方に追加情報にある修正方法を使用しなかった理由は、 macos 向けのコードのような形にしたほうが、追加の関数も必要無く、必要性の不明な /bin/sh を呼び出しを回避できるからです。

</details>