### PR TITLE
Fix duplicated and crashing DBus tray icon

### DIFF
--- a/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
+++ b/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
@@ -23,6 +23,7 @@ namespace Avalonia.FreeDesktop
         private (int, int, byte[]) _icon;
 
         private string? _sysTrayServiceName;
+        private bool _sysTrayServiceNameOwned;
         private string? _tooltipText;
         private bool _isDisposed;
         private bool _serviceConnected;
@@ -52,8 +53,8 @@ namespace Avalonia.FreeDesktop
 
             MenuExporter = DBusMenuExporter.TryCreateDetachedNativeMenu(dbusMenuPath, _connection);
 
+            // Note: the object is only exported from CreateTrayIcon, once the name is owned.
             _statusNotifierItemDbusObj = new StatusNotifierItemDbusObj(_connection, dbusMenuPath);
-            _connection.AddMethodHandler(_statusNotifierItemDbusObj);
             _statusNotifierItemDbusObj.ActivationDelegate += () => OnClicked?.Invoke();
 
             WatchAsync();
@@ -93,6 +94,11 @@ namespace Avalonia.FreeDesktop
                     OnOwnerChanged(owner);
                 }
             }
+            catch (OperationCanceledException)
+            {
+                // Cancelled by Dispose. Can't be filtered on _isDisposed: the continuation
+                // is posted to the dispatcher and runs after Dispose has completed.
+            }
             catch (Exception e) when (!_isDisposed)
             {
                 Logger.TryGet(LogEventLevel.Error, "DBUS")
@@ -110,8 +116,6 @@ namespace Avalonia.FreeDesktop
                 _serviceConnected = true;
                 _statusNotifierWatcher = new StatusNotifierWatcher(_connection, "org.kde.StatusNotifierWatcher", "/StatusNotifierWatcher");
 
-                DestroyTrayIcon();
-
                 if (_isVisible)
                     CreateTrayIcon();
             }
@@ -124,25 +128,45 @@ namespace Avalonia.FreeDesktop
 
         private async void CreateTrayIcon()
         {
-            if (_connection is null || !_serviceConnected || _isDisposed || _statusNotifierWatcher is null)
+            if (_connection is null || !_serviceConnected || _isDisposed || _statusNotifierItemDbusObj is null || _statusNotifierWatcher is null)
                 return;
 
+            try
+            {
+                // Reused for the lifetime of the icon: a new instance id looks like a new item to the host.
+                if (_sysTrayServiceName is null)
+                {
 #if NET5_0_OR_GREATER
-            var pid = Environment.ProcessId;
+                    var pid = Environment.ProcessId;
 #else
-            var pid = Process.GetCurrentProcess().Id;
+                    var pid = Process.GetCurrentProcess().Id;
 #endif
-            var tid = s_trayIconInstanceId++;
+                    var tid = s_trayIconInstanceId++;
+                    _sysTrayServiceName = FormattableString.Invariant($"org.kde.StatusNotifierItem-{pid}-{tid}");
+                }
 
-            _connection.RemoveMethodHandler(_statusNotifierItemDbusObj!.Path);
-            _connection.AddMethodHandler(_statusNotifierItemDbusObj);
+                if (!_sysTrayServiceNameOwned)
+                {
+                    // Set before awaiting, so that a concurrent hide queues its ReleaseName instead of skipping it.
+                    _sysTrayServiceNameOwned = true;
+                    await _connection.RequestNameAsync(_sysTrayServiceName);
+                }
 
-            _sysTrayServiceName = FormattableString.Invariant($"org.kde.StatusNotifierItem-{pid}-{tid}");
-            await _connection.RequestNameAsync(_sysTrayServiceName);
-            await _statusNotifierWatcher.RegisterStatusNotifierItemAsync(_sysTrayServiceName);
+                // Exported only while the name is owned: a host scanning the bus would otherwise find the
+                // object under the unique connection name and register a second, duplicate item.
+                _connection.AddMethodHandler(_statusNotifierItemDbusObj);
 
-            _statusNotifierItemDbusObj!.SetTitleAndTooltip(_tooltipText);
-            _statusNotifierItemDbusObj.SetIcon(_icon);
+                await _statusNotifierWatcher.RegisterStatusNotifierItemAsync(_sysTrayServiceName);
+
+                _statusNotifierItemDbusObj.SetTitleAndTooltip(_tooltipText);
+                _statusNotifierItemDbusObj.SetIcon(_icon);
+            }
+            catch (Exception e)
+            {
+                if (!_isDisposed)
+                    Logger.TryGet(LogEventLevel.Error, "DBUS")
+                        ?.Log(this, "Unable to register the system tray icon.\n{Exception}", e);
+            }
         }
 
         private void DestroyTrayIcon()
