### PR TITLE
Headless: Use Avalonia.Input.MouseDevice.Primary for consistency with desktop platforms (configurable)

### DIFF
--- a/src/Avalonia.Base/Input/MouseDevice.cs
+++ b/src/Avalonia.Base/Input/MouseDevice.cs
@@ -18,6 +18,8 @@ namespace Avalonia.Input
         private static MouseDevice? _primary;
         internal static MouseDevice Primary => _primary ??= new MouseDevice();
 
+        internal static void ResetPrimaryForUnitTests() => _primary = null;
+
         private int _clickCount;
         private Rect _lastClickRect;
         private ulong _lastClickTime;

--- a/src/Headless/Avalonia.Headless/AvaloniaHeadlessPlatform.cs
+++ b/src/Headless/Avalonia.Headless/AvaloniaHeadlessPlatform.cs
@@ -14,9 +14,9 @@ namespace Avalonia.Headless
         internal static Compositor? Compositor { get; private set; }
         private static IRenderTimer? s_renderTimer;
 
-        private class HeadlessWindowingPlatform(PixelFormat frameBufferFormat, bool overlayPopups) : IWindowingPlatform
+        private class HeadlessWindowingPlatform(AvaloniaHeadlessPlatformOptions options) : IWindowingPlatform
         {
-            public IWindowImpl CreateWindow() => new HeadlessWindowImpl(frameBufferFormat, overlayPopups);
+            public IWindowImpl CreateWindow() => new HeadlessWindowImpl(options);
             public ITopLevelImpl CreateEmbeddableTopLevel() => CreateEmbeddableWindow();
 
             public IWindowImpl CreateEmbeddableWindow() => throw new PlatformNotSupportedException();
@@ -34,6 +34,9 @@ namespace Avalonia.Headless
 
         internal static void Initialize(AvaloniaHeadlessPlatformOptions opts)
         {
+            if (opts.UseSharedMouseDevice == true)
+                MouseDevice.ResetPrimaryForUnitTests();
+
             var clipboardImpl = new HeadlessClipboardImplStub();
             var clipboard = new Clipboard(clipboardImpl);
 
@@ -49,7 +52,7 @@ namespace Avalonia.Headless
                 .Bind<IPlatformIconLoader>().ToSingleton<HeadlessIconLoaderStub>()
                 .Bind<IKeyboardDevice>().ToConstant(new KeyboardDevice())
                 .Bind<IRenderLoop>().ToConstant(Rendering.RenderLoop.FromTimer(s_renderTimer))
-                .Bind<IWindowingPlatform>().ToConstant(new HeadlessWindowingPlatform(opts.FrameBufferFormat, opts.OverlayPopups))
+                .Bind<IWindowingPlatform>().ToConstant(new HeadlessWindowingPlatform(opts))
                 .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>()
                 .Bind<KeyGestureFormatInfo>().ToConstant(new KeyGestureFormatInfo(new Dictionary<Key, string>() { }));
             Compositor = new Compositor( null);
@@ -123,6 +126,14 @@ namespace Avalonia.Headless
         /// </summary>
         // TODO13: Change the default to false to match the other desktop platforms.
         public bool OverlayPopups { get; set; } = true;
+
+        /// <summary>
+        /// Shares a single mouse device between all top-levels when set to true, so that pointer capture
+        /// and click counting are global rather than per-window, as they are on the other platforms.
+        /// When null or false, every top-level gets its own mouse device.
+        /// </summary>
+        // TODO13: Change the default to true to match the other platforms.
+        public bool? UseSharedMouseDevice { get; set; }
     }
 
     public static class AvaloniaHeadlessPlatformExtensions

--- a/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -22,30 +22,28 @@ namespace Avalonia.Headless
         private readonly IKeyboardDevice _keyboard;
         private readonly IScreenImpl _screen;
         private readonly Stopwatch _st = Stopwatch.StartNew();
-        private readonly Pointer _mousePointer;
         private WriteableBitmap? _lastRenderedFrame;
         private readonly object _sync = new object();
-        private readonly PixelFormat _frameBufferFormat;
-        private readonly bool _overlayPopups;
+        private readonly AvaloniaHeadlessPlatformOptions _options;
         private readonly HeadlessWindowImpl? _popupParent;
         private readonly IPopupPositioner? _popupPositioner;
         private readonly List<HeadlessWindowImpl> _openPopups = new();
         public bool IsPopup { get; }
 
-        public HeadlessWindowImpl(PixelFormat frameBufferFormat, bool overlayPopups)
+        public HeadlessWindowImpl(AvaloniaHeadlessPlatformOptions options)
         {
             Surfaces = [this];
             _keyboard = AvaloniaLocator.Current.GetRequiredService<IKeyboardDevice>();
             _screen = new HeadlessScreensStub();
-            _mousePointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, true);
-            MouseDevice = new MouseDevice(_mousePointer);
+            MouseDevice = options.UseSharedMouseDevice == true
+                ? Avalonia.Input.MouseDevice.Primary
+                : new MouseDevice(new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, true));
             ClientSize = new Size(1024, 768);
