### PR TITLE
Implement UIA TextPattern for TextBox on Windows

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
@@ -577,9 +577,32 @@ namespace Avalonia.Automation.Peers
         public event EventHandler<AutomationPropertyChangedEventArgs>? PropertyChanged;
 
         /// <summary>
+        /// Occurs when the text selection (or caret position, for a collapsed selection) of an
+        /// <see cref="Provider.ITextProvider"/> peer has changed.
+        /// </summary>
+        public event EventHandler? TextSelectionChanged;
+
+        /// <summary>
+        /// Occurs when the text content of an <see cref="Provider.ITextProvider"/> peer has
+        /// changed.
+        /// </summary>
+        public event EventHandler? TextChanged;
+
+        /// <summary>
         /// Raises an event to notify the automation client the children of the peer have changed.
         /// </summary>
         protected void RaiseChildrenChangedEvent() => ChildrenChanged?.Invoke(this, EventArgs.Empty);
+
+        /// <summary>
+        /// Raises an event to notify the automation client that the text selection or caret
+        /// position has changed.
+        /// </summary>
+        protected void RaiseTextSelectionChangedEvent() => TextSelectionChanged?.Invoke(this, EventArgs.Empty);
+
+        /// <summary>
+        /// Raises an event to notify the automation client that the text content has changed.
+        /// </summary>
+        protected void RaiseTextChangedEvent() => TextChanged?.Invoke(this, EventArgs.Empty);
 
         /// <summary>
         /// Raises an event to notify the automation client of a changed property value.

--- a/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.TextRange.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.TextRange.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Automation.Provider;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Utils;
+using Avalonia.VisualTree;
+
+namespace Avalonia.Automation.Peers
+{
+    public partial class TextBoxAutomationPeer
+    {
+        /// <summary>
+        /// A <c>[start,end)</c> character-index range into a <see cref="Controls.TextBox"/>'s text,
+        /// implementing <see cref="ITextRangeProvider"/> against <see cref="TextPresenter"/>'s
+        /// text layout. <see cref="_start"/> and <see cref="_end"/> are always kept normalized
+        /// (<c>_start &lt;= _end</c>), clamped to <c>[0, Text.Length]</c>.
+        /// </summary>
+        private sealed class TextRange : ITextRangeProvider
+        {
+            private readonly TextBoxAutomationPeer _peer;
+            private int _start;
+            private int _end;
+
+            public TextRange(TextBoxAutomationPeer peer, int start, int end)
+            {
+                _peer = peer;
+                Normalize(start, end);
+            }
+
+            private string Text => _peer.Owner.Text ?? string.Empty;
+
+            private void Normalize(int start, int end)
+            {
+                if (start > end)
+                    (start, end) = (end, start);
+
+                var length = Text.Length;
+                _start = Math.Clamp(start, 0, length);
+                _end = Math.Clamp(end, 0, length);
+            }
+
+            private int GetEndpoint(TextPatternRangeEndpoint endpoint) => endpoint == TextPatternRangeEndpoint.Start ? _start : _end;
+
+            public ITextRangeProvider Clone() => new TextRange(_peer, _start, _end);
+
+            public bool Compare(ITextRangeProvider range) =>
+                range is TextRange other && other._peer == _peer && other._start == _start && other._end == _end;
+
+            public int CompareEndpoints(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint)
+            {
+                var target = (TextRange)targetRange;
+                return GetEndpoint(endpoint).CompareTo(target.GetEndpoint(targetEndpoint));
+            }
+
+            public void ExpandToEnclosingUnit(TextUnit unit)
+            {
+                var text = Text;
+                var caretIndex = Math.Min(_start, text.Length);
+
+                switch (unit)
+                {
+                    case TextUnit.Character:
+                        _start = caretIndex;
+                        _end = Math.Min(caretIndex + 1, text.Length);
+                        break;
+
+                    case TextUnit.Word:
+                    {
+                        var start = caretIndex;
+                        var end = caretIndex;
+
+                        if (!StringUtils.IsStartOfWord(text, caretIndex))
+                            start = StringUtils.PreviousWord(text, caretIndex);
+
+                        if (!StringUtils.IsEndOfWord(text, caretIndex))
+                            end = StringUtils.NextWord(text, caretIndex);
+
+                        Normalize(start, Math.Max(start, end));
+                        break;
+                    }
+
+                    case TextUnit.Line:
+                    {
+                        var (lineStart, lineEnd) = GetLineBounds(caretIndex);
+                        Normalize(lineStart, lineEnd);
+                        break;
+                    }
+
+                    case TextUnit.Paragraph:
+                    {
+                        var (paraStart, paraEnd) = GetParagraphBounds(text, caretIndex);
+                        Normalize(paraStart, paraEnd);
+                        break;
+                    }
+
+                    // Format/Page/Document degenerate to the whole document: TextBox has no
+                    // formatting-attribute runs or pagination.
+                    case TextUnit.Format:
+                    case TextUnit.Page:
+                    case TextUnit.Document:
+                    default:
+                        Normalize(0, text.Length);
+                        break;
+                }
+            }
+
+            public ITextRangeProvider? FindAttribute(int attribute, object? value, bool backward) => null;
+
+            public ITextRangeProvider? FindText(string text, bool backward, bool ignoreCase)
+            {
+                var haystack = Text.Substring(_start, _end - _start);
+                var comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+                var index = backward
+                    ? haystack.LastIndexOf(text, comparison)
+                    : haystack.IndexOf(text, comparison);
+
+                if (index < 0)
+                    return null;
+
+                var start = _start + index;
+                return new TextRange(_peer, start, start + text.Length);
+            }
+
+            public object GetAttributeValue(int attribute) => AutomationTextAttributeNotSupported.Instance;
+
+            public IReadOnlyList<Rect> GetBoundingRectangles()
+            {
+                var presenter = _peer.Owner.Presenter;
+                if (presenter is null || _start == _end)
+                    return Array.Empty<Rect>();
+
+                if (presenter.GetVisualRoot() is not Visual root)
+                    return Array.Empty<Rect>();
+
+                var transform = presenter.TransformToVisual(root);
+                if (transform is null)
+                    return Array.Empty<Rect>();
+
+                var rects = presenter.TextLayout.HitTestTextRange(_start, _end - _start);
+                var result = new List<Rect>();
+
+                foreach (var rect in rects)
+                {
+                    var snapped = PixelRect.FromRect(rect, 1).ToRect(1);
+                    result.Add(snapped.TransformToAABB(transform.Value));
+                }
+
+                return result;
+            }
+
+            public AutomationPeer GetEnclosingElement() => _peer;
+
+            public string GetText(int maxLength)
+            {
+                var text = Text.Substring(_start, _end - _start);
+                return maxLength >= 0 && text.Length > maxLength ? text.Substring(0, maxLength) : text;
+            }
+
+            public int Move(TextUnit unit, int count)
+            {
+                if (count == 0)
+                    return 0;
+
+                var length = _end - _start;
+                var (newStart, moved) = MoveIndex(_start, unit, count);
+
+                Normalize(newStart, newStart + length);
+                return moved;
+            }
+
+            public int MoveEndpointByUnit(TextPatternRangeEndpoint endpoint, TextUnit unit, int count)
+            {
+                if (count == 0)
+                    return 0;
+
+                var (newValue, moved) = MoveIndex(GetEndpoint(endpoint), unit, count);
+
+                if (endpoint == TextPatternRangeEndpoint.Start)
+                    Normalize(newValue, Math.Max(newValue, _end));
+                else
+                    Normalize(Math.Min(_start, newValue), newValue);
+
+                return moved;
+            }
+
+            public void MoveEndpointByRange(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint)
+            {
+                var target = (TextRange)targetRange;
+                var value = target.GetEndpoint(targetEndpoint);
+
+                if (endpoint == TextPatternRangeEndpoint.Start)
+                    Normalize(value, Math.Max(value, _end));
+                else
+                    Normalize(Math.Min(_start, value), value);
+            }
+
+            public void Select()
+            {
+                var owner = _peer.Owner;
+                // CaretIndex's setter collapses SelectionStart/SelectionEnd to itself, so it must
+                // be set first; setting SelectionStart/SelectionEnd afterwards only moves
+                // CaretIndex back when the two endpoints end up equal (see TextBox's
+                // OnSelectionStartChanged/OnSelectionEndChanged), so this order preserves the
+                // intended [_start, _end) selection with the caret left at _end.
+                owner.CaretIndex = _end;
+                owner.SelectionStart = _start;
+                owner.SelectionEnd = _end;
+            }
+
+            public void AddToSelection() => Select();
+
+            public void RemoveFromSelection() => throw new NotSupportedException();
+
+            public void ScrollIntoView(bool alignToTop) => _peer.BringIntoView();
+
+            public IReadOnlyList<AutomationPeer> GetChildren() => Array.Empty<AutomationPeer>();
+
+            private (int NewIndex, int Moved) MoveIndex(int index, TextUnit unit, int count)
+            {
+                var text = Text;
+
+                switch (unit)
+                {
+                    case TextUnit.Line:
+                        return MoveByLine(index, count);
+
+                    case TextUnit.Word:
+                        return MoveByWord(text, index, count);
+
+                    case TextUnit.Format:
+                    case TextUnit.Paragraph:
+                    case TextUnit.Page:
+                    case TextUnit.Document:
+                    {
+                        // Degenerates to Document: a single move jumps to the corresponding end.
+                        var target = count > 0 ? text.Length : 0;
+                        var moved = target == index ? 0 : (count > 0 ? 1 : -1);
+                        return (target, moved);
+                    }
+
+                    case TextUnit.Character:
+                    default:
+                    {
+                        var target = Math.Clamp(index + count, 0, text.Length);
+                        return (target, target - index);
+                    }
+                }
+            }
+
+            private (int NewIndex, int Moved) MoveByWord(string text, int index, int count)
+            {
+                var pos = index;
+                var moved = 0;
+
+                if (count > 0)
+                {
+                    for (var i = 0; i < count; i++)
+                    {
+                        var next = StringUtils.NextWord(text, pos);
+                        if (next == pos)
+                            break;
+                        pos = next;
+                        moved++;
+                    }
+                }
+                else
+                {
+                    for (var i = 0; i < -count; i++)
+                    {
+                        var prev = StringUtils.PreviousWord(text, pos);
+                        if (prev == pos)
+                            break;
+                        pos = prev;
+                        moved--;
+                    }
+                }
+
+                return (pos, moved);
+            }
+
+            private (int NewIndex, int Moved) MoveByLine(int index, int count)
+            {
+                var presenter = _peer.Owner.Presenter;
+                if (presenter is null)
+                    return (index, 0);
+
+                var layout = presenter.TextLayout;
+                var lineIndex = layout.GetLineIndexFromCharacterIndex(index, false);
+                var targetLine = Math.Clamp(lineIndex + count, 0, layout.TextLines.Count - 1);
+                var moved = targetLine - lineIndex;
+
+                return (layout.TextLines[targetLine].FirstTextSourceIndex, moved);
+            }
+
+            private (int Start, int End) GetLineBounds(int index)
+            {
+                var presenter = _peer.Owner.Presenter;
+                if (presenter is null)
+                    return (index, index);
+
+                var layout = presenter.TextLayout;
+                var lineIndex = layout.GetLineIndexFromCharacterIndex(index, false);
+                var line = layout.TextLines[lineIndex];
+
+                return (line.FirstTextSourceIndex, line.FirstTextSourceIndex + line.Length);
+            }
+
+            private static (int Start, int End) GetParagraphBounds(string text, int index)
+            {
+                if (text.Length == 0)
+                    return (0, 0);
+
+                var start = text.LastIndexOf('\n', Math.Max(0, Math.Min(index, text.Length) - 1)) + 1;
+                var end = text.IndexOf('\n', Math.Min(index, text.Length));
+                if (end < 0)
+                    end = text.Length;
+                else
+                    end += 1;
+
+                return (start, end);
+            }
+        }
+    }
+}

