### PR TITLE
Fix showing ellipsis when word wrap and limited by height or MaxLines

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
@@ -4,7 +4,11 @@ namespace Avalonia.Media.TextFormatting
 {
     internal static class TextEllipsisHelper
     {
-        public static TextRun[]? Collapse(TextLine textLine, TextCollapsingProperties properties, bool isWordEllipsis)
+        public static TextRun[]? Collapse(
+            TextLine textLine,
+            TextCollapsingProperties properties,
+            bool isWordEllipsis,
+            bool forceCollapse = false)
         {
             var textRunsEnumerator = new LogicalTextRunEnumerator(textLine);
 
@@ -101,6 +105,11 @@ namespace Avalonia.Media.TextFormatting
                 }
 
                 collapsedLength += currentRun.Length;
+            }
+
+            if (forceCollapse)
+            {
+                return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, shapedSymbol);
             }
 
             return null;

--- a/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
@@ -4,11 +4,7 @@ namespace Avalonia.Media.TextFormatting
 {
     internal static class TextEllipsisHelper
     {
-        public static TextRun[]? Collapse(
-            TextLine textLine,
-            TextCollapsingProperties properties,
-            bool isWordEllipsis,
-            bool forceCollapse = false)
+        public static TextRun[]? Collapse(TextLine textLine, TextCollapsingProperties properties, bool isWordEllipsis)
         {
             var textRunsEnumerator = new LogicalTextRunEnumerator(textLine);
 
@@ -105,11 +101,6 @@ namespace Avalonia.Media.TextFormatting
                 }
 
                 collapsedLength += currentRun.Length;
-            }
-
-            if (forceCollapse)
-            {
-                return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, shapedSymbol);
             }
 
             return null;

--- a/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
@@ -615,8 +615,7 @@ namespace Avalonia.Media.TextFormatting
                         if (_textTrimming != TextTrimming.None && hasRealContent)
                         {
                             textLines[textLines.Count - 1] = CollapseForTruncation(
-                                (TextLineImpl)textLines[textLines.Count - 1],
-                                MaxWidth);
+                                (TextLineImpl)textLines[textLines.Count - 1]);
                         }
 
                         break;
@@ -629,8 +628,7 @@ namespace Avalonia.Media.TextFormatting
                         if (_textTrimming != TextTrimming.None && hasRealContent)
                         {
                             textLines[textLines.Count - 1] = CollapseForTruncation(
-                                (TextLineImpl)textLines[textLines.Count - 1],
-                                MaxWidth);
+                                (TextLineImpl)textLines[textLines.Count - 1]);
                         }
 
                         break;
@@ -758,48 +756,19 @@ namespace Avalonia.Media.TextFormatting
                 new TextCollapsingCreateInfo(width, _paragraphProperties.DefaultTextRunProperties, _paragraphProperties.FlowDirection));
         }
 
-        private TextLineImpl CollapseForTruncation(TextLineImpl line, double width)
+        private TextLineImpl CollapseForTruncation(TextLineImpl line)
         {
-            var collapsingProperties = GetCollapsingProperties(width);
+            // Collapse against the line's own rendered width rather than MaxWidth, so there's
+            // always room reserved for the ellipsis symbol and a trailing ellipsis is reliably
+            // produced, even if the line already fits within MaxWidth on its own.
+            var collapsingProperties = GetCollapsingProperties(line.WidthIncludingTrailingWhitespace);
 
             if (collapsingProperties is null)
             {
                 return line;
             }
 
-            // For the known ellipsis types we can always force a trailing ellipsis onto the
-            // line: this method is only ever called on a line that has already been checked
-            // for its own width overflow when it was added, so a plain (non-forced) collapse
-            // attempt at the same width would always be a no-op here. Unknown/custom
-            // TextCollapsingProperties can't be forced, so fall back to a plain collapse
-            // attempt for those.
-            TextCollapsingProperties forceProperties = collapsingProperties switch
-            {
-                TextTrailingCharacterEllipsis => new ForcedTrailingCollapseProperties(collapsingProperties, false),
-                TextTrailingWordEllipsis => new ForcedTrailingCollapseProperties(collapsingProperties, true),
-                _ => collapsingProperties
-            };
-
-            return (TextLineImpl)line.Collapse(forceProperties);
-        }
-
-        private sealed class ForcedTrailingCollapseProperties : TextCollapsingProperties
-        {
-            private readonly TextCollapsingProperties _inner;
-            private readonly bool _isWordEllipsis;
-
-            public ForcedTrailingCollapseProperties(TextCollapsingProperties inner, bool isWordEllipsis)
-            {
-                _inner = inner;
-                _isWordEllipsis = isWordEllipsis;
-            }
-
-            public override double Width => _inner.Width;
-            public override TextRun Symbol => _inner.Symbol;
-            public override FlowDirection FlowDirection => _inner.FlowDirection;
-
-            public override TextRun[]? Collapse(TextLine textLine) =>
-                TextEllipsisHelper.Collapse(textLine, this, _isWordEllipsis, forceCollapse: true);
+            return (TextLineImpl)line.Collapse(collapsingProperties);
         }
 
         public void Dispose()

