### PR TITLE
[osx] Use NSTrackingInVisibleRect for mouse movement tracking

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -81,9 +81,9 @@
 
     // NSTrackingInVisibleRect makes AppKit follow the visible bounds of the view.
     // Because of this, the tracking area does not need to change on resize.
-    // Do not remove and add the area again on each live-resize tick. If you do, AppKit
-    // queues synthetic enter and exit events with stale locations. These events corrupt
-    // the pointer position after a resize and force it to the top left.
+    // Do not remove and add the area again on each live-resize tick.
+    // If you do, AppKit queues synthetic enter and exit events with stale locations.
+    // These events corrupt the pointer position after a resize and force it to the top left.
     NSTrackingAreaOptions options = NSTrackingActiveAlways | NSTrackingMouseMoved |
         NSTrackingMouseEnteredAndExited | NSTrackingEnabledDuringMouseDrag | NSTrackingInVisibleRect;
     _area = [[NSTrackingArea alloc] initWithRect:NSZeroRect options:options owner:self userInfo:nullptr];

--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -78,7 +78,17 @@
     [self setLayerContentsRedrawPolicy: NSViewLayerContentsRedrawDuringViewResize];
 
     _parent = parent;
-    _area = nullptr;
+
+    // NSTrackingInVisibleRect makes AppKit follow the visible bounds of the view.
+    // Because of this, the tracking area does not need to change on resize.
+    // Do not remove and add the area again on each live-resize tick. If you do, AppKit
+    // queues synthetic enter and exit events with stale locations. These events corrupt
+    // the pointer position after a resize and force it to the top left.
+    NSTrackingAreaOptions options = NSTrackingActiveAlways | NSTrackingMouseMoved |
+        NSTrackingMouseEnteredAndExited | NSTrackingEnabledDuringMouseDrag | NSTrackingInVisibleRect;
+    _area = [[NSTrackingArea alloc] initWithRect:NSZeroRect options:options owner:self userInfo:nullptr];
+    [self addTrackingArea:_area];
+
     _lastPixelSize.Height = 100;
     _lastPixelSize.Width = 100;
     [self registerForDraggedTypes: @[@"public.data", GetAvnCustomDataType()]];
@@ -126,24 +136,11 @@
 {
     [super setFrameSize:newSize];
 
-    if(_area != nullptr)
-    {
-        [self removeTrackingArea:_area];
-        _area = nullptr;
-    }
-
     auto parent = _parent.tryGet();
     if (parent == nullptr)
     {
         return;
     }
-
-    NSRect rect = NSZeroRect;
-    rect.size = newSize;
-
-    NSTrackingAreaOptions options = NSTrackingActiveAlways | NSTrackingMouseMoved | NSTrackingMouseEnteredAndExited | NSTrackingEnabledDuringMouseDrag;
-    _area = [[NSTrackingArea alloc] initWithRect:rect options:options owner:self userInfo:nullptr];
-    [self addTrackingArea:_area];
 
     parent->UpdateCursor();
 
@@ -256,8 +253,12 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
         return;
     }
 
-    NSPoint eventLocation = [event locationInWindow];
-    
+    // AppKit synthesizes enter and exit events for the tracked geometry.
+    // They can have stale locations. Use the current pointer location instead.
+    NSPoint eventLocation = event.type == NSEventTypeMouseEntered || event.type == NSEventTypeMouseExited
+        ? [[self window] mouseLocationOutsideOfEventStream]
+        : [event locationInWindow];
+
     auto viewLocation = [self convertPoint:NSMakePoint(0, 0) toView:nil];
     
     auto localPoint = NSMakePoint(eventLocation.x - viewLocation.x, viewLocation.y - eventLocation.y);
@@ -390,7 +391,11 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
         parent->TopLevelEvents->RawMouseEvent(type, pointerType, timestamp, modifiers, point, delta, pressure, xTilt, yTilt);
     }
 
-    [super mouseMoved:event];
+    // Forward only real mouse-moved events up the responder chain. Synthetic enter and
+    // exit events can have stale locations. If these events go up the chain as mouseMoved:,
+    // the window frame tracks the mouse at an incorrect position.
+    if (event.type == NSEventTypeMouseMoved)
+        [super mouseMoved:event];
 }
 
 - (BOOL) resignFirstResponder
