### PR TITLE
Update TabbedPage.xaml color resources

### DIFF
--- a/src/Avalonia.Themes.Simple/Controls/TabbedPage.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/TabbedPage.xaml
@@ -15,9 +15,9 @@
 
   <SolidColorBrush x:Key="TabbedPageTabItemHeaderBackgroundUnselected" Color="Transparent" />
   <SolidColorBrush x:Key="TabbedPageTabItemHeaderBackgroundSelected" Color="Transparent" />
-  <SolidColorBrush x:Key="TabbedPageTabItemHeaderBackgroundUnselectedPointerOver" Color="{DynamicResource ThemeControlMidBrush}" />
+  <SolidColorBrush x:Key="TabbedPageTabItemHeaderBackgroundUnselectedPointerOver" Color="{DynamicResource ThemeControlMidColor}" />
   <SolidColorBrush x:Key="TabbedPageTabItemHeaderBackgroundSelectedPointerOver" Color="Transparent" />
-  <SolidColorBrush x:Key="TabbedPageTabItemHeaderBackgroundUnselectedPressed" Color="{DynamicResource ThemeControlHighlightMidBrush}" />
+  <SolidColorBrush x:Key="TabbedPageTabItemHeaderBackgroundUnselectedPressed" Color="{DynamicResource ThemeControlHighlightMidColor}" />
   <SolidColorBrush x:Key="TabbedPageTabItemHeaderBackgroundSelectedPressed" Color="Transparent" />
   <SolidColorBrush x:Key="TabbedPageTabItemHeaderBackgroundDisabled" Color="Transparent" />
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Resolve: It binds Color to the Brush resources here, which throws InvalidCastException as soon as the DynamicResource resolves. Pointed at the Color keys.


## What is the current behavior?
It binds Color to the Brush resources here, which throws InvalidCastException as soon as the DynamicResource resolves. Pointed at the Color keys.


## What is the updated/expected behavior with this PR?
Bind to Color resource

## Checklist

- [x ] Added unit tests (if possible)?
- [x ] Added XML documentation to any related classes?
- [x ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
