### PR TITLE
Fix tooltip flickering

### DIFF
--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -78,7 +78,7 @@ namespace Avalonia.Controls
         {
             var currentToolTip = _tipControl?.GetValue(ToolTip.ToolTipProperty);
 
-            if (root == currentToolTip?.PopupHost?.HostedVisualTreeRoot)
+            if (root == currentToolTip?.PopupHost?.HostedVisualTreeRoot?.GetInputRoot())
             {
                 // Don't update while the pointer is over a tooltip
                 return;

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -14,10 +14,11 @@ namespace Avalonia.Controls
         private readonly IDisposable _subscriptions;
 
         private Control? _tipControl;
+        private bool _pointerOverTip;
+        private bool _pointerOverOwner;
+        private int _pendingCloseId;
         private long _lastTipCloseTime;
         private DispatcherTimer? _timer;
-        private ulong _lastTipEventTime;
-        private ulong _lastWindowEventTime;
 
         public ToolTipService(IInputManager inputManager)
         {
@@ -30,6 +31,7 @@ namespace Avalonia.Controls
         public void Dispose()
         {
             StopTimer();
+            CancelPendingClose();
             _subscriptions.Dispose();
         }
 
@@ -37,15 +39,35 @@ namespace Avalonia.Controls
         {
             if (e is RawPointerEventArgs pointerEvent)
             {
-                bool isTooltipEvent = false;
-                if (_tipControl?.GetValue(ToolTip.ToolTipProperty) is { } currentTip && e.Root == (currentTip.PopupHost as Visual)?.GetInputRoot())
+                var currentTip = _tipControl?.GetValue(ToolTip.ToolTipProperty);
+
+                // The input root of the tip itself, for popup windows only, not overlays.
+                var tipPopupInputRoot = (currentTip?.PopupHost as Visual)?.GetInputRoot() is { } root &&
+                                   root.RootElement != _tipControl?.VisualRoot ?
+                    root :
+                    null;
+
+                var isTipEvent = tipPopupInputRoot is not null && e.Root == tipPopupInputRoot;
+                var isTipOwnerWindowEvent = e.Root.RootElement == _tipControl?.VisualRoot;
+
+                if (isTipEvent || isTipOwnerWindowEvent)
                 {
-                    isTooltipEvent = true;
-                    _lastTipEventTime = pointerEvent.Timestamp;
-                }
-                else if (e.Root.RootElement == _tipControl?.VisualRoot)
-                {
-                    _lastWindowEventTime = pointerEvent.Timestamp;
+                    // The pointer is on one of the two windows (tip or owner) involved: remember which one, and cancel any
+                    // close scheduled by a previous LeaveWindow on the other one.
+                    if (pointerEvent.Type != RawPointerEventType.LeaveWindow)
+                    {
+                        _pointerOverTip = isTipEvent;
+                        _pointerOverOwner = isTipOwnerWindowEvent;
+                        CancelPendingClose();
+                    }
+                    else if (isTipEvent)
+                    {
+                        _pointerOverTip = false;
+                    }
+                    else
+                    {
+                        _pointerOverOwner = false;
+                    }
                 }
 
                 switch (pointerEvent.Type)
@@ -53,10 +75,24 @@ namespace Avalonia.Controls
                     case RawPointerEventType.Move:
                         Update(pointerEvent.Root, pointerEvent.InputHitTestResult.element as Visual);
                         break;
-                    case RawPointerEventType.LeaveWindow when (e.Root.RootElement == _tipControl?.VisualRoot && _lastTipEventTime != e.Timestamp) || (isTooltipEvent && _lastWindowEventTime != e.Timestamp):
-                        ClearTip();
-                        _tipControl = null;
+
+                    case RawPointerEventType.LeaveWindow:
+                        if ((isTipEvent && !_pointerOverOwner) || (isTipOwnerWindowEvent && !_pointerOverTip))
+                        {
+                            if (tipPopupInputRoot is not null)
+                            {
+                                // The pointer is leaving one of the two windows, but there's a chance it's going to
+                                // the other one. Schedule a close and cancel it if we receive another event.
+                                SchedulePendingClose();
+                            }
+                            else
+                            {
+                                CloseCurrentTip();
+                            }
+                        }
+
                         break;
+
                     case RawPointerEventType.LeftButtonDown:
                     case RawPointerEventType.RightButtonDown:
                     case RawPointerEventType.MiddleButtonDown:
@@ -70,6 +106,7 @@ namespace Avalonia.Controls
                 {
                     StopTimer();
                     _tipControl?.ClearValue(ToolTip.IsOpenProperty);
+                    _pointerOverTip = false;
                 }
             }
         }
@@ -110,6 +147,35 @@ namespace Avalonia.Controls
 
             OnTipControlChanged(_tipControl, newControl);
             _tipControl = newControl;
+            _pointerOverTip = false;
+            _pointerOverOwner = false;
+        }
+
+        private void SchedulePendingClose()
+        {
+            var control = _tipControl;
+            var closeId = ++_pendingCloseId;
+
+            // Post below input priority: any pointer event is processed before this callback and gets a chance to cancel it.
+            Dispatcher.UIThread.Post(
+                () =>
+                {
+                    if (_pendingCloseId == closeId && _tipControl == control)
+                        CloseCurrentTip();
+                },
+                DispatcherPriority.Background);
+        }
+
+        private void CancelPendingClose()
+            => ++_pendingCloseId;
+
+        private void CloseCurrentTip()
+        {
+            StopTimer();
+            _tipControl?.ClearValue(ToolTip.IsOpenProperty);
+            _tipControl = null;
+            _pointerOverTip = false;
+            _pointerOverOwner = false;
         }
 
         private void ServiceEnabledChanged(AvaloniaPropertyChangedEventArgs<bool> args)

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -596,6 +596,16 @@ namespace Avalonia.X11
                 MouseEvent(RawPointerEventType.Move, ref ev, ev.MotionEvent.state);
             else if (ev.type == XEventName.LeaveNotify)
                 MouseEvent(RawPointerEventType.LeaveWindow, ref ev, ev.CrossingEvent.state);
+            else if (ev.type == XEventName.EnterNotify)
+            {
+                if (ev.CrossingEvent.detail is
+                    NotifyDetail.NotifyNonlinear or
+                    NotifyDetail.NotifyNonlinearVirtual or
+                    NotifyDetail.NotifyVirtual)
+                {
+                    MouseEvent(RawPointerEventType.Move, ref ev, ev.CrossingEvent.state);
+                }
+            }
             else if (ev.type == XEventName.PropertyNotify)
             {
                 OnPropertyChange(ev.PropertyEvent.atom, ev.PropertyEvent.state == 0);

--- a/src/Avalonia.X11/XI2Manager.cs
+++ b/src/Avalonia.X11/XI2Manager.cs
@@ -293,24 +293,36 @@ namespace Avalonia.X11
 
         private void OnEnterLeaveEvent(IXI2Client client, ref XIEnterLeaveEvent ev)
         {
+            var detail = ev.detail;
+            if (detail != XiEnterLeaveDetail.XINotifyNonlinearVirtual &&
+                detail != XiEnterLeaveDetail.XINotifyNonlinear &&
+                detail != XiEnterLeaveDetail.XINotifyVirtual)
+                return;
+
+            var buttons = ParsedDeviceEvent.ParseButtonState(ev.buttons.MaskLen, ev.buttons.Mask);
+            if (buttons != default)
+                return;
+
             if (ev.evtype == XiEventType.XI_Leave)
             {
-                var buttons = ParsedDeviceEvent.ParseButtonState(ev.buttons.MaskLen, ev.buttons.Mask);
-                var detail = ev.detail;
-                if ((detail == XiEnterLeaveDetail.XINotifyNonlinearVirtual ||
-                     detail == XiEnterLeaveDetail.XINotifyNonlinear ||
-                     detail == XiEnterLeaveDetail.XINotifyVirtual)
-                    && buttons == default)
+                foreach (var scroller in _pointerDevice.Scrollers)
                 {
-                    foreach (var scroller in _pointerDevice.Scrollers)
-                    {
-                        _pointerDevice.Valuators[scroller.Number].Value = 0;
-                    }
-
-                    client.ScheduleXI2Input(new RawPointerEventArgs(client.MouseDevice, (ulong)ev.time.ToInt64(),
-                        client.InputRoot,
-                        RawPointerEventType.LeaveWindow, new Point(ev.event_x, ev.event_y), buttons));
+                    _pointerDevice.Valuators[scroller.Number].Value = 0;
                 }
+
+                client.ScheduleXI2Input(new RawPointerEventArgs(client.MouseDevice, (ulong)ev.time.ToInt64(),
+                    client.InputRoot,
+                    RawPointerEventType.LeaveWindow, new Point(ev.event_x, ev.event_y), buttons));
+            }
+            else if (ev.evtype == XiEventType.XI_Enter)
+            {
+                client.ScheduleXI2Input(new RawPointerEventArgs(
+                    client.MouseDevice,
+                    (ulong)ev.time.ToInt64(),
+                    client.InputRoot,
+                    RawPointerEventType.Move,
+                    new Point(ev.event_x, ev.event_y),
+                    ((XModifierMask)ev.mods.Effective).ToRawInputModifiers()));
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
@@ -28,6 +28,54 @@ namespace Avalonia.Controls.UnitTests
             Assert.IsType<PopupRoot>(toolTip.PopupHost);
             Assert.Same(TopLevel.GetTopLevel(toolTip), toolTip.PopupHost);
         }
+
+        [Fact]
+        public void Should_Not_Close_When_Pointer_Is_Over_ToolTip_Window_Without_Hit_Test_Result()
+        {
+            using var app = UnitTestApplication.Start(ConfigureServices(TestServices.FocusableWindow));
+
+            var target = new Decorator
+            {
+                [ToolTip.TipProperty] = "Tip",
+                [ToolTip.ShowDelayProperty] = 0
+            };
+
+            var scope = SetupWindow(target);
+
+            scope.MouseEnter(target);
+            AssertToolTipOpen(target);
+
+            var toolTip = Assert.IsType<ToolTip>(target.GetValue(ToolTip.ToolTipProperty));
+            var toolTipRoot = Assert.IsType<PopupRoot>(toolTip.PopupHost).GetInputRoot();
+            Assert.NotNull(toolTipRoot);
+
+            scope.SendRawPointerEvent(RawPointerEventType.Move, toolTipRoot, scope.GetPointerPosition(null));
+
+            AssertToolTipOpen(target);
+        }
+
+        [Fact]
+        public void Should_Not_Close_When_Leaving_Window_Right_After_ToolTip_Opened_Under_Pointer()
+        {
+            using var app = UnitTestApplication.Start(ConfigureServices(TestServices.FocusableWindow));
+
+            var target = new Decorator
+            {
+                [ToolTip.TipProperty] = "Tip",
+                [ToolTip.ShowDelayProperty] = 0
+            };
+
+            var scope = SetupWindow(target);
+
+            scope.MouseEnter(target);
+            AssertToolTipOpen(target);
+
+            // The pointer is still over the adorned control: this leave event is only caused by the tooltip window
+            // being displayed on top of it (macOS case).
+            scope.SendRawPointerEvent(RawPointerEventType.LeaveWindow, scope.Window.InputRoot, scope.GetPointerPosition(target));
+
+            AssertToolTipOpen(target);
+        }
     }
 
     public class ToolTipTests_Overlay : ToolTipTests, IDisposable
@@ -74,7 +122,7 @@ namespace Avalonia.Controls.UnitTests
 
         protected abstract void VerifyToolTipType(Control control);
 
-        private void AssertToolTipOpen(Control control)
+        protected void AssertToolTipOpen(Control control)
         {
             Assert.True(ToolTip.GetIsOpen(control));
             VerifyToolTipType(control);
@@ -505,7 +553,7 @@ namespace Avalonia.Controls.UnitTests
             target[ToolTip.TipProperty] = null;
 
             Assert.False(ToolTip.GetIsOpen(target));
-		}
+        }
 
         [Fact]
         public void Should_Close_When_Pointer_Leaves_Window()
@@ -531,7 +579,7 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
-        private Action<Control?> SetupWindowAndGetMouseEnterAction(Control windowContent, [CallerMemberName] string? testName = null)
+        protected ToolTipTestScope SetupWindow(Control windowContent, [CallerMemberName] string? testName = null)
         {
             var windowImpl = MockWindowingPlatform.CreateWindowMock();
             SetupWindowMock(windowImpl);
@@ -554,10 +602,31 @@ namespace Avalonia.Controls.UnitTests
             Assert.True(windowContent.IsMeasureValid);
             Assert.True(windowContent.IsVisible);
 
-            var controlIds = new Dictionary<Control, int>();
-            IInputRoot? lastRoot = null;
+            return new ToolTipTestScope(
+                window,
+                windowImpl,
+                (point, control) => hitTesterMock
+                    .Setup(m => m.HitTestFirst(point, It.IsAny<Visual>(), It.IsAny<Func<Visual, bool>>()))
+                    .Returns(control));
+        }
 
-            return control =>
+        private Action<Control?> SetupWindowAndGetMouseEnterAction(Control windowContent, [CallerMemberName] string? testName = null)
+            => SetupWindow(windowContent, testName).MouseEnter;
+
+        private void SetupWindowAndActivateToolTip(Control windowContent, Control? targetOverride = null, [CallerMemberName] string? testName = null)
+            => SetupWindowAndGetMouseEnterAction(windowContent, testName)(targetOverride ?? windowContent);
+
+        protected sealed class ToolTipTestScope(Window window, Mock<IWindowImpl> windowImpl, Action<Point, Control?> setupHitTest)
+        {
+            private readonly Dictionary<Control, int> _controlIds = new();
+            private IInputRoot? _lastRoot;
+
+            public Window Window { get; } = window;
+
+            /// <summary>
+            /// Returns a pointer position which hit tests to <paramref name="control"/>, or to nothing when it's null.
+            /// </summary>
+            public Point GetPointerPosition(Control? control)
             {
                 Point point;
 
@@ -567,36 +636,48 @@ namespace Avalonia.Controls.UnitTests
                 }
                 else
                 {
-                    if (!controlIds.TryGetValue(control, out int id))
+                    if (!_controlIds.TryGetValue(control, out int id))
                     {
-                        id = controlIds[control] = controlIds.Count;
+                        id = _controlIds[control] = _controlIds.Count;
                     }
                     point = new Point(id, int.MaxValue);
                 }
 
-                hitTesterMock.Setup(m => m.HitTestFirst(point, It.IsAny<Visual>(), It.IsAny<Func<Visual, bool>>()))
-                    .Returns(control);
+                setupHitTest(point, control);
 
-                var root = control?.GetInputRoot() ?? window.InputRoot;
+                return point;
+            }
+
+            /// <summary>
+            /// Moves the pointer over <paramref name="control"/>, leaving the previous root if it changed.
+            /// </summary>
+            public void MouseEnter(Control? control)
+            {
+                var point = GetPointerPosition(control);
+                var root = control?.GetInputRoot() ?? Window.InputRoot;
                 var timestamp = (ulong)DateTime.Now.Ticks;
 
                 windowImpl.Object.Input!(new RawPointerEventArgs(s_mouseDevice, timestamp, root,
                         RawPointerEventType.Move, point, RawInputModifiers.None));
 
-                if (lastRoot != null && lastRoot != root)
+                if (_lastRoot != null && _lastRoot != root)
                 {
-                    ((PresentationSource)lastRoot)?.PlatformImpl?.Input?.Invoke(new RawPointerEventArgs(s_mouseDevice, timestamp,
-                        lastRoot, RawPointerEventType.LeaveWindow, new Point(-1,-1), RawInputModifiers.None));
+                    ((PresentationSource)_lastRoot)?.PlatformImpl?.Input?.Invoke(new RawPointerEventArgs(s_mouseDevice, timestamp,
+                        _lastRoot, RawPointerEventType.LeaveWindow, new Point(-1,-1), RawInputModifiers.None));
                 }
 
-                lastRoot = root;
+                _lastRoot = root;
 
                 Assert.True(control == null || control.IsPointerOver);
-            };
-        }
+            }
 