--- a/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.cs
@@ -1,10 +1,16 @@
-﻿using Avalonia.Automation.Provider;
+using System;
+using System.Collections.Generic;
+using Avalonia.Automation.Provider;
 using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Automation.Peers
 {
-    public class TextBoxAutomationPeer : ControlAutomationPeer, IValueProvider
+    public partial class TextBoxAutomationPeer : ControlAutomationPeer, IValueProvider, ITextProvider
     {
+        private bool _selectionChangeRaisePending;
+
         public TextBoxAutomationPeer(TextBox owner)
             : base(owner)
         {
@@ -16,6 +22,33 @@ namespace Avalonia.Automation.Peers
         public string? Value => Owner.Text;
         public void SetValue(string? value) => Owner.Text = value;
 
+        public IReadOnlyList<ITextRangeProvider> GetSelection()
+        {
+            var start = Math.Min(Owner.SelectionStart, Owner.SelectionEnd);
+            var end = Math.Max(Owner.SelectionStart, Owner.SelectionEnd);
+            return new ITextRangeProvider[] { new TextRange(this, start, end) };
+        }
+
+        public IReadOnlyList<ITextRangeProvider> GetVisibleRanges() => new ITextRangeProvider[] { DocumentRange };
+
+        public ITextRangeProvider? RangeFromChild(AutomationPeer childElement) => null;
+
+        public ITextRangeProvider RangeFromPoint(Point point)
+        {
+            var presenter = Owner.Presenter;
+            if (presenter is null)
+                return DocumentRange;
+
+            var local = TranslateFromOwner(point, presenter);
+            var hit = presenter.TextLayout.HitTestPoint(local);
+            var index = hit.CharacterHit.FirstCharacterIndex + hit.CharacterHit.TrailingLength;
+            return new TextRange(this, index, index);
+        }
+
+        public ITextRangeProvider DocumentRange => new TextRange(this, 0, Owner.Text?.Length ?? 0);
+
+        public SupportedTextSelection SupportedTextSelection => Provider.SupportedTextSelection.Single;
+
         protected override AutomationControlType GetAutomationControlTypeCore()
         {
             return AutomationControlType.Edit;
@@ -25,10 +58,47 @@ namespace Avalonia.Automation.Peers
 
         protected virtual void OwnerPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
         {
-            if(e.Property == TextBox.TextProperty)
+            if (e.Property == TextBox.TextProperty)
             {
                 RaisePropertyChangedEvent(ValuePatternIdentifiers.ValueProperty, e.OldValue, e.NewValue);
+                RaiseTextChangedEvent();
             }
+            else if (e.Property == TextBox.CaretIndexProperty ||
+                     e.Property == TextBox.SelectionStartProperty ||
+                     e.Property == TextBox.SelectionEndProperty)
+            {
+                ScheduleSelectionChangedRaise();
+            }
+        }
+
+        private void ScheduleSelectionChangedRaise()
+        {
+            if (_selectionChangeRaisePending)
+                return;
+
+            _selectionChangeRaisePending = true;
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                _selectionChangeRaisePending = false;
+                RaiseTextSelectionChangedEvent();
+            }, DispatcherPriority.Normal);
+        }
+
+        /// <summary>
+        /// Converts a point in the peer's own top-level coordinate space (the space
+        /// <see cref="RangeFromPoint"/> receives points in, matching
+        /// <see cref="AutomationPeer.GetBoundingRectangle"/>'s convention) into the given
+        /// presenter's local coordinate space.
+        /// </summary>
+        private static Point TranslateFromOwner(Point point, Visual presenter)
+        {
+            var root = presenter.GetVisualRoot() as Visual;
+            if (root is null)
+                return point;
+
+            var toPresenter = root.TransformToVisual(presenter);
+            return toPresenter.HasValue ? point.Transform(toPresenter.Value) : point;
         }
     }
 }

