### PR TITLE
Fix Nuke build warnings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageVersion Include="Appium.WebDriver" Version="5.2.0" />
     <PackageVersion Include="Avalonia.Angle.Windows.Natives" Version="2.1.27548.20260419" />
@@ -37,7 +36,7 @@
     <PackageVersion Include="MonoMac.NetStandard" Version="0.0.4" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Nito.AsyncEx.Context" Version="5.1.2" />
-    <PackageVersion Include="NuGet.Protocol" Version="7.0.1" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.9.0" />
     <PackageVersion Include="Nuke.Common" Version="10.1.0" />
     <PackageVersion Include="Numerge" Version="1.0.0" />
     <PackageVersion Include="NUnit" Version="4.5.1" />
@@ -76,7 +75,6 @@
     <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
-
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.VisualStudio.SlnGen" Version="8.5.17" PrivateAssets="all" />
   </ItemGroup>

--- a/nukebuild/ApiDiffHelper.cs
+++ b/nukebuild/ApiDiffHelper.cs
@@ -399,7 +399,11 @@ public static class ApiDiffHelper
     {
         var packageSource = new PackageSource(NightlyFeedUri) { ProtocolVersion = 3 };
         var repository = Repository.Factory.GetCoreV3(packageSource);
-        var findPackageByIdResource = await repository.GetResourceAsync<FindPackageByIdResource>();
+
+        var findPackageByIdResource =
+            await repository.GetResourceAsync<FindPackageByIdResource>() ??
+            throw new InvalidOperationException($"{nameof(FindPackageByIdResource)} not found on {packageSource}");
+
         return new NuGetDownloadContext(packageSource, findPackageByIdResource);
     }
 

--- a/nukebuild/_build.csproj
+++ b/nukebuild/_build.csproj
@@ -13,10 +13,9 @@
   <ItemGroup>
     <PackageReference Include="Nuke.Common" />
     <PackageReference Include="Numerge" />
-    <!-- Keep in sync with Avalonia.Build.Tasks -->
     <PackageReference Include="Mono.Cecil" />
-    <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="All" />
     <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="System.Security.Cryptography.Xml" VersionOverride="10.0.11" /> <!-- Local override to avoid security warnings --> 
     <PackageDownload Include="Microsoft.DotNet.ApiCompat.Tool" Version="[10.0.100]" />
     <PackageDownload Include="Microsoft.DotNet.ApiDiff.Tool" Version="[10.0.100-rtm.25531.102]" />
     <PackageDownload Include="dotnet-ilrepack" Version="[2.0.44]" />

--- a/samples/ControlGallery.WinUI/ControlGallery.WinUI.csproj
+++ b/samples/ControlGallery.WinUI/ControlGallery.WinUI.csproj
@@ -7,7 +7,6 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <WinUISDKReferences>false</WinUISDKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>

--- a/samples/WinUIEmbedSample/WinUIEmbedSample.csproj
+++ b/samples/WinUIEmbedSample/WinUIEmbedSample.csproj
@@ -7,7 +7,6 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <WinUISDKReferences>false</WinUISDKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>


### PR DESCRIPTION
## What does the pull request do?
This PR fixes several warnings that occur during the Nuke project build. Obsolete packages are updated, and a direct dependency on a specific MSBuild version is removed.

Plus, `<PublishProfile>`  elements are removed from the WinUI projects: we didn't version those files, and they cause warnings in VS and Rider when missing.