### PR TITLE
Add week numbers support to Calendar

### DIFF
--- a/samples/ControlCatalog/Pages/CalendarDatePickerPage.xaml
+++ b/samples/ControlCatalog/Pages/CalendarDatePickerPage.xaml
@@ -49,6 +49,9 @@
 
         <TextBlock Text="Validation Example"/>
         <CalendarDatePicker SelectedDate="{CompiledBinding ValidatedDateExample, Mode=TwoWay}"/>
+        
+        <TextBlock Text="WeekNumbers example"/>
+        <CalendarDatePicker IsWeekNumberVisible="True" />
       </StackPanel>
 
     </StackPanel>

--- a/samples/ControlCatalog/Pages/CalendarPage.xaml
+++ b/samples/ControlCatalog/Pages/CalendarPage.xaml
@@ -22,7 +22,7 @@
         <Calendar SelectionMode="SingleDate" />
       </StackPanel>
       <StackPanel>
-        <TextBlock Text="Disabled" />
+        <TextBlock Text="Disabled"/>
         <Calendar IsEnabled="False" />
       </StackPanel>
       <StackPanel>

--- a/samples/ControlCatalog/Pages/CalendarPage.xaml
+++ b/samples/ControlCatalog/Pages/CalendarPage.xaml
@@ -14,23 +14,23 @@
         </Style>
       </WrapPanel.Styles>
       <StackPanel>
-        <TextBlock Text="SelectionMode: None"/>
+        <TextBlock Text="SelectionMode: None" />
         <Calendar SelectionMode="None" />
       </StackPanel>
       <StackPanel>
-        <TextBlock Text="SelectionMode: SingleDate"/>
+        <TextBlock Text="SelectionMode: SingleDate" />
         <Calendar SelectionMode="SingleDate" />
       </StackPanel>
       <StackPanel>
-        <TextBlock Text="Disabled"/>
+        <TextBlock Text="Disabled" />
         <Calendar IsEnabled="False" />
       </StackPanel>
       <StackPanel>
-        <TextBlock Text="SelectionMode: SingleRange"/>
+        <TextBlock Text="SelectionMode: SingleRange" />
         <Calendar SelectionMode="SingleRange" />
       </StackPanel>
       <StackPanel>
-        <TextBlock Text="SelectionMode: MultipleRange"/>
+        <TextBlock Text="SelectionMode: MultipleRange" />
         <Calendar SelectionMode="MultipleRange" />
       </StackPanel>
       <StackPanel>
@@ -39,14 +39,23 @@
                   AllowTapRangeSelection="True" />
       </StackPanel>
       <StackPanel>
-        <TextBlock Text="DisplayDates"/>
+        <TextBlock Text="DisplayDates" />
         <Calendar Name="DisplayDatesCalendar"
                   SelectionMode="SingleDate" />
       </StackPanel>
       <StackPanel>
-        <TextBlock Text="BlackoutDates"/>
+        <TextBlock Text="BlackoutDates" />
         <Calendar Name="BlackoutDatesCalendar"
                   SelectionMode="SingleDate" />
+      </StackPanel>
+      <StackPanel>
+        <TextBlock Text="WeekNumbers" />
+        <Calendar Name="WeekNumbers"
+                  IsWeekNumberVisible="True">
+          <Calendar.Resources>
+            <x:String x:Key="StringCalendarWeekNumberHeader">#</x:String>
+          </Calendar.Resources>
+        </Calendar>
       </StackPanel>
     </WrapPanel>
   </StackPanel>

--- a/samples/ControlCatalog/Pages/CalendarPage.xaml
+++ b/samples/ControlCatalog/Pages/CalendarPage.xaml
@@ -49,8 +49,10 @@
                   SelectionMode="SingleDate" />
       </StackPanel>
       <StackPanel>
-        <TextBlock Text="WeekNumbers" />
+        <TextBlock Text="WeekNumbers (ISO-Week)" />
         <Calendar Name="WeekNumbers"
+                  WeekNumberRule="FirstFourDayWeek"
+                  FirstDayOfWeek="Monday"
                   IsWeekNumberVisible="True">
           <Calendar.Resources>
             <x:String x:Key="StringCalendarWeekNumberHeader">#</x:String>

--- a/samples/ControlCatalog/Pages/CalendarPage.xaml
+++ b/samples/ControlCatalog/Pages/CalendarPage.xaml
@@ -14,11 +14,11 @@
         </Style>
       </WrapPanel.Styles>
       <StackPanel>
-        <TextBlock Text="SelectionMode: None" />
+        <TextBlock Text="SelectionMode: None"/>
         <Calendar SelectionMode="None" />
       </StackPanel>
       <StackPanel>
-        <TextBlock Text="SelectionMode: SingleDate" />
+        <TextBlock Text="SelectionMode: SingleDate"/>
         <Calendar SelectionMode="SingleDate" />
       </StackPanel>
       <StackPanel>
@@ -26,11 +26,11 @@
         <Calendar IsEnabled="False" />
       </StackPanel>
       <StackPanel>
-        <TextBlock Text="SelectionMode: SingleRange" />
+        <TextBlock Text="SelectionMode: SingleRange"/>
         <Calendar SelectionMode="SingleRange" />
       </StackPanel>
       <StackPanel>
-        <TextBlock Text="SelectionMode: MultipleRange" />
+        <TextBlock Text="SelectionMode: MultipleRange"/>
         <Calendar SelectionMode="MultipleRange" />
       </StackPanel>
       <StackPanel>
@@ -39,12 +39,12 @@
                   AllowTapRangeSelection="True" />
       </StackPanel>
       <StackPanel>
-        <TextBlock Text="DisplayDates" />
+        <TextBlock Text="DisplayDates"/>
         <Calendar Name="DisplayDatesCalendar"
                   SelectionMode="SingleDate" />
       </StackPanel>
       <StackPanel>
-        <TextBlock Text="BlackoutDates" />
+        <TextBlock Text="BlackoutDates"/>
         <Calendar Name="BlackoutDatesCalendar"
                   SelectionMode="SingleDate" />
       </StackPanel>

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -379,9 +379,12 @@ namespace Avalonia.Controls
 
         /// <summary>
         /// Gets or sets the rule used to determine the first week of the year for week number display.
-        /// The default is taken from the current culture. Use <see cref="CalendarWeekNumberRule.Iso"/>
-        /// for ISO 8601 week numbering.
+        /// The default is taken from the current culture.
         /// </summary>
+        /// <remarks>
+        /// Use <c>WeekNumberRule</c> = <see cref="CalendarWeekRule.FirstFourDayWeek"/> in combination with <c>FirstDayOfWeek</c> = <see cref="DayOfWeek.Monday"/>
+        /// for ISO 8601 week numbering. (see also: <see cref="ISOWeek"/>)
+        /// </remarks>
         public CalendarWeekRule WeekNumberRule
         {
             get => GetValue(WeekNumberRuleProperty);
@@ -2244,6 +2247,8 @@ namespace Avalonia.Controls
             DisplayDateProperty.Changed.AddClassHandler<Calendar>((x, e) => x.OnDisplayDateChanged(e));
             DisplayDateStartProperty.Changed.AddClassHandler<Calendar>((x, e) => x.OnDisplayDateStartChanged(e));
             DisplayDateEndProperty.Changed.AddClassHandler<Calendar>((x, e) => x.OnDisplayDateEndChanged(e));
+            IsWeekNumberVisibleProperty.Changed.AddClassHandler<Calendar>((x, _) => x.UpdateMonths());
+            WeekNumberRuleProperty.Changed.AddClassHandler<Calendar>((x, _) => x.UpdateMonths());
             KeyDownEvent.AddClassHandler<Calendar>((x, e) => x.Calendar_KeyDown(e));
             KeyUpEvent.AddClassHandler<Calendar>((x, e) => x.Calendar_KeyUp(e));
         }

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -459,6 +459,7 @@ namespace Avalonia.Controls
                         }
                 }
             }
