### PR TITLE
(Wayland) Add toplevel app id

### DIFF
--- a/src/Avalonia.Wayland/Server/Persistent/WSurface.cs
+++ b/src/Avalonia.Wayland/Server/Persistent/WSurface.cs
@@ -660,7 +660,7 @@ class WXdgTopLevel : WXdgShellSurface, IWXdgTopLevel
         if (_title != null)
             _xdgTopLevel.SetTitle(_title);
 
-        SetAppID(globals.WlAppId);
+        SetAppId(globals.WlAppId);
 
         // Re-apply cached min/max if they were ever set on a previous
         // (now-dead) connection. The OnConnected commit below will
@@ -708,9 +708,9 @@ class WXdgTopLevel : WXdgShellSurface, IWXdgTopLevel
         _xdgTopLevel?.SetTitle(title ?? string.Empty);
     }
 
-    private void SetAppID(string? appId)
+    private void SetAppId(string? appId)
     {
-        var id = appId ?? Process.GetCurrentProcess().ProcessName;
+        var id = string.IsNullOrWhiteSpace(appId) ? Process.GetCurrentProcess().ProcessName : appId;
         if (_xdgTopLevel is null)
             return;
         _xdgTopLevel.SetAppId(id);

--- a/src/Avalonia.Wayland/Server/Persistent/WSurface.cs
+++ b/src/Avalonia.Wayland/Server/Persistent/WSurface.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Input;
@@ -27,7 +28,7 @@ class WSurface : IPersistentWaylandObject, IWSurface, IWaylandFramebufferSurface
     protected WpViewport? Viewport { get; private set; }
     protected int? LastPreferredBufferScale { get; private set; }
     protected double? PreferredFractionalScale { get; private set; }
-    protected List<WaylandOutputsTracker.Output> Outputs  { get; } = new();
+    protected List<WaylandOutputsTracker.Output> Outputs { get; } = new();
     private WlCallback? _frameCallback;
     private bool _hitTestVisible = true;
     private double _currentScale = 1;
@@ -659,6 +660,8 @@ class WXdgTopLevel : WXdgShellSurface, IWXdgTopLevel
         if (_title != null)
             _xdgTopLevel.SetTitle(_title);
 
+        SetAppID(globals.WlAppId);
+
         // Re-apply cached min/max if they were ever set on a previous
         // (now-dead) connection. The OnConnected commit below will
         // promote the queued double-buffered state.
@@ -672,9 +675,9 @@ class WXdgTopLevel : WXdgShellSurface, IWXdgTopLevel
         // Prefer compositor-provided bounds
         if (_pendingBatch.Bounds is { Width: > 0, Height: > 0 } bounds)
             return new Size(bounds.Width, bounds.Height);
-        
+
         // Fallback: compute from output geometry
-        Size? maxSize = null;  
+        Size? maxSize = null;
         var outputs = Outputs.Count > 0 ? Outputs : Globals!.Outputs.Outputs;
         foreach (var o in outputs)
         {
@@ -703,6 +706,14 @@ class WXdgTopLevel : WXdgShellSurface, IWXdgTopLevel
     {
         _title = title;
         _xdgTopLevel?.SetTitle(title ?? string.Empty);
+    }
+
+    private void SetAppID(string? appId)
+    {
+        var id = appId ?? Process.GetCurrentProcess().ProcessName;
+        if (_xdgTopLevel is null)
+            return;
+        _xdgTopLevel.SetAppId(id);
     }
 
     public void SetMinMaxSize(Size? minSize, Size? maxSize)
@@ -744,8 +755,10 @@ class WXdgTopLevel : WXdgShellSurface, IWXdgTopLevel
         // size of a surface is illegal and will result in an invalid_size
         // error." Clamp the minimum down to the maximum (≥0 maintained);
         // 0 on max means "unconstrained" and lets any min through.
-        if (maxW > 0 && minW > maxW) minW = maxW;
-        if (maxH > 0 && minH > maxH) minH = maxH;
+        if (maxW > 0 && minW > maxW)
+            minW = maxW;
+        if (maxH > 0 && minH > maxH)
+            minH = maxH;
 
         _xdgTopLevel.SetMinSize(minW, minH);
         _xdgTopLevel.SetMaxSize(maxW, maxH);
@@ -773,17 +786,17 @@ class WXdgTopLevel : WXdgShellSurface, IWXdgTopLevel
             && cookie.TryConsume(display, out var seat, out var serial))
             _xdgTopLevel.Resize(seat, serial, edge);
     }
-    
+
     protected override void OnConfigureBatchComplete(uint serial)
     {
         var batch = _pendingBatch;
         batch.Serial = serial;
         batch.MaxSize = CalculateMaxSize();
         _pendingBatch = new();
-        
+
         _topLevelEventSink.OnConfigure(batch);
         BasicInitCompletedTcs.TrySetResult(batch);
-        
+
         base.OnConfigureBatchComplete(serial);
     }
 