-            _frameBufferFormat = frameBufferFormat;
-            _overlayPopups = overlayPopups;
+            _options = options;
         }
 
         private HeadlessWindowImpl(HeadlessWindowImpl popupParent)
-            : this(popupParent._frameBufferFormat, popupParent._overlayPopups)
+            : this(popupParent._options)
         {
             IsPopup = true;
             _popupParent = popupParent;
@@ -233,7 +231,7 @@ namespace Avalonia.Headless
 
         public ILockedFramebuffer Lock()
         {
-            var bmp = new WriteableBitmap(PixelSize.FromSize(ClientSize, RenderScaling), new Vector(96, 96) * RenderScaling, _frameBufferFormat, AlphaFormat.Premul);
+            var bmp = new WriteableBitmap(PixelSize.FromSize(ClientSize, RenderScaling), new Vector(96, 96) * RenderScaling, _options.FrameBufferFormat, AlphaFormat.Premul);
             var fb = bmp.Lock();
             return new FramebufferProxy(fb, () =>
             {
@@ -403,7 +401,7 @@ namespace Avalonia.Headless
             PositionChanged?.Invoke(point);
         }
 
-        public IPopupImpl? CreatePopup() => _overlayPopups ? null : new HeadlessWindowImpl(this);
+        public IPopupImpl? CreatePopup() => _options.OverlayPopups ? null : new HeadlessWindowImpl(this);
 
         public IReadOnlyList<TopLevel> GetOpenPopups()
         {

--- a/tests/Avalonia.Headless.NUnit.PerTest.UnitTests/Avalonia.Headless.NUnit.PerTest.UnitTests.csproj
+++ b/tests/Avalonia.Headless.NUnit.PerTest.UnitTests/Avalonia.Headless.NUnit.PerTest.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(AvsCurrentTargetFramework)</TargetFramework>
     <IsTestProject>true</IsTestProject>
-    <DefineConstants>$(DefineConstants);NUNIT</DefineConstants>
+    <DefineConstants>$(DefineConstants);NUNIT;PERTEST</DefineConstants>
     <EnableNUnitRunner>true</EnableNUnitRunner>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/tests/Avalonia.Headless.UnitTests/AssertHelper.cs
+++ b/tests/Avalonia.Headless.UnitTests/AssertHelper.cs
@@ -49,4 +49,13 @@ internal static class AssertHelper
 #endif
     }
 
+    public static void NotSame(object? expected, object? actual)
+    {
+#if NUNIT
+        Assert.That(expected, Is.Not.SameAs(actual));
+#elif XUNIT
+        Assert.NotSame(expected, actual);
+#endif
+    }
+
 }

--- a/tests/Avalonia.Headless.UnitTests/MouseDeviceTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/MouseDeviceTests.cs
@@ -1,0 +1,90 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+
+namespace Avalonia.Headless.UnitTests;
+
+public class MouseDeviceTests
+{
+#if NUNIT
+    [AvaloniaTest]
+#elif XUNIT
+    [AvaloniaFact]
+#endif
+    public void Pointer_Is_Shared_Between_Windows_When_Requested()
+    {
+        var firstWindow = CreateWindow(out var firstTarget);
+        var secondWindow = CreateWindow(out var secondTarget);
+
+        IPointer firstPointer = null, secondPointer = null;
+        firstTarget.PointerPressed += (_, e) => firstPointer = e.Pointer;
+        secondTarget.PointerPressed += (_, e) => secondPointer = e.Pointer;
+
+        Click(firstWindow);
+        Click(secondWindow);
+
+        AssertHelper.NotNull(firstPointer);
+        AssertHelper.NotNull(secondPointer);
+
+        if (TestApplication.UsesSharedMouseDevice)
+            AssertHelper.Same(firstPointer, secondPointer);
+        else
+            AssertHelper.NotSame(firstPointer, secondPointer);
+
+        firstWindow.Close();
+        secondWindow.Close();
+    }
+
+#if NUNIT
+    [AvaloniaTest]
+#elif XUNIT
+    [AvaloniaFact]
+#endif
+    public void Pointer_Capture_Crosses_TopLevels_When_Device_Is_Shared()
+    {
+        var popupChild = new Border { Width = 80, Height = 30, Background = Brushes.Blue };
+        var target = new Border { Background = Brushes.Red };
+        var popup = new Popup { PlacementTarget = target, Child = popupChild };
+        var window = new Window
+        {
+            Width = 100,
+            Height = 100,
+            Content = new Panel { Children = { target, popup } }
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        popup.Open();
+        Dispatcher.UIThread.RunJobs();
+
+        object moveTarget = null;
+        target.PointerMoved += (s, _) => moveTarget = s;
+        popupChild.PointerMoved += (s, _) => moveTarget = s;
+
+        // Pressing captures the pointer implicitly on the window's border.
+        window.MouseDown(new Point(50, 50), MouseButton.Left);
+        window.GetOpenPopups()[0].MouseMove(new Point(40, 15));
+
+        AssertHelper.Same(TestApplication.UsesSharedMouseDevice ? target : popupChild, moveTarget);
+
+        window.MouseUp(new Point(50, 50), MouseButton.Left);
+        window.Close();
+    }
+
+    private static Window CreateWindow(out Border target)
+    {
+        target = new Border { Background = Brushes.Red };
+        var window = new Window { Width = 100, Height = 100, Content = target };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return window;
+    }
+
+    private static void Click(Window window)
+    {
+        window.MouseDown(new Point(50, 50), MouseButton.Left);
+        window.MouseUp(new Point(50, 50), MouseButton.Left);
+    }
+}

--- a/tests/Avalonia.Headless.UnitTests/TestApplication.cs
+++ b/tests/Avalonia.Headless.UnitTests/TestApplication.cs
@@ -9,12 +9,23 @@ public class TestApplication : Application
         Styles.Add(new SimpleTheme());
     }
 
+    /// <summary>
+    /// Enabled by the PerTest projects only, so that both mouse device modes are covered.
+    /// </summary>
+    public static bool UsesSharedMouseDevice =>
+#if PERTEST
+        true;
+#else
+        false;
+#endif
+
     public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<TestApplication>()
         .UseHarfBuzz()
         .UseSkia()
         .UseHeadless(new AvaloniaHeadlessPlatformOptions
         {
             UseHeadlessDrawing = false,
-            OverlayPopups = false
+            OverlayPopups = false,
+            UseSharedMouseDevice = UsesSharedMouseDevice
         });
 }

--- a/tests/Avalonia.Headless.XUnit.PerTest.UnitTests/Avalonia.Headless.XUnit.PerTest.UnitTests.csproj
+++ b/tests/Avalonia.Headless.XUnit.PerTest.UnitTests/Avalonia.Headless.XUnit.PerTest.UnitTests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>$(AvsCurrentTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsTestProject>true</IsTestProject>
-    <DefineConstants>$(DefineConstants);XUNIT</DefineConstants>
+    <DefineConstants>$(DefineConstants);XUNIT;PERTEST</DefineConstants>
   </PropertyGroup>
 
   <Import Project="..\..\build\UnitTests.NetCore.targets" />


### PR DESCRIPTION
This PR (optionally) makes headless platform to be more consistent with desktop platforms that use single MouseDevice for all their windows.

There are corner cases where it's important to follow that exact behavior. Expected to be default with 13.x.