@@ -150,14 +174,28 @@ namespace Avalonia.FreeDesktop
             if (_connection is null || !_serviceConnected || _isDisposed || _statusNotifierItemDbusObj is null || _sysTrayServiceName is null)
                 return;
 
-            _connection!.ReleaseNameAsync(_sysTrayServiceName);
             _connection.RemoveMethodHandler(_statusNotifierItemDbusObj.Path);
+        }
+
+        /// <summary>
+        /// Releasing the name is what makes a host drop the item, unexporting the object isn't observable.
+        /// Call after <see cref="DestroyTrayIcon"/>, and not when the watcher merely goes away: the object
+        /// must never be exported while the name is unowned.
+        /// </summary>
+        private void ReleaseTrayServiceName()
+        {
+            if (_connection is null || _sysTrayServiceName is null || !_sysTrayServiceNameOwned)
+                return;
+
+            _sysTrayServiceNameOwned = false;
+            _connection.ReleaseNameAsync(_sysTrayServiceName);
         }
 
         public void Dispose()
         {
             IsActive = false;
             DestroyTrayIcon();
+            ReleaseTrayServiceName();
             (MenuExporter as IDisposable)?.Dispose();
             _watchCts?.Cancel();
             _isDisposed = true;
@@ -215,6 +253,7 @@ namespace Avalonia.FreeDesktop
                     break;
                 case false when _isVisible:
                     DestroyTrayIcon();
+                    ReleaseTrayServiceName();
                     break;
             }
 

--- a/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
+++ b/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
@@ -23,7 +23,10 @@ namespace Avalonia.FreeDesktop
         private (int, int, byte[]) _icon;
 
         private string? _sysTrayServiceName;
-        private bool _sysTrayServiceNameOwned;
+        // Non-null from the moment the name is asked for. Tracking the request instead of a bool keeps
+        // a refused acquisition from being mistaken for ownership, and lets a hide that races the
+        // request wait for it before releasing.
+        private Task? _sysTrayServiceNameRequest;
         private string? _tooltipText;
         private bool _isDisposed;
         private bool _serviceConnected;
@@ -145,12 +148,8 @@ namespace Avalonia.FreeDesktop
                     _sysTrayServiceName = FormattableString.Invariant($"org.kde.StatusNotifierItem-{pid}-{tid}");
                 }
 
-                if (!_sysTrayServiceNameOwned)
-                {
-                    // Set before awaiting, so that a concurrent hide queues its ReleaseName instead of skipping it.
-                    _sysTrayServiceNameOwned = true;
-                    await _connection.RequestNameAsync(_sysTrayServiceName);
-                }
+                _sysTrayServiceNameRequest ??= _connection.RequestNameAsync(_sysTrayServiceName);
+                await _sysTrayServiceNameRequest;
 
                 // Exported only while the name is owned: a host scanning the bus would otherwise find the
                 // object under the unique connection name and register a second, duplicate item.