--- a/src/Avalonia.Controls/Automation/Provider/ITextProvider.cs
+++ b/src/Avalonia.Controls/Automation/Provider/ITextProvider.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using Avalonia.Automation.Peers;
+
+namespace Avalonia.Automation.Provider
+{
+    /// <summary>
+    /// Indicates the degree to which a control supports text selection.
+    /// </summary>
+    /// <remarks>
+    /// <list type="table">
+    ///   <item>
+    ///     <term>Windows</term>
+    ///     <description><c>SupportedTextSelection</c></description>
+    ///   </item>
+    ///   <item>
+    ///     <term>macOS</term>
+    ///     <description>No mapping.</description>
+    ///   </item>
+    /// </list>
+    /// </remarks>
+    public enum SupportedTextSelection
+    {
+        None,
+        Single,
+        Multiple,
+    }
+
+    /// <summary>
+    /// Exposes methods and properties to support access by a UI Automation client to controls
+    /// that expose content as text, allowing clients to track the caret and selection and to
+    /// navigate the text a character/word/line at a time.
+    /// </summary>
+    /// <remarks>
+    /// <list type="table">
+    ///   <item>
+    ///     <term>Windows</term>
+    ///     <description><c>ITextProvider</c></description>
+    ///   </item>
+    ///   <item>
+    ///     <term>macOS</term>
+    ///     <description>No mapping.</description>
+    ///   </item>
+    /// </list>
+    /// </remarks>
+    public interface ITextProvider
+    {
+        /// <summary>
+        /// Gets the currently selected text ranges. If nothing is selected, this returns a
+        /// single degenerate (zero-length) range at the current caret position rather than an
+        /// empty collection, so that screen readers can track caret-only movement.
+        /// </summary>
+        /// <remarks>
+        /// <list type="table">
+        ///   <item>
+        ///     <term>Windows</term>
+        ///     <description><c>ITextProvider.GetSelection</c></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>macOS</term>
+        ///     <description>No mapping.</description>
+        ///   </item>
+        /// </list>
+        /// </remarks>
+        IReadOnlyList<ITextRangeProvider> GetSelection();
+
+        /// <summary>
+        /// Gets the currently visible text ranges.
+        /// </summary>
+        /// <remarks>
+        /// <list type="table">
+        ///   <item>
+        ///     <term>Windows</term>
+        ///     <description><c>ITextProvider.GetVisibleRanges</c></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>macOS</term>
+        ///     <description>No mapping.</description>
+        ///   </item>
+        /// </list>
+        /// </remarks>
+        IReadOnlyList<ITextRangeProvider> GetVisibleRanges();
+
+        /// <summary>
+        /// Gets the text range enclosing the given child element, or null if the control has no
+        /// child text elements.
+        /// </summary>
+        /// <remarks>
+        /// <list type="table">
+        ///   <item>
+        ///     <term>Windows</term>
+        ///     <description><c>ITextProvider.RangeFromChild</c></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>macOS</term>
+        ///     <description>No mapping.</description>
+        ///   </item>
+        /// </list>
+        /// </remarks>
+        ITextRangeProvider? RangeFromChild(AutomationPeer childElement);
+
+        /// <summary>
+        /// Gets the degenerate text range nearest to the given point, in the peer's own
+        /// top-level coordinate space (see <see cref="AutomationPeer.GetBoundingRectangle"/>).
+        /// </summary>
+        /// <remarks>
+        /// <list type="table">
+        ///   <item>
+        ///     <term>Windows</term>
+        ///     <description><c>ITextProvider.RangeFromPoint</c></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>macOS</term>
+        ///     <description>No mapping.</description>
+        ///   </item>
+        /// </list>
+        /// </remarks>
+        ITextRangeProvider RangeFromPoint(Point point);
+
+        /// <summary>
+        /// Gets a text range enclosing the entire content of the control.
+        /// </summary>
+        /// <remarks>
+        /// <list type="table">
+        ///   <item>
+        ///     <term>Windows</term>
+        ///     <description><c>ITextProvider.GetDocumentRange</c></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>macOS</term>
+        ///     <description>No mapping.</description>
+        ///   </item>
+        /// </list>
+        /// </remarks>
+        ITextRangeProvider DocumentRange { get; }
+
+        /// <summary>
+        /// Gets a value that specifies the type of text selection that is supported by the
+        /// control.
+        /// </summary>
+        /// <remarks>
+        /// <list type="table">
+        ///   <item>
+        ///     <term>Windows</term>
+        ///     <description><c>ITextProvider.GetSupportedTextSelection</c></description>
+        ///   </item>
+        ///   <item>
+        ///     <term>macOS</term>
+        ///     <description>No mapping.</description>
+        ///   </item>
+        /// </list>
+        /// </remarks>
+        SupportedTextSelection SupportedTextSelection { get; }
+    }
+}

--- a/src/Avalonia.Controls/Automation/Provider/ITextRangeProvider.cs
+++ b/src/Avalonia.Controls/Automation/Provider/ITextRangeProvider.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using Avalonia.Automation.Peers;
+
+namespace Avalonia.Automation.Provider
+{
+    /// <summary>
+    /// Identifies one endpoint of a text range.
+    /// </summary>
+    public enum TextPatternRangeEndpoint
+    {
+        Start,
+        End,
+    }
+
+    /// <summary>
+    /// Identifies the granularity a text range is expanded/moved/compared by.
+    /// </summary>
+    public enum TextUnit
+    {
+        Character,
+        Format,
+        Word,
+        Line,
+        Paragraph,
+        Page,
+        Document,
+    }
+
+    /// <summary>
+    /// Represents a contiguous span of text within an <see cref="ITextProvider"/>, used by UI
+    /// Automation clients (screen readers) to track and navigate a control's caret/selection.
+    /// </summary>
+    /// <remarks>
+    /// <list type="table">
+    ///   <item>
+    ///     <term>Windows</term>
+    ///     <description><c>ITextRangeProvider</c></description>
+    ///   </item>
+    ///   <item>
+    ///     <term>macOS</term>
+    ///     <description>No mapping.</description>
+    ///   </item>
+    /// </list>
+    /// </remarks>
+    public interface ITextRangeProvider
+    {
+        ITextRangeProvider Clone();
+        bool Compare(ITextRangeProvider range);
+        int CompareEndpoints(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint);
+        void ExpandToEnclosingUnit(TextUnit unit);
+        ITextRangeProvider? FindAttribute(int attribute, object? value, bool backward);
+        ITextRangeProvider? FindText(string text, bool backward, bool ignoreCase);
+
+        /// <summary>
+        /// Gets the value of the given text attribute across the range, or
+        /// <see cref="AutomationTextAttributeNotSupported.Instance"/> if the control does not
+        /// support querying that attribute.
+        /// </summary>
+        object GetAttributeValue(int attribute);
+
+        /// <summary>
+        /// Gets the bounding rectangles of the range, in the peer's own top-level coordinate
+        /// space (see <see cref="AutomationPeer.GetBoundingRectangle"/>).
+        /// </summary>
+        IReadOnlyList<Rect> GetBoundingRectangles();
+        AutomationPeer GetEnclosingElement();
+        string GetText(int maxLength);
+        int Move(TextUnit unit, int count);
+        int MoveEndpointByUnit(TextPatternRangeEndpoint endpoint, TextUnit unit, int count);
+        void MoveEndpointByRange(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint);
+        void Select();
+        void AddToSelection();
+        void RemoveFromSelection();
+        void ScrollIntoView(bool alignToTop);
+        IReadOnlyList<AutomationPeer> GetChildren();
+    }
+
+    /// <summary>
+    /// Sentinel value returned from <see cref="ITextRangeProvider.GetAttributeValue"/> when the
+    /// requested attribute is not supported by the control, distinguishing "not supported" from
+    /// an attribute whose value is legitimately <see langword="null"/>.
+    /// </summary>
+    public sealed class AutomationTextAttributeNotSupported
+    {
+        public static readonly AutomationTextAttributeNotSupported Instance = new();
+        private AutomationTextAttributeNotSupported() { }
+    }
+}

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -370,6 +370,12 @@ namespace Avalonia.Controls
         }
 
         private TextPresenter? _presenter;