-        private void SetupWindowAndActivateToolTip(Control windowContent, Control? targetOverride = null, [CallerMemberName] string? testName = null) =>
-            SetupWindowAndGetMouseEnterAction(windowContent, testName)(targetOverride ?? windowContent);
+            /// <summary>
+            /// Sends a raw pointer event, as a platform backend would do.
+            /// </summary>
+            public void SendRawPointerEvent(RawPointerEventType type, IInputRoot root, Point position)
+                => windowImpl.Object.Input!(new RawPointerEventArgs(
+                    s_mouseDevice, (ulong)DateTime.Now.Ticks, root, type, position, RawInputModifiers.None));
+        }
     }
 
     internal class ToolTipViewModel

--- a/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
@@ -575,6 +575,8 @@ namespace Avalonia.Controls.UnitTests
                 topLevel!.PlatformImpl!.Input!(new RawPointerEventArgs(s_mouseDevice, (ulong)DateTime.Now.Ticks, topLevel.InputRoot,
                     RawPointerEventType.LeaveWindow, default(RawPointerPoint), RawInputModifiers.None));
 
+                Dispatcher.UIThread.RunJobs(null, TestContext.Current.CancellationToken);
+
                 Assert.False(ToolTip.GetIsOpen(target));
             }
         }


### PR DESCRIPTION
## What does the pull request do?
This PR resolves several problems with tooltips flickering, notably on macOS, X11 and Wayland.

