### PR TITLE
add support for CreateSourceInfo in design window loader

### DIFF
--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
@@ -157,9 +157,12 @@ namespace Avalonia.Build.Tasks
                 var arg1 = new CustomAttributeArgument(strType, "AvaloniaUseCompiledBindingsByDefault");
                 var arg2 = new CustomAttributeArgument(strType, defaultCompileBindings.ToString());
                 asm.CustomAttributes.Add(new CustomAttribute(ctor) { ConstructorArguments = { arg1, arg2 } });
-                var arg3 = new CustomAttributeArgument(strType, "AvaloniaXamlCreateSourceInfo");
-                var arg4 = new CustomAttributeArgument(strType, createSourceInfo.ToString());
-                asm.CustomAttributes.Add(new CustomAttribute(ctor) { ConstructorArguments = { arg3, arg4 } });
+                if (createSourceInfo)
+                {
+                    var arg3 = new CustomAttributeArgument(strType, "AvaloniaXamlCreateSourceInfo");
+                    var arg4 = new CustomAttributeArgument(strType, createSourceInfo.ToString());
+                    asm.CustomAttributes.Add(new CustomAttribute(ctor) { ConstructorArguments = { arg3, arg4 } });
+                }
             }
 
             TypeDefinition AddClass(string name, TypeAttributes extraAttributes = 0)

--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
@@ -157,6 +157,9 @@ namespace Avalonia.Build.Tasks
                 var arg1 = new CustomAttributeArgument(strType, "AvaloniaUseCompiledBindingsByDefault");
                 var arg2 = new CustomAttributeArgument(strType, defaultCompileBindings.ToString());
                 asm.CustomAttributes.Add(new CustomAttribute(ctor) { ConstructorArguments = { arg1, arg2 } });
+                var arg3 = new CustomAttributeArgument(strType, "AvaloniaXamlCreateSourceInfo");
+                var arg4 = new CustomAttributeArgument(strType, createSourceInfo.ToString());
+                asm.CustomAttributes.Add(new CustomAttribute(ctor) { ConstructorArguments = { arg3, arg4 } });
             }
 
             TypeDefinition AddClass(string name, TypeAttributes extraAttributes = 0)

--- a/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
+++ b/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
@@ -40,12 +40,15 @@ namespace Avalonia.DesignerSupport
                 var localAsm = assemblyPath != null ? Assembly.LoadFrom(Path.GetFullPath(assemblyPath)) : null;
                 var useCompiledBindings = localAsm?.GetCustomAttributes<AssemblyMetadataAttribute>()
                     .FirstOrDefault(a => a.Key == "AvaloniaUseCompiledBindingsByDefault")?.Value;
+                var createSourceInfo = localAsm?.GetCustomAttributes<AssemblyMetadataAttribute>()
+                    .FirstOrDefault(a => a.Key == "AvaloniaXamlCreateSourceInfo")?.Value;
 
                 var loaded = loader.Load(new RuntimeXamlLoaderDocument(baseUri, stream), new RuntimeXamlLoaderConfiguration
                 {
                     LocalAssembly = localAsm,
                     DesignMode = true,
-                    UseCompiledBindingsByDefault = bool.TryParse(useCompiledBindings, out var parsedValue) && parsedValue
+                    UseCompiledBindingsByDefault = bool.TryParse(useCompiledBindings, out var parsedValue) && parsedValue,
+                    CreateSourceInfo = bool.TryParse(createSourceInfo, out var parsedCreateSourceInfo) && parsedCreateSourceInfo
                 });
 
                 var control = Design.CreatePreviewWithControl(loaded);

--- a/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
+++ b/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
@@ -40,15 +40,12 @@ namespace Avalonia.DesignerSupport
                 var localAsm = assemblyPath != null ? Assembly.LoadFrom(Path.GetFullPath(assemblyPath)) : null;
                 var useCompiledBindings = localAsm?.GetCustomAttributes<AssemblyMetadataAttribute>()
                     .FirstOrDefault(a => a.Key == "AvaloniaUseCompiledBindingsByDefault")?.Value;
