### PR TITLE
Add Content attribute to ContentPresenter

### DIFF
--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -364,6 +364,7 @@ namespace Avalonia.Controls.Presenters
         /// <summary>
         /// Gets or sets the content to be displayed by the presenter.
         /// </summary>
+        [Content]
         [DependsOn(nameof(ContentTemplate))]
         public object? Content
         {

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
@@ -43,6 +43,17 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
         }
 
         [Fact]
+        public void ContentPresenter_Default_Content_Property_Is_Set()
+        {
+            var xaml = @"<ContentPresenter xmlns='https://github.com/avaloniaui'>Foo</ContentPresenter>";
+
+            var target = AvaloniaRuntimeXamlLoader.Parse<ContentPresenter>(xaml);
+
+            Assert.NotNull(target);
+            Assert.Equal("Foo", target.Content);
+        }
+
+        [Fact]
         public void Attached_Property_Is_Set()
         {
             var xaml =


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds the `Content` attribute to `ContentPresenter.Content` so XAML treats it as the default content property, matching `ContentControl.Content`.
