### PR TITLE
Use ItemTemplate for ComboBox's selection box for controls

### DIFF
--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -425,6 +425,10 @@ namespace Avalonia.Controls
             {
                 CoerceValue(SelectionBoxItemTemplateProperty);
             }
+            else if (change.Property == SelectionBoxItemTemplateProperty)
+            {
+                UpdateSelectionBoxItem(SelectedItem);
+            }
             else if (change.Property == IsEditableProperty && change.GetNewValue<bool>())
             {
                 UpdateInputTextFromSelection(SelectedItem);
@@ -443,8 +447,11 @@ namespace Avalonia.Controls
             }
             else if (change.Property == DisplayMemberBindingProperty)
             {
-                CoerceValue(SelectionBoxItemTemplateProperty);
                 HandleTextValueBindingValueChanged(null, change);
+                // The base handler invalidates the cached template: run it before coercing.
+                base.OnPropertyChanged(change);
+                CoerceValue(SelectionBoxItemTemplateProperty);
+                return;
             }
             else if (change.Property == TextSearch.TextBindingProperty)
             {

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -102,7 +102,7 @@ namespace Avalonia.Controls
             if (template is not null) return template;
             if(obj is ComboBox comboBox && template is null)
             {
-                return comboBox.ItemTemplate;
+                return comboBox.GetEffectiveItemTemplate();
             }
             return template;
         }
@@ -443,6 +443,7 @@ namespace Avalonia.Controls
             }
             else if (change.Property == DisplayMemberBindingProperty)
             {
+                CoerceValue(SelectionBoxItemTemplateProperty);
                 HandleTextValueBindingValueChanged(null, change);
             }
             else if (change.Property == TextSearch.TextBindingProperty)
@@ -533,18 +534,24 @@ namespace Avalonia.Controls
 
         private void UpdateSelectionBoxItem(object? item)
         {
-            var contentControl = item as IContentControl;
-
-            if (contentControl != null)
+            if (item is IContentControl contentControl)
             {
                 item = contentControl.Content;
             }
 
-            var control = item as Control;
-
-            if (control != null)
+            if (item is null)
             {
-                if (VisualRoot is object)
+                SelectionBoxItem = null;
+                return;
+            }
+
+            if (SelectionBoxItemTemplate is not null)
+            {
+                SelectionBoxItem = item;
+            }
+            else if (item is Control control)
+            {
+                if (VisualRoot is not null)
                 {
                     control.Measure(Size.Infinity);
 
@@ -565,22 +572,7 @@ namespace Avalonia.Controls
             }
             else
             {
-                if (item is not null && ItemTemplate is null && SelectionBoxItemTemplate is null && DisplayMemberBinding is { } binding)
-                {
-                    var template = new FuncDataTemplate<object?>((_, _) =>
-                    new TextBlock
-                    {
-                        [TextBlock.DataContextProperty] = item,
-                        [!TextBlock.TextProperty] = binding,
-                    });
-                    var text = template.Build(item);
-                    SelectionBoxItem = text;
-                }
-                else
-                {
-                    SelectionBoxItem = item;
-                }
-                
+                SelectionBoxItem = item;
             }
         }
 

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -776,7 +776,7 @@ namespace Avalonia.Controls
                 LogicalChildren.RemoveAll(toRemove);
         }
 
-        private IDataTemplate? GetEffectiveItemTemplate()
+        private protected IDataTemplate? GetEffectiveItemTemplate()
         {
             if (ItemTemplate is { } itemTemplate)
                 return itemTemplate;

--- a/tests/Avalonia.Controls.UnitTests/ComboBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ComboBoxTests.cs
@@ -825,6 +825,99 @@ namespace Avalonia.Controls.UnitTests
             Assert.Same(item, textBlock.Tag);
         }
 
