### PR TITLE
Fix - Invalidate image measure when DrawingImage source invalidates

### DIFF
--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -40,7 +40,7 @@ namespace Avalonia.Controls
                 StretchDirection.Both);
 
         private Rect _currentDrawingBounds;
-        private bool _subcribedToDrawingImageSource;
+        private bool _subscribedToDrawingImageSource;
 
         static Image()
         {
@@ -159,15 +159,15 @@ namespace Avalonia.Controls
             if(change.Property == SourceProperty)
             {
                 _currentDrawingBounds = default;
-                if(change.OldValue is DrawingImage oldDrawingImage && _subcribedToDrawingImageSource)
+                if(change.OldValue is DrawingImage oldDrawingImage && _subscribedToDrawingImageSource)
                 {
-                    _subcribedToDrawingImageSource = false;
+                    _subscribedToDrawingImageSource = false;
                     oldDrawingImage.Invalidated -= OnSourceInvalidated;
                 }
 
                 if(change.NewValue is DrawingImage newDrawingImage && IsAttachedToVisualTree)
                 {
-                    _subcribedToDrawingImageSource = true;
+                    _subscribedToDrawingImageSource = true;
                     newDrawingImage.Invalidated += OnSourceInvalidated;
                 }
             }
@@ -177,9 +177,9 @@ namespace Avalonia.Controls
         {
             base.OnAttachedToVisualTree(e);
 
-            if(!_subcribedToDrawingImageSource && Source is DrawingImage drawingImage)
+            if(!_subscribedToDrawingImageSource && Source is DrawingImage drawingImage)
             {
-                _subcribedToDrawingImageSource = true;
+                _subscribedToDrawingImageSource = true;
                 drawingImage.Invalidated += OnSourceInvalidated;
             }
         }
@@ -188,9 +188,9 @@ namespace Avalonia.Controls
         {
             base.OnDetachedFromVisualTree(e);
 
-            if (_subcribedToDrawingImageSource && Source is DrawingImage drawingImage)
+            if (_subscribedToDrawingImageSource && Source is DrawingImage drawingImage)
             {
-                _subcribedToDrawingImageSource = false;
+                _subscribedToDrawingImageSource = false;
                 drawingImage.Invalidated -= OnSourceInvalidated;
             }
         }

--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -40,6 +40,7 @@ namespace Avalonia.Controls
                 StretchDirection.Both);
 
         private Rect _currentDrawingBounds;
+        private bool _subcribedToDrawingImageSource;
 
         static Image()
         {
@@ -158,15 +159,39 @@ namespace Avalonia.Controls
             if(change.Property == SourceProperty)
             {
                 _currentDrawingBounds = default;
-                if(change.OldValue is IAffectsRender oldAffectsRender)
+                if(change.OldValue is DrawingImage oldDrawingImage && _subcribedToDrawingImageSource)
                 {
-                    oldAffectsRender.Invalidated -= OnSourceInvalidated;
+                    _subcribedToDrawingImageSource = false;
+                    oldDrawingImage.Invalidated -= OnSourceInvalidated;
                 }
 
-                if(change.NewValue is IAffectsRender newAffectsRender)
+                if(change.NewValue is DrawingImage newDrawingImage && IsAttachedToVisualTree)
                 {
-                    newAffectsRender.Invalidated += OnSourceInvalidated;
+                    _subcribedToDrawingImageSource = true;
+                    newDrawingImage.Invalidated += OnSourceInvalidated;
                 }
+            }
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+
+            if(!_subcribedToDrawingImageSource && Source is DrawingImage drawingImage)
+            {
+                _subcribedToDrawingImageSource = true;
+                drawingImage.Invalidated += OnSourceInvalidated;
+            }
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+
+            if (_subcribedToDrawingImageSource && Source is DrawingImage drawingImage)
+            {
+                _subcribedToDrawingImageSource = false;
+                drawingImage.Invalidated -= OnSourceInvalidated;
             }
         }
 

--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Automation;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Automation.Peers;
@@ -146,6 +147,29 @@ namespace Avalonia.Controls
             {
                 return new Size();
             }
