### PR TITLE
Android - Remove legacy mono android trace debugging files

### DIFF
--- a/samples/ControlCatalog.Android/ControlCatalog.Android.csproj
+++ b/samples/ControlCatalog.Android/ControlCatalog.Android.csproj
@@ -14,16 +14,6 @@
     </AndroidResource>
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(AndroidEnableProfiler)'=='True'">
-    <IsEmulator Condition="'$(IsEmulator)' == ''">True</IsEmulator>
-    <DebugSymbols>True</DebugSymbols>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <AndroidEnvironment Condition="'$(IsEmulator)'=='True'" Include="environment.emulator.txt" />
-    <AndroidEnvironment Condition="'$(IsEmulator)'!='True'" Include="environment.device.txt" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" />
   </ItemGroup>

--- a/samples/ControlCatalog.Android/environment.device.txt
+++ b/samples/ControlCatalog.Android/environment.device.txt
@@ -1,1 +1,0 @@
-﻿DOTNET_DiagnosticPorts=127.0.0.1:9000,suspend

--- a/samples/ControlCatalog.Android/environment.emulator.txt
+++ b/samples/ControlCatalog.Android/environment.emulator.txt
@@ -1,1 +1,0 @@
-﻿DOTNET_DiagnosticPorts=10.0.2.2:9001,suspend


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Removes legacy mono android debugging files from ControlCatalog.Android. This allows the project to build and run with CoreCLR on android. Also, these are outdated.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
