### PR TITLE
Fix VirtualizingStackPanel ScrollToEnd with variable-sized items

### DIFF
--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -818,6 +818,18 @@ namespace Avalonia.Controls
                 return;
             }
 
+            var horizontal = Orientation == Orientation.Horizontal;
+            var viewportEnd = horizontal ? _viewport.Right : _viewport.Bottom;
+
+            if (!_hasReachedEnd && MathUtilities.GreaterThanOrClose(
+                viewportEnd,
+                horizontal ? Bounds.Width : Bounds.Height))
+            {
+                index = itemCount - 1;
+                position = viewportEnd - EstimateElementSizeU();
+                return;
+            }
+
             // If we have realised elements and a valid StartU then try to use this information to
             // get the anchor element.
             if (_realizedElements?.StartU is { } u && !double.IsNaN(u))
@@ -907,6 +919,9 @@ namespace Avalonia.Controls
             var index = viewport.anchorIndex;
             var horizontal = Orientation == Orientation.Horizontal;
             var u = viewport.anchorU;
+            var viewportEnd = horizontal ? _viewport.Right : _viewport.Bottom;
+            var anchorAtEnd = !_hasReachedEnd && index == items.Count - 1 &&
+                MathUtilities.GreaterThanOrClose(viewportEnd, horizontal ? Bounds.Width : Bounds.Height);
                     
             // Reset boundary flags
             _hasReachedStart = false;
@@ -928,6 +943,12 @@ namespace Avalonia.Controls
                 
                 var sizeU = horizontal ? e.DesiredSize.Width : e.DesiredSize.Height;
                 var sizeV = horizontal ? e.DesiredSize.Height : e.DesiredSize.Width;
+
+                if (anchorAtEnd && index == viewport.anchorIndex)
+                {
+                    u = viewportEnd - sizeU;
+                    viewport.anchorU = u;
+                }
 
                 _measureElements!.Add(index, e, u, sizeU);
                 viewport.measuredV = Math.Max(viewport.measuredV, sizeV);

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -141,6 +141,41 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Theory]
+        [InlineData(Orientation.Vertical, 0d)]
+        [InlineData(Orientation.Vertical, 0.5d)]
+        [InlineData(Orientation.Horizontal, 0d)]
+        [InlineData(Orientation.Horizontal, 0.5d)]
+        public void ScrollToEnd_Arrives_At_End_When_Items_Have_Different_Sizes(Orientation orientation, double bufferFactor)
+        {
+            using var app = App();
+            var horizontal = orientation == Orientation.Horizontal;
+            var items = Enumerable.Range(0, 100)
+                .Select(x => horizontal ? (object)new ItemWithWidth(x, x < 60 ? 10 : 50) : new ItemWithHeight(x, x < 60 ? 10 : 50))
+                .ToList();
+            var (target, scroll, itemsControl) = CreateUnrootedTarget<ItemsControl>(
+                items: items,
+                itemTemplate: horizontal ? CanvasWithWidthTemplate : CanvasWithHeightTemplate,
+                orientation: orientation,
+                bufferFactor: bufferFactor);
+            scroll.Template = ScrollViewerTemplateWithScrollBars();
+            CreateRoot(itemsControl).LayoutManager.ExecuteInitialLayoutPass();
+
+            scroll.Offset = horizontal ? new Vector(850, 0) : new Vector(0, 850);
+            Layout(target);
+
+            (horizontal ? scroll.HorizontalScrollBar : scroll.VerticalScrollBar)?.ScrollToEnd();
+            Layout(target);
+
+            Assert.Equal(
+                horizontal ? scroll.Extent.Width - scroll.Viewport.Width : scroll.Extent.Height - scroll.Viewport.Height,
+                horizontal ? scroll.Offset.X : scroll.Offset.Y);
+            Assert.Equal(items.Count - 1, target.LastRealizedIndex);
+            Assert.Equal(
+                horizontal ? target.ViewPort.Right : target.ViewPort.Bottom,
+                horizontal ? target.GetRealizedElements().Last()!.Bounds.Right : target.GetRealizedElements().Last()!.Bounds.Bottom);
+        }
+
+        [Theory]
         [InlineData(0d, 10)]
         [InlineData(0.5d, 20)]
         public void Scrolling_Up_To_Index_Does_Not_Create_A_Page_Of_Unrealized_Elements(double bufferFactor, int expectedCount)