+            monthControl?.UpdateWeekNumberLabelsVisibility();
             OnDisplayModeChanged(new CalendarModeChangedEventArgs((CalendarMode)e.OldValue, mode));
         }
         private static bool IsValidDisplayMode(CalendarMode mode)

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -375,7 +375,7 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<CalendarWeekRule> WeekNumberRuleProperty =
             AvaloniaProperty.Register<Calendar, CalendarWeekRule>(
                 nameof(WeekNumberRule),
-                defaultValue: (CalendarWeekRule)DateTimeHelper.GetCurrentDateFormat().CalendarWeekRule);
+                defaultValue: DateTimeHelper.GetCurrentDateFormat().CalendarWeekRule);
 
         /// <summary>
         /// Gets or sets the rule used to determine the first week of the year for week number display.

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Globalization;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
@@ -353,6 +354,40 @@ namespace Avalonia.Controls
             set => SetValue(HeaderBackgroundProperty, value);
         }
 
+        /// <summary>
+        /// Defines the <see cref="IsWeekNumberVisible"/> property.
+        /// </summary>
+        public static readonly StyledProperty<bool> IsWeekNumberVisibleProperty =
+            AvaloniaProperty.Register<Calendar, bool>(nameof(IsWeekNumberVisible));
+
+        /// <summary>
+        /// Gets or sets a value indicating whether week numbers are shown in the month view.
+        /// </summary>
+        public bool IsWeekNumberVisible
+        {
+            get => GetValue(IsWeekNumberVisibleProperty);
+            set => SetValue(IsWeekNumberVisibleProperty, value);
+        }
+
+        /// <summary>
+        /// Defines the <see cref="WeekNumberRule"/> property.
+        /// </summary>
+        public static readonly StyledProperty<CalendarWeekRule> WeekNumberRuleProperty =
+            AvaloniaProperty.Register<Calendar, CalendarWeekRule>(
+                nameof(WeekNumberRule),
+                defaultValue: (CalendarWeekRule)DateTimeHelper.GetCurrentDateFormat().CalendarWeekRule);
+
+        /// <summary>
+        /// Gets or sets the rule used to determine the first week of the year for week number display.
+        /// The default is taken from the current culture. Use <see cref="CalendarWeekNumberRule.Iso"/>
+        /// for ISO 8601 week numbering.
+        /// </summary>
+        public CalendarWeekRule WeekNumberRule
+        {
+            get => GetValue(WeekNumberRuleProperty);
+            set => SetValue(WeekNumberRuleProperty, value);
+        }
+        
         public static readonly StyledProperty<CalendarMode> DisplayModeProperty =
             AvaloniaProperty.Register<Calendar, CalendarMode>(
                 nameof(DisplayMode),

--- a/src/Avalonia.Controls/Calendar/CalendarItem.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarItem.cs
@@ -19,12 +19,13 @@ namespace Avalonia.Controls.Primitives
     /// Represents the currently displayed month or year on a
     /// <see cref="T:Avalonia.Controls.Calendar" />.
     /// </summary>
-    [TemplatePart(PART_ElementHeaderButton,   typeof(Button))]
-    [TemplatePart(PART_ElementMonthView,      typeof(Grid))]
-    [TemplatePart(PART_ElementNextButton,     typeof(Button))]
-    [TemplatePart(PART_ElementPreviousButton, typeof(Button))]
-    [TemplatePart(PART_ElementYearView,       typeof(Grid))]
-    [PseudoClasses(":calendardisabled")]
+    [TemplatePart(PART_ElementHeaderButton,     typeof(Button))]
+    [TemplatePart(PART_ElementMonthView,        typeof(Grid))]
+    [TemplatePart(PART_ElementNextButton,       typeof(Button))]
+    [TemplatePart(PART_ElementPreviousButton,   typeof(Button))]
+    [TemplatePart(PART_ElementYearView,         typeof(Grid))]
+    [TemplatePart(PART_ElementWeekNumberColumn, typeof(Panel))]
+    [PseudoClasses(":calendardisabled", ":hasweeknumbers")]
     public sealed class CalendarItem : TemplatedControl
     {
         /// <summary>
@@ -37,6 +38,7 @@ namespace Avalonia.Controls.Primitives
         private const string PART_ElementNextButton = "PART_NextButton";
         private const string PART_ElementMonthView = "PART_MonthView";
         private const string PART_ElementYearView = "PART_YearView";
+        private const string PART_ElementWeekNumberColumn = "PART_ElementWeekNumberColumn";
 
         private Button? _headerButton;
         private Button? _nextButton;
@@ -164,6 +166,11 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         internal Grid? YearView { get; set; }
         
+        /// <summary>
+        /// Gets the Grid that hosts the week number labels when in month mode.
+        /// </summary>
+        internal Grid? WeekNumberLabels { get; set; }
+        
         private void PopulateGrids()
         {
             if (MonthView != null)
@@ -210,6 +217,21 @@ namespace Avalonia.Controls.Primitives
                 MonthView.Children.AddRange(children);
             }
 
+            if (WeekNumberLabels != null)
+            {
+                using var children = new PooledList<Control>(Calendar.RowsPerMonth);
+                
+                for (int i = 1; i < Calendar.RowsPerMonth; i++)
+                {
+                    var cell = new ContentControl();
+                    cell.SetValue(Grid.RowProperty, i);
+                    cell.TemplatedParent = this;
+                    children.Add(cell);
+                }
+                
+                WeekNumberLabels.Children.AddRange(children);
+            }
+
             if (YearView != null)
             {
                 var childCount = Calendar.RowsPerYear * Calendar.ColumnsPerYear;
@@ -254,6 +276,7 @@ namespace Avalonia.Controls.Primitives
             NextButton = e.NameScope.Find<Button>(PART_ElementNextButton);
             MonthView = e.NameScope.Find<Grid>(PART_ElementMonthView);
             YearView = e.NameScope.Find<Grid>(PART_ElementYearView);
+            WeekNumberLabels = e.NameScope.Find<Grid>(PART_ElementWeekNumberColumn);
             
             if (Owner != null)
             {
@@ -373,6 +396,7 @@ namespace Avalonia.Controls.Primitives
             {
                 SetDayTitles();
                 SetCalendarDayButtons(_currentMonth);
+                UpdateWeekNumberLabels(_currentMonth);
             }
         }
         private void SetMonthModeHeaderButton()
@@ -586,6 +610,36 @@ namespace Avalonia.Controls.Primitives
                         Owner.HoverStartIndex = Calendar.ColumnsPerMonth * Calendar.RowsPerMonth - 1;
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Updates the week number labels if <see cref="Calendar.IsWeekNumberVisible"/> is true and the
+        /// <see cref="Calendar.DisplayMode"/> is set to <see cref="CalendarMode.Month"/>.
+        /// </summary>
+        private void UpdateWeekNumberLabels(DateTime firstDayOfMonth)
+        {
+            // if we don't have a week number labels grid, or it has no children, then we don't need to update
+            if (WeekNumberLabels is null || WeekNumberLabels.Children.Count == 0)
+                return;
+            
+            int lastMonthToDisplay = PreviousMonthDays(firstDayOfMonth);
+            DateTime firstDateDisplayed = DateTimeHelper.CompareYearMonth(firstDayOfMonth, DateTime.MinValue) > 0
+                ? _calendar.AddDays(firstDayOfMonth, -lastMonthToDisplay)
+                : firstDayOfMonth;
+
+            bool show = Owner?.IsWeekNumberVisible ?? false;
+            var rule = Owner?.WeekNumberRule ?? DateTimeHelper.GetCurrentDateFormat().CalendarWeekRule;
+            var firstDayOfWeek = Owner?.FirstDayOfWeek ?? DateTimeHelper.GetCurrentDateFormat().FirstDayOfWeek;
+
+            PseudoClasses.Set(":hasweeknumbers", show);
+            
+            for (int i = 0; i < WeekNumberLabels.Children.Count; i++)
+            {
+                DateTime firstDayOfRow = _calendar.AddDays(firstDateDisplayed, i * NumberOfDaysPerWeek);
+
+                var label = WeekNumberLabels.Children[i] as ContentControl;
+                label?.Content = DateTimeHelper.GetWeekOfYear(firstDayOfRow, rule, firstDayOfWeek, _calendar);
             }
         }
 

--- a/src/Avalonia.Controls/Calendar/CalendarItem.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarItem.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Controls.Primitives
     [TemplatePart(PART_ElementNextButton,       typeof(Button))]
     [TemplatePart(PART_ElementPreviousButton,   typeof(Button))]
     [TemplatePart(PART_ElementYearView,         typeof(Grid))]
-    [TemplatePart(PART_ElementWeekNumberColumn, typeof(Panel))]
+    [TemplatePart(PART_ElementWeekNumberLabels, typeof(Grid))]
     [PseudoClasses(":calendardisabled", ":hasweeknumbers")]
     public sealed class CalendarItem : TemplatedControl
     {
@@ -38,7 +38,7 @@ namespace Avalonia.Controls.Primitives
         private const string PART_ElementNextButton = "PART_NextButton";
         private const string PART_ElementMonthView = "PART_MonthView";
         private const string PART_ElementYearView = "PART_YearView";
-        private const string PART_ElementWeekNumberColumn = "PART_ElementWeekNumberColumn";
+        private const string PART_ElementWeekNumberLabels = "PART_ElementWeekNumberLabels";
 
         private Button? _headerButton;
         private Button? _nextButton;
@@ -276,7 +276,7 @@ namespace Avalonia.Controls.Primitives
             NextButton = e.NameScope.Find<Button>(PART_ElementNextButton);
             MonthView = e.NameScope.Find<Grid>(PART_ElementMonthView);
             YearView = e.NameScope.Find<Grid>(PART_ElementYearView);
-            WeekNumberLabels = e.NameScope.Find<Grid>(PART_ElementWeekNumberColumn);
+            WeekNumberLabels = e.NameScope.Find<Grid>(PART_ElementWeekNumberLabels);
             
             if (Owner != null)
             {
@@ -619,6 +619,10 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         private void UpdateWeekNumberLabels(DateTime firstDayOfMonth)
         {
+            // first set the pseudo classes
+            bool show = Owner?.IsWeekNumberVisible ?? false;
+            PseudoClasses.Set(":hasweeknumbers", show);
+            
             // if we don't have a week number labels grid, or it has no children, then we don't need to update
             if (WeekNumberLabels is null || WeekNumberLabels.Children.Count == 0)
                 return;
@@ -628,11 +632,8 @@ namespace Avalonia.Controls.Primitives
                 ? _calendar.AddDays(firstDayOfMonth, -lastMonthToDisplay)
                 : firstDayOfMonth;
 
-            bool show = Owner?.IsWeekNumberVisible ?? false;
             var rule = Owner?.WeekNumberRule ?? DateTimeHelper.GetCurrentDateFormat().CalendarWeekRule;
             var firstDayOfWeek = Owner?.FirstDayOfWeek ?? DateTimeHelper.GetCurrentDateFormat().FirstDayOfWeek;
-
-            PseudoClasses.Set(":hasweeknumbers", show);
             
             for (int i = 0; i < WeekNumberLabels.Children.Count; i++)
             {

--- a/src/Avalonia.Controls/Calendar/CalendarItem.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarItem.cs
@@ -1,4 +1,4 @@
-﻿// (c) Copyright Microsoft Corporation.
+// (c) Copyright Microsoft Corporation.
 // This source is subject to the Microsoft Public License (Ms-PL).
 // Please see https://go.microsoft.com/fwlink/?LinkID=131993 for details.
 // All other rights reserved.
@@ -627,6 +627,8 @@ namespace Avalonia.Controls.Primitives
             if (WeekNumberLabels is null || WeekNumberLabels.Children.Count == 0)
                 return;
             
+            UpdateWeekNumberLabelsVisibility();
+            
             int lastMonthToDisplay = PreviousMonthDays(firstDayOfMonth);
             DateTime firstDateDisplayed = DateTimeHelper.CompareYearMonth(firstDayOfMonth, DateTime.MinValue) > 0
                 ? _calendar.AddDays(firstDayOfMonth, -lastMonthToDisplay)
@@ -634,13 +636,31 @@ namespace Avalonia.Controls.Primitives
 
             var rule = Owner?.WeekNumberRule ?? DateTimeHelper.GetCurrentDateFormat().CalendarWeekRule;
             var firstDayOfWeek = Owner?.FirstDayOfWeek ?? DateTimeHelper.GetCurrentDateFormat().FirstDayOfWeek;
-            
-            for (int i = 0; i < WeekNumberLabels.Children.Count; i++)
+
+            // We have 6 rows with weeks. The ControlTheme may have added more children to the Grid (Header, Background, ...).
+            // We only want to update the last 6 children of the Grid, which are the week number labels.
+            var startIndex = WeekNumberLabels.Children.Count - (Calendar.RowsPerMonth - 1);
+            for (int i = startIndex; i < WeekNumberLabels.Children.Count; i++)
             {
-                DateTime firstDayOfRow = _calendar.AddDays(firstDateDisplayed, i * NumberOfDaysPerWeek);
+                var daysToAdd = (i - startIndex) * NumberOfDaysPerWeek;
+                DateTime firstDayOfRow = _calendar.AddDays(firstDateDisplayed, daysToAdd);
 
                 var label = WeekNumberLabels.Children[i] as ContentControl;
                 label?.Content = DateTimeHelper.GetWeekOfYear(firstDayOfRow, rule, firstDayOfWeek, _calendar);
+            }
+        }
+
+        /// <summary>
+        /// Updates the visibility of the week number labels based on the <see cref="Calendar.IsWeekNumberVisible"/> property
+        /// and the <see cref="Calendar.DisplayMode"/>.
+        /// </summary>
+        /// <exception cref="NotImplementedException"></exception>
+        internal void UpdateWeekNumberLabelsVisibility()
+        {
+            if (WeekNumberLabels is not null && Owner is not null)
+            {
+                WeekNumberLabels.IsVisible =
+                    Owner.IsWeekNumberVisible && Owner.DisplayMode == CalendarMode.Month;
             }
         }
 

--- a/src/Avalonia.Controls/Calendar/CalendarItem.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarItem.cs
@@ -169,7 +169,7 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Gets the Grid that hosts the week number labels when in month mode.
         /// </summary>
-        internal Grid? WeekNumberLabels { get; set; }
+        private Grid? WeekNumberLabels { get; set; }
         
         private void PopulateGrids()
         {

--- a/src/Avalonia.Controls/Calendar/DateTimeHelper.cs
+++ b/src/Avalonia.Controls/Calendar/DateTimeHelper.cs
@@ -131,5 +131,30 @@ namespace Avalonia.Controls
             var format = GetCurrentDateFormat();
             return date.Year.ToString(format);
         }
+
+        /// <summary>
+        /// Gets the week-of-year number for the specified date.
+        /// </summary>
+        /// <param name="date">The date.</param>
+        /// <param name="rule">The rule that defines what constitutes the first week of the year.</param>
+        /// <param name="firstDayOfWeek">The first day of the week.</param>
+        /// <param name="calendar">the calendar to use.</param>
+        /// <returns>The week number that <paramref name="date"/> falls in.</returns>
+        /// <remarks>
+        /// This method fixes an issue where .NET's Calendar.GetWeekOfYear incorrectly returns week 53 for
+        /// late-December dates that ISO 8601 assigns to week 1 of the next year (e.g. 2018-12-31).
+        /// </remarks>
+        public static int GetWeekOfYear(DateTime date, 
+            CalendarWeekRule rule, 
+            DayOfWeek firstDayOfWeek, 
+            System.Globalization.Calendar calendar)
+        {
+            // .NET's Calendar.GetWeekOfYear incorrectly returns week 53 for late-December dates
+            // that ISO 8601 assigns to week 1 of the next year (e.g. 2018-12-31).
+            if (rule == CalendarWeekRule.FirstFourDayWeek && firstDayOfWeek == DayOfWeek.Monday)
+                return ISOWeek.GetWeekOfYear(date);
+
+            return calendar.GetWeekOfYear(date, rule, firstDayOfWeek);
+        }
     }
 }

--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.Properties.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.Properties.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
@@ -148,6 +149,18 @@ namespace Avalonia.Controls
         /// </summary>
         public static readonly StyledProperty<VerticalAlignment> VerticalContentAlignmentProperty =
             ContentControl.VerticalContentAlignmentProperty.AddOwner<CalendarDatePicker>();
+
+        /// <summary>
+        /// Defines the <see cref="IsWeekNumberVisible"/> property.
+        /// </summary>
+        public static readonly StyledProperty<bool> IsWeekNumberVisibleProperty =
+            Calendar.IsWeekNumberVisibleProperty.AddOwner<CalendarDatePicker>();
+
+        /// <summary>
+        /// Defines the <see cref="WeekNumberRule"/> property.
+        /// </summary>
+        public static readonly StyledProperty<CalendarWeekRule> WeekNumberRuleProperty =
+            Calendar.WeekNumberRuleProperty.AddOwner<CalendarDatePicker>();
 
         /// <summary>
         /// Gets a collection of dates that are marked as not selectable.
@@ -388,6 +401,20 @@ namespace Avalonia.Controls
         {
             get => GetValue(VerticalContentAlignmentProperty);
             set => SetValue(VerticalContentAlignmentProperty, value);
+        }
+
+        /// <inheritdoc cref="Calendar.IsWeekNumberVisible"/>
+        public bool IsWeekNumberVisible
+        {
+            get => GetValue(IsWeekNumberVisibleProperty);
+            set => SetValue(IsWeekNumberVisibleProperty, value);
+        }
+
+        /// <inheritdoc cref="Calendar.WeekNumberRule"/>
+        public CalendarWeekRule WeekNumberRule
+        {
+            get => GetValue(WeekNumberRuleProperty);
+            set => SetValue(WeekNumberRuleProperty, value);
         }
     }
 }

--- a/src/Avalonia.Themes.Fluent/Accents/FluentControlResources.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentControlResources.xaml
@@ -416,6 +416,7 @@
       <StaticResource x:Key="CalendarViewNavigationButtonBorderBrush" ResourceKey="SystemControlTransparentBrush" />
       <x:Double x:Key="CalendarFontSize">20</x:Double>
       <x:Double x:Key="CalendarDayButtonFontSize">12</x:Double>
+      <x:Double x:Key="CalendarWeekNumberFontSize">12</x:Double>
       <FontWeight x:Key="CalendarViewTodayFontWeight">SemiBold</FontWeight>
 
       <!-- Resources for Expander.xaml -->
@@ -1262,6 +1263,7 @@
       <StaticResource x:Key="CalendarViewNavigationButtonBorderBrush" ResourceKey="SystemControlTransparentBrush" />
       <x:Double x:Key="CalendarFontSize">20</x:Double>
       <x:Double x:Key="CalendarDayButtonFontSize">12</x:Double>
+      <x:Double x:Key="CalendarWeekNumberFontSize">12</x:Double>
       <FontWeight x:Key="CalendarViewTodayFontWeight">SemiBold</FontWeight>
 
       <!-- Resources for Expander.xaml -->

--- a/src/Avalonia.Themes.Fluent/Controls/CalendarDatePicker.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CalendarDatePicker.xaml
@@ -133,7 +133,9 @@
                           SelectedDate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedDate, Mode=TwoWay}"
                           DisplayDate="{TemplateBinding DisplayDate}"
                           DisplayDateStart="{TemplateBinding DisplayDateStart}"
-                          DisplayDateEnd="{TemplateBinding DisplayDateEnd}" />
+                          DisplayDateEnd="{TemplateBinding DisplayDateEnd}"
+                          IsWeekNumberVisible="{TemplateBinding IsWeekNumberVisible}"
+                          WeekNumberRule="{TemplateBinding WeekNumberRule}" />
               </Popup>
             </Grid>
           </Panel>

--- a/src/Avalonia.Themes.Fluent/Controls/CalendarItem.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CalendarItem.xaml
@@ -123,24 +123,13 @@
                     IsVisible="{Binding #PART_MonthView.IsVisible}" 
                     Grid.Row="1" 
                     Grid.Column="1" />
-            <!-- Header for the Weeks. -->
-            <ContentControl Name="WeekNumberHeader" 
-                            Grid.Row="1"
-                            Content="{DynamicResource StringCalendarWeekNumberHeader}"
-                            Height="38"
-                            MinWidth="38"
-                            FontSize="{DynamicResource CalendarWeekNumberFontSize}"
-                            VerticalAlignment="Top"
-                            VerticalContentAlignment="Center"
-                            HorizontalContentAlignment="Center"
-                            IsVisible="False" />
             <!-- The below Grid will be feed by the week numbers -->
             <Grid Name="PART_ElementWeekNumberLabels"
                   Grid.Row="1"
                   Grid.Column="0"
+                  MinWidth="38"
                   IsVisible="False">
               <Grid.RowDefinitions>
-                <!--This should always be the week day names??-->
                 <RowDefinition Height="38" />
                 <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
                 <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
@@ -149,6 +138,13 @@
                 <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
                 <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
               </Grid.RowDefinitions>
+              <!-- Header for the Weeks. -->
+              <ContentControl Name="WeekNumberHeader" 
+                              Grid.Row="0"
+                              Content="{DynamicResource StringCalendarWeekNumberHeader}"
+                              FontSize="{DynamicResource CalendarWeekNumberFontSize}"
+                              VerticalContentAlignment="Center"
+                              HorizontalContentAlignment="Center" />
             </Grid>
             <Grid Name="PART_MonthView" 
                   Grid.Column="1" 
@@ -204,16 +200,13 @@
       <Setter Property="Stroke" Value="{DynamicResource CalendarViewNavigationButtonForegroundPressed}" />
     </Style>
     <Style Selector="^:hasweeknumbers">
+      <Setter Property="MinWidth" Value="332" />
       <Style Selector="^ /template/ Grid#PART_ElementWeekNumberLabels">
-        <Setter Property="IsVisible" Value="True" />
         <Style Selector="^ ContentControl">
           <Setter Property="FontSize" Value="{DynamicResource CalendarWeekNumberFontSize}" />
           <Setter Property="HorizontalContentAlignment" Value="Center" />
           <Setter Property="VerticalContentAlignment" Value="Center" />
         </Style>
-      </Style>
-      <Style Selector="^ /template/ ContentControl#WeekNumberHeader">
-        <Setter Property="IsVisible" Value="True" />
       </Style>
     </Style>
   </ControlTheme>

--- a/src/Avalonia.Themes.Fluent/Controls/CalendarItem.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CalendarItem.xaml
@@ -10,7 +10,8 @@
         x:ClassModifier="internal">
   <Design.PreviewWith>
     <Border Padding="20">
-      <Calendar DisplayDate="2000-01-01">
+      <Calendar DisplayDate="2000-01-01" 
+                IsWeekNumberVisible="True">
         <Calendar.BlackoutDates>
           <CalendarDateRange>
             <x:Arguments>
@@ -75,8 +76,9 @@
                  basically...MinWidth of DayItem = 40, 40 * 7 = 280 + margins/padding = ~294
                  Viewport height is set from # of rows displayed (2-8) in Month mode, = ~290 for 6 weeks (+ day names)
                  -->
-          <Grid VerticalAlignment="Stretch" HorizontalAlignment="Stretch" RowDefinitions="40,*" MinWidth="294">
-            <Grid ColumnDefinitions="5*,*,*">
+          <Grid VerticalAlignment="Stretch" HorizontalAlignment="Stretch" ColumnDefinitions="Auto, *" RowDefinitions="40,*" MinWidth="294">
+            <Grid ColumnDefinitions="5*,*,*"
+                  Grid.ColumnSpan="2">
               <Button Name="PART_HeaderButton"
                       Theme="{StaticResource FluentCalendarButton}"
                       Foreground="{TemplateBinding Foreground}"
@@ -110,8 +112,34 @@
               </Button>
             </Grid>
             <!--Border below is used only for MonthView but it can't be moved inside of Grid because CalendarItem expects it to be empty and it will cause side-effects-->
-            <Border Name="BackgroundLayer" Background="{TemplateBinding BorderBrush}" Margin="0,38,0,0" IsVisible="{Binding #PART_MonthView.IsVisible}" Grid.Row="1" />
-            <Grid Name="PART_MonthView" Grid.Row="1" IsVisible="False" MinHeight="290">
+            <Border Name="BackgroundLayer" 
+                    Background="{TemplateBinding BorderBrush}" 
+                    Margin="0,38,0,0" 
+                    IsVisible="{Binding #PART_MonthView.IsVisible}" 
+                    Grid.Row="1" 
+                    Grid.Column="1" />
+            <!-- Header for the Weeks. -->
+            <ContentControl Name="WeekNumberHeader" 
+                            Grid.Row="1"
+                            Content="{DynamicResource StringCalendarWeekNumberHeader}"
+                            Height="38"
+                            MinWidth="38"
+                            FontSize="{DynamicResource CalendarWeekNumberFontSize}"
+                            VerticalAlignment="Top"
+                            VerticalContentAlignment="Center"
+                            HorizontalContentAlignment="Center"
+                            IsVisible="False" />
+            <!-- The below Grid will be feed by the week numbers -->
+            <Grid Name="PART_ElementWeekNumberColumn"
+                  Grid.Row="1"
+                  Grid.Column="0"
+                  IsVisible="False"
+                  RowDefinitions="38,*,*,*,*,*,*" />
+            <Grid Name="PART_MonthView" 
+                  Grid.Column="1" 
+                  Grid.Row="1" 
+                  IsVisible="False" 
+                  MinHeight="290">
               <Grid.RowDefinitions>
                 <!--This should always be the week day names??-->
                 <RowDefinition Height="38" />
@@ -136,6 +164,7 @@
                   Background="{TemplateBinding BorderBrush}"
                   MinHeight="290"
                   Grid.Row="1"
+                  Grid.ColumnSpan="2" 
                   IsVisible="False">
               <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
@@ -158,6 +187,19 @@
     </Style>
     <Style Selector="^ /template/ Button:pressed > Path">
       <Setter Property="Stroke" Value="{DynamicResource CalendarViewNavigationButtonForegroundPressed}" />
+    </Style>
+    <Style Selector="^:hasweeknumbers">
+      <Style Selector="^ /template/ Grid#PART_ElementWeekNumberColumn">
+        <Setter Property="IsVisible" Value="True" />
+        <Style Selector="^ ContentControl">
+          <Setter Property="FontSize" Value="{DynamicResource CalendarWeekNumberFontSize}" />
+          <Setter Property="HorizontalContentAlignment" Value="Center" />
+          <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+      </Style>
+      <Style Selector="^ /template/ ContentControl#WeekNumberHeader">
+        <Setter Property="IsVisible" Value="True" />
+      </Style>
     </Style>
   </ControlTheme>
 </ResourceDictionary>

--- a/src/Avalonia.Themes.Fluent/Controls/CalendarItem.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CalendarItem.xaml
@@ -76,7 +76,12 @@
                  basically...MinWidth of DayItem = 40, 40 * 7 = 280 + margins/padding = ~294
                  Viewport height is set from # of rows displayed (2-8) in Month mode, = ~290 for 6 weeks (+ day names)
                  -->
-          <Grid VerticalAlignment="Stretch" HorizontalAlignment="Stretch" ColumnDefinitions="Auto, *" RowDefinitions="40,*" MinWidth="294">
+          <Grid VerticalAlignment="Stretch" 
+                HorizontalAlignment="Stretch" 
+                ColumnDefinitions="Auto, *" 
+                RowDefinitions="40,*" 
+                MinWidth="294"
+                Grid.IsSharedSizeScope="True" >
             <Grid ColumnDefinitions="5*,*,*"
                   Grid.ColumnSpan="2">
               <Button Name="PART_HeaderButton"
@@ -130,11 +135,21 @@
                             HorizontalContentAlignment="Center"
                             IsVisible="False" />
             <!-- The below Grid will be feed by the week numbers -->
-            <Grid Name="PART_ElementWeekNumberColumn"
+            <Grid Name="PART_ElementWeekNumberLabels"
                   Grid.Row="1"
                   Grid.Column="0"
-                  IsVisible="False"
-                  RowDefinitions="38,*,*,*,*,*,*" />
+                  IsVisible="False">
+              <Grid.RowDefinitions>
+                <!--This should always be the week day names??-->
+                <RowDefinition Height="38" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+              </Grid.RowDefinitions>
+            </Grid>
             <Grid Name="PART_MonthView" 
                   Grid.Column="1" 
                   Grid.Row="1" 
@@ -143,12 +158,12 @@
               <Grid.RowDefinitions>
                 <!--This should always be the week day names??-->
                 <RowDefinition Height="38" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
               </Grid.RowDefinitions>
               <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -189,7 +204,7 @@
       <Setter Property="Stroke" Value="{DynamicResource CalendarViewNavigationButtonForegroundPressed}" />
     </Style>
     <Style Selector="^:hasweeknumbers">
-      <Style Selector="^ /template/ Grid#PART_ElementWeekNumberColumn">
+      <Style Selector="^ /template/ Grid#PART_ElementWeekNumberLabels">
         <Setter Property="IsVisible" Value="True" />
         <Style Selector="^ ContentControl">
           <Setter Property="FontSize" Value="{DynamicResource CalendarWeekNumberFontSize}" />

--- a/src/Avalonia.Themes.Fluent/Controls/CalendarItem.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CalendarItem.xaml
@@ -131,12 +131,12 @@
                   IsVisible="False">
               <Grid.RowDefinitions>
                 <RowDefinition Height="38" />
-                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
               </Grid.RowDefinitions>
               <!-- Header for the Weeks. -->
               <ContentControl Name="WeekNumberHeader" 
@@ -154,12 +154,12 @@
               <Grid.RowDefinitions>
                 <!--This should always be the week day names??-->
                 <RowDefinition Height="38" />
-                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
               </Grid.RowDefinitions>
               <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />

--- a/src/Avalonia.Themes.Fluent/Strings/InvariantResources.xaml
+++ b/src/Avalonia.Themes.Fluent/Strings/InvariantResources.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:ClassModifier="internal">
   <!-- Calendar -->
-  <x:String x:Key="StringCalendarWeekNumberHeader">{}</x:String> <!-- The {} creates an empty string -->
+  <x:String x:Key="StringCalendarWeekNumberHeader"> </x:String> <!-- Just one whitespace to preserve the resource -->
   <!-- DatePicker -->
   <x:String x:Key="StringDatePickerDayText">day</x:String>
   <x:String x:Key="StringDatePickerMonthText">month</x:String>

--- a/src/Avalonia.Themes.Fluent/Strings/InvariantResources.xaml
+++ b/src/Avalonia.Themes.Fluent/Strings/InvariantResources.xaml
@@ -1,6 +1,8 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:ClassModifier="internal">
+  <!-- Calendar -->
+  <x:String x:Key="StringCalendarWeekNumberHeader">{}</x:String> <!-- The {} creates an empty string -->
   <!-- DatePicker -->
   <x:String x:Key="StringDatePickerDayText">day</x:String>
   <x:String x:Key="StringDatePickerMonthText">month</x:String>

--- a/src/Avalonia.Themes.Simple/Controls/CalendarDatePicker.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/CalendarDatePicker.xaml
@@ -128,7 +128,9 @@
                       FirstDayOfWeek="{TemplateBinding FirstDayOfWeek}"
                       IsTodayHighlighted="{TemplateBinding IsTodayHighlighted}"
                       SelectedDate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedDate,
-                                                     Mode=TwoWay}" />
+                                                     Mode=TwoWay}"
+                      IsWeekNumberVisible="{TemplateBinding IsWeekNumberVisible}"
+                      WeekNumberRule="{TemplateBinding WeekNumberRule}" />
           </Popup>
         </Grid>
       </ControlTemplate>