-                var createSourceInfo = localAsm?.GetCustomAttributes<AssemblyMetadataAttribute>()
-                    .FirstOrDefault(a => a.Key == "AvaloniaXamlCreateSourceInfo")?.Value;
 
                 var loaded = loader.Load(new RuntimeXamlLoaderDocument(baseUri, stream), new RuntimeXamlLoaderConfiguration
                 {
                     LocalAssembly = localAsm,
                     DesignMode = true,
-                    UseCompiledBindingsByDefault = bool.TryParse(useCompiledBindings, out var parsedValue) && parsedValue,
-                    CreateSourceInfo = bool.TryParse(createSourceInfo, out var parsedCreateSourceInfo) && parsedCreateSourceInfo
+                    UseCompiledBindingsByDefault = bool.TryParse(useCompiledBindings, out var parsedValue) && parsedValue
                 });
 
                 var control = Design.CreatePreviewWithControl(loaded);

--- a/src/Markup/Avalonia.Markup.Xaml/RuntimeXamlLoaderConfiguration.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/RuntimeXamlLoaderConfiguration.cs
@@ -1,10 +1,16 @@
 using System;
+using System.Linq;
 using System.Reflection;
 
 namespace Avalonia.Markup.Xaml;
 
 public class RuntimeXamlLoaderConfiguration
 {
+    /// <summary>
+    /// When enabled, the XAML compiler embeds SourceInfo metadata (file path, line, and column) into generated code.
+    /// </summary>
+    private bool? _createSourceInfo = null;
+
     /// <summary>
     /// Default assembly for clr-namespace:.
     /// </summary>
@@ -24,9 +30,24 @@ public class RuntimeXamlLoaderConfiguration
 
     /// <summary>
     /// When enabled, the XAML compiler embeds SourceInfo metadata (file path, line, and column) into generated code.
-    /// Default is 'false'.
+    /// When not explicitly set, the 'AvaloniaXamlCreateSourceInfo' from the LocalAssembly will be used to determine the value.
     /// </summary>
-    public bool CreateSourceInfo { get; set; } = false;
+    public bool CreateSourceInfo 
+    { 
+        get {
+            if(_createSourceInfo == null)
+            {
+                if(LocalAssembly is {} asm)
+                {
+                    var createSourceInfo = asm.GetCustomAttributes<AssemblyMetadataAttribute>()
+                        .FirstOrDefault(a => a.Key == "AvaloniaXamlCreateSourceInfo")?.Value;
+                    return bool.TryParse(createSourceInfo, out var parsedCreateSourceInfo) && parsedCreateSourceInfo;
+                }
+            }   
+            return _createSourceInfo ?? false;
+        }
+        set => _createSourceInfo = value; 
+    }
 
     /// <summary>
     /// XAML diagnostics handler.


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

This PR enables `XamlSourceInfo` creation in the Design Previewer.

Custom controls can already retrieve XAML source location information from control instances. However, `XamlSourceInfo` was previously only generated for compile-time XAML and not for XAML loaded through the `RuntimeXamlLoader` used by the Designer.

This PR makes source information available in the Designer as well. This allows custom libraries and tooling to implement features such as **Jump to Source**, for example:

https://github.com/Unrealiter/Avalonia.JumpToSource

### Known limitation

For instances created from the XAML file currently open in the Designer, the returned `XamlSourceInfo` currently contains `"runtimexaml0"` as the filename instead of the path to the actual XAML file.

The line and offset information is correct.

For example, to make the `ToJumpSource` test in `Avalonia.JumpToSource` work with the Designer, I had to special-case `"runtimexaml0"` and determine the path of the currently active XAML file by other means.

Source information for controls originating from other resources/pages continues to contain the expected source information.

## Improves issues

Improves #20524 for the Designer
