### PR TITLE
Fix WrapPanel layout jitter with LineSpacing

### DIFF
--- a/src/Avalonia.Controls/WrapPanel.cs
+++ b/src/Avalonia.Controls/WrapPanel.cs
@@ -228,6 +228,7 @@ namespace Avalonia.Controls
             bool itemExists = false;
             bool lineExists = false;
             var itemsAlignment = ItemsAlignment;
+            var useLayoutRounding = UseLayoutRounding;
             // If we have infinite space on the U axis, we always use Start alignment to avoid strange behavior
             if (uvConstraint.U is double.PositiveInfinity)
                 itemsAlignment = WrapPanelItemsAlignment.Start;
@@ -250,7 +251,7 @@ namespace Avalonia.Controls
                     itemHeightSet ? itemHeight : child.DesiredSize.Height);
 
                 var nextSpacing = itemExists && child.IsVisible ? itemSpacing : 0;
-                if (MathUtilities.GreaterThan(curLineSize.U + childSize.U + nextSpacing, uvConstraint.U)) // Need to switch to another line
+                if (GreaterThan(useLayoutRounding, curLineSize.U + childSize.U + nextSpacing, uvConstraint.U)) // Need to switch to another line
                 {
                     panelSize.U = Max(curLineSize.U, panelSize.U);
                     panelSize.V += curLineSize.V + (lineExists ? lineSpacing : 0);
@@ -299,6 +300,7 @@ namespace Avalonia.Controls
             bool itemExists = false;
             bool lineExists = false;
             var itemsAlignment = ItemsAlignment;
+            var useLayoutRounding = UseLayoutRounding;
             // If we have infinite space on the U axis, we always use Start alignment to avoid strange behavior
             if (uvFinalSize.U is double.PositiveInfinity)
                 itemsAlignment = WrapPanelItemsAlignment.Start;
@@ -311,7 +313,7 @@ namespace Avalonia.Controls
                     itemHeightSet ? itemHeight : child.DesiredSize.Height);
 
                 var nextSpacing = itemExists && child.IsVisible ? itemSpacing : 0;
-                if (MathUtilities.GreaterThan(curLineSize.U + childSize.U + nextSpacing, uvFinalSize.U)) // Need to switch to another line
+                if (GreaterThan(useLayoutRounding, curLineSize.U + childSize.U + nextSpacing, uvFinalSize.U)) // Need to switch to another line
                 {
                     accumulatedV += lineExists ? lineSpacing : 0; // add spacing to arrange line first
                     ArrangeLine(curLineSize.V, firstInLine, i);
@@ -406,6 +408,13 @@ namespace Avalonia.Controls
                 double GetChildU(int i) => useItemU ? itemU :
                     isHorizontal ? children[i].DesiredSize.Width : children[i].DesiredSize.Height;
             }
+        }
+
+        private static bool GreaterThan(bool useLayoutRounding, double value1, double value2)
+        {
+            return useLayoutRounding
+                ? value1 > value2 && value1 - value2 > LayoutHelper.LayoutEpsilon
+                : MathUtilities.GreaterThan(value1, value2);
         }
 
         private struct UVSize

--- a/tests/Avalonia.Controls.UnitTests/WrapPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WrapPanelTests.cs
@@ -261,6 +261,56 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Rect(0, 140, 30, 50), target.Children[3].Bounds);
         }
 
+        [Theory]
+        [InlineData(true, 50)]
+        [InlineData(false, 110)]
+        public void Measure_Respects_Layout_Rounding_At_Wrap_Boundary(bool useLayoutRounding, double expectedHeight)
+        {
+            var target = new WrapPanel
+            {
+                UseLayoutRounding = useLayoutRounding,
+                ItemSpacing = 10,
+                LineSpacing = 10,
+                Children =
+                {
+                    new Border { Width = 45, Height = 50 },
+                    new Border { Width = 45, Height = 50 },
+                }
+            };
+
+            target.Measure(new Size(100 - LayoutHelper.LayoutEpsilon / 2, double.PositiveInfinity));
+
+            Assert.Equal(expectedHeight, target.DesiredSize.Height);
+        }
+
+        [Theory]
+        [InlineData(true, 0)]
+        [InlineData(false, 60)]
+        public void Arrange_Respects_Layout_Rounding_At_Wrap_Boundary(bool useLayoutRounding, double expectedSecondChildY)
+        {
+            var target = new WrapPanel
+            {
+                UseLayoutRounding = useLayoutRounding,
+                ItemSpacing = 10,
+                LineSpacing = 10,
+                Children =
+                {
+                    new Border { Width = 45, Height = 50, UseLayoutRounding = false },
+                    new Border
+                    {
+                        Width = 45 + LayoutHelper.LayoutEpsilon / 2,
+                        Height = 50,
+                        UseLayoutRounding = false,
+                    },
+                }
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, 100, 110));
+
+            Assert.Equal(expectedSecondChildY, target.Children[1].Bounds.Y);
+        }
+
         [Fact]
         public void Lays_Out_Horizontally_On_Separate_Lines_With_Spacing_Invisible()
         {
@@ -350,7 +400,7 @@ namespace Avalonia.Controls.UnitTests
                     new Border // line 1
                     {
                         Width = 50,
-                        Height = 50 
+                        Height = 50
                     },
                 }
             };


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes WrapPanel layout jitter near a wrap boundary when `LineSpacing` is set.


## What is the current behavior?
With layout rounding enabled at 125% display scaling, a sub-layout-epsilon overflow can cause inconsistent line wrapping during layout, making child elements visibly jitter while resizing.
<img width="1282" height="1036" alt="bugdemo1" src="https://github.com/user-attachments/assets/22a4dc70-e22a-453a-895b-af138ae7efc7" />


## What is the updated/expected behavior with this PR?
WrapPanel treats an overflow within `LayoutHelper.LayoutEpsilon` as fitting when layout rounding is enabled.
<img width="1282" height="1036" alt="bugdemo" src="https://github.com/user-attachments/assets/da2028c3-9102-418f-8634-c4d3927e7dec" />


## How was the solution implemented (if it's not obvious)?
Use `LayoutHelper.LayoutEpsilon` for the wrap-boundary comparison when `UseLayoutRounding` is enabled.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Fixes #18814
