### PR TITLE
Improve StorageBookmarkHelper.TryDecodeBookmark

### DIFF
--- a/src/Avalonia.Base/Platform/Storage/FileIO/StorageBookmarkHelper.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/StorageBookmarkHelper.cs
@@ -86,20 +86,19 @@ internal static class StorageBookmarkHelper
 
         Span<byte> decodedBookmark;
 
-        // Each base64 character represents 6 bits, but to be safe, 
-        var arrayPool = ArrayPool<byte>.Shared.Rent(HeaderLength + base64bookmark.Length * 6);
-        if (Convert.TryFromBase64Chars(base64bookmark, arrayPool, out int bytesWritten))
-        {
-            decodedBookmark = arrayPool.AsSpan().Slice(0, bytesWritten);
-        }
-        else
-        {
-            nativeBookmark = null;
-            return DecodeResult.InvalidFormat;
-        }
+        var arrayPool = ArrayPool<byte>.Shared.Rent(HeaderLength + base64bookmark.Length / 4 * 3);
 
         try
         {
+            // Each base64 character represents 6 bits, but to be safe, 
+            if (!Convert.TryFromBase64Chars(base64bookmark, arrayPool, out int bytesWritten))
+            {
+                nativeBookmark = null;
+                return DecodeResult.InvalidFormat;
+            }
+
+            decodedBookmark = arrayPool.AsSpan(..bytesWritten);
+
             if (decodedBookmark.Length < HeaderLength
                 // Check if decoded string starts with the correct prefix, checking v1 at the same time.
                 && !AvaHeaderPrefix.SequenceEqual(decodedBookmark.Slice(0, AvaHeaderPrefix.Length)))


### PR DESCRIPTION
## What does the pull request do?

Improved logic in `StorageBookmarkHelper.TryDecodeBookmark`:
1. The rented array was oversized.
2. Some code that uses the rented array, although unlikely to throw an exception, was outside the `try` block.
3. There is no need to call `.AsSpan().Slice(...)`, because `AsSpan` has overloads for slicing.
4. `if`/`else` with return can be rewritten to reduce indentation, improving code readability.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

None.