--- a/src/Avalonia.Themes.Simple/Controls/CalendarItem.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/CalendarItem.xaml
@@ -110,16 +110,6 @@
                   </Button>
                 </Grid>
 
-                <ContentControl Name="WeekNumberHeader" 
-                                Grid.Row="1"
-                                Content="{DynamicResource StringCalendarWeekNumberHeader}"
-                                FontSize="9.5"
-                                MinWidth="20"
-                                VerticalAlignment="Top"
-                                VerticalContentAlignment="Center"
-                                HorizontalContentAlignment="Center"
-                                IsVisible="False" />
-                
                 <Grid Name="PART_ElementWeekNumberLabels" 
                       Grid.Row="1"
                       Grid.Column="0"
@@ -136,6 +126,12 @@
                     <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
                     <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
                   </Grid.RowDefinitions>
+                  <!-- week number header -->
+                  <ContentControl Content="{DynamicResource StringCalendarWeekNumberHeader}"
+                                  FontSize="9.5"
+                                  VerticalAlignment="Top"
+                                  VerticalContentAlignment="Center"
+                                  HorizontalContentAlignment="Center" />
                 </Grid>
 
                 <Grid Name="PART_MonthView"
@@ -211,16 +207,12 @@
     
     <Style Selector="^:hasweeknumbers">
       <Style Selector="^ /template/ Grid#PART_ElementWeekNumberLabels">