+
+        /// <summary>
+        /// Gives the automation peer access to the text layout/hit-testing surface.
+        /// </summary>
+        internal TextPresenter? Presenter => _presenter;
+
         private ScrollViewer? _scrollViewer;
         private readonly TextBoxTextInputMethodClient _imClient = new();
         private readonly UndoRedoHelper<UndoRedoState> _undoRedoHelper;

--- a/src/Windows/Avalonia.Win32.Automation/AutomationNode.Text.cs
+++ b/src/Windows/Avalonia.Win32.Automation/AutomationNode.Text.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Automation.Provider;
+using UIA = Avalonia.Win32.Automation.Interop;
+
+namespace Avalonia.Win32.Automation
+{
+    internal partial class AutomationNode : UIA.ITextProvider
+    {
+        UIA.ITextRangeProvider[] UIA.ITextProvider.GetSelection() =>
+            InvokeSync<ITextProvider, IReadOnlyList<ITextRangeProvider>>(x => x.GetSelection())
+                .Select(r => (UIA.ITextRangeProvider)new Win32TextRangeProvider(this, r))
+                .ToArray();
+
+        UIA.ITextRangeProvider[] UIA.ITextProvider.GetVisibleRanges() =>
+            InvokeSync<ITextProvider, IReadOnlyList<ITextRangeProvider>>(x => x.GetVisibleRanges())
+                .Select(r => (UIA.ITextRangeProvider)new Win32TextRangeProvider(this, r))
+                .ToArray();
+
+        UIA.ITextRangeProvider UIA.ITextProvider.RangeFromChild(UIA.IRawElementProviderSimple childElement)
+        {
+            // No control implementing ITextProvider today has child text elements (e.g.
+            // TextBox), so this is never meaningfully invoked; fall back to the document range,
+            // which is never null, to satisfy the non-nullable COM interop contract.
+            var range = InvokeSync<ITextProvider, ITextRangeProvider>(x => x.DocumentRange);
+            return new Win32TextRangeProvider(this, range);
+        }
+
+        UIA.ITextRangeProvider UIA.ITextProvider.RangeFromPoint(UIA.UiaPoint point)
+        {
+            var range = InvokeSync<ITextProvider, ITextRangeProvider>(t => t.RangeFromPoint(new Point(point.X, point.Y)));
+            return new Win32TextRangeProvider(this, range);
+        }
+
+        UIA.ITextRangeProvider UIA.ITextProvider.GetDocumentRange()
+        {
+            var range = InvokeSync<ITextProvider, ITextRangeProvider>(x => x.DocumentRange);
+            return new Win32TextRangeProvider(this, range);
+        }
+
+        UIA.SupportedTextSelection UIA.ITextProvider.GetSupportedTextSelection() =>
+            InvokeSync<ITextProvider, UIA.SupportedTextSelection>(x => (UIA.SupportedTextSelection)x.SupportedTextSelection);
+    }
+}

--- a/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
+++ b/src/Windows/Avalonia.Win32.Automation/AutomationNode.cs
@@ -66,6 +66,8 @@ namespace Avalonia.Win32.Automation
             s_nodes.Add(peer, this);
             peer.ChildrenChanged += OnPeerChildrenChanged;
             peer.PropertyChanged += OnPeerPropertyChanged;
+            peer.TextSelectionChanged += OnPeerTextSelectionChanged;
+            peer.TextChanged += OnPeerTextChanged;
 
             if (Peer.GetProvider<AAP.IEmbeddedRootProvider>() is { } embeddedRoot)
                 embeddedRoot.FocusChanged += OnEmbeddedRootFocusChanged;
@@ -99,6 +101,7 @@ namespace Avalonia.Win32.Automation
                 UiaPatternId.ScrollItem => this,
                 UiaPatternId.Selection => ThisIfPeerImplementsProvider<AAP.ISelectionProvider>(),
                 UiaPatternId.SelectionItem => ThisIfPeerImplementsProvider<AAP.ISelectionItemProvider>(),
+                UiaPatternId.Text => ThisIfPeerImplementsProvider<AAP.ITextProvider>(),
                 UiaPatternId.Toggle => ThisIfPeerImplementsProvider<AAP.IToggleProvider>(),
                 UiaPatternId.Value => ThisIfPeerImplementsProvider<AAP.IValueProvider>(),
                 _ => null,
@@ -196,21 +199,9 @@ namespace Avalonia.Win32.Automation
         void IRawElementProviderSimple2.ShowContextMenu() => InvokeSync(() => Peer.ShowContextMenu());
         void IInvokeProvider.Invoke() => InvokeSync((AAP.IInvokeProvider x) => x.Invoke());
 
-        protected void InvokeSync(Action action)
-        {
-            if (Dispatcher.UIThread.CheckAccess())
-                action();
-            else
-                Dispatcher.UIThread.InvokeAsync(action).Wait();
-        }
+        protected void InvokeSync(Action action) => Win32DispatcherHelper.InvokeSync(action);
 
-        protected T InvokeSync<T>(Func<T> func)
-        {
-            if (Dispatcher.UIThread.CheckAccess())
-                return func();
-            else
-                return Dispatcher.UIThread.InvokeAsync(func).Result;
-        }
+        protected T InvokeSync<T>(Func<T> func) => Win32DispatcherHelper.InvokeSync(func);
 
         protected void InvokeSync<TInterface>(Action<TInterface> action)
         {
@@ -271,6 +262,20 @@ namespace Avalonia.Win32.Automation
                 (int)UiaEventId.LiveRegionChanged);
         }
 
+        protected void RaiseTextSelectionChanged()
+        {
+            UiaCoreProviderApi.UiaRaiseAutomationEvent(
+                this,
+                (int)UiaEventId.Text_TextSelectionChanged);
+        }
+
+        protected void RaiseTextChanged()
+        {
+            UiaCoreProviderApi.UiaRaiseAutomationEvent(
+                this,
+                (int)UiaEventId.Text_TextChanged);
+        }
+
         private RootAutomationNode? GetRoot()
         {
             Dispatcher.UIThread.VerifyAccess();
@@ -298,6 +303,10 @@ namespace Avalonia.Win32.Automation
                 RaiseLiveRegionChanged();
             }
         }