@@ -813,9 +826,9 @@ class WXdgTopLevel : WXdgShellSurface, IWXdgTopLevel
 
     internal class TopLevelListener(WXdgTopLevel p) : XdgToplevel.Listener
     {
-        protected override void ConfigureBounds(XdgToplevel eventSender, int width, int height) => 
+        protected override void ConfigureBounds(XdgToplevel eventSender, int width, int height) =>
             p._pendingBatch.Bounds = new(width, height);
-        
+
         protected override void Configure(XdgToplevel eventSender, int width, int height, ReadOnlySpan<byte> states)
         {
             p._pendingBatch.Size = new(width, height);
@@ -886,7 +899,7 @@ class WXdgPopup : WXdgShellSurface, IWXdgPopup
         _popupEventSink = eventSink;
         _parent = parent;
     }
-    
+
     public void UpdatePositioner(XdgPopupPositionerParams positioner)
     {
         var hadPrevious = _positioner.HasValue;
@@ -943,9 +956,12 @@ class WXdgPopup : WXdgShellSurface, IWXdgPopup
     /// </summary>
     internal void TryAttachToParent()
     {
-        if (_xdgPopup != null) return;                         // already attached
-        if (XdgSurface == null) return;                       // we're not connected
-        if (_positioner is not { } pos) return;                // UI hasn't supplied positioner yet
+        if (_xdgPopup != null)
+            return;                         // already attached
+        if (XdgSurface == null)
+            return;                       // we're not connected
+        if (_positioner is not { } pos)
+            return;                // UI hasn't supplied positioner yet
         if (!_parent.IsMapped || _parent.XdgSurface is not { } parentXdgSurface)
         {
             // Parent not yet mapped — register; parent will call us back

--- a/src/Avalonia.Wayland/Server/Transient/WaylandGlobals.cs
+++ b/src/Avalonia.Wayland/Server/Transient/WaylandGlobals.cs
@@ -34,6 +34,7 @@ class WaylandGlobals
     public WpViewporter? Viewporter { get; }
     public ZwpTextInputManagerV3? TextInputManagerV3 { get; }
     public ZxdgExporterV2? XdgExporter { get; }
+    public string? WlAppId { get; }
     /// <summary>
     /// Bound when the compositor advertises <c>zxdg_output_manager_v1</c>.
     /// When present, screens use <c>zxdg_output_v1.logical_*</c> as the
@@ -90,7 +91,7 @@ class WaylandGlobals
         if (descriptor.Interface.Version < maxVersion)
             throw new AvaloniaWaylandException(
                 $"{descriptor.Interface.Name} v{maxVersion} is not supported by current bindings");
-        
+
         if (!_knownGlobals.TryGetValue(descriptor.Interface.Name, out var global))
             return null;
         if (global.version < minVersion)
@@ -124,7 +125,7 @@ class WaylandGlobals
             eventSender.Pong(serial);
         }
     }
-    
+
     public WaylandGlobals(WaylandConnection connection, WaylandWorker worker, WaylandPlatformOptions platformOptions,
         WaylandOutputsSinkProxy? outputsSink)
     {
@@ -144,6 +145,7 @@ class WaylandGlobals
         FractionalScaleManager = Bind<WpFractionalScaleManagerV1>(1, 1, null);
         Viewporter = Bind<WpViewporter>(1, 1, null);
         TextInputManagerV3 = Bind<ZwpTextInputManagerV3>(1, 1, null);
+        WlAppId = platformOptions.AppId;
         XdgExporter = Bind<ZxdgExporterV2>(1, 1, null);
         // Require v3 of zxdg_output_manager_v1 so wl_output.done acts as
         // the unified terminator (xdg_output.done is deprecated since
@@ -158,7 +160,7 @@ class WaylandGlobals
         XdgDecorationManager = platformOptions.ForceDrawnDecorationsInternal
             ? null
             : Bind<ZxdgDecorationManagerV1>(1, 1, null);
-        
+
         // Seats may have been announced before the data-device manager / text-input
         // manager were bound — InputDispatcher backfills now and constructs the
         // text-input-v3 facade if the manager is available.

--- a/src/Avalonia.Wayland/WaylandPlatformOptions.cs
+++ b/src/Avalonia.Wayland/WaylandPlatformOptions.cs
@@ -92,7 +92,7 @@ public class WaylandPlatformOptions
     public Action<Exception>? ExternalGLibMainLoopExceptionLogger { get; set; }
 
     ///<summary>
-    ///The App or client ID that the Wayland App should use
+    ///The App or client ID that the Wayland App should use.
     ///</summary>
     public string? AppId { get; set; }
 

--- a/src/Avalonia.Wayland/WaylandPlatformOptions.cs
+++ b/src/Avalonia.Wayland/WaylandPlatformOptions.cs
@@ -90,4 +90,10 @@ public class WaylandPlatformOptions
     /// Only used when <see cref="UseGLibMainLoop"/> is enabled.
     /// </summary>
     public Action<Exception>? ExternalGLibMainLoopExceptionLogger { get; set; }
+
+    ///<summary>
+    ///The App or client ID that the Wayland App should use
+    ///</summary>
+    public string? AppId { get; set; }
+
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Makes the Wayland backend set an app id instead of leaving this unset. An app id is required by freedesktop to load correct taskbar icons and such. Will default to ProcessName the way the x11 backend behaves if not set with WaylandPlatformOptions


## What is the current behavior?
Wayland backend leaves app id unset.


## What is the updated/expected behavior with this PR?
Wayland backend now sets app id. Will default to the process name if not explicitly set.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation



## Fixed issues
Fixes #21783

## New API
```
 .UseWaylandWithFallback()
    .With(new WaylandPlatformOptions{
         AppId = "myApp"
  })

```