-        <Setter Property="IsVisible" Value="True" />
         <Style Selector="^ ContentControl">
           <Setter Property="FontSize" Value="9.5" />
           <Setter Property="HorizontalContentAlignment" Value="Center" />
           <Setter Property="VerticalAlignment" Value="Stretch" />
           <Setter Property="VerticalContentAlignment" Value="Center" />
         </Style>
-      </Style>
-      <Style Selector="^ /template/ ContentControl#WeekNumberHeader">
-        <Setter Property="IsVisible" Value="True" />
       </Style>
     </Style>
   </ControlTheme>

--- a/src/Avalonia.Themes.Simple/Controls/CalendarItem.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/CalendarItem.xaml
@@ -113,8 +113,8 @@
                 <ContentControl Name="WeekNumberHeader" 
                                 Grid.Row="1"
                                 Content="{DynamicResource StringCalendarWeekNumberHeader}"
-                                Margin="0, 4"
                                 FontSize="9.5"
+                                MinWidth="20"
                                 VerticalAlignment="Top"
                                 VerticalContentAlignment="Center"
                                 HorizontalContentAlignment="Center"
@@ -124,6 +124,7 @@
                       Grid.Row="1"
                       Grid.Column="0"
                       IsVisible="False"
+                      MinWidth="20"
                       Margin="6,-1,6,6"
                       VerticalAlignment="Stretch">
                   <Grid.RowDefinitions>

