### PR TITLE
RefreshContainer - show refresh indicator when refresh is triggered programmatically

### DIFF
--- a/samples/ControlCatalog/Pages/RefreshContainerPage.axaml
+++ b/samples/ControlCatalog/Pages/RefreshContainerPage.axaml
@@ -27,6 +27,7 @@
             </generic:List>
           </ComboBox.ItemsSource>
         </ComboBox>
+        <Button Content="Refresh" Name="RefreshButton"/>
       </StackPanel>
     </StackPanel>
     <RefreshContainer Name="Refresh"

--- a/samples/ControlCatalog/Pages/RefreshContainerPage.axaml.cs
+++ b/samples/ControlCatalog/Pages/RefreshContainerPage.axaml.cs
@@ -11,9 +11,16 @@ namespace ControlCatalog.Pages
         {
             InitializeComponent();
 
+            RefreshButton.Click += RefreshButton_Click;
+
             _viewModel = new RefreshContainerViewModel();
 
             DataContext = _viewModel;
+        }
+
+        private void RefreshButton_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            Refresh.RequestRefresh();
         }
 
         private async void RefreshContainerPage_RefreshRequested(object? sender, RefreshRequestedEventArgs e)

--- a/samples/ControlCatalog/ViewModels/RefreshContainerViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/RefreshContainerViewModel.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
-using Avalonia.Controls.Notifications;
-using ControlCatalog.Pages;
 using MiniMvvm;
 
 namespace ControlCatalog.ViewModels

--- a/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
+++ b/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
@@ -321,8 +321,8 @@ namespace Avalonia.Controls
 
         private void RefreshCompleted()
         {
+            RefreshInfoProvider?.InteractionRatio = 0;
             RefreshVisualizerState = RefreshVisualizerState.Idle;
-
             RefreshInfoProvider?.OnRefreshCompleted();
         }
 

--- a/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
+++ b/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
@@ -312,6 +312,7 @@ namespace Avalonia.Controls
         /// </summary>
         public void RequestRefresh()
         {
+            RefreshInfoProvider?.InteractionRatio = 1;
             RefreshVisualizerState = RefreshVisualizerState.Refreshing;
             RefreshInfoProvider?.OnRefreshStarted();
 

--- a/tests/Avalonia.Controls.UnitTests/PullToRefresh/RefreshVisualizerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/PullToRefresh/RefreshVisualizerTests.cs
@@ -1,0 +1,36 @@
+using Avalonia.Controls.PullToRefresh;
+using Avalonia.Input;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests.PullToRefresh
+{
+    public class RefreshVisualizerTests : ScopedTestBase
+    {
+        [Fact]
+        public void InteractionRatio_Is_One_While_Refreshing_And_Zero_After_Completion()
+        {
+            var provider = new RefreshInfoProvider(
+                PullDirection.TopToBottom,
+                new Size(100, 100),
+                visual: null);
+
+            var visualizer = new RefreshVisualizer();
+            visualizer.RefreshInfoProvider = provider;
+
+            var sawDuringRefresh = false;
+
+            visualizer.RefreshRequested += (s, e) =>
+            {
+                Assert.Equal(1d, provider.InteractionRatio);
+                sawDuringRefresh = true;
+            };
+
+            visualizer.RequestRefresh();
+
+            Assert.True(sawDuringRefresh, "RefreshRequested event should have been raised");
+
+            Assert.Equal(0d, provider.InteractionRatio);
+        }
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes a regression from https://github.com/AvaloniaUI/Avalonia/pull/18617 . Previously, when RefreshContainer is refreshing, the refresh visualizer is set to its full offset and animated. Currently, this visualizer is set to an offset computed from the current interaction ratio of the refresh container. For refreshes started with gestures, the interaction ratio is equal to or close to 1, so the visualizer is visible, but not from refreshes started programmatically, which will have 0 as the value.

This fix sets `InteractionRatio` to 1 when refresh is requested, fully showing the refresh indicator. The value is always set to 0 when refresh ends.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/21912