@@ -558,7 +563,10 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
 
 - (void)mouseEntered:(NSEvent *)event
 {
-    [self mouseEvent:event withType:Move];
+    // If the pointer is not inside the view, the enter event is false. Ignore it.
+    NSPoint location = [self convertPoint:[[self window] mouseLocationOutsideOfEventStream] fromView:nil];
+    if (NSPointInRect(location, self.bounds))
+        [self mouseEvent:event withType:Move];
     [super mouseEntered:event];
 }
 

--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -391,9 +391,8 @@ static void ConvertTilt(NSPoint tilt, float* xTilt, float* yTilt)
         parent->TopLevelEvents->RawMouseEvent(type, pointerType, timestamp, modifiers, point, delta, pressure, xTilt, yTilt);
     }
 
-    // Forward only real mouse-moved events up the responder chain. Synthetic enter and
-    // exit events can have stale locations. If these events go up the chain as mouseMoved:,
-    // the window frame tracks the mouse at an incorrect position.
+    // This handler is shared by all mouse event types. Only real mouse-moved
+    // events must continue up the responder chain as mouseMoved:
     if (event.type == NSEventTypeMouseMoved)
         [super mouseMoved:event];
 }


### PR DESCRIPTION
I finally got so annoyed with this that I took the time to try to fix it.

When you resize a window on macOS, you sometimes see the traffic-light icons highlight, and the drop-down menu for window positioning appear. This is because we had set up an NSTrackingArea on every `setFrameSize`, which caused stale locations to be set for the window's mouse position. That would happen to be located in the top-left corner, which would make macOS think the buttons were being highlighted. Instead of recreating it, we can use [NSTrackingInVisibleRect](https://developer.apple.com/documentation/appkit/nstrackingarea/options-swift.struct/invisiblerect?changes=_7_3_1&language=objc) once. AppKit follows that; we get the same events, and it doesn't break the mouse positioning.

For tracking enter and exit, we can use the real cursor events with `mouseLocationOutsideOfEventStream.` and `NSEventTypeMouseMoved`.


** Copilot stuff below ** 
---

This pull request addresses issues with mouse tracking and event handling in the `AvnView` implementation for macOS. The changes ensure more reliable pointer tracking during and after view resizes, and prevent stale or synthetic mouse events from corrupting the pointer state. The most important changes are grouped below by theme.

**Mouse Tracking Improvements:**

* The tracking area `_area` is now created with the `NSTrackingInVisibleRect` option during initialization, so it automatically follows the visible bounds of the view and does not need to be recreated on every resize. This prevents AppKit from queuing synthetic enter/exit events with stale locations during live-resize, which previously corrupted pointer positions. (`AvnView.mm`, [native/Avalonia.Native/src/OSX/AvnView.mmL81-R91](diffhunk://#diff-efec56d05bee7f20337b1060ff1d2bec8a5137d1e576dc58c1ab3e17b9a0d153L81-R91))
* The logic to remove and recreate the tracking area in the `setFrameSize:` method was removed, since the tracking area now automatically adjusts with the view. (`AvnView.mm`, [native/Avalonia.Native/src/OSX/AvnView.mmL129-L147](diffhunk://#diff-efec56d05bee7f20337b1060ff1d2bec8a5137d1e576dc58c1ab3e17b9a0d153L129-L147))

**Mouse Event Handling Fixes:**

* For synthetic mouse enter/exit events, the current pointer location is now obtained using `mouseLocationOutsideOfEventStream` instead of using the stale event location. This ensures accurate pointer position reporting. (`AvnView.mm`, [native/Avalonia.Native/src/OSX/AvnView.mmL259-R260](diffhunk://#diff-efec56d05bee7f20337b1060ff1d2bec8a5137d1e576dc58c1ab3e17b9a0d153L259-R260))
* Only real `mouseMoved` events are forwarded up the responder chain; synthetic enter/exit events are not, preventing the window frame from tracking the mouse at incorrect positions. (`AvnView.mm`, [native/Avalonia.Native/src/OSX/AvnView.mmR394-R397](diffhunk://#diff-efec56d05bee7f20337b1060ff1d2bec8a5137d1e576dc58c1ab3e17b9a0d153R394-R397))
* In `mouseEntered:`, the code now checks if the pointer is actually inside the view before processing the event, ignoring false enter events. (`AvnView.mm`, [native/Avalonia.Native/src/OSX/AvnView.mmR566-R568](diffhunk://#diff-efec56d05bee7f20337b1060ff1d2bec8a5137d1e576dc58c1ab3e17b9a0d153R566-R568))