@@ -163,6 +162,11 @@ namespace Avalonia.FreeDesktop
             }
             catch (Exception e)
             {
+                // A refused name must not stick around as if it were owned: drop the request so the
+                // next attempt asks again. A failure after that point leaves ownership untouched.
+                if (_sysTrayServiceNameRequest is { Status: not TaskStatus.RanToCompletion })
+                    _sysTrayServiceNameRequest = null;
+
                 if (!_isDisposed)
                     Logger.TryGet(LogEventLevel.Error, "DBUS")
                         ?.Log(this, "Unable to register the system tray icon.\n{Exception}", e);
@@ -184,11 +188,28 @@ namespace Avalonia.FreeDesktop
         /// </summary>
         private void ReleaseTrayServiceName()
         {
-            if (_connection is null || _sysTrayServiceName is null || !_sysTrayServiceNameOwned)
+            if (_connection is null || _sysTrayServiceName is null || _sysTrayServiceNameRequest is not { } request)
                 return;
 
-            _sysTrayServiceNameOwned = false;
-            _connection.ReleaseNameAsync(_sysTrayServiceName);
+            _sysTrayServiceNameRequest = null;
+            ReleaseTrayServiceName(request, _connection, _sysTrayServiceName);
+        }
+
+        private async void ReleaseTrayServiceName(Task request, DBusConnection connection, string name)
+        {
+            try
+            {
+                // Awaiting the request first: releasing a name that is still being acquired would
+                // leave it owned. If the acquisition failed there is nothing to release.
+                await request;
+                await connection.ReleaseNameAsync(name);
+            }
+            catch (Exception e)
+            {
+                if (!_isDisposed)
+                    Logger.TryGet(LogEventLevel.Error, "DBUS")
+                        ?.Log(this, "Unable to release the system tray icon name.\n{Exception}", e);
+            }
         }
 
         public void Dispose()

--- a/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
+++ b/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
@@ -27,6 +27,9 @@ namespace Avalonia.FreeDesktop
         // a refused acquisition from being mistaken for ownership, and lets a hide that races the
         // request wait for it before releasing.
         private Task? _sysTrayServiceNameRequest;
+        // The bus keeps a name registered until the release is acknowledged, so a show right after a
+        // hide has to wait this out before asking for the same name again.
+        private Task? _sysTrayServiceNameRelease;
         private string? _tooltipText;
         private bool _isDisposed;
         private bool _serviceConnected;
@@ -134,6 +137,8 @@ namespace Avalonia.FreeDesktop
             if (_connection is null || !_serviceConnected || _isDisposed || _statusNotifierItemDbusObj is null || _statusNotifierWatcher is null)
                 return;
 
+            Task? request = null;
+
             try
             {
                 // Reused for the lifetime of the icon: a new instance id looks like a new item to the host.
@@ -148,8 +153,23 @@ namespace Avalonia.FreeDesktop
                     _sysTrayServiceName = FormattableString.Invariant($"org.kde.StatusNotifierItem-{pid}-{tid}");
                 }
 
-                _sysTrayServiceNameRequest ??= _connection.RequestNameAsync(_sysTrayServiceName);
-                await _sysTrayServiceNameRequest;
+                if (_sysTrayServiceNameRelease is { } release)
+                {
+                    await release;
+                    if (ReferenceEquals(_sysTrayServiceNameRelease, release))
+                        _sysTrayServiceNameRelease = null;
+                    if (!ShouldShowTrayIcon)
+                        return;
+                }
+
+                request = _sysTrayServiceNameRequest ??= _connection.RequestNameAsync(_sysTrayServiceName);
+                await request;
+
+                // A hide or a dispose during the request queued its release on this very task, so it runs
+                // after this continuation: exporting now would leave the object up under a name that is no
+                // longer owned, which is what the duplicate item grows from.
+                if (!ShouldShowTrayIcon || !ReferenceEquals(_sysTrayServiceNameRequest, request))
+                    return;
 
                 // Exported only while the name is owned: a host scanning the bus would otherwise find the
                 // object under the unique connection name and register a second, duplicate item.
@@ -157,14 +177,18 @@ namespace Avalonia.FreeDesktop
 
                 await _statusNotifierWatcher.RegisterStatusNotifierItemAsync(_sysTrayServiceName);
 
+                if (!ShouldShowTrayIcon)
+                    return;
+
                 _statusNotifierItemDbusObj.SetTitleAndTooltip(_tooltipText);
                 _statusNotifierItemDbusObj.SetIcon(_icon);
             }
             catch (Exception e)
             {
-                // A refused name must not stick around as if it were owned: drop the request so the
-                // next attempt asks again. A failure after that point leaves ownership untouched.
-                if (_sysTrayServiceNameRequest is { Status: not TaskStatus.RanToCompletion })
+                // A refused name must not stick around as if it were owned: drop the request so the next
+                // attempt asks again. Only this call's own request, and only when it never completed: a
+                // failure further down leaves ownership untouched, as does a newer request replacing it.
+                if (request is { Status: not TaskStatus.RanToCompletion } && ReferenceEquals(_sysTrayServiceNameRequest, request))
                     _sysTrayServiceNameRequest = null;
 
                 if (!_isDisposed)
@@ -172,6 +196,10 @@ namespace Avalonia.FreeDesktop
                         ?.Log(this, "Unable to register the system tray icon.\n{Exception}", e);
             }
         }