--- a/src/Avalonia.Themes.Simple/Controls/CalendarItem.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/CalendarItem.xaml
@@ -120,7 +120,7 @@
                                 HorizontalContentAlignment="Center"
                                 IsVisible="False" />
                 
-                <Grid Name="PART_ElementWeekNumberColumn" 
+                <Grid Name="PART_ElementWeekNumberLabels" 
                       Grid.Row="1"
                       Grid.Column="0"
                       IsVisible="False"
@@ -209,7 +209,7 @@
     </Style>
     
     <Style Selector="^:hasweeknumbers">
-      <Style Selector="^ /template/ Grid#PART_ElementWeekNumberColumn">
+      <Style Selector="^ /template/ Grid#PART_ElementWeekNumberLabels">
         <Setter Property="IsVisible" Value="True" />
         <Style Selector="^ ContentControl">
           <Setter Property="FontSize" Value="9.5" />

--- a/src/Avalonia.Themes.Simple/Controls/CalendarItem.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/CalendarItem.xaml
@@ -119,12 +119,12 @@
                       VerticalAlignment="Stretch">
                   <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewHeaderRow" />
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
                   </Grid.RowDefinitions>
                   <!-- week number header -->
                   <ContentControl Content="{DynamicResource StringCalendarWeekNumberHeader}"