+        [Fact]
+        public void ItemTemplate_Is_Applied_To_Control_Item_In_SelectionBox_When_Changed()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+            var item = new Canvas();
+            var target = new ComboBox { Items = { item }, SelectedIndex = 0 };
+
+            var window = new Window { Content = target };
+            window.Show();
+            window.LayoutManager.ExecuteInitialLayoutPass();
+
+            AssertSelectionBoxItemIsVisualBrushOf(target, item);
+
+            target.ItemTemplate = new FuncDataTemplate<object?>((x, _) => new TextBlock { Tag = x });
+            window.LayoutManager.ExecuteLayoutPass();
+
+            var textBlock = Assert.IsType<TextBlock>(GetSelectionBoxControl(target).Presenter?.Child);
+            Assert.Same(item, textBlock.Tag);
+
+            target.ItemTemplate = null;
+            window.LayoutManager.ExecuteLayoutPass();
+
+            AssertSelectionBoxItemIsVisualBrushOf(target, item);
+        }
+
+        [Fact]
+        public void DisplayMemberBinding_Is_Applied_To_Control_Item_In_SelectionBox_When_Changed()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+            var item = new Canvas { Tag = "foo" };
+            var target = new ComboBox { Items = { item }, SelectedIndex = 0 };
+
+            var window = new Window { Content = target };
+            window.Show();
+            window.LayoutManager.ExecuteInitialLayoutPass();
+
+            AssertSelectionBoxItemIsVisualBrushOf(target, item);
+
+            target.DisplayMemberBinding = CompiledBinding.Create((Canvas c) => c.Tag);
+            window.LayoutManager.ExecuteLayoutPass();
+
+            var textBlock = Assert.IsType<TextBlock>(GetSelectionBoxControl(target).Presenter?.Child);
+            Assert.Equal("foo", textBlock.Text);
+
+            target.DisplayMemberBinding = null;
+            window.LayoutManager.ExecuteLayoutPass();
+
+            AssertSelectionBoxItemIsVisualBrushOf(target, item);
+        }
+
+        [Fact]
+        public void SelectionBoxItemTemplate_Is_Applied_To_Control_Item_In_SelectionBox_When_Changed()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+            var item = new Canvas();
+            var target = new ComboBox { Items = { item }, SelectedIndex = 0 };
+
+            var window = new Window { Content = target };
+            window.Show();
+            window.LayoutManager.ExecuteInitialLayoutPass();
+
+            AssertSelectionBoxItemIsVisualBrushOf(target, item);
+
+            target.SelectionBoxItemTemplate = new FuncDataTemplate<object?>((x, _) => new TextBlock { Tag = x });
+            window.LayoutManager.ExecuteLayoutPass();
+
+            var textBlock = Assert.IsType<TextBlock>(GetSelectionBoxControl(target).Presenter?.Child);
+            Assert.Same(item, textBlock.Tag);
+
+            target.SelectionBoxItemTemplate = null;
+            window.LayoutManager.ExecuteLayoutPass();
+
+            AssertSelectionBoxItemIsVisualBrushOf(target, item);
+        }
+
+        private static ContentControl GetSelectionBoxControl(ComboBox target)
+        {
+            var selectionBoxControl = target.FindDescendantOfType<ContentControl>(
+                false, c => c.ContentTemplate == target.SelectionBoxItemTemplate);
+            Assert.NotNull(selectionBoxControl);
+            return selectionBoxControl;
+        }
+
+        private static void AssertSelectionBoxItemIsVisualBrushOf(ComboBox target, Control item)
+        {
+            var rectangle = Assert.IsType<Rectangle>(target.SelectionBoxItem);
+            var visualBrush = Assert.IsType<VisualBrush>(rectangle.Fill);
+            Assert.Same(item, visualBrush.Visual);
+        }
+
         private sealed record Item(string Value, string Display);
 
         [Fact]

--- a/tests/Avalonia.Controls.UnitTests/ComboBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ComboBoxTests.cs
@@ -702,6 +702,129 @@ namespace Avalonia.Controls.UnitTests
             Assert.Null(target.SelectionBoxItem);
         }
 