+
+        // Entry conditions of CreateTrayIcon, re-read after every await: the icon can be hidden or
+        // disposed while the bus answers.
+        private bool ShouldShowTrayIcon => !_isDisposed && _isVisible && _serviceConnected;
 
         private void DestroyTrayIcon()
         {
@@ -192,10 +220,10 @@ namespace Avalonia.FreeDesktop
                 return;
 
             _sysTrayServiceNameRequest = null;
-            ReleaseTrayServiceName(request, _connection, _sysTrayServiceName);
+            _sysTrayServiceNameRelease = ReleaseTrayServiceName(request, _connection, _sysTrayServiceName);
         }
 
-        private async void ReleaseTrayServiceName(Task request, DBusConnection connection, string name)
+        private async Task ReleaseTrayServiceName(Task request, DBusConnection connection, string name)
         {
             try
             {

--- a/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
+++ b/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
@@ -23,12 +23,9 @@ namespace Avalonia.FreeDesktop
         private (int, int, byte[]) _icon;
 
         private string? _sysTrayServiceName;
-        // Non-null from the moment the name is asked for. Tracking the request instead of a bool keeps
-        // a refused acquisition from being mistaken for ownership, and lets a hide that races the
-        // request wait for it before releasing.
+        // This task shows if the name request is in progress, complete, or failed.
         private Task? _sysTrayServiceNameRequest;
-        // The bus keeps a name registered until the release is acknowledged, so a show right after a
-        // hide has to wait this out before asking for the same name again.
+        // The bus keeps the name until the release is complete. A request before that fails.
         private Task? _sysTrayServiceNameRelease;
         private string? _tooltipText;
         private bool _isDisposed;
@@ -59,7 +56,7 @@ namespace Avalonia.FreeDesktop
 
             MenuExporter = DBusMenuExporter.TryCreateDetachedNativeMenu(dbusMenuPath, _connection);
 
-            // Note: the object is only exported from CreateTrayIcon, once the name is owned.
+            // CreateTrayIcon exports this object when the connection owns the name.
             _statusNotifierItemDbusObj = new StatusNotifierItemDbusObj(_connection, dbusMenuPath);
             _statusNotifierItemDbusObj.ActivationDelegate += () => OnClicked?.Invoke();
 
@@ -102,8 +99,7 @@ namespace Avalonia.FreeDesktop
             }
             catch (OperationCanceledException)
             {
-                // Cancelled by Dispose. Can't be filtered on _isDisposed: the continuation
-                // is posted to the dispatcher and runs after Dispose has completed.
+                // Dispose cancels this task. The continuation runs after Dispose sets _isDisposed.
             }
             catch (Exception e) when (!_isDisposed)
             {
@@ -141,7 +137,7 @@ namespace Avalonia.FreeDesktop
 
             try
             {
-                // Reused for the lifetime of the icon: a new instance id looks like a new item to the host.
+                // Keep the name for the life of the icon. A new id shows a new item to the host.
                 if (_sysTrayServiceName is null)
                 {
 #if NET5_0_OR_GREATER
@@ -165,14 +161,13 @@ namespace Avalonia.FreeDesktop
                 request = _sysTrayServiceNameRequest ??= _connection.RequestNameAsync(_sysTrayServiceName);
                 await request;
 
-                // A hide or a dispose during the request queued its release on this very task, so it runs
-                // after this continuation: exporting now would leave the object up under a name that is no
-                // longer owned, which is what the duplicate item grows from.
+                // The icon can become hidden or disposed while the bus answers. The release then runs
+                // after this line.
                 if (!ShouldShowTrayIcon || !ReferenceEquals(_sysTrayServiceNameRequest, request))
                     return;
 
-                // Exported only while the name is owned: a host scanning the bus would otherwise find the
-                // object under the unique connection name and register a second, duplicate item.
+                // Export the object only while the connection owns the name. If not, a host that scans
+                // the bus adds a second item.
                 _connection.AddMethodHandler(_statusNotifierItemDbusObj);
 
                 await _statusNotifierWatcher.RegisterStatusNotifierItemAsync(_sysTrayServiceName);
@@ -185,9 +180,8 @@ namespace Avalonia.FreeDesktop
             }
             catch (Exception e)
             {
-                // A refused name must not stick around as if it were owned: drop the request so the next
-                // attempt asks again. Only this call's own request, and only when it never completed: a
-                // failure further down leaves ownership untouched, as does a newer request replacing it.
+                // Clear only this request, and only if it did not complete. The next call then asks for
+                // the name again.
                 if (request is { Status: not TaskStatus.RanToCompletion } && ReferenceEquals(_sysTrayServiceNameRequest, request))
                     _sysTrayServiceNameRequest = null;
 
@@ -197,8 +191,7 @@ namespace Avalonia.FreeDesktop
             }
         }
 
-        // Entry conditions of CreateTrayIcon, re-read after every await: the icon can be hidden or
-        // disposed while the bus answers.
+        // CreateTrayIcon reads these conditions again after each await.
         private bool ShouldShowTrayIcon => !_isDisposed && _isVisible && _serviceConnected;
 
         private void DestroyTrayIcon()
@@ -210,9 +203,8 @@ namespace Avalonia.FreeDesktop
         }
 
         /// <summary>
-        /// Releasing the name is what makes a host drop the item, unexporting the object isn't observable.
-        /// Call after <see cref="DestroyTrayIcon"/>, and not when the watcher merely goes away: the object
-        /// must never be exported while the name is unowned.
+        /// Releases the bus name. A host removes the item when the name goes away.
+        /// Call this after <see cref="DestroyTrayIcon"/>, but not when the watcher stops.
         /// </summary>
         private void ReleaseTrayServiceName()
         {
@@ -227,8 +219,7 @@ namespace Avalonia.FreeDesktop
         {
             try
             {
-                // Awaiting the request first: releasing a name that is still being acquired would
-                // leave it owned. If the acquisition failed there is nothing to release.
+                // Wait for the request. A release before the connection owns the name has no effect.
                 await request;
                 await connection.ReleaseNameAsync(name);
             }

--- a/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
+++ b/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
@@ -29,6 +29,7 @@ namespace Avalonia.FreeDesktop
         private Task? _sysTrayServiceNameRelease;
         private string? _tooltipText;
         private bool _isDisposed;
+        private bool _itemExported;
         private bool _serviceConnected;
         private bool _isVisible = true;
 
@@ -167,8 +168,13 @@ namespace Avalonia.FreeDesktop
                     return;
 
                 // Export the object only while the connection owns the name. If not, a host that scans
-                // the bus adds a second item.
-                _connection.AddMethodHandler(_statusNotifierItemDbusObj);
+                // the bus adds a second item. Two calls can get here together, and a second export
+                // throws.
+                if (!_itemExported)
+                {
+                    _connection.AddMethodHandler(_statusNotifierItemDbusObj);
+                    _itemExported = true;
+                }
 
                 await _statusNotifierWatcher.RegisterStatusNotifierItemAsync(_sysTrayServiceName);
 
@@ -200,6 +206,7 @@ namespace Avalonia.FreeDesktop
                 return;
 
             _connection.RemoveMethodHandler(_statusNotifierItemDbusObj.Path);
+            _itemExported = false;
         }
 
         /// <summary>

--- a/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
+++ b/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
@@ -57,7 +57,6 @@ namespace Avalonia.FreeDesktop
 
             MenuExporter = DBusMenuExporter.TryCreateDetachedNativeMenu(dbusMenuPath, _connection);
 
-            // CreateTrayIcon exports this object when the connection owns the name.
             _statusNotifierItemDbusObj = new StatusNotifierItemDbusObj(_connection, dbusMenuPath);
             _statusNotifierItemDbusObj.ActivationDelegate += () => OnClicked?.Invoke();
 
@@ -100,12 +99,14 @@ namespace Avalonia.FreeDesktop
             }
             catch (OperationCanceledException)
             {
-                // Dispose cancels this task. The continuation runs after Dispose sets _isDisposed.
+                // Dispose cancels this task.
             }
-            catch (Exception e) when (!_isDisposed)
+            catch (Exception e)
             {
-                Logger.TryGet(LogEventLevel.Error, "DBUS")
-                    ?.Log(this, "Interface 'org.kde.StatusNotifierWatcher' is unavailable.\n{Exception}", e);
+                // An exception that leaves this method ends the process.
+                if (!_isDisposed)
+                    Logger.TryGet(LogEventLevel.Error, "DBUS")
+                        ?.Log(this, "Interface 'org.kde.StatusNotifierWatcher' is unavailable.\n{Exception}", e);
             }
         }
 