@@ -141,12 +141,12 @@
                       IsVisible="False">
                   <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewHeaderRow" />
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
                   </Grid.RowDefinitions>
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />

--- a/src/Avalonia.Themes.Simple/Controls/CalendarItem.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/CalendarItem.xaml
@@ -118,7 +118,7 @@
                       Margin="6,-1,6,6"
                       VerticalAlignment="Stretch">
                   <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewHeaderRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewHeaderRow" />
                     <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
                     <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
                     <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
@@ -140,7 +140,7 @@
                       Margin="6,-1,6,6"
                       IsVisible="False">
                   <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewHeaderRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewHeaderRow" />
                     <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
                     <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />
                     <RowDefinition Height="Auto" SharedSizeGroup="CalendarMonthViewWeekRow" />

--- a/src/Avalonia.Themes.Simple/Controls/CalendarItem.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/CalendarItem.xaml
@@ -8,6 +8,9 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:ClassModifier="internal">
+  <Design.PreviewWith>
+    <Calendar IsWeekNumberVisible="True" />
+  </Design.PreviewWith>
   <ControlTheme x:Key="{x:Type CalendarItem}"
                 TargetType="CalendarItem">
     <Setter Property="CornerRadius" Value="1" />
@@ -23,7 +26,7 @@
             <Border BorderBrush="{DynamicResource ThemeBackgroundBrush}"
                     BorderThickness="2"
                     CornerRadius="1">
-              <Grid>
+              <Grid  Grid.IsSharedSizeScope="True">
                 <Grid.RowDefinitions>
                   <RowDefinition Height="Auto" />
                   <RowDefinition Height="*" />
@@ -31,7 +34,6 @@
                 <Grid.ColumnDefinitions>
                   <ColumnDefinition Width="Auto" />
                   <ColumnDefinition Width="*" />
-                  <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
                 <Grid.Styles>
@@ -60,65 +62,94 @@
                   </Style>
                 </Grid.Styles>
 
-                <Rectangle Grid.ColumnSpan="3"
-                           Height="22"
-                           VerticalAlignment="Top"
-                           Fill="{TemplateBinding HeaderBackground}"
-                           Stretch="Fill" />
+                <Grid Grid.ColumnSpan="2" >
+                  <Rectangle Grid.ColumnSpan="3"
+                             Height="22"
+                             VerticalAlignment="Top"
+                             Fill="{TemplateBinding HeaderBackground}"
+                             Stretch="Fill" />
 
-                <Button Name="PART_PreviousButton"
-                        HorizontalAlignment="Left"
-                        Classes="CalendarHeader CalendarNavigation"
-                        IsVisible="False">
+                  <Button Name="PART_PreviousButton"
+                          HorizontalAlignment="Left"
+                          Classes="CalendarHeader CalendarNavigation"
+                          IsVisible="False">
 
-                  <Path Width="6"
-                        Height="10"
-                        Margin="14,-6,0,0"
-                        HorizontalAlignment="Left"
-                        VerticalAlignment="Center"
-                        Data="M288.75,232.25 L288.75,240.625 L283,236.625 z"
-                        Stretch="Fill" />
+                    <Path Width="6"
+                          Height="10"
+                          Margin="14,-6,0,0"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
+                          Data="M288.75,232.25 L288.75,240.625 L283,236.625 z"
+                          Stretch="Fill" />
 