+        }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if(change.Property == SourceProperty)
+            {
+                if(change.OldValue is IAffectsRender oldAffectsRender)
+                {
+                    oldAffectsRender.Invalidated -= OnSourceInvalidated;
+                }
+
+                if(change.NewValue is IAffectsRender newAffectsRender)
+                {
+                    newAffectsRender.Invalidated += OnSourceInvalidated;
+                }
+            }
+        }
+
+        private void OnSourceInvalidated(object? sender, EventArgs e)
+        {
+            InvalidateMeasure();
         }
 
         protected override AutomationPeer OnCreateAutomationPeer()

--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -197,7 +197,7 @@ namespace Avalonia.Controls
 
         private void OnSourceInvalidated(object? sender, EventArgs e)
         {
-             if(Source is DrawingImage drawingImage && drawingImage.Drawing is { } drawing)
+             if(IsAttachedToVisualTree && Source is DrawingImage drawingImage && drawingImage.Drawing is { } drawing)
             {
                 var bounds = drawing.GetBounds();
                 if(bounds != _currentDrawingBounds)

--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -7,7 +7,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Metadata;
 
 namespace Avalonia.Controls
-{   
+{
     /// <summary>
     /// Displays a <see cref="Bitmap"/> image.
     /// </summary>
@@ -18,7 +18,7 @@ namespace Avalonia.Controls
         /// </summary>
         public static readonly StyledProperty<IImage?> SourceProperty =
             AvaloniaProperty.Register<Image, IImage?>(nameof(Source));
-        
+
         /// <summary>
         /// Defines the <see cref="BlendMode"/> property.
         /// </summary>
@@ -88,7 +88,7 @@ namespace Avalonia.Controls
 
         /// <inheritdoc />
         protected override bool BypassFlowDirectionPolicies => true;
-        
+
         /// <summary>
         /// Renders the control.
         /// </summary>
@@ -156,16 +156,16 @@ namespace Avalonia.Controls
         {
             base.OnPropertyChanged(change);
 
-            if(change.Property == SourceProperty)
+            if (change.Property == SourceProperty)
             {
                 _currentDrawingBounds = default;
-                if(change.OldValue is DrawingImage oldDrawingImage && _subscribedToDrawingImageSource)
+                if (change.OldValue is DrawingImage oldDrawingImage && _subscribedToDrawingImageSource)
                 {
                     _subscribedToDrawingImageSource = false;
                     oldDrawingImage.Invalidated -= OnSourceInvalidated;
                 }
 
-                if(change.NewValue is DrawingImage newDrawingImage && IsAttachedToVisualTree)
+                if (change.NewValue is DrawingImage newDrawingImage && IsAttachedToVisualTree)
                 {
                     _subscribedToDrawingImageSource = true;
                     newDrawingImage.Invalidated += OnSourceInvalidated;
@@ -177,7 +177,7 @@ namespace Avalonia.Controls
         {
             base.OnAttachedToVisualTree(e);
 
-            if(!_subscribedToDrawingImageSource && Source is DrawingImage drawingImage)
+            if (!_subscribedToDrawingImageSource && Source is DrawingImage drawingImage)
             {
                 _subscribedToDrawingImageSource = true;
                 drawingImage.Invalidated += OnSourceInvalidated;
@@ -197,10 +197,10 @@ namespace Avalonia.Controls
 
         private void OnSourceInvalidated(object? sender, EventArgs e)
         {
-             if(IsAttachedToVisualTree && Source is DrawingImage drawingImage && drawingImage.Drawing is { } drawing)
+            if (IsAttachedToVisualTree && Source is DrawingImage drawingImage && drawingImage.Drawing is { } drawing)
             {
                 var bounds = drawing.GetBounds();
-                if(bounds != _currentDrawingBounds)
+                if (bounds != _currentDrawingBounds)
                 {
                     InvalidateMeasure();
                 }

--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -38,6 +38,7 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<Image, StretchDirection>(
                 nameof(StretchDirection),
                 StretchDirection.Both);
+        private Rect _currentDrawingBounds;
 
         static Image()
         {
@@ -155,6 +156,7 @@ namespace Avalonia.Controls
 
             if(change.Property == SourceProperty)
             {
+                _currentDrawingBounds = default;
                 if(change.OldValue is IAffectsRender oldAffectsRender)
                 {
                     oldAffectsRender.Invalidated -= OnSourceInvalidated;
@@ -169,7 +171,15 @@ namespace Avalonia.Controls
 
         private void OnSourceInvalidated(object? sender, EventArgs e)
         {
-            InvalidateMeasure();
+             if(Source is DrawingImage drawingImage && drawingImage.Drawing is { } drawing)
+            {
+                var bounds = drawing.GetBounds();
+                if(bounds != _currentDrawingBounds)
+                {
+                    InvalidateMeasure();
+                }
+                _currentDrawingBounds = bounds;
+            }
         }
 
         protected override AutomationPeer OnCreateAutomationPeer()

--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -38,6 +38,7 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<Image, StretchDirection>(
                 nameof(StretchDirection),
                 StretchDirection.Both);
+
         private Rect _currentDrawingBounds;
 
         static Image()

--- a/tests/Avalonia.Controls.UnitTests/ImageTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ImageTests.cs
@@ -1,7 +1,8 @@
-using Moq;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
+using Avalonia.Threading;
 using Avalonia.UnitTests;
+using Moq;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
@@ -163,6 +164,35 @@ namespace Avalonia.Controls.UnitTests
             target.Arrange(new Rect(0, 0, 25, 100));
 
             Assert.Equal(new Size(25, 100), target.Bounds.Size);
+        }
+
+        [Fact]
+        public void DrawingImage_Source_Invalidates_Measure()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+            GeometryDrawing drawing = new GeometryDrawing();
+            drawing.Geometry = new RectangleGeometry(new Rect(0, 0, 500, 500));
+            DrawingImage image = new DrawingImage(drawing);
+            var target = new Image
+            {
+                Stretch = Stretch.None,
+                HorizontalAlignment = Layout.HorizontalAlignment.Center,
+                VerticalAlignment = Layout.VerticalAlignment.Center,
+                Source = image
+            };
+
+            var root = new TestRoot(target);
+            root.ExecuteInitialLayoutPass();
+
+            Assert.Equal(new Size(500, 500), target.DesiredSize);
+
+            Dispatcher.UIThread.Invoke(() =>
+            {
+                drawing.Geometry = new RectangleGeometry(new Rect(0, 0, 600, 600));
+                Dispatcher.UIThread.RunJobs();
+                root.LayoutManager.ExecuteLayoutPass();
+                Assert.Equal(new Size(600, 600), target.DesiredSize);
+            });
         }
 
         private static IBitmap CreateBitmap(int width, int height)

--- a/tests/Avalonia.Controls.UnitTests/ImageTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ImageTests.cs
@@ -186,13 +186,12 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.Equal(new Size(500, 500), target.DesiredSize);
 
-            Dispatcher.UIThread.Invoke(() =>
-            {
-                drawing.Geometry = new RectangleGeometry(new Rect(0, 0, 600, 600));
-                Dispatcher.UIThread.RunJobs();
-                root.LayoutManager.ExecuteLayoutPass();
-                Assert.Equal(new Size(600, 600), target.DesiredSize);
-            });
+            drawing.Geometry = new RectangleGeometry(new Rect(0, 0, 600, 600));
+
+            Dispatcher.UIThread.RunJobs(null, TestContext.Current.CancellationToken);
+            root.LayoutManager.ExecuteLayoutPass();
+
+            Assert.Equal(new Size(600, 600), target.DesiredSize);
         }
 
         private static IBitmap CreateBitmap(int width, int height)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR invalidates an image when an `IAffectsRender` source invalidates.


## What is the current behavior?
`DrawingImage` sources can change bounds when their geometry changes. Image assumes a fixed size for their sources, so when a drawing image invalidates, the image renders the new geometry with the old bounds.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/21869