### PR TITLE
[Android] Fix TryGetFileFromPathAsync/TryGetFolderFromPathAsync returning null for content:// URI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,6 +69,7 @@
     <PackageVersion Include="Tmds.DBus.Generator" Version="0.94.1" />
     <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.7.1.3" />
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0.2" />
+    <PackageVersion Include="Xamarin.AndroidX.DocumentFile" Version="1.1.0.3" />
     <PackageVersion Include="Xamarin.AndroidX.Window" Version="1.5.1.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Xunit.StaFact" Version="3.0.13" />

--- a/src/Android/Avalonia.Android/Avalonia.Android.csproj
+++ b/src/Android/Avalonia.Android/Avalonia.Android.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />
     <PackageReference Include="Xamarin.AndroidX.AppCompat" />
     <PackageReference Include="Xamarin.AndroidX.Window" />
+    <PackageReference Include="Xamarin.AndroidX.DocumentFile" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Avalonia.Base\Avalonia.Base.csproj" />

--- a/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageProvider.cs
+++ b/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageProvider.cs
@@ -19,6 +19,8 @@ namespace Avalonia.Android.Platform.Storage;
 internal class AndroidStorageProvider : IStorageProvider
 {
     public static ReadOnlySpan<byte> AndroidKey => "android"u8;
+    private const string ContentUriScheme = "content";
+    private const string FileUriScheme = "file";
     private readonly Activity _activity;
 
     public AndroidStorageProvider(Activity activity)
@@ -63,7 +65,7 @@ internal class AndroidStorageProvider : IStorageProvider
         //     to read or write files in your application-specific directories [...]"
         // Consequently, we don't try to check for that permission here anymore.
 
-        if (filePath.Scheme == "file" && androidUri.Path is not null)
+        if (filePath.Scheme == FileUriScheme && androidUri.Path is not null)
         {
             var javaFile = new JavaFile(androidUri.Path);
             if (javaFile.Exists() && javaFile.IsFile)
@@ -72,7 +74,7 @@ internal class AndroidStorageProvider : IStorageProvider
             }
             return null;
         }
-        else if (filePath.Scheme == "content" && _activity.ContentResolver is not null)
+        else if (filePath.Scheme == ContentUriScheme && _activity.ContentResolver is not null)
         {
             try
             {
@@ -109,7 +111,7 @@ internal class AndroidStorageProvider : IStorageProvider
             return null;
         }
 
-        if (folderPath.Scheme == "file" && androidUri.Path is not null)
+        if (folderPath.Scheme == FileUriScheme && androidUri.Path is not null)
         {
             var javaFile = new JavaFile(androidUri.Path);
             if (javaFile.Exists() && javaFile.IsDirectory)
@@ -118,7 +120,7 @@ internal class AndroidStorageProvider : IStorageProvider
             }
             return null;
         }