@@ -150,7 +151,7 @@ namespace Avalonia.FreeDesktop
                     _sysTrayServiceName = FormattableString.Invariant($"org.kde.StatusNotifierItem-{pid}-{tid}");
                 }
 
-                if (_sysTrayServiceNameRelease is { } release)
+                while (_sysTrayServiceNameRelease is { } release)
                 {
                     await release;
                     if (ReferenceEquals(_sysTrayServiceNameRelease, release))
@@ -162,14 +163,12 @@ namespace Avalonia.FreeDesktop
                 request = _sysTrayServiceNameRequest ??= _connection.RequestNameAsync(_sysTrayServiceName);
                 await request;
 
-                // The icon can become hidden or disposed while the bus answers. The release then runs
-                // after this line.
+                // A hide while the bus answers queues the release after this line.
                 if (!ShouldShowTrayIcon || !ReferenceEquals(_sysTrayServiceNameRequest, request))
                     return;
 
-                // Export the object only while the connection owns the name. If not, a host that scans
-                // the bus adds a second item. Two calls can get here together, and a second export
-                // throws.
+                // A host that scans the bus adds a second item if the object is exported before the
+                // connection owns the name. Two calls can reach this line, and a second export throws.
                 if (!_itemExported)
                 {
                     _connection.AddMethodHandler(_statusNotifierItemDbusObj);
@@ -188,7 +187,7 @@ namespace Avalonia.FreeDesktop
             {
                 // Clear only this request, and only if it did not complete. The next call then asks for
                 // the name again.
-                if (request is { Status: not TaskStatus.RanToCompletion } && ReferenceEquals(_sysTrayServiceNameRequest, request))
+                if (request is { IsCompletedSuccessfully: false } && ReferenceEquals(_sysTrayServiceNameRequest, request))
                     _sysTrayServiceNameRequest = null;
 
                 if (!_isDisposed)
@@ -202,32 +201,38 @@ namespace Avalonia.FreeDesktop
 
         private void DestroyTrayIcon()
         {
-            if (_connection is null || !_serviceConnected || _isDisposed || _statusNotifierItemDbusObj is null || _sysTrayServiceName is null)
+            if (_connection is null || _statusNotifierItemDbusObj is null || !_itemExported)
                 return;
 
             _connection.RemoveMethodHandler(_statusNotifierItemDbusObj.Path);
             _itemExported = false;
         }
 
-        /// <summary>
-        /// Releases the bus name. A host removes the item when the name goes away.
-        /// Call this after <see cref="DestroyTrayIcon"/>, but not when the watcher stops.
-        /// </summary>
+        // A host removes the item when the name goes away. Keep the name when only the watcher stops.
         private void ReleaseTrayServiceName()
         {
             if (_connection is null || _sysTrayServiceName is null || _sysTrayServiceNameRequest is not { } request)
                 return;
 
             _sysTrayServiceNameRequest = null;
-            _sysTrayServiceNameRelease = ReleaseTrayServiceName(request, _connection, _sysTrayServiceName);
+            _sysTrayServiceNameRelease = ReleaseTrayServiceNameAsync(request, _connection, _sysTrayServiceName);
         }
 
-        private async Task ReleaseTrayServiceName(Task request, DBusConnection connection, string name)
+        private async Task ReleaseTrayServiceNameAsync(Task request, DBusConnection connection, string name)
         {
             try
             {
                 // Wait for the request. A release before the connection owns the name has no effect.
-                await request;
+                try
+                {
+                    await request;
+                }
+                catch
+                {
+                    // CreateTrayIcon logs this failure. There is no name to release.
+                    return;
+                }
+
                 await connection.ReleaseNameAsync(name);
             }
             catch (Exception e)

--- a/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
+++ b/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
@@ -286,25 +286,22 @@ namespace Avalonia.FreeDesktop
 
         public void SetIsVisible(bool visible)
         {
-            if (_isDisposed || !_serviceConnected)
-            {
-                _isVisible = visible;
+            if (_isDisposed || visible == _isVisible)
                 return;
-            }
 
-            switch (visible)
-            {
-                case true when !_isVisible:
-                    DestroyTrayIcon();
-                    CreateTrayIcon();
-                    break;
-                case false when _isVisible:
-                    DestroyTrayIcon();
-                    ReleaseTrayServiceName();
-                    break;
-            }
-
+            // CreateTrayIcon reads _isVisible. Set it first.
             _isVisible = visible;
+
+            if (visible)
+            {
+                CreateTrayIcon();
+            }
+            else
+            {
+                DestroyTrayIcon();
+                // Release the name also when the watcher is away. A hidden icon must not own a name.
+                ReleaseTrayServiceName();
+            }
         }
 
         public void SetToolTipText(string? text)


### PR DESCRIPTION
## What does the pull request do?

Fixes two defects in `DBusTrayIconImpl`.

**Duplicate icon (#21978).** The `/StatusNotifierItem` object was exported before the connection owned an `org.kde.StatusNotifierItem-*` name, and the name got a new instance id on every watcher restart. A host that scans the bus (gnome-shell-extension-appindicator) then keyed the item by the unique connection name and by the well-known name: two entries, two icons. The object is now exported only while the name is owned, and the name is kept for the life of the icon. Hide releases the name.

**Crash on exit (#21979).** `WatchAsync` and `CreateTrayIcon` are `async void`. An exception after `Dispose` did not match the exception filters and ended the process (exit code 134). Both methods now catch all exceptions.

No public API changes.

## What is the updated/expected behavior with this PR?

One tray icon per application across host restarts. Hide and show reuse the same item. Dispose and shutdown complete without a crash.

## Testing

Manual test on GNOME Shell 48.5 with the AppIndicator extension, polling `org.kde.StatusNotifierWatcher.RegisteredStatusNotifierItems`: extension restarts, hide/show cycles (also fast toggles and a show during a pending release), dispose. Unpatched build: duplicate entry and exit code 134. Patched build: one entry, exit code 0.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Fixed issues

Fixes #21978
Fixes #21979

Related to #13130 (item lost when the host restarts while the watcher name stays; not addressed here).