@@ -2500,6 +2535,33 @@ namespace Avalonia.Controls.UnitTests
                 {
                     Name = "PART_ScrollContentPresenter",
                 }.RegisterInNameScope(ns));
+        }
+
+        private static IControlTemplate ScrollViewerTemplateWithScrollBars()
+        {
+            return new FuncControlTemplate<ScrollViewer>((_, ns) =>
+            {
+                var presenter = new ScrollContentPresenter
+                {
+                    Name = "PART_ScrollContentPresenter",
+                }.RegisterInNameScope(ns);
+
+                var horizontalScrollBar = new ScrollBar
+                {
+                    Name = "PART_HorizontalScrollBar",
+                    Orientation = Orientation.Horizontal,
+                    VerticalAlignment = VerticalAlignment.Bottom
+                }.RegisterInNameScope(ns);
+
+                var verticalScrollBar = new ScrollBar
+                {
+                    Name = "PART_VerticalScrollBar",
+                    Orientation = Orientation.Vertical,
+                    HorizontalAlignment = HorizontalAlignment.Right
+                }.RegisterInNameScope(ns);
+
+                return new Panel { Children = { presenter, horizontalScrollBar, verticalScrollBar } };
+            });
         }
 
         private static IDisposable App() => UnitTestApplication.Start(TestServices.RealFocus);

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -150,7 +150,7 @@ namespace Avalonia.Controls.UnitTests
             using var app = App();
             var horizontal = orientation == Orientation.Horizontal;
             var items = Enumerable.Range(0, 100)
-                .Select(x => horizontal ? (object)new ItemWithWidth(x, x < 60 ? 10 : 50) : new ItemWithHeight(x, x < 60 ? 10 : 50))
+                .Select(x => horizontal ? (object)new ItemWithWidth(x, x < 60 ? 20 : 50) : new ItemWithHeight(x, x < 60 ? 20 : 50))
                 .ToList();
             var (target, scroll, itemsControl) = CreateUnrootedTarget<ItemsControl>(
                 items: items,
@@ -159,9 +159,6 @@ namespace Avalonia.Controls.UnitTests
                 bufferFactor: bufferFactor);
             scroll.Template = ScrollViewerTemplateWithScrollBars();
             CreateRoot(itemsControl).LayoutManager.ExecuteInitialLayoutPass();
-
-            scroll.Offset = horizontal ? new Vector(850, 0) : new Vector(0, 850);
-            Layout(target);
 
             (horizontal ? scroll.HorizontalScrollBar : scroll.VerticalScrollBar)?.ScrollToEnd();
             Layout(target);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes `VirtualizingStackPanel` failing to scroll to the actual end when `ScrollBar.ScrollToEnd()` is called and trailing items have different sizes.


## What is the current behavior?
<img width="1282" height="1036" alt="bugdemo3" src="https://github.com/user-attachments/assets/3c206696-a07a-40e3-8c2c-7d2b26820226" />



## What is the updated/expected behavior with this PR?
<img width="1282" height="1036" alt="bugdemo4" src="https://github.com/user-attachments/assets/06233c79-9d6d-44a0-a5f9-6d145c092261" />



## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
When the viewport reaches the current panel end before all items have been
measured, `VirtualizingStackPanel` uses the last item as the realization anchor.
After measuring that item, its position is corrected using the actual size so
the extent and offset can be synchronized to the real end.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Fixes #22013 