-        else if (folderPath.Scheme == "content")
+        else if (folderPath.Scheme == ContentUriScheme)
         {
             try
             {

--- a/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageProvider.cs
+++ b/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageProvider.cs
@@ -7,6 +7,7 @@ using Android;
 using Android.App;
 using Android.Content;
 using Android.Provider;
+using AndroidX.DocumentFile.Provider;
 using Avalonia.Platform.Storage;
 using Avalonia.Platform.Storage.FileIO;
 using AndroidUri = Android.Net.Uri;
@@ -62,10 +63,29 @@ internal class AndroidStorageProvider : IStorageProvider
         //     to read or write files in your application-specific directories [...]"
         // Consequently, we don't try to check for that permission here anymore.
 
-        var javaFile = new JavaFile(androidUriPath);
-        if (javaFile.Exists() && javaFile.IsFile)
+        if (filePath.Scheme == "file" && androidUri.Path is not null)
         {
-            return new BclStorageFile(new System.IO.FileInfo(javaFile.AbsolutePath));
+            var javaFile = new JavaFile(androidUri.Path);
+            if (javaFile.Exists() && javaFile.IsFile)
+            {
+                return new BclStorageFile(new System.IO.FileInfo(javaFile.AbsolutePath));
+            }
+            return null;
+        }
+        else if (filePath.Scheme == "content" && _activity.ContentResolver is not null)
+        {
+            try
+            {
+                using var stream = _activity.ContentResolver.OpenInputStream(androidUri);
+                if (stream is not null)
+                {
+                    return new AndroidStorageFile(_activity, androidUri);
+                }
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
 
         return null;
@@ -89,10 +109,43 @@ internal class AndroidStorageProvider : IStorageProvider
             return null;
         }
 
-        var javaFile = new JavaFile(androidUriPath);
-        if (javaFile.Exists() && javaFile.IsDirectory)
+        if (folderPath.Scheme == "file" && androidUri.Path is not null)
         {
-            return new BclStorageFolder(new System.IO.DirectoryInfo(javaFile.AbsolutePath));
+            var javaFile = new JavaFile(androidUri.Path);
+            if (javaFile.Exists() && javaFile.IsDirectory)
+            {
+                return new BclStorageFolder(new System.IO.DirectoryInfo(javaFile.AbsolutePath));
+            }
+            return null;
+        }
+        else if (folderPath.Scheme == "content")
+        {
+            try
+            {
+                if (OperatingSystem.IsAndroidVersionAtLeast(21))
+                {
+                    if (DocumentsContract.IsTreeUri(androidUri))
+                    {
+                        var docId = DocumentsContract.GetTreeDocumentId(androidUri);
+                        if (!string.IsNullOrEmpty(docId))
+                        {
+                            return new AndroidStorageFolder(_activity, androidUri, false);
+                        }
+                    }
+                    else
+                    {
+                        var documentFile = DocumentFile.FromSingleUri(_activity, androidUri);
+                        if (documentFile is not null && documentFile.Exists() && documentFile.IsDirectory)
+                        {
+                            return new AndroidStorageFolder(_activity, androidUri, false);
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
 
         return null;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes `TryGetFileFromPathAsync` and `TryGetFolderFromPathAsync` on Android to properly handle `content://` URIs by using `ContentResolver`/`DocumentFile` instead of `Java.IO.File`.


## What is the current behavior?
`TryGetFileFromPathAsync` and `TryGetFolderFromPathAsync` return `null` for `content://` URIs on Android.

The current implementation uses `Java.IO.File` to check file existence. For `content://` URIs, the path portion (e.g., `/tree/primary%3AMusic%2F...`) is a virtual path that doesn't exist on the file system, so `Exists()` always returns `false`.

This is a regression from 12.0.4. The behavior was broken in 12.0.5+ when the implementation was changed without considering `content://` URIs.


## What is the updated/expected behavior with this PR?
- `file://` URIs → `Java.IO.File` (existing behavior)
- `content://` URIs → `ContentResolver`/`DocumentFile` (fixed)
- `TryGetFileFromPathAsync` now correctly returns `IStorageFile` for `content://` URIs
- `TryGetFolderFromPathAsync` now correctly returns `IStorageFolder` for `content://` URIs


## How was the solution implemented (if it's not obvious)?
The methods now check the URI scheme and route to the appropriate implementation:

**For `TryGetFileFromPathAsync`:**
- `content://` URIs → `ContentResolver.OpenInputStream()` to verify file exists, then returns `AndroidStorageFile`

**For `TryGetFolderFromPathAsync`:**
- `tree` URIs → `DocumentsContract.GetTreeDocumentId()` to verify, then returns `AndroidStorageFolder`
- `document` URIs → `DocumentFile.FromSingleUri()` to verify, then returns `AndroidStorageFolder`


## Dependencies
- Added `Xamarin.AndroidX.DocumentFile` package reference for `DocumentFile.FromSingleUri()` support.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #21960