### Regression (Windows)

First, a comparison wasn't correctly updated with the top level changes made in #20732, and some existing logic failed, causing the tooltip to close early on all platforms, including Windows, when hit testing wasn't yet ready (more on that in another issue).

### Fixing non-Windows platforms

Aside from that regression, the root cause is that if the tooltip opens under the pointer for any reason, moving the mouse from the original window to the tooltip triggers a `LeaveWindow` input event, effectively closing the tooltip. The pointer then returns to the original window, reopening the tooltip. Repeat.

On Windows, a mechanism exists to prevent that (added in #15596). However, it doesn't work well on other platforms: while on Windows a `Move` event is received on the tooltip before the `LeaveWindow` event on the owner window, on macOS, X11, and Wayland, the `LeaveWindow` event is received first.

The existing solution compared timestamps and I've first tried to use a similar logic. However, it turns out that isn't reliable since timestamps are more precise on macOS/X11/Wayland.

Instead, when a `LeaveWindow` event arrives, Avalonia now posts a "close the tooltip" action with background priority to the dispatcher. If any input is received in the meantime (which has a higher priority than `Background`), the close is canceled. This works very well on all platforms.

Also, X11 now generates a `Move` raw pointer event if a window is mapped directly under the pointer, matching what happens on other platforms (Windows and macOS handle this naturally for us, and we already synthesize one for Wayland). Otherwise, we don't get anything other than a `LeaveWindow` event.

## Fixed issues
 - #11179
 - #19218
 - #20980
 - #21820