-                </Button>
+                  </Button>
 
-                <Button Name="PART_HeaderButton"
-                        Grid.Column="1"
-                        Padding="1,5,1,9"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Classes="CalendarHeader"
-                        FontSize="10.5"
-                        FontWeight="Bold" />
+                  <Button Name="PART_HeaderButton"
+                          Grid.Column="1"
+                          Padding="1,5,1,9"
+                          HorizontalAlignment="Center"
+                          VerticalAlignment="Center"
+                          Classes="CalendarHeader"
+                          FontSize="10.5"
+                          FontWeight="Bold" />
 
-                <Button Name="PART_NextButton"
-                        Grid.Column="2"
-                        HorizontalAlignment="Right"
-                        Classes="CalendarHeader CalendarNavigation"
-                        IsVisible="False">
+                  <Button Name="PART_NextButton"
+                          Grid.Column="2"
+                          HorizontalAlignment="Right"
+                          Classes="CalendarHeader CalendarNavigation"
+                          IsVisible="False">
 
-                  <Path Width="6"
-                        Height="10"
-                        Margin="0,-6,14,0"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Center"
-                        Data="M282.875,231.875 L282.875,240.375 L288.625,236 z"
-                        Stretch="Fill" />
+                    <Path Width="6"
+                          Height="10"
+                          Margin="0,-6,14,0"
+                          HorizontalAlignment="Right"
+                          VerticalAlignment="Center"
+                          Data="M282.875,231.875 L282.875,240.375 L288.625,236 z"
+                          Stretch="Fill" />
 
-                </Button>
+                  </Button>
+                </Grid>
+
+                <ContentControl Name="WeekNumberHeader" 
+                                Grid.Row="1"
+                                Content="{DynamicResource StringCalendarWeekNumberHeader}"
+                                Margin="0, 4"
+                                FontSize="9.5"
+                                VerticalAlignment="Top"
+                                VerticalContentAlignment="Center"
+                                HorizontalContentAlignment="Center"
+                                IsVisible="False" />
+                
+                <Grid Name="PART_ElementWeekNumberColumn" 
+                      Grid.Row="1"
+                      Grid.Column="0"
+                      IsVisible="False"
+                      Margin="6,-1,6,6"
+                      VerticalAlignment="Stretch">
+                  <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewHeaderRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                  </Grid.RowDefinitions>
+                </Grid>
 
                 <Grid Name="PART_MonthView"
                       Grid.Row="1"
-                      Grid.ColumnSpan="3"
+                      Grid.Column="1"
                       Margin="6,-1,6,6"
                       IsVisible="False">
                   <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewHeaderRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
+                    <RowDefinition Height="Auto" SharedSizeGroup="CalendarMothViewWeekRow" />
                   </Grid.RowDefinitions>
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -175,6 +206,21 @@
 
     <Style Selector="^:calendardisabled /template/ Rectangle#DisabledVisual">
       <Setter Property="IsVisible" Value="True" />
+    </Style>
+    
+    <Style Selector="^:hasweeknumbers">
+      <Style Selector="^ /template/ Grid#PART_ElementWeekNumberColumn">
+        <Setter Property="IsVisible" Value="True" />
+        <Style Selector="^ ContentControl">
+          <Setter Property="FontSize" Value="9.5" />
+          <Setter Property="HorizontalContentAlignment" Value="Center" />
+          <Setter Property="VerticalAlignment" Value="Stretch" />
+          <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+      </Style>
+      <Style Selector="^ /template/ ContentControl#WeekNumberHeader">
+        <Setter Property="IsVisible" Value="True" />
+      </Style>
     </Style>
   </ControlTheme>
 </ResourceDictionary>

