### PR TITLE
Wayland: set xdg_toplevel app id

### DIFF
--- a/src/Avalonia.Wayland/Server/Persistent/WSurface.cs
+++ b/src/Avalonia.Wayland/Server/Persistent/WSurface.cs
@@ -646,6 +646,10 @@ class WXdgTopLevel : WXdgShellSurface, IWXdgTopLevel
             throw new AvaloniaWaylandException("Expected at least one wl_output at this point");
         _pendingBatch = new();
         _xdgTopLevel = XdgSurface!.GetToplevel(new TopLevelListener(this));
+        // The app id ties the window to its .desktop entry (icon, name, grouping).
+        // It's connection state, so it's (re-)sent for every toplevel on every connect.
+        if (Globals.AppId is { Length: > 0 } appId)
+            _xdgTopLevel.SetAppId(appId);
         if (!_csdSticky && Globals.XdgDecorationManager is { } decoMgr)
         {
             _decoration = decoMgr.GetToplevelDecoration(

--- a/src/Avalonia.Wayland/Server/Transient/WaylandGlobals.cs
+++ b/src/Avalonia.Wayland/Server/Transient/WaylandGlobals.cs
@@ -50,6 +50,13 @@ class WaylandGlobals
     /// </summary>
     public ZxdgDecorationManagerV1? XdgDecorationManager { get; }
 
+    /// <summary>
+    /// The value from <see cref="WaylandPlatformOptions.AppId"/>, applied to every xdg_toplevel via
+    /// <c>xdg_toplevel.set_app_id</c> when it's connected. <c>null</c> or empty means the request
+    /// isn't sent at all, leaving the compositor's default (no app id) in place.
+    /// </summary>
+    public string? AppId { get; }
+
     public bool HasFractionalScaling => FractionalScaleManager != null && Viewporter != null;
 
     class RegistryListener(WaylandGlobals p) : NWayland.Protocols.Wayland.WlRegistry.Listener
@@ -130,6 +137,7 @@ class WaylandGlobals
     {
         Connection = connection;
         Worker = worker;
+        AppId = platformOptions.AppId;
         InputDispatcher = new WaylandInputDispatcher(this);
         Outputs = new WaylandOutputsTracker(outputsSink);
         Registry = connection.Display.GetRegistry(new RegistryListener(this), connection.Queue);

--- a/src/Avalonia.Wayland/WaylandPlatformOptions.cs
+++ b/src/Avalonia.Wayland/WaylandPlatformOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Avalonia.OpenGL;
 
 // XxxPlatformOptions are deliberately in global Avalonia namespace
@@ -13,6 +14,19 @@ namespace Avalonia;
 /// </summary>
 public class WaylandPlatformOptions
 {
+    /// <summary>
+    /// The application ID reported to the compositor via <c>xdg_toplevel.set_app_id</c> for every
+    /// window. It is the Wayland counterpart of <c>X11PlatformOptions.WmClass</c> and should match
+    /// the basename of the application's <c>.desktop</c> file without the extension
+    /// (e.g. <c>org.example.MyApp</c> for <c>org.example.MyApp.desktop</c>), as required by the
+    /// freedesktop.org Desktop Entry Specification.
+    /// The compositor uses this value to associate the window with its desktop entry, which is what
+    /// provides the icon and the display name shown in docks, task switchers and window lists, and
+    /// to group the application's windows together.
+    /// Defaults to the entry assembly name; when it can't be determined, no app id is set at all.
+    /// </summary>
+    public string? AppId { get; set; }
+
     /// <summary>
     /// The name of the Wayland display to connect to (e.g. <c>wayland-0</c>). When <c>null</c>,
     /// the <c>WAYLAND_DISPLAY</c> environment variable is used. Ignored when <see cref="DisplayFd"/> is set.
@@ -90,4 +104,16 @@ public class WaylandPlatformOptions
     /// Only used when <see cref="UseGLibMainLoop"/> is enabled.
     /// </summary>
     public Action<Exception>? ExternalGLibMainLoopExceptionLogger { get; set; }
+
+    public WaylandPlatformOptions()
+    {
+        try
+        {
+            AppId = Assembly.GetEntryAssembly()?.GetName().Name;
+        }
+        catch
+        {
+            //
+        }
+    }
 }


### PR DESCRIPTION
## What does the pull request do?

Adds `WaylandPlatformOptions.AppId` and sends `xdg_toplevel.set_app_id` for every toplevel when it connects.

Today the Wayland backend never sends `set_app_id`, so the compositor sees an empty app id and cannot associate the window with its `.desktop` entry. The practical effect on GNOME is a nameless window with a generic icon in the dash and the window switcher; window rules and grouping that key off the app id don't work either. `StartupWMClass` in the desktop entry does not help, as that is X11-only.

Fixes #21783.

## Implementation

* `WaylandPlatformOptions.AppId` mirrors `X11PlatformOptions.WmClass`, including defaulting to the entry assembly name in the options constructor, so both Linux backends behave the same out of the box.
* The value is carried on `WaylandGlobals` and applied in `WXdgTopLevel.OnConnected`, right after `GetToplevel`. App id is connection state, so like the cached title it is re-sent for every toplevel on every connect and survives a compositor reconnect.
* A `null` or empty value sends no request at all, which keeps the current behaviour for anyone who explicitly clears it.

## Verification

Ran a sample app on GNOME 49 (Wayland) with `WAYLAND_DEBUG=1`:

* explicit `.With(new WaylandPlatformOptions { AppId = "com.example.AppIdProbe" })` → `-> xdg_toplevel#64.set_app_id("com.example.AppIdProbe")`, sent before `set_title`;
* no options → `-> xdg_toplevel#64.set_app_id("consumer")`, i.e. the entry assembly name.

Also verified in a real application (a tray/GUI client whose desktop entry is `vantah.desktop`): with `AppId = "vantah"` the request now goes out as `set_app_id("vantah")`, where previously no such request appeared in the protocol trace at all.

## Breaking changes

None. Applications that never touch `WaylandPlatformOptions` start reporting their assembly name as the app id, which matches what the X11 backend already reports as `WM_CLASS`.
