### PR TITLE
Fix TextBlock ellipsis not showing with TextWrapping and MaxLines

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
@@ -632,7 +632,7 @@ namespace Avalonia.Media.TextFormatting
                     //Fulfill max lines constraint
                     if (MaxLines > 0 && textLines.Count >= MaxLines)
                     {
-                        if (textLine.TextLineBreak is { IsSplit: true } && !textLine.HasCollapsed)
+                        if (textLine.TextLineBreak is { IsSplit: true })
                         {
                             textLines[textLines.Count - 1] = textLine.Collapse(GetCollapsingProperties(textLine.WidthIncludingTrailingWhitespace));
                         }

--- a/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
@@ -632,9 +632,9 @@ namespace Avalonia.Media.TextFormatting
                     //Fulfill max lines constraint
                     if (MaxLines > 0 && textLines.Count >= MaxLines)
                     {
-                        if (textLine.TextLineBreak is { IsSplit: true })
+                        if (textLine.TextLineBreak is { IsSplit: true } && !textLine.HasCollapsed)
                         {
-                            textLines[textLines.Count - 1] = textLine.Collapse(GetCollapsingProperties(WidthIncludingTrailingWhitespace));
+                            textLines[textLines.Count - 1] = textLine.Collapse(GetCollapsingProperties(textLine.WidthIncludingTrailingWhitespace));
                         }
 
                         break;

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
@@ -626,6 +626,73 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
             }
         }
 
+        public static IEnumerable<object[]> MaxLinesEllipsisData
+        {
+            get
+            {
+                yield return new object[] { TextTrimming.CharacterEllipsis };
+                yield return new object[] { TextTrimming.WordEllipsis };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MaxLinesEllipsisData))]
+        public void Should_Add_Ellipsis_When_MaxLines_Cuts_Short_Wrapped_Line(TextTrimming trimming)
+        {
+            using (Start())
+            {
+                const string text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+                var probe = new TextLayout(
+                    text,
+                    Typeface.Default,
+                    12,
+                    Brushes.Black,
+                    textWrapping: TextWrapping.Wrap,
+                    textTrimming: trimming,
+                    maxWidth: 80
+                );
+
+                var maxLineWidth = probe.TextLines.Max(l => l.WidthIncludingTrailingWhitespace);
+
+                var cutIndex = -1;
+                for (var i = 0; i < probe.TextLines.Count - 1; i++)
+                {
+                    var line = probe.TextLines[i];
+
+                    // Shorter = line was wrapped, but not because of max width, so it will be cut off by max lines and should have ellipsis added.
+                    if (line.TextLineBreak is { IsSplit: true } && line.WidthIncludingTrailingWhitespace < (maxLineWidth - 0.01))
+                    {
+                        cutIndex = i;
+                        break;
+                    }
+                }
+
+                Assert.True(cutIndex >= 0, "Test data does not satisfy the bug-reproduction condition. Adjust text/maxWidth.");
+
+                var layout = new TextLayout(
+                    text,
+                    Typeface.Default,
+                    12,
+                    Brushes.Black,
+                    textWrapping: TextWrapping.Wrap,
+                    textTrimming: trimming,
+                    maxWidth: 80,
+                    maxLines: cutIndex + 1);
+
+                var lastLine = layout.TextLines[layout.TextLines.Count - 1];
+
+                Assert.True(lastLine.HasCollapsed, "The wrapped line cut off by MaxLines must be collapsed.");
+
+                var formattedLineText = string.Concat(lastLine.TextRuns.Select(r => r.Text.ToString()));
+                Assert.Contains("\u2026", formattedLineText);
+                Assert.Equal(cutIndex + 1, layout.TextLines.Count);
+
+                probe.Dispose();
+                layout.Dispose();
+            }
+        }
+
         [Fact]
         public void Should_Produce_Fixed_Height_Lines()
         {

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
@@ -642,32 +642,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
             using (Start())
             {
                 const string text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
-
-                var probe = new TextLayout(
-                    text,
-                    Typeface.Default,
-                    12,
-                    Brushes.Black,
-                    textWrapping: TextWrapping.Wrap,
-                    textTrimming: trimming,
-                    maxWidth: 80
-                );
-
-                var maxLineWidth = probe.TextLines.Max(l => l.WidthIncludingTrailingWhitespace);
-
-                var cutIndex = -1;
-                for (var i = 0; i < probe.TextLines.Count - 1; i++)
-                {
-                    var line = probe.TextLines[i];
-
-                    if (line.TextLineBreak is { IsSplit: true } && line.WidthIncludingTrailingWhitespace < (maxLineWidth - 0.01))
-                    {
-                        cutIndex = i;
-                        break;
-                    }
-                }
-
-                Assert.True(cutIndex >= 0, "Test data does not satisfy the bug-reproduction condition. Adjust text/maxWidth.");
+                const int maxLines = 2;
 
                 var layout = new TextLayout(
                     text,
@@ -676,18 +651,17 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                     Brushes.Black,
                     textWrapping: TextWrapping.Wrap,
                     textTrimming: trimming,
-                    maxWidth: 80,
-                    maxLines: cutIndex + 1);
+                    maxWidth: 180,
+                    maxLines: maxLines);
+
+                Assert.Equal(maxLines, layout.TextLines.Count);
 
                 var lastLine = layout.TextLines[layout.TextLines.Count - 1];
+                var formattedLineText = string.Concat(lastLine.TextRuns.Select(r => r.Text.ToString()));
 
                 Assert.True(lastLine.HasCollapsed, "The wrapped line cut off by MaxLines must be collapsed.");
+                Assert.Equal('\u2026', formattedLineText.Last());
 
-                var formattedLineText = string.Concat(lastLine.TextRuns.Select(r => r.Text.ToString()));
-                Assert.Contains("\u2026", formattedLineText);
-                Assert.Equal(cutIndex + 1, layout.TextLines.Count);
-
-                probe.Dispose();
                 layout.Dispose();
             }
         }

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
@@ -660,7 +660,6 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                 {
                     var line = probe.TextLines[i];
 
-                    // Shorter = line was wrapped, but not because of max width, so it will be cut off by max lines and should have ellipsis added.
                     if (line.TextLineBreak is { IsSplit: true } && line.WidthIncludingTrailingWhitespace < (maxLineWidth - 0.01))
                     {
                         cutIndex = i;


### PR DESCRIPTION
## What does the pull request do?
When MaxLines is greater than 0 (e.g., 2 in the issue example) and the current line 
count reaches MaxLines, the last line is collapsed using textLine.Collapse(). However, 
GetCollapsingProperties was being passed the maximum width of the entire TextLayout 
instead of the width of that specific line, so ellipses were not being added correctly.

This issue has been fixed.

## What is the current behavior?
When `TextWrapping` and `MaxLines` are both set, the last line that exceeds the maximum 
line count is truncated without an ellipsis. For example:

```xml
<TextBlock Text="Very long text that wraps across multiple lines"
           TextWrapping="Wrap"
           MaxLines="2"
           TextTrimming="CharacterEllipsis" />
```
Result: The second line is truncated without "...".

## What is the updated/expected behavior with this PR?
The ellipsis is consistently displayed on the last line when text exceeds the maximum 
line count, matching the behavior of single-line TextBlock with `TextTrimming` set.

## How was the solution implemented (if it's not obvious)?

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #17633