+
+        private void OnPeerTextSelectionChanged(object? sender, EventArgs e) => RaiseTextSelectionChanged();
+
+        private void OnPeerTextChanged(object? sender, EventArgs e) => RaiseTextChanged();
 
         private void OnEmbeddedRootFocusChanged(object? sender, EventArgs e)
         {

--- a/src/Windows/Avalonia.Win32.Automation/Interop/ITextProvider.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Interop/ITextProvider.cs
@@ -15,6 +15,20 @@ internal enum SupportedTextSelection
     Multiple,
 }
 
+/// <summary>
+/// Matches the native UIA <c>UiaPoint</c> struct (two packed doubles), which
+/// <see cref="ITextProvider.RangeFromPoint"/> takes by value per the real COM ABI — unlike
+/// <see cref="IRawElementProviderFragmentRoot.ElementProviderFromPoint"/>, which takes two
+/// separate scalar doubles. Passing two scalar doubles here instead of this struct mismatches
+/// the native calling convention and corrupts the call.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct UiaPoint
+{
+    public double X;
+    public double Y;
+}
+
 [GeneratedComInterface(Options = ComInterfaceOptions.ManagedObjectWrapper)]
 [Guid("3589c92c-63f3-4367-99bb-ada653b77cf2")]
 internal partial interface ITextProvider
@@ -25,7 +39,7 @@ internal partial interface ITextProvider
     ITextRangeProvider[] GetVisibleRanges();
     ITextRangeProvider RangeFromChild(IRawElementProviderSimple childElement);
 
-    ITextRangeProvider RangeFromPoint(double X, double Y);
+    ITextRangeProvider RangeFromPoint(UiaPoint point);
 
     ITextRangeProvider GetDocumentRange();
     SupportedTextSelection GetSupportedTextSelection();

--- a/src/Windows/Avalonia.Win32.Automation/Interop/UiaCoreProviderApi.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Interop/UiaCoreProviderApi.cs
@@ -87,5 +87,15 @@ namespace Avalonia.Win32.Automation.Interop
 
         [LibraryImport("UIAutomationCore.dll", StringMarshalling = StringMarshalling.Utf8)]
         public static partial int UiaDisconnectProvider(IRawElementProviderSimple? provider);
+
+        /// <summary>
+        /// Gets the reserved COM value UI Automation clients (e.g. NVDA) expect back from
+        /// <c>ITextRangeProvider.GetAttributeValue</c> for an attribute the control doesn't
+        /// support. Returning a plain sentinel like <c>-1</c> instead is read by at least NVDA as
+        /// a real (truthy) attribute value rather than "not supported" — e.g. for the hyperlink
+        /// attribute, that gets a plain TextBox announced as a link.
+        /// </summary>
+        [LibraryImport("UIAutomationCore.dll", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int UiaGetReservedNotSupportedValue(out IntPtr punkNotSupportedValue);
     }
 }

--- a/src/Windows/Avalonia.Win32.Automation/Marshalling/SafeArrayMarshaller.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Marshalling/SafeArrayMarshaller.cs
@@ -10,7 +10,7 @@ internal static class SafeArrayMarshaller<T> where T : notnull
 {
     public static SafeArrayRef ConvertToUnmanaged(T[]? managed) =>
         managed is null ? new SafeArrayRef()
-        : SafeArrayRef.TryCreate(managed, out var result, out _) ? result.Value
+        : SafeArrayRef.TryCreate(managed, typeof(T), out var result, out _) ? result.Value
         : throw new NotImplementedException($"SafeArray marshalling for '{managed?.GetType().Name}' is not implemented.");
 
     public static T[]? ConvertToManaged(SafeArrayRef unmanaged) => SafeArrayRef.ToArray<T>(unmanaged);

--- a/src/Windows/Avalonia.Win32.Automation/Marshalling/SafeArrayRef.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Marshalling/SafeArrayRef.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 // ReSharper disable InconsistentNaming
 
 namespace Avalonia.Win32.Automation.Marshalling;
@@ -15,6 +16,8 @@ namespace Avalonia.Win32.Automation.Marshalling;
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 internal unsafe partial struct SafeArrayRef
 {
+    private static readonly ComWrappers s_comWrappers = new StrategyBasedComWrappers();
+
     private SAFEARRAY* _ptr;
 
     internal struct SAFEARRAY
@@ -160,7 +163,10 @@ internal unsafe partial struct SafeArrayRef
         });
     }
 
-    public static bool TryCreate(IEnumerable? managed, [NotNullWhen(true)] out SafeArrayRef? safearray, out VarEnum varEnum)
+    public static bool TryCreate(IEnumerable? managed, [NotNullWhen(true)] out SafeArrayRef? safearray, out VarEnum varEnum) =>
+        TryCreate(managed, elementType: null, out safearray, out varEnum);
+
+    public static bool TryCreate(IEnumerable? managed, Type? elementType, [NotNullWhen(true)] out SafeArrayRef? safearray, out VarEnum varEnum)
     {
         safearray = default;
         varEnum = default;
@@ -178,13 +184,13 @@ internal unsafe partial struct SafeArrayRef
                 List<T> list => CollectionsMarshal.AsSpan(list),
                 _ => collection.ToArray()
             };
-            return CreateFromSpan<T>(collectionSpan, varEnum);
+            return CreateFromSpan<T>(collectionSpan, varEnum, iid: null);
         }
 
-        static SafeArrayRef CreateFromSpan<T>(ReadOnlySpan<T> span, VarEnum varEnum)
+        static SafeArrayRef CreateFromSpan<T>(ReadOnlySpan<T> span, VarEnum varEnum, Guid? iid)
         {
             var bound = new SAFEARRAYBOUND { cElements = (uint)span.Length, lLbound = 0 };
-            var safearray = SafeArrayCreate(varEnum, 1, bound);
+            var safearray = iid is { } guid ? SafeArrayCreateEx(varEnum, 1, bound, &guid) : SafeArrayCreate(varEnum, 1, bound);
             if (span.Length == 0)
             {
                 return new SafeArrayRef
@@ -224,7 +230,7 @@ internal unsafe partial struct SafeArrayRef
                     pointers[i] = Marshal.StringToBSTR(strings[i]);
                 }
 
-                return CreateFromSpan<IntPtr>(pointers.AsSpan(0, strings.Count), varEnum);
+                return CreateFromSpan<IntPtr>(pointers.AsSpan(0, strings.Count), varEnum, iid: null);
             }
             finally
             {
@@ -243,7 +249,7 @@ internal unsafe partial struct SafeArrayRef
                     shorts[i] = bools[i] ? ComVariant.VARIANT_TRUE : ComVariant.VARIANT_FALSE;
                 }
 
-                return CreateFromSpan<short>(shorts.AsSpan(0, bools.Count), varEnum);
+                return CreateFromSpan<short>(shorts.AsSpan(0, bools.Count), varEnum, iid: null);
             }
             finally
             {
@@ -251,7 +257,7 @@ internal unsafe partial struct SafeArrayRef
             }
         }
 