--- a/tests/Avalonia.Controls.UnitTests/CalendarTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CalendarTests.cs
@@ -1,10 +1,13 @@
-﻿using Xunit;
+using Xunit;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.UnitTests;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.UnitTests
 {
@@ -439,6 +442,194 @@ namespace Avalonia.Controls.UnitTests
 
             // Verify the flag was reset
             Assert.False((bool)field.GetValue(calendarItem)!);
+        }
+
+
+        // --- Week number tests ---
+
+        [Fact]
+        public void IsWeekNumberVisible_Defaults_To_False()
+        {
+            var calendar = new Calendar();
+            Assert.False(calendar.IsWeekNumberVisible);
+        }
+
+        [Fact]
+        public void WeekNumberRule_Defaults_To_Culture_CalendarWeekRule()
+        {
+            var calendar = new Calendar();
+            Assert.IsType<CalendarWeekRule>(calendar.WeekNumberRule);
+        }
+
+        [Fact]
+        public void IsWeekNumberVisible_Can_Be_Set()
+        {
+            var calendar = new Calendar();
+            calendar.IsWeekNumberVisible = true;
+            Assert.True(calendar.IsWeekNumberVisible);
+        }
+
+        [Fact]
+        public void WeekNumberRule_Can_Be_Set()
+        {
+            var calendar = new Calendar();
+            calendar.WeekNumberRule = CalendarWeekRule.FirstFourDayWeek;
+            Assert.Equal(CalendarWeekRule.FirstFourDayWeek, calendar.WeekNumberRule);
+        }
+
+        [Theory]
+        // ISO 8601: week 1 of 2023 starts on Monday 2 Jan 2023
+        [InlineData(2023, 1, 2, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday, 1)]
+        // 2022-12-31 is still in ISO week 52 of 2022
+        [InlineData(2022, 12, 31, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday, 52)]
+        // .NET bug: 2018-12-31 is a Monday and is ISO week 1 of 2019, not week 53 of 2018
+        [InlineData(2018, 12, 31, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday, 1)]
+        // US rule: week 1 always starts on Jan 1
+        [InlineData(2023, 1, 1, CalendarWeekRule.FirstDay, DayOfWeek.Sunday, 1)]
+        [InlineData(2023, 12, 31, CalendarWeekRule.FirstDay, DayOfWeek.Sunday, 53)]
+        public void GetWeekOfYear_Returns_Correct_Week_Number(
+            int year, int month, int day,
+            CalendarWeekRule rule,
+            DayOfWeek firstDayOfWeek,
+            int expectedWeek)
+        {
+            var _calendar = new GregorianCalendar();
+            var date = new DateTime(year, month, day);
+            int week = DateTimeHelper.GetWeekOfYear(date, rule, firstDayOfWeek, _calendar);
+            Assert.Equal(expectedWeek, week);
+        }
+
+
+        // ------------------------------------------------------------------------
+        //  ISO‑week fallback tests – verify that GetWeekOfYear returns the expected
+        //  week numbers for edge‑case dates.
+        // ------------------------------------------------------------------------
+        [Theory]
+        // 31 Dec 2018 is part of ISO‑week 1 of 2019
+        [InlineData(2018, 12, 31, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday, 1)]
+        // 1 Jan 2020 is also ISO‑week 1 (Monday)
+        [InlineData(2020, 01, 01, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday, 1)]
+        // 29 Dec 2014 (Monday) should be week 1 of 2015 (ISO)
+        [InlineData(2014, 12, 29, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday, 1)]
+        // 30 Dec 2019 (Monday) is week 1 of 2020 (ISO)
+        [InlineData(2019, 12, 30, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday, 1)]
+        public void GetWeekOfYear_IsoWeekFallback_Returns_Correct_Week(
+            int year, int month, int day,
+            CalendarWeekRule rule,
+            DayOfWeek firstDay,
+            int expectedWeek)
+        {
+            var _calendar = new GregorianCalendar();
+            var date = new DateTime(year, month, day);
+            // DateTimeHelper is the internal helper used by Calendar.
+            // It falls back to ISO‑week calculation when the culture’s
+            // CalendarWeekRule does not produce a valid week.
+            int week = DateTimeHelper.GetWeekOfYear(date, rule, firstDay, _calendar);
+            Assert.Equal(expectedWeek, week);
+        }
+
+        // ------------------------------------------------------------------------
+        //  Property change refresh tests – ensure the control updates its
+        //  visual state when week‑number related properties are changed.
+        // ------------------------------------------------------------------------
+        [Fact]
+        public void Changing_IsWeekNumberVisible_Toggles_HasWeekNumbers_PseudoClass()
+        {
+            var calendar = CreateTestCalendar();
+            
+            calendar.ApplyTemplate();
+            calendar.DisplayMode = CalendarMode.Month;
+            calendar.IsWeekNumberVisible = false;
+
+            // Grab the CalendarItem from the visual tree
+            var calendarItem = calendar.GetVisualDescendants()
+                .OfType<CalendarItem>()
+                .FirstOrDefault();
+            Assert.NotNull(calendarItem);
+            
+            calendarItem.ApplyTemplate();
+
+            // Assert pseudo-class is NOT set
+            Assert.False(calendarItem.Classes.Contains(":hasweeknumbers"));
+            
+            // Turn on week numbers
+            calendar.IsWeekNumberVisible = true;
+            
+            // Assert pseudo-class IS set
+            Assert.True(calendarItem.Classes.Contains(":hasweeknumbers"));
+        }
+
+        [Fact]
+        public void Changing_WeekNumberRule_Refreshes_WeekNumber_Labels()
+        {
+            var calendar = CreateTestCalendar();
+            
+            // Apply template so that the internal CalendarItem is created
+            calendar.ApplyTemplate();
+
+            calendar.DisplayMode = CalendarMode.Month;
+            calendar.IsWeekNumberVisible = true;
+            // Use ISO‑rule (FirstFourDayWeek) for the test
+            calendar.WeekNumberRule = CalendarWeekRule.FirstFourDayWeek;
+            calendar.FirstDayOfWeek = DayOfWeek.Monday;
+            calendar.DisplayDate = new DateTime(2021, 01, 04); // First Monday of 2021
+
+            // Grab the CalendarItem from the visual tree
+            var calendarItem = calendar.GetVisualDescendants()
+                .OfType<CalendarItem>()
+                .FirstOrDefault();
+            Assert.NotNull(calendarItem);
+            
+            calendarItem.ApplyTemplate();
+
+            // The first week‑number label should display “1” for the first week of 2021
+            var weekLabelsGrid = calendarItem.GetVisualDescendants()
+                .OfType<Grid>()
+                .FirstOrDefault(x => x.Name == "PART_ElementWeekNumberLabels");
+            Assert.NotNull(weekLabelsGrid);
+            var firstLabel = weekLabelsGrid.Children.OfType<ContentControl>().First(x => Grid.GetRow(x) == 2);
+            Assert.Equal(1, firstLabel.Content);
+
+            // Change the rule to use FirstDay (which for 2021‑01‑04 would be week 2)
+            calendar.WeekNumberRule = CalendarWeekRule.FirstDay;
+
+            // Force a layout pass – in unit‑tests this is enough to trigger the update
+            calendar.InvalidateMeasure();
+            calendar.UpdateLayout();
+
+            // After the rule change the first visible week number should now be “2”
+            firstLabel = weekLabelsGrid.Children.OfType<ContentControl>().First(x => Grid.GetRow(x) == 2);
+            Assert.Equal(2, firstLabel.Content);
+        }
+
+        private static Calendar CreateTestCalendar()
+        {
+            var cal = new Calendar();
+            var template = new FuncControlTemplate<Calendar>((c, scope) => new Panel()
+            {
+                Name = "PART_Root",
+                Children =
+                {
+                    new CalendarItem()
+                    {
+                        Name = "PART_CalendarItem",
+                        Owner = c,
+                        DayTitleTemplate = new FuncTemplate<Control>(() => new TextBlock()),
+                        Template = new FuncControlTemplate<CalendarItem>((_, itemScope) => new Grid()
+                        {
+                            Children =
+                            {
+                                new Grid { Name = "PART_MonthView" }.RegisterInNameScope(itemScope),
+                                new Grid { Name = "PART_YearView" }.RegisterInNameScope(itemScope),
+                                new Grid { Name = "PART_ElementWeekNumberLabels" }.RegisterInNameScope(itemScope)
+                            }
+                        })
+                    }.RegisterInNameScope(scope)
+                }
+            }.RegisterInNameScope(scope));
+            cal.Template = template;
+
+            return cal;
         }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
> [!Note]
> This PR addesses the API review from #21311 . Decided to use a blank new branch since the new API proposal is easier to discuss that way. 

Adds week number display to both Calendar and CalendarDatePicker in month view (Fluent and Simple themes).

This is the final result (using FluentTheme) 
<img width="353" height="368" alt="image" src="https://github.com/user-attachments/assets/bcf58591-34ef-4863-97b9-9e8eddd16a1d" />

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Calendar and CalendarDatePicker only show day-of-week headers and date cells in month view. There is no way to display week numbers alongside the calendar grid.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

- A new week-number column can be shown on the left side of the month grid by setting `IsWeekNumberVisible="True"`.
- The column header is configurable via `DynamicResouce: StringCalendarWeekNumberHeader`
- The week numbering rule is configurable via `WeekNumberRule` using the `System.Globalization.CalendarWeekRule`. Use `WeekNumberRule="FirstFourDayWeek"` in combination with `FirstDayOfWeek="Monday"` for ISO 8601 week numbering. Defaults to the current culture's rule.
- All properties are mirrored on CalendarDatePicker, where they propagate to the inner popup calendar.
- In FluentTheme the calendar does not shrink when switching from month view to year/decade view. A new :hasweeknumbers pseudo-class on CalendarItem is used in the Fluent theme to hold the minimum width stable.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

### API diff

```diff
// Avalonia.Controls.Calendar — 3 new properties
+public static readonly StyledProperty<bool> IsWeekNumberVisibleProperty;
+public bool IsWeekNumberVisible { get; set; }                       // default: false

+public static readonly StyledProperty<CalendarWeekNumberRule> WeekNumberRuleProperty;
+public CalendarWeekNumberRule WeekNumberRule { get; set; }          // default: current culture

// Avalonia.Controls.CalendarDatePicker — same 2 properties via AddOwner
+public static readonly StyledProperty<bool> IsWeekNumberVisibleProperty;
+public bool IsWeekNumberVisible { get; set; }

+public static readonly StyledProperty<CalendarWeekNumberRule> WeekNumberRuleProperty;
+public CalendarWeekNumberRule WeekNumberRule { get; set; }

// Avalonia.Controls.Primitives.CalendarItem — new pseudo-class, new Template part
-[PseudoClasses(":calendardisabled")]
+[PseudoClasses(":calendardisabled", ":hasweeknumbers")]
+[TemplatePart(PART_ElementWeekNumberLabels, typeof(Grid))]
```

### ISO 8601 week number fix — `DateTimeHelper.GetWeekOfYear`

.NET's `Calendar.GetWeekOfYear` with `FirstFourDayWeek` + `Monday` incorrectly returns week 53 for late-December dates that ISO 8601 assigns to week 1 of the next year (e.g. 2018-12-31 → ISO week 1 of 2019). Added a helper mehtod to solve this: 

```cs
public static int GetWeekOfYear(DateTime date, 
    CalendarWeekRule rule, 
    DayOfWeek firstDayOfWeek, 
    System.Globalization.Calendar calendar)
{
    // .NET's Calendar.GetWeekOfYear incorrectly returns week 53 for late-December dates
    // that ISO 8601 assigns to week 1 of the next year (e.g. 2018-12-31).
    if (rule == CalendarWeekRule.FirstFourDayWeek && firstDayOfWeek == DayOfWeek.Monday)
        return ISOWeek.GetWeekOfYear(date);

    return calendar.GetWeekOfYear(date, rule, firstDayOfWeek);
}
```

## Checklist

- [x] Added unit tests (if possible)? -> Let me know if any more test is needed
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation --> To be done when the PR is accepted

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes #7976 
Closes #21311 
