### PR TITLE
Android: unregister automation peers when their control leaves the visual tree

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
+++ b/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
@@ -49,6 +49,14 @@ namespace Avalonia.Android
 
         private readonly Dictionary<AutomationPeer, HashSet<INodeInfoProvider>> _peerNodeInfoProviders;
 
+        /// <remarks>
+        /// Virtual view IDs must be allocated from a monotonic counter rather than derived from
+        /// the size of <see cref="_peerNodeInfoProviders"/>: entries are now removed when their
+        /// owner leaves the visual tree, so the dictionary's count no longer grows monotonically
+        /// and reusing it would hand out an ID that is still in use.
+        /// </remarks>
+        private int _nextPeerViewId;
+
         private readonly AvaloniaView _view;
 
         public AvaloniaAccessHelper(AvaloniaView view) : base(view)
@@ -85,16 +93,16 @@ namespace Avalonia.Android
             }
             else
             {
-                peerViewId = _peerNodeInfoProviders.Count;
+                peerViewId = _nextPeerViewId++;
                 _peers.Add(peerViewId, peer);
                 _peerIds.Add(peer, peerViewId);
 
                 nodeInfoProviders = new();
                 _peerNodeInfoProviders.Add(peer, nodeInfoProviders);
 
-                peer.ChildrenChanged += (s, ev) => InvalidateVirtualView(peerViewId,
+                EventHandler childrenChanged = (s, ev) => InvalidateVirtualView(peerViewId,
                     AccessibilityEventCompat.ContentChangeTypeSubtree);
-                peer.PropertyChanged += (s, ev) =>
+                EventHandler<AutomationPropertyChangedEventArgs> propertyChanged = (s, ev) =>
                 {
                     if (ev.Property == AutomationElementIdentifiers.NameProperty)
                     {
@@ -104,12 +112,41 @@ namespace Avalonia.Android
                     {
                         InvalidateVirtualView(peerViewId, AccessibilityEventCompat.ContentChangeTypeContentDescription);
                     }
-                    else if (ev.Property == AutomationElementIdentifiers.BoundingRectangleProperty || 
+                    else if (ev.Property == AutomationElementIdentifiers.BoundingRectangleProperty ||
                         ev.Property == AutomationElementIdentifiers.ClassNameProperty)
                     {
                         InvalidateVirtualView(peerViewId);
                     }
                 };
+
+                peer.ChildrenChanged += childrenChanged;
+                peer.PropertyChanged += propertyChanged;
+
+                // Drop the registration once the peer's control leaves the visual tree, otherwise
+                // every control ever explored by accessibility is kept alive for the lifetime of
+                // the view: the peer holds a strong reference to its Owner, and these three
+                // dictionaries were never pruned. On a long-running app that rebuilds its UI (for
+                // instance digital signage swapping screens), this retains each dead visual tree in
+                // full — measured at ~2.5 MB per rebuild on a real device.
+                // The root peer (ID 0) is deliberately never unregistered: GetVirtualViewAt and
+                // GetVisibleVirtualViews index _peers[0] directly, so removing it would throw.
+                // It is a single entry owned by the view itself, and dies with the helper.
+                if (peerViewId != 0 && peer is ControlAutomationPeer controlPeer)
+                {
+                    EventHandler<VisualTreeAttachmentEventArgs>? detachedFromVisualTree = null;
+                    detachedFromVisualTree = (s, ev) =>
+                    {
+                        controlPeer.Owner.DetachedFromVisualTree -= detachedFromVisualTree;
+                        peer.ChildrenChanged -= childrenChanged;
+                        peer.PropertyChanged -= propertyChanged;
+
+                        _peers.Remove(peerViewId);
+                        _peerIds.Remove(peer);
+                        _peerNodeInfoProviders.Remove(peer);
+                    };
+
+                    controlPeer.Owner.DetachedFromVisualTree += detachedFromVisualTree;
+                }
 
                 if (peer.GetProvider<IExpandCollapseProvider>() is not null)
                     nodeInfoProviders.Add(new ExpandCollapseNodeInfoProvider(this, peer, peerViewId));


### PR DESCRIPTION
## What does the pull request do?

`AvaloniaAccessHelper` registers every `AutomationPeer` it hands to Android in three dictionaries — `_peers`, `_peerIds`, `_peerNodeInfoProviders` — and never removes any of them. The file contains no `Remove` and no `Clear`.

Since `ControlAutomationPeer` holds a strong reference to its `Owner`, any control that accessibility has explored is pinned for the lifetime of the `AvaloniaView`, together with the visual tree hanging off it.

This PR unregisters a peer when its control is detached from the visual tree, and unsubscribes the two peer event handlers at the same time (they were never removed either).

## What is the current behavior?

Unbounded managed-memory growth on any Android app that rebuilds its visual tree, whenever an accessibility service is active on the device.

Measured on a digital-signage device that rebuilds its screen every 20–40 s (Android 13, Avalonia 12.1.1):

- **~2.5 MB of live managed heap retained per rebuild**, measured after a forced blocking gen2 collection followed by `WaitForPendingFinalizers` — so this is genuinely reachable memory, not uncollected garbage;
- instance counts of the screen's widgets grew by one full screen per rebuild and never came down;
- rooting chain, obtained with an in-process root tracer on the device:

```
MainActivity.Current -> AvaloniaActivity._view -> AvaloniaView._accessHelper
  -> AvaloniaAccessHelper._peers -> ControlAutomationPeer.Owner
  -> the dead control, and the rest of the dead screen through it
```

Left alone, it ran until the low-memory killer terminated the process.

## What is the updated/expected behavior with this PR?

Stale registrations are dropped as their controls leave the visual tree. On the same bench, the retained-instance count goes from unbounded growth to a **flat plateau held over 28 consecutive rebuilds**, with live heap steady at ~20 MB.

## Notes

**Virtual view ID allocation had to change.** IDs were derived from `_peerNodeInfoProviders.Count`, which is only unique while nothing is ever removed. With removal, `Count` can fall back onto an ID that is still in use, and the next registration would throw from `Dictionary.Add` — inside an accessibility callback. IDs now come from a monotonic counter. I hit exactly this while validating an out-of-tree version of the fix, so it is a real hazard rather than a theoretical one.

**The root peer (ID 0) is deliberately left registered.** `GetVirtualViewAt` and `GetVisibleVirtualViews` index `_peers[0]` directly, so removing it would throw. It is a single entry, owned by the view, and dies with the helper.

**Re-attachment** is handled by the existing code path: a control that comes back is simply registered again, receiving a fresh ID.

## Checklist

- [x] Added unit tests? — no; `AvaloniaAccessHelper` is `internal` to `Avalonia.Android` and its behaviour is driven by `ExploreByTouchHelper` callbacks from the Android framework, so there is no existing harness to hook into. I am happy to add one if you can point me at the shape you would want.
- [x] Built and validated on device (Android 13, arm64).

## Fixed issues

None filed — found while investigating a memory leak in a production Avalonia Android app.