-        static SafeArrayRef CreateFromObjects(IReadOnlyList<object> objects, VarEnum varEnum)
+        static SafeArrayRef CreateFromObjects(IReadOnlyList<object> objects, VarEnum varEnum, Type? elementType)
         {
             Debug.Assert(varEnum == VarEnum.VT_UNKNOWN); // other types not supported yet
             var pointers = ArrayPool<IntPtr>.Shared.Rent(objects.Count);
@@ -259,13 +265,25 @@ internal unsafe partial struct SafeArrayRef
             {
                 for (int i = 0; i < objects.Count; i++)
                 {
-                    if (ComWrappers.TryGetComInstance(objects[i], out var pointer))
-                    {
-                        pointers[i] = pointer;
-                    }
+                    // TryGetComInstance only returns a wrapper that already exists; it does NOT
+                    // create one. For objects that have never previously been exposed to COM
+                    // (e.g. a freshly constructed ITextRangeProvider, unlike long-lived cached
+                    // AutomationNode instances that are usually already wrapped via prior tree
+                    // navigation), this silently failed and left `pointers[i]` as uninitialized
+                    // garbage from the (unzeroed) ArrayPool rental, corrupting the SAFEARRAY and
+                    // crashing native UIA code that later reads it. Always get-or-create instead.
+                    pointers[i] = s_comWrappers.GetOrCreateComInterfaceForObject(
+                        objects[i], CreateComInterfaceFlags.None);
                 }
 
-                return CreateFromSpan<IntPtr>(pointers, varEnum);
+                // Tag the array with the element interface's IID (FADF_HAVEIID) via
+                // SafeArrayCreateEx rather than a plain SafeArrayCreate. Without it, native code
+                // marshaling the array across a process boundary (e.g. UIA delivering it to an
+                // out-of-process client such as NVDA) doesn't know which interface each raw
+                // IUnknown* element pointer actually is, which crashes when it tries to build a
+                // proxy for it.
+                var iid = elementType?.GUID;
+                return CreateFromSpan<IntPtr>(pointers.AsSpan(0, objects.Count), varEnum, iid);
             }
             finally
             {
@@ -295,7 +313,7 @@ internal unsafe partial struct SafeArrayRef
 
             IReadOnlyList<string> strings => CreateFromStrings(strings, varEnum = VarEnum.VT_BSTR),
 
-            IReadOnlyList<object> objects => CreateFromObjects(objects, varEnum = VarEnum.VT_UNKNOWN),
+            IReadOnlyList<object> objects => CreateFromObjects(objects, varEnum = VarEnum.VT_UNKNOWN, elementType),
             
             _ => null
         };
@@ -305,6 +323,9 @@ internal unsafe partial struct SafeArrayRef
 
     [LibraryImport("oleaut32.dll")]
     private static unsafe partial SAFEARRAY* SafeArrayCreate(VarEnum vt, uint cDims, in SAFEARRAYBOUND rgsabound);
+
+    [LibraryImport("oleaut32.dll")]
+    private static unsafe partial SAFEARRAY* SafeArrayCreateEx(VarEnum vt, uint cDims, in SAFEARRAYBOUND rgsabound, Guid* pvExtra);
 
     [LibraryImport("oleaut32.dll")]
     private static unsafe partial void SafeArrayDestroy(SAFEARRAY* array);

--- a/src/Windows/Avalonia.Win32.Automation/Win32DispatcherHelper.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Win32DispatcherHelper.cs
@@ -1,0 +1,30 @@
+using System;
+using Avalonia.Threading;
+
+namespace Avalonia.Win32.Automation
+{
+    /// <summary>
+    /// Marshals UI Automation COM calls, which can arrive on an arbitrary thread, onto the
+    /// Avalonia UI thread. Shared by <see cref="AutomationNode"/> and other COM wrapper objects
+    /// (e.g. <see cref="Win32TextRangeProvider"/>) that are not themselves an
+    /// <see cref="AutomationNode"/>.
+    /// </summary>
+    internal static class Win32DispatcherHelper
+    {
+        public static void InvokeSync(Action action)
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+                action();
+            else
+                Dispatcher.UIThread.InvokeAsync(action).Wait();
+        }
+
+        public static T InvokeSync<T>(Func<T> func)
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+                return func();
+            else
+                return Dispatcher.UIThread.InvokeAsync(func).Result;
+        }
+    }
+}