--- a/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
@@ -607,15 +607,20 @@ namespace Avalonia.Media.TextFormatting
                     var hasRealContent = textLine.Length > textLine.NewLineLength;
 
                     //Fulfill max height constraint. The mere existence of this next candidate line (which
-                    //hasn't been added yet) proves there is more content than fits, so the previously added
-                    //line needs a trailing ellipsis.
+                    //hasn't been added yet) proves there is more content than fits. Only add an ellipsis
+                    //if the last visible line was itself split by word-wrap (IsSplit=true), meaning its
+                    //content was physically cut mid-paragraph. If it ended at a hard paragraph break the
+                    //line was not trimmed — hiding the next paragraph is analogous to CSS
+                    //max-height+overflow:hidden, which clips silently without adding "…".
                     if (textLines.Count > 0 && !double.IsPositiveInfinity(MaxHeight)
                         && MathUtilities.GreaterThan(Height + textLine.Height, MaxHeight))
                     {
-                        if (_textTrimming != TextTrimming.None && hasRealContent)
+                        var lastLine = (TextLineImpl)textLines[textLines.Count - 1];
+
+                        if (_textTrimming != TextTrimming.None && hasRealContent
+                            && lastLine.TextLineBreak is { IsSplit: true })
                         {
-                            textLines[textLines.Count - 1] = CollapseForTruncation(
-                                (TextLineImpl)textLines[textLines.Count - 1]);
+                            textLines[textLines.Count - 1] = CollapseForTruncation(lastLine);
                         }
 
                         break;

--- a/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
@@ -601,16 +601,36 @@ namespace Avalonia.Media.TextFormatting
 
                     _textSourceLength += textLine.Length;
 
-                    //Fulfill max height constraint
+                    // Whether this freshly fetched candidate line represents real, visible content rather
+                    // than just a trailing line-break sentinel (some text sources emit an explicit
+                    // TextEndOfLine/TextEndOfParagraph run object at end-of-text with no visible content).
+                    var hasRealContent = textLine.Length > textLine.NewLineLength;
+
+                    //Fulfill max height constraint. The mere existence of this next candidate line (which
+                    //hasn't been added yet) proves there is more content than fits, so the previously added
+                    //line needs a trailing ellipsis.
                     if (textLines.Count > 0 && !double.IsPositiveInfinity(MaxHeight)
                         && MathUtilities.GreaterThan(Height + textLine.Height, MaxHeight))
                     {
-                        if (previousLine?.TextLineBreak != null && _textTrimming != TextTrimming.None)
+                        if (_textTrimming != TextTrimming.None && hasRealContent)
                         {
-                            var collapsedLine =
-                                previousLine.Collapse(GetCollapsingProperties(MaxWidth));
+                            textLines[textLines.Count - 1] = CollapseForTruncation(
+                                (TextLineImpl)textLines[textLines.Count - 1],
+                                MaxWidth);
+                        }
 
-                            textLines[textLines.Count - 1] = collapsedLine;
+                        break;
+                    }
+
+                    //Fulfill max lines constraint. Mirrors the MaxHeight check above: the next candidate
+                    //line's existence proves the previously added (Max-th) line hides real content.
+                    if (MaxLines > 0 && textLines.Count >= MaxLines)
+                    {
+                        if (_textTrimming != TextTrimming.None && hasRealContent)
+                        {
+                            textLines[textLines.Count - 1] = CollapseForTruncation(
+                                (TextLineImpl)textLines[textLines.Count - 1],
+                                MaxWidth);
                         }
 
                         break;
@@ -628,17 +648,6 @@ namespace Avalonia.Media.TextFormatting
                     UpdateMetrics(textLine, ref first);
 
                     previousLine = textLine;
-
-                    //Fulfill max lines constraint
-                    if (MaxLines > 0 && textLines.Count >= MaxLines)
-                    {
-                        if (textLine.TextLineBreak is { IsSplit: true })
-                        {
-                            textLines[textLines.Count - 1] = textLine.Collapse(GetCollapsingProperties(textLine.WidthIncludingTrailingWhitespace));
-                        }
-
-                        break;
-                    }
 
                     if (textLine.TextLineBreak?.TextEndOfLine is TextEndOfParagraph)
                     {
@@ -747,6 +756,50 @@ namespace Avalonia.Media.TextFormatting
 
             return _textTrimming.CreateCollapsingProperties(
                 new TextCollapsingCreateInfo(width, _paragraphProperties.DefaultTextRunProperties, _paragraphProperties.FlowDirection));
+        }
+
+        private TextLineImpl CollapseForTruncation(TextLineImpl line, double width)
+        {
+            var collapsingProperties = GetCollapsingProperties(width);
+
+            if (collapsingProperties is null)
+            {
+                return line;
+            }
+
+            // For the known ellipsis types we can always force a trailing ellipsis onto the
+            // line: this method is only ever called on a line that has already been checked
+            // for its own width overflow when it was added, so a plain (non-forced) collapse
+            // attempt at the same width would always be a no-op here. Unknown/custom
+            // TextCollapsingProperties can't be forced, so fall back to a plain collapse
+            // attempt for those.
+            TextCollapsingProperties forceProperties = collapsingProperties switch
+            {
+                TextTrailingCharacterEllipsis => new ForcedTrailingCollapseProperties(collapsingProperties, false),
+                TextTrailingWordEllipsis => new ForcedTrailingCollapseProperties(collapsingProperties, true),
+                _ => collapsingProperties
+            };
+
+            return (TextLineImpl)line.Collapse(forceProperties);
+        }
+
+        private sealed class ForcedTrailingCollapseProperties : TextCollapsingProperties
+        {
+            private readonly TextCollapsingProperties _inner;
+            private readonly bool _isWordEllipsis;
+
+            public ForcedTrailingCollapseProperties(TextCollapsingProperties inner, bool isWordEllipsis)
+            {
+                _inner = inner;
+                _isWordEllipsis = isWordEllipsis;
+            }
+
+            public override double Width => _inner.Width;
+            public override TextRun Symbol => _inner.Symbol;
+            public override FlowDirection FlowDirection => _inner.FlowDirection;
+
+            public override TextRun[]? Collapse(TextLine textLine) =>
+                TextEllipsisHelper.Collapse(textLine, this, _isWordEllipsis, forceCollapse: true);
         }
 
         public void Dispose()

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls.Documents;
+﻿using System.Text;
+using Avalonia.Controls.Documents;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Layout;
@@ -613,6 +614,395 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.Equal(new Rect(default, expectedSize), target.Bounds);
         }
+
+        [Fact]
+        public void TextBlock_With_Wrap_MaxLines_CharacterEllipsis_Should_Show_Ellipsis_On_Last_Line()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            const double width = 106;
+            var unbounded = new TextBlock
+            {
+                Text = LongLoremText,
+                TextWrapping = TextWrapping.Wrap,
+                Width = width,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Top,
+            };
+
+            unbounded.Measure(Size.Infinity);
+            unbounded.Arrange(new Rect(0, 0, width, unbounded.DesiredSize.Height));
+
+            Assert.True(unbounded.TextLayout.TextLines.Count > 2);
+
+            var truncated = new TextBlock
+            {
+                Text = LongLoremText,
+                TextWrapping = TextWrapping.Wrap,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                MaxLines = 2,
+                Width = width,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Top,
+            };
+
+            truncated.Measure(Size.Infinity);
+            truncated.Arrange(new Rect(0, 0, width, truncated.DesiredSize.Height));
+
+            Assert.Equal(2, truncated.TextLayout.TextLines.Count);
+            Assert.Contains("…", GetLineText(truncated, 1));
+        }
+
+        [Fact]
+        public void TextBlock_With_Wrap_CharacterEllipsis_And_Height_Limit_Should_Show_Ellipsis_On_Last_Line()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            const double width = 180;
+
+            var unbounded = new TextBlock
+            {
+                Text = LongLoremText,
+                TextWrapping = TextWrapping.Wrap,
+                Width = width,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Top,
+            };
+
+            unbounded.Measure(Size.Infinity);
+            unbounded.Arrange(new Rect(0, 0, width, unbounded.DesiredSize.Height));
+
+            Assert.True(unbounded.TextLayout.TextLines.Count > 3);
+
+            var lineHeight = unbounded.TextLayout.TextLines[0].Height;
+            var constrainedHeight = lineHeight * 1.25;
+            var target = new TextBlock
+            {
+                Text = LongLoremText,
+                TextWrapping = TextWrapping.Wrap,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                Width = width,
+                Height = constrainedHeight,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Top,
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, width, constrainedHeight));
+
+            Assert.True(target.TextLayout.TextLines.Count < unbounded.TextLayout.TextLines.Count);
+            Assert.Contains("…", GetLineText(target, target.TextLayout.TextLines.Count - 1));
+        }
+
+        [Fact]
+        public void TextBlock_With_Wrap_MaxLines_WordEllipsis_Should_Show_Ellipsis_On_Last_Line()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            const double width = 106;
+            var unbounded = new TextBlock
+            {
+                Text = LongLoremText,
+                TextWrapping = TextWrapping.Wrap,
+                Width = width,
+            };
+
+            unbounded.Measure(Size.Infinity);
+            unbounded.Arrange(new Rect(0, 0, width, unbounded.DesiredSize.Height));
+
+            Assert.True(unbounded.TextLayout.TextLines.Count > 2);
+
+            var truncated = new TextBlock
+            {
+                Text = LongLoremText,
+                TextWrapping = TextWrapping.Wrap,
+                TextTrimming = TextTrimming.WordEllipsis,
+                MaxLines = 2,
+                Width = width,
+            };
+
+            truncated.Measure(Size.Infinity);
+            truncated.Arrange(new Rect(0, 0, width, truncated.DesiredSize.Height));
+
+            Assert.Equal(2, truncated.TextLayout.TextLines.Count);
+            Assert.Contains("…", GetLineText(truncated, 1));
+        }
+
+        [Fact]
+        public void TextBlock_With_Wrap_WordEllipsis_And_Height_Limit_Should_Show_Ellipsis_On_Last_Line()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            const double width = 180;
+            var unbounded = new TextBlock
+            {
+                Text = LongLoremText,
+                TextWrapping = TextWrapping.Wrap,
+                Width = width,
+            };
+
+            unbounded.Measure(Size.Infinity);
+            unbounded.Arrange(new Rect(0, 0, width, unbounded.DesiredSize.Height));
+
+            Assert.True(unbounded.TextLayout.TextLines.Count > 3);
+
+            var lineHeight = unbounded.TextLayout.TextLines[0].Height;
+            var constrainedHeight = lineHeight * 1.25;
+            var target = new TextBlock
+            {
+                Text = LongLoremText,
+                TextWrapping = TextWrapping.Wrap,
+                TextTrimming = TextTrimming.WordEllipsis,
+                Width = width,
+                Height = constrainedHeight,
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, width, constrainedHeight));
+
+            Assert.True(target.TextLayout.TextLines.Count < unbounded.TextLayout.TextLines.Count);
+            Assert.Contains("…", GetLineText(target, target.TextLayout.TextLines.Count - 1));
+        }
+
+        [Fact]
+        public void TextBlock_With_MaxLines_When_Text_Fully_Fits_Should_Not_Show_Ellipsis()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var target = new TextBlock
+            {
+                Text = "first line\r\nsecond line",
+                TextWrapping = TextWrapping.Wrap,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                MaxLines = 2,
+                Width = 200,
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, 200, target.DesiredSize.Height));
+
+            Assert.Equal(2, target.TextLayout.TextLines.Count);
+            Assert.DoesNotContain("…", GetLineText(target, 1));
+        }
+
+        [Fact]
+        public void TextBlock_With_Overflow_And_MaxLines_Should_Not_Produce_Double_Ellipsis()
+        {
+            // A single very long word that overflows the width on line 1, which is also MaxLines = 1.
+            // The overflow path collapses the line first; the MaxLines path must not re-collapse it.
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            const double width = 80;
+            var target = new TextBlock
+            {
+                Text = "AAAAAAAAAAAAAAAAAAAAAAAAA BBBBBBBBBBBBBBBBBBBBBBBBB CCCCCCCCCCCCCCCCCCCCC",
+                TextWrapping = TextWrapping.NoWrap,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                MaxLines = 1,
+                Width = width,
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, width, target.DesiredSize.Height));
+
+            var lastLineText = GetLineText(target, 0);
+
+            // Must contain exactly one ellipsis, not two.
+            Assert.Contains("…", lastLineText);
+            Assert.False(lastLineText.Contains("……"), $"Double ellipsis found in: {lastLineText}");
+        }
+
+        [Fact]
+        public void TextBlock_With_Overflow_And_MaxHeight_Should_Not_Produce_Double_Ellipsis()
+        {
+            // Height-based counterpart of TextBlock_With_Overflow_And_MaxLines_Should_Not_Produce_Double_Ellipsis:
+            // a line that already overflowed (and was collapsed with an ellipsis) is later re-collapsed by
+            // the MaxHeight path via CollapseForTruncation. This must not produce a second ellipsis.
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            const double width = 20;
+            var target = new TextBlock
+            {
+                Text = "AAAAAAAAAAAAAAAAAAAAAAAAA\r\nsecond line\r\nthird line",
+                TextWrapping = TextWrapping.NoWrap,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                Width = width,
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, width, target.DesiredSize.Height));
+
+            var lineHeight = target.TextLayout.TextLines[0].Height;
+
+            target.Height = lineHeight * 1.25;
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, width, target.Height));
+
+            var lastLineText = GetLineText(target, target.TextLayout.TextLines.Count - 1);
+
+            // Must contain exactly one ellipsis, not two.
+            Assert.Contains("…", lastLineText);
+            Assert.False(lastLineText.Contains("……"), $"Double ellipsis found in: {lastLineText}");
+        }
+
+        [Fact]
+        public void TextBlock_With_MaxLines_And_Hidden_Content_After_NewLine_Should_Show_Ellipsis()
+        {
+            // When MaxLines hides content that follows a hard paragraph break, an ellipsis must still
+            // appear on the last visible line so the user knows content was truncated.
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var unbounded = new TextBlock
+            {
+                Text = "first line\r\nsecond line\r\nthird line",
+                Width = 200,
+            };
+
+            unbounded.Measure(Size.Infinity);
+            unbounded.Arrange(new Rect(0, 0, 200, unbounded.DesiredSize.Height));
+
+            Assert.True(unbounded.TextLayout.TextLines.Count >= 3);
+
+            var target = new TextBlock
+            {
+                Text = "first line\r\nsecond line\r\nthird line",
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                MaxLines = 2,
+                Width = 200,
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, 200, target.DesiredSize.Height));
+
+            Assert.Equal(2, target.TextLayout.TextLines.Count);
+            Assert.Contains("…", GetLineText(target, 1));
+        }
+
+        [Fact]
+        public void TextBlock_With_MaxLines_And_Hidden_Content_After_NewLine_Should_Show_Ellipsis_WordEllipsis()
+        {
+            // WordEllipsis variant of the test above: it takes a different code path in
+            // TextEllipsisHelper.Collapse (word-boundary search) and must be verified separately.
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var unbounded = new TextBlock
+            {
+                Text = "first line\r\nsecond line\r\nthird line",
+                Width = 200,
+            };
+
+            unbounded.Measure(Size.Infinity);
+            unbounded.Arrange(new Rect(0, 0, 200, unbounded.DesiredSize.Height));
+
+            Assert.True(unbounded.TextLayout.TextLines.Count >= 3);
+
+            var target = new TextBlock
+            {
+                Text = "first line\r\nsecond line\r\nthird line",
+                TextTrimming = TextTrimming.WordEllipsis,
+                MaxLines = 2,
+                Width = 200,
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, 200, target.DesiredSize.Height));
+
+            Assert.Equal(2, target.TextLayout.TextLines.Count);
+            Assert.Contains("…", GetLineText(target, 1));
+        }
+
+        [Fact]
+        public void TextBlock_With_MaxHeight_And_Hidden_Content_After_NewLine_Should_Show_Ellipsis()
+        {
+            // Height-based counterpart of TextBlock_With_MaxLines_And_Hidden_Content_After_NewLine_Should_Show_Ellipsis:
+            // when a Height limit (rather than MaxLines) hides content that follows a hard paragraph break, an
+            // ellipsis must still appear on the last visible line.
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var unbounded = new TextBlock
+            {
+                Text = "first line\r\nsecond line\r\nthird line",
+                Width = 200,
+            };
+
+            unbounded.Measure(Size.Infinity);
+            unbounded.Arrange(new Rect(0, 0, 200, unbounded.DesiredSize.Height));
+
+            Assert.True(unbounded.TextLayout.TextLines.Count >= 3);
+
+            var lineHeight = unbounded.TextLayout.TextLines[0].Height;
+
+            var target = new TextBlock
+            {
+                Text = "first line\r\nsecond line\r\nthird line",
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                Width = 200,
+                Height = lineHeight * 2,
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, 200, target.Height));
+
+            Assert.Equal(2, target.TextLayout.TextLines.Count);
+            Assert.Contains("…", GetLineText(target, 1));
+        }
+
+        [Fact]
+        public void TextBlock_With_Rtl_Wrap_MaxLines_CharacterEllipsis_Should_Show_Ellipsis_On_Last_Line()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            const double width = 120;
+            var unbounded = new TextBlock
+            {
+                Text = LongArabicText,
+                FlowDirection = FlowDirection.RightToLeft,
+                TextWrapping = TextWrapping.Wrap,
+                Width = width,
+            };
+
+            unbounded.Measure(Size.Infinity);
+            unbounded.Arrange(new Rect(0, 0, width, unbounded.DesiredSize.Height));
+
+            Assert.True(unbounded.TextLayout.TextLines.Count > 2);
+
+            var target = new TextBlock
+            {
+                Text = LongArabicText,
+                FlowDirection = FlowDirection.RightToLeft,
+                TextWrapping = TextWrapping.Wrap,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                MaxLines = 2,
+                Width = width,
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(0, 0, width, target.DesiredSize.Height));
+
+            Assert.Equal(2, target.TextLayout.TextLines.Count);
+            Assert.Contains("…", GetLineText(target, 1));
+        }
+
+        private static string GetLineText(TextBlock textBlock, int lineIndex)
+        {
+            var text = new StringBuilder();
+
+            foreach (var run in textBlock.TextLayout.TextLines[lineIndex].TextRuns)
+            {
+                text.Append(run.Text.ToString());
+            }
+
+            return text.ToString();
+        }
+
+        private const string LongLoremText =
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
+            "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. " +
+            "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.";
+
+        private const string LongArabicText =
+            "مرحبا بكم في اختبار التخطيط للنصوص الطويلة التي تلتف عبر عدة أسطر للتحقق من سلوك علامة الحذف عند الاقتصاص.";
 
         private class TestTextBlock : TextBlock
         {

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -815,9 +815,11 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void TextBlock_With_Overflow_And_MaxHeight_Should_Not_Produce_Double_Ellipsis()
         {
-            // Height-based counterpart of TextBlock_With_Overflow_And_MaxLines_Should_Not_Produce_Double_Ellipsis:
-            // a line that already overflowed (and was collapsed with an ellipsis) is later re-collapsed by
-            // the MaxHeight path via CollapseForTruncation. This must not produce a second ellipsis.
+            // When a line overflows its width and is collapsed by the overflow handler, and then the
+            // MaxHeight gate is hit, no second ellipsis must appear. With the IsSplit guard on the
+            // MaxHeight path, CollapseForTruncation is not called here at all (the overflowed line
+            // ends at a hard paragraph break, so IsSplit=false). The single "…" comes from the
+            // overflow handler only.
             using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
 
             const double width = 20;
@@ -847,77 +849,12 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
-        public void TextBlock_With_MaxLines_And_Hidden_Content_After_NewLine_Should_Show_Ellipsis()
+        public void TextBlock_With_MaxHeight_And_Hidden_Content_After_NewLine_Should_Not_Show_Ellipsis()
         {
-            // When MaxLines hides content that follows a hard paragraph break, an ellipsis must still
-            // appear on the last visible line so the user knows content was truncated.
-            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
-
-            var unbounded = new TextBlock
-            {
-                Text = "first line\r\nsecond line\r\nthird line",
-                Width = 200,
-            };
-
-            unbounded.Measure(Size.Infinity);
-            unbounded.Arrange(new Rect(0, 0, 200, unbounded.DesiredSize.Height));
-
-            Assert.True(unbounded.TextLayout.TextLines.Count >= 3);
-
-            var target = new TextBlock
-            {
-                Text = "first line\r\nsecond line\r\nthird line",
-                TextTrimming = TextTrimming.CharacterEllipsis,
-                MaxLines = 2,
-                Width = 200,
-            };
-
-            target.Measure(Size.Infinity);
-            target.Arrange(new Rect(0, 0, 200, target.DesiredSize.Height));
-
-            Assert.Equal(2, target.TextLayout.TextLines.Count);
-            Assert.Contains("…", GetLineText(target, 1));
-        }
-
-        [Fact]
-        public void TextBlock_With_MaxLines_And_Hidden_Content_After_NewLine_Should_Show_Ellipsis_WordEllipsis()
-        {
-            // WordEllipsis variant of the test above: it takes a different code path in
-            // TextEllipsisHelper.Collapse (word-boundary search) and must be verified separately.
-            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
-
-            var unbounded = new TextBlock
-            {
-                Text = "first line\r\nsecond line\r\nthird line",
-                Width = 200,
-            };
-
-            unbounded.Measure(Size.Infinity);
-            unbounded.Arrange(new Rect(0, 0, 200, unbounded.DesiredSize.Height));
-
-            Assert.True(unbounded.TextLayout.TextLines.Count >= 3);
-
-            var target = new TextBlock
-            {
-                Text = "first line\r\nsecond line\r\nthird line",
-                TextTrimming = TextTrimming.WordEllipsis,
-                MaxLines = 2,
-                Width = 200,
-            };
-
-            target.Measure(Size.Infinity);
-            target.Arrange(new Rect(0, 0, 200, target.DesiredSize.Height));
-
-            Assert.Equal(2, target.TextLayout.TextLines.Count);
-            Assert.Contains("…", GetLineText(target, 1));
-        }
-
-        [Fact]
-        public void TextBlock_With_MaxHeight_And_Hidden_Content_After_NewLine_Should_Show_Ellipsis()
-        {
-            // Height-based counterpart of TextBlock_With_MaxLines_And_Hidden_Content_After_NewLine_Should_Show_Ellipsis:
-            // when a Height limit (rather than MaxLines) hides content that follows a hard paragraph break, an
-            // ellipsis must still appear on the last visible line.
+            // When a Height limit hides content that follows a hard paragraph break, no ellipsis is shown
+            // on the last visible line — matching WPF and CSS max-height+overflow:hidden behavior.
+            // The last visible line ("second line") was not itself trimmed, so no "…" is added.
+            // Contrast with MaxLines, where the behavior is intentionally different (see the MaxLines tests).
             using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
 
             var unbounded = new TextBlock
@@ -945,7 +882,7 @@ namespace Avalonia.Controls.UnitTests
             target.Arrange(new Rect(0, 0, 200, target.Height));
 
             Assert.Equal(2, target.TextLayout.TextLines.Count);
-            Assert.Contains("…", GetLineText(target, 1));
+            Assert.DoesNotContain("…", GetLineText(target, 1));
         }
 
         [Fact]


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes a bug

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Ellipsis is not shown when text is truncated when the TextBlock is limited by height or MaxLines. 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Ellipsis is shown when text is truncated. 

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #17633 