### PR TITLE
Expose application name through native menu bar automation

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/NativeMenuBarAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/NativeMenuBarAutomationPeer.cs
@@ -8,5 +8,11 @@ namespace Avalonia.Automation.Peers
         {
             return AutomationControlType.MenuBar;
         }
+
+        protected override string? GetNameCore()
+        {
+            var name = base.GetNameCore();
+            return string.IsNullOrWhiteSpace(name) ? Application.Current?.Name : name;
+        }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/Automation/NativeMenuBarAutomationPeerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Automation/NativeMenuBarAutomationPeerTests.cs
@@ -28,6 +28,17 @@ public class NativeMenuBarAutomationPeerTests
 
             Assert.Equal(AutomationControlType.MenuBar, peer.GetAutomationControlType());
         }
+
+        [Fact]
+        public void Name_Falls_Back_To_Application_Name()
+        {
+            using var app = UnitTestApplication.Start();
+            UnitTestApplication.Current.Name = "Test Application";
+            var control = new NativeMenuBar { Template = CreateTemplate() };
+            var peer = (NativeMenuBarAutomationPeer)ControlAutomationPeer.CreatePeerForElement(control);
+
+            Assert.Equal("Test Application", peer.GetName());
+        }
     }
 
     private static FuncControlTemplate CreateTemplate()


### PR DESCRIPTION
## What does the pull request do?

Uses `Application.Name` as the accessible name for `NativeMenuBar` when no explicit automation name is set.

## What is the current behavior?

`NativeMenuBar` has no accessible name by default.

## What is the updated/expected behavior with this PR?

Accessibility clients receive the application name. Explicit automation names continue to take precedence.

## Checklist

- [x] Added unit tests
- [ ] Added XML documentation to any related classes
- [ ] Consider submitting a documentation PR