--- a/src/Windows/Avalonia.Win32.Automation/Win32TextRangeProvider.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Win32TextRangeProvider.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
+using Avalonia.Win32.Automation.Interop;
+using AAP = Avalonia.Automation.Provider;
+using UIA = Avalonia.Win32.Automation.Interop;
+
+namespace Avalonia.Win32.Automation
+{
+    /// <summary>
+    /// Wraps a single platform-agnostic <see cref="AAP.ITextRangeProvider"/> instance as a COM
+    /// <see cref="UIA.ITextRangeProvider"/>. Unlike <see cref="AutomationNode"/>, instances of
+    /// this class are not cached/identity-stable per peer — a fresh wrapper is created for every
+    /// range returned from <see cref="AutomationNode"/>'s <c>ITextProvider</c> methods and from
+    /// range-producing members below, mirroring how UI Automation text ranges are themselves
+    /// transient value-like objects.
+    /// </summary>
+    [GeneratedComClass]
+    internal partial class Win32TextRangeProvider : UIA.ITextRangeProvider
+    {
+        private readonly AutomationNode _owner;
+        private readonly AAP.ITextRangeProvider _inner;
+
+        public Win32TextRangeProvider(AutomationNode owner, AAP.ITextRangeProvider inner)
+        {
+            _owner = owner;
+            _inner = inner;
+        }
+
+        private T Invoke<T>(Func<AAP.ITextRangeProvider, T> func)
+        {
+            try
+            {
+                return Win32DispatcherHelper.InvokeSync(() => func(_inner));
+            }
+            catch (AggregateException e) when (e.InnerException is ElementNotEnabledException)
+            {
+                throw new COMException(e.Message, UiaCoreProviderApi.UIA_E_ELEMENTNOTENABLED);
+            }
+        }
+
+        private void Invoke(Action<AAP.ITextRangeProvider> action) => Invoke<object?>(x => { action(x); return null; });
+
+        UIA.ITextRangeProvider UIA.ITextRangeProvider.Clone() =>
+            new Win32TextRangeProvider(_owner, Invoke(x => x.Clone()));
+
+        bool UIA.ITextRangeProvider.Compare(UIA.ITextRangeProvider range) =>
+            Invoke(x => x.Compare(Unwrap(range)));
+
+        int UIA.ITextRangeProvider.CompareEndpoints(UIA.TextPatternRangeEndpoint endpoint, UIA.ITextRangeProvider targetRange, UIA.TextPatternRangeEndpoint targetEndpoint) =>
+            Invoke(x => x.CompareEndpoints((AAP.TextPatternRangeEndpoint)endpoint, Unwrap(targetRange), (AAP.TextPatternRangeEndpoint)targetEndpoint));
+
+        void UIA.ITextRangeProvider.ExpandToEnclosingUnit(UIA.TextUnit unit) =>
+            Invoke(x => x.ExpandToEnclosingUnit((AAP.TextUnit)unit));
+
+        UIA.ITextRangeProvider UIA.ITextRangeProvider.FindAttribute(int attribute, object value, bool backward)
+        {
+            var result = Invoke(x => x.FindAttribute(attribute, value, backward));
+            // UIA permits a null return to mean "not found"; the interop interface isn't
+            // annotated nullable, so the null-forgiving operator suppresses the mismatch.
+            return result is null ? null! : new Win32TextRangeProvider(_owner, result);
+        }
+
+        UIA.ITextRangeProvider UIA.ITextRangeProvider.FindText(string text, bool backward, bool ignoreCase)
+        {
+            var result = Invoke(x => x.FindText(text, backward, ignoreCase));
+            return result is null ? null! : new Win32TextRangeProvider(_owner, result);
+        }
+
+        object UIA.ITextRangeProvider.GetAttributeValue(int attribute)
+        {
+            var value = Invoke(x => x.GetAttributeValue(attribute));
+            if (value is not AAP.AutomationTextAttributeNotSupported)
+                return value;
+
+            // A plain sentinel like -1 gets misread by at least NVDA as a real (truthy)
+            // attribute value rather than "not supported" — e.g. for the hyperlink attribute,
+            // that makes NVDA announce a plain TextBox as a link. Return UIA's actual reserved
+            // "not supported" COM value instead.
+            var hr = UiaCoreProviderApi.UiaGetReservedNotSupportedValue(out var punk);
+            if (hr < 0 || punk == IntPtr.Zero)
+                return -1;
+
+            try
+            {
+#pragma warning disable CA1416 // This whole assembly only ever builds/runs on Windows.
+                return Marshal.GetObjectForIUnknown(punk);
+#pragma warning restore CA1416
+            }
+            finally
+            {
+                Marshal.Release(punk);
+            }
+        }
+
+        double[] UIA.ITextRangeProvider.GetBoundingRectangles()
+        {
+            var rects = Invoke(x => x.GetBoundingRectangles());
+            var flat = new double[rects.Count * 4];
+
+            for (var i = 0; i < rects.Count; i++)
+            {
+                var screen = _owner.Peer.ToScreen(rects[i]) ?? default;
+                flat[i * 4 + 0] = screen.X;
+                flat[i * 4 + 1] = screen.Y;
+                flat[i * 4 + 2] = screen.Width;
+                flat[i * 4 + 3] = screen.Height;
+            }
+
+            return flat;
+        }
+
+        UIA.IRawElementProviderSimple UIA.ITextRangeProvider.GetEnclosingElement() =>
+            AutomationNode.GetOrCreate(Invoke(x => x.GetEnclosingElement()));
+
+        string UIA.ITextRangeProvider.GetText(int maxLength) => Invoke(x => x.GetText(maxLength));
+
+        int UIA.ITextRangeProvider.Move(UIA.TextUnit unit, int count) =>
+            Invoke(x => x.Move((AAP.TextUnit)unit, count));
+
+        int UIA.ITextRangeProvider.MoveEndpointByUnit(UIA.TextPatternRangeEndpoint endpoint, UIA.TextUnit unit, int count) =>
+            Invoke(x => x.MoveEndpointByUnit((AAP.TextPatternRangeEndpoint)endpoint, (AAP.TextUnit)unit, count));
+
+        void UIA.ITextRangeProvider.MoveEndpointByRange(UIA.TextPatternRangeEndpoint endpoint, UIA.ITextRangeProvider targetRange, UIA.TextPatternRangeEndpoint targetEndpoint) =>
+            Invoke(x => x.MoveEndpointByRange((AAP.TextPatternRangeEndpoint)endpoint, Unwrap(targetRange), (AAP.TextPatternRangeEndpoint)targetEndpoint));
+
+        void UIA.ITextRangeProvider.Select() => Invoke(x => x.Select());
+        void UIA.ITextRangeProvider.AddToSelection() => Invoke(x => x.AddToSelection());
+        void UIA.ITextRangeProvider.RemoveFromSelection() => Invoke(x => x.RemoveFromSelection());
+        void UIA.ITextRangeProvider.ScrollIntoView(bool alignToTop) => Invoke(x => x.ScrollIntoView(alignToTop));
+
+        UIA.IRawElementProviderSimple[] UIA.ITextRangeProvider.GetChildren() =>
+            Invoke(x => x.GetChildren()).Select(p => (UIA.IRawElementProviderSimple)AutomationNode.GetOrCreate(p)).ToArray();
+
+        private static AAP.ITextRangeProvider Unwrap(UIA.ITextRangeProvider range) => ((Win32TextRangeProvider)range)._inner;
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/Automation/TextBoxAutomationPeerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Automation/TextBoxAutomationPeerTests.cs
@@ -1,0 +1,233 @@
+#nullable enable
+
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
+using Avalonia.Automation.Provider;
+using Avalonia.Harfbuzz;
+using Avalonia.Headless;
+using Avalonia.Input.Platform;
+using Avalonia.Media;
+using Avalonia.Platform;
+using Avalonia.Threading;
+using Avalonia.UnitTests;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests.Automation;
+
+public class TextBoxAutomationPeerTests : ScopedTestBase
+{
+    private static TestServices Services => TestServices.MockThreadingInterface.With(
+        standardCursorFactory: Mock.Of<ICursorFactory>(),
+        renderInterface: new HeadlessPlatformRenderInterface(),
+        textShaperImpl: new HarfBuzzTextShaper(),
+        fontManagerImpl: new TestFontManager(),
+        assetLoader: new StandardAssetLoader());
+
+    private static (TextBox TextBox, TextBoxAutomationPeer Peer) Create(string text, int selectionStart = 0, int selectionEnd = 0)
+    {
+        var textBox = new TextBox
+        {
+            Template = TextBoxTests.CreateTemplate(),
+            Text = text,
+            SelectionStart = selectionStart,
+            SelectionEnd = selectionEnd,
+        };
+
+        var root = new TestRoot { Child = textBox };
+        textBox.ApplyTemplate();
+        root.LayoutManager.ExecuteInitialLayoutPass();
+
+        var peer = (TextBoxAutomationPeer)ControlAutomationPeer.CreatePeerForElement(textBox);
+        return (textBox, peer);
+    }
+
+    [Fact]
+    public void GetSelection_Returns_Degenerate_Range_At_Caret_When_Nothing_Selected()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var (textBox, peer) = Create("hello world", selectionStart: 4, selectionEnd: 4);
+
+            var selection = Assert.Single(peer.GetSelection());
+
+            Assert.Equal(4, textBox.CaretIndex);
+            Assert.Equal("", selection.GetText(-1));
+            Assert.True(selection.Compare(selection.Clone()));
+        }
+    }
+
+    [Fact]
+    public void GetSelection_Returns_Normalized_Range_For_Forward_Selection()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var (_, peer) = Create("hello world", selectionStart: 2, selectionEnd: 5);
+
+            var selection = Assert.Single(peer.GetSelection());
+
+            Assert.Equal("llo", selection.GetText(-1));
+        }
+    }
+
+    [Fact]
+    public void GetSelection_Returns_Normalized_Range_For_Reverse_Selection()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var (_, peer) = Create("hello world", selectionStart: 5, selectionEnd: 2);
+
+            var selection = Assert.Single(peer.GetSelection());
+
+            Assert.Equal("llo", selection.GetText(-1));
+        }
+    }
+
+    [Fact]
+    public void DocumentRange_GetText_Returns_Whole_Text()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var (textBox, peer) = Create("hello world");
+
+            Assert.Equal(textBox.Text, peer.DocumentRange.GetText(-1));
+        }
+    }
+
+    [Fact]
+    public void Move_By_Character_Shifts_Range_And_Clamps_At_Bounds()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var (_, peer) = Create("hello", selectionStart: 0, selectionEnd: 0);
+
+            var range = peer.GetSelection()[0];
+
+            var moved = range.Move(TextUnit.Character, 3);
+            Assert.Equal(3, moved);
+            Assert.Equal("", range.GetText(-1));
+
+            // Clamp: only 2 characters left to move before hitting the end of "hello" (index 5).
+            moved = range.Move(TextUnit.Character, 10);
+            Assert.Equal(2, moved);
+        }
+    }
+
+    [Fact]
+    public void MoveEndpointByUnit_Character_Extends_End_Without_Moving_Start()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var (_, peer) = Create("hello", selectionStart: 1, selectionEnd: 1);
+
+            var range = peer.GetSelection()[0];
+            var moved = range.MoveEndpointByUnit(TextPatternRangeEndpoint.End, TextUnit.Character, 3);
+
+            Assert.Equal(3, moved);
+            Assert.Equal("ell", range.GetText(-1));
+        }
+    }
+
+    [Fact]
+    public void ExpandToEnclosingUnit_Word_Selects_Whole_Word()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var (_, peer) = Create("hello world", selectionStart: 7, selectionEnd: 7);
+
+            var range = peer.GetSelection()[0];
+            range.ExpandToEnclosingUnit(TextUnit.Word);
+
+            Assert.Equal("world", range.GetText(-1));
+        }
+    }
+
+    [Fact]
+    public void GetBoundingRectangles_Returns_NonEmpty_Rects_For_NonDegenerate_Range()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var (_, peer) = Create("hello world", selectionStart: 0, selectionEnd: 5);
+
+            var rects = peer.GetSelection()[0].GetBoundingRectangles();
+
+            Assert.NotEmpty(rects);
+        }
+    }
+
+    [Fact]
+    public void GetBoundingRectangles_Returns_Empty_For_Degenerate_Range()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var (_, peer) = Create("hello world", selectionStart: 3, selectionEnd: 3);
+
+            var rects = peer.GetSelection()[0].GetBoundingRectangles();
+
+            Assert.Empty(rects);
+        }
+    }
+
+    [Fact]
+    public void Select_Updates_Caret_And_Selection_Together()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var (textBox, peer) = Create("hello world");
+
+            var target = peer.GetSelection()[0];
+            target.MoveEndpointByUnit(TextPatternRangeEndpoint.End, TextUnit.Character, 5);
+            target.Select();
+
+            Assert.Equal(0, textBox.SelectionStart);
+            Assert.Equal(5, textBox.SelectionEnd);
+            Assert.Equal(5, textBox.CaretIndex);
+        }
+    }
+
+    [Fact]
+    public void Text_Change_Raises_TextChanged_And_Value_PropertyChanged()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var (textBox, peer) = Create("hello");
+
+            var textChangedRaised = 0;
+            var valueChangedRaised = 0;
+            peer.TextChanged += (_, _) => textChangedRaised++;
+            peer.PropertyChanged += (_, e) =>
+            {
+                if (e.Property == ValuePatternIdentifiers.ValueProperty)
+                    valueChangedRaised++;
+            };
+
+            textBox.Text = "goodbye";
+
+            Assert.Equal(1, textChangedRaised);
+            Assert.Equal(1, valueChangedRaised);
+        }
+    }
+
+    [Fact]
+    public void SelectAll_Raises_Single_Coalesced_TextSelectionChanged()
+    {
+        using (UnitTestApplication.Start(Services))
+        {
+            var (textBox, peer) = Create("hello world");
+
+            var raised = 0;
+            peer.TextSelectionChanged += (_, _) => raised++;
+
+            textBox.SelectAll();
+
+            // The coalescing raise is posted to the dispatcher; pump the queue so the posted
+            // continuation runs, then assert it fired exactly once for the
+            // SelectionStart+SelectionEnd(+CaretIndex) burst.
+#pragma warning disable xUnit1051 // no async test context/cancellation applies to this synchronous dispatcher pump
+            Dispatcher.UIThread.RunJobs();
+#pragma warning restore xUnit1051
+
+            Assert.Equal(1, raised);
+        }
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

`TextBox` on Windows previously only exposed `ValuePattern`, so UI Automation clients (screen readers such as NVDA) had no way to track the caret or selection while editing — focusing the control announced the whole text once, but arrowing through it, selecting, or editing gave no further feedback.

This adds a full `TextPattern`/`TextRangeProvider` implementation for `TextBox` on Windows:
- New platform-agnostic `Avalonia.Automation.Provider.ITextProvider`/`ITextRangeProvider` contracts, implemented by `TextBoxAutomationPeer` and a nested `TextRange` type against `TextBox`/`TextPresenter`/`TextLayout` (character/word/line navigation, selection, bounding rectangles).
- `AutomationPeer` gains `TextSelectionChanged`/`TextChanged` events, raised by `TextBoxAutomationPeer` and coalesced so a single edit produces one UIA event rather than one per touched property.
- Win32 glue (`AutomationNode.Text.cs`, `Win32TextRangeProvider`) wires the above into the existing `GeneratedComInterface`-based UIA provider, wrapping fresh `ITextRangeProvider` instances since, unlike `AutomationNode`, they aren't cached per-peer.

Along the way, found and fixed several real bugs in the existing (previously unused/untested) `Win32.Automation` interop and marshalling code, surfaced only once an out-of-process client (NVDA) actually exercised it:
- `ITextProvider.RangeFromPoint` took two scalar `double`s instead of the `UiaPoint` struct the real UIA ABI expects.
- `SafeArrayRef.CreateFromObjects` used `ComWrappers.TryGetComInstance` (only returns a wrapper that *already exists*, doesn't create one) instead of `GetOrCreateComInterfaceForObject`, silently leaving uninitialized `ArrayPool`-rented pointer data in the SAFEARRAY for objects with no prior COM exposure — this reliably crashed the process (`UIAutomationCore!ProtobufHelper::WriteTextRangeArray`, a null-pointer dereference) as soon as NVDA queried `GetSelection()`.
- Interface-typed SAFEARRAYs were built with `SafeArrayCreate` instead of `SafeArrayCreateEx`, so they carried no IID (`FADF_HAVEIID`) — native code marshaling such an array to an out-of-process client has no way to know which interface each element pointer is.
- `ITextRangeProvider.GetAttributeValue` returned a plain `-1` for unsupported attributes instead of UIA's reserved "not supported" sentinel (`UiaGetReservedNotSupportedValue`). NVDA reads a plain `-1` as a real (truthy) attribute value; for the hyperlink attribute this made a plain `TextBox` get announced as a link.

## What is the current behavior?

`TextBox` on Windows only implements `ValuePattern`. Screen readers get a single whole-text announcement on focus and no further caret/selection/edit feedback.

## What is the updated/expected behavior with this PR?

`TextBox` on Windows now implements `TextPattern` as well. To test: run a Windows build with NVDA (or another UIA-based screen reader) active, focus a `TextBox`, and confirm caret position, character/word navigation, and selection are announced correctly while typing and arrowing through text.

## How was the solution implemented (if it's not obvious)?

Three layers, built and verified in this order:
1. **Platform-agnostic layer** (`Avalonia.Controls`) — `ITextProvider`/`ITextRangeProvider` interfaces plus the `TextBoxAutomationPeer`/`TextRange` implementation. Covered by unit tests, no COM involved.
2. **Win32 COM glue** (`Avalonia.Win32.Automation`) — `AutomationNode.Text.cs` implements the existing (previously unused) `UIA.ITextProvider` interop interface by delegating to layer 1 via the existing `InvokeSync` dispatcher-marshaling helpers (now shared via the extracted `Win32DispatcherHelper`, since `Win32TextRangeProvider` isn't an `AutomationNode` and needs the same marshaling). `Win32TextRangeProvider` wraps a single `ITextRangeProvider` instance as its `UIA.ITextRangeProvider` COM counterpart.
3. **Marshalling fixes** — the four bugs listed above in `SafeArrayRef`/`ITextProvider`'s interop declaration, none of which were previously exercised by any existing pattern (`ISelectionProvider` etc. only ever return already-wrapped, long-lived `AutomationNode` instances, so the `TryGetComInstance`/missing-IID gaps never surfaced before).

Root-caused the crash and the "announced as a link" misbehavior using `cdb` (WinDbg's console debugger) attached to the live process, and verified the fix with NVDA actually running against a real build.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None. `TextBoxAutomationPeer` gains new interface implementations (`ITextProvider`) but its existing public surface (`IValueProvider`) is unchanged.

## Obsoletions / Deprecations

None.

## Fixed issues

<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->