+        [Fact]
+        public void ItemTemplate_Is_Applied_To_Control_Item_In_DropDown()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+            var item = new Canvas();
+            var target = new ComboBox
+            {
+                Items = { item },
+                ItemTemplate = new FuncDataTemplate<object?>((x, _) => new TextBlock { Tag = x }),
+                SelectedIndex = 0
+            };
+
+            var window = new Window { Content = target };
+            window.Show();
+            window.LayoutManager.ExecuteInitialLayoutPass();
+
+            target.IsDropDownOpen = true;
+            window.LayoutManager.ExecuteLayoutPass();
+
+            var container = Assert.IsType<ComboBoxItem>(target.ContainerFromIndex(0));
+            var textBlock = Assert.IsType<TextBlock>(container.Presenter?.Child);
+            Assert.Same(item, textBlock.Tag);
+        }
+
+        [Fact]
+        public void DisplayMemberBinding_Is_Applied_To_Control_Item_In_DropDown()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+            var item = new Canvas { Tag = "foo" };
+            var target = new ComboBox
+            {
+                Items = { item },
+                DisplayMemberBinding = CompiledBinding.Create((Canvas c) => c.Tag),
+                SelectedIndex = 0
+            };
+
+            var window = new Window { Content = target };
+            window.Show();
+            window.LayoutManager.ExecuteInitialLayoutPass();
+
+            target.IsDropDownOpen = true;
+            window.LayoutManager.ExecuteLayoutPass();
+
+            var container = Assert.IsType<ComboBoxItem>(target.ContainerFromIndex(0));
+            var textBlock = Assert.IsType<TextBlock>(container.Presenter?.Child);
+            Assert.Equal("foo", textBlock.Text);
+        }
+
+        [Fact]
+        public void ItemTemplate_Is_Applied_To_Control_Item_In_SelectionBox()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+            var item = new Canvas();
+            var target = new ComboBox
+            {
+                Items = { item },
+                ItemTemplate = new FuncDataTemplate<object?>((x, _) => new TextBlock { Tag = x }),
+                SelectedIndex = 0
+            };
+
+            var window = new Window { Content = target };
+            window.Show();
+            window.LayoutManager.ExecuteInitialLayoutPass();
+
+            var selectionBoxControl = target.FindDescendantOfType<ContentControl>(
+                false, c => c.ContentTemplate == target.SelectionBoxItemTemplate);
+            Assert.NotNull(selectionBoxControl);
+            var textBlock = Assert.IsType<TextBlock>(selectionBoxControl.Presenter?.Child);
+            Assert.Same(item, textBlock.Tag);
+        }
+
+        [Fact]
+        public void DisplayMemberBinding_Is_Applied_To_Control_Item_In_SelectionBox()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+            var item = new Canvas { Tag = "foo" };
+
+            var target = new ComboBox
+            {
+                Items = { item },
+                DisplayMemberBinding = CompiledBinding.Create((Canvas c) => c.Tag),
+                SelectedIndex = 0
+            };
+
+            var window = new Window { Content = target };
+            window.Show();
+            window.LayoutManager.ExecuteInitialLayoutPass();
+
+            var selectionBoxControl = target.FindDescendantOfType<ContentControl>(
+                false, c => c.ContentTemplate == target.SelectionBoxItemTemplate);
+            Assert.NotNull(selectionBoxControl);
+            var textBlock = Assert.IsType<TextBlock>(selectionBoxControl.Presenter?.Child);
+            Assert.Equal("foo", textBlock.Text);
+        }
+
+        [Fact]
+        public void SelectionBoxItemTemplate_Is_Applied_To_Control_Item_In_SelectionBox()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+            var item = new Canvas();
+            var target = new ComboBox
+            {
+                Items = { item },
+                SelectionBoxItemTemplate = new FuncDataTemplate<object?>((x, _) => new TextBlock { Tag = x }),
+                SelectedIndex = 0
+            };
+
+            var window = new Window { Content = target };
+            window.Show();
+            window.LayoutManager.ExecuteInitialLayoutPass();
+
+            var selectionBoxControl = target.FindDescendantOfType<ContentControl>(
+                false, c => c.ContentTemplate == target.SelectionBoxItemTemplate);
+            Assert.NotNull(selectionBoxControl);
+            var textBlock = Assert.IsType<TextBlock>(selectionBoxControl.Presenter?.Child);
+            Assert.Same(item, textBlock.Tag);
+        }
+
         private sealed record Item(string Value, string Display);
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that the logic used to display a `Control` in a `ComboBox` 's dropdown is also applied to its selection box. While it's a bit unusual to have a `Control` plus an `ItemTemplate` for it, Avalonia should be consistent.

Unit tests have been added.

## What is the current behavior?
Setting `ItemTemplate` or `DisplayMemberBinding` on a `ComboBox` whose items are controls works for items in the list, but not for the item displayed in the selection box. See #20572.

## What is the updated/expected behavior with this PR?
`SelectionBoxItemTemplate`, `ItemTemplate` or `DisplayMemberBinding` are applied to the selection box's item, even if it's a `Control`, matching what happens for items in the dropdown.

## Fixed issues
 - Fixes #20572
 - Supersedes #20587