### PR TITLE
In Avalonia with Vulkan backend prevented throwing an VK_ERROR_OUT_OF_DATE_KHR exception when resizing

### DIFF
--- a/src/Avalonia.Vulkan/Interop/VulkanDisplay.cs
+++ b/src/Avalonia.Vulkan/Interop/VulkanDisplay.cs
@@ -119,7 +119,10 @@ internal class VulkanDisplay : IDisposable
             preTransform = supportsIdentityTransform && isRotated
                 ? VkSurfaceTransformFlagsKHR.VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR
                 : capabilities.currentTransform,
-            compositeAlpha = VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+            compositeAlpha = capabilities.supportedCompositeAlpha.HasAllFlags(
+                VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR)
+                ? VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR
+                : VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
             presentMode = presentMode,
             clipped = 1,
             oldSwapchain = oldDisplay?._swapchain ?? default

--- a/src/Avalonia.Vulkan/Interop/VulkanDisplay.cs
+++ b/src/Avalonia.Vulkan/Interop/VulkanDisplay.cs
@@ -119,10 +119,7 @@ internal class VulkanDisplay : IDisposable
             preTransform = supportsIdentityTransform && isRotated
                 ? VkSurfaceTransformFlagsKHR.VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR
                 : capabilities.currentTransform,
-            compositeAlpha = capabilities.supportedCompositeAlpha.HasAllFlags(
-                VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR)
-                ? VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR
-                : VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+            compositeAlpha = VkCompositeAlphaFlagsKHR.VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
             presentMode = presentMode,
             clipped = 1,
             oldSwapchain = oldDisplay?._swapchain ?? default
@@ -332,9 +329,24 @@ internal class VulkanDisplay : IDisposable
             pResults = &result
         };
         
-        _context.DeviceApi.vkQueuePresentKHR(_context.MainQueueHandle, ref presentInfo)
-            .ThrowOnError("vkQueuePresentKHR");
-        result.ThrowOnError("vkQueuePresentKHR");
+        var presentResult = _context.DeviceApi.vkQueuePresentKHR(_context.MainQueueHandle, ref presentInfo);
+        
+        // We need to check both presentResult and result because some drivers may report different results,
+        // for example, presentResult can be VK_SUCCESS but result can be VK_ERROR_OUT_OF_DATE_KHR.
+        if ((presentResult is VkResult.VK_ERROR_OUT_OF_DATE_KHR or VkResult.VK_SUBOPTIMAL_KHR) ||
+            (result is VkResult.VK_ERROR_OUT_OF_DATE_KHR or VkResult.VK_SUBOPTIMAL_KHR))
+        {
+            RecreateSwapchain();
+        }
+        else if (presentResult == VkResult.VK_ERROR_SURFACE_LOST_KHR || result == VkResult.VK_ERROR_SURFACE_LOST_KHR)
+        {
+            RecreateSurface();
+        }
+        else
+        {
+            result.ThrowOnError("vkQueuePresentKHR");
+            presentResult.ThrowOnError("vkQueuePresentKHR");
+        }        
     }
     
     public void Dispose()


### PR DESCRIPTION
When the Avalonia app with Vulkan backend is resized, a VK_ERROR_OUT_OF_DATE_KHR exception may be thrown after the call to `vkQueuePresentKHR` (in `VulkanDisplay.cs`).

This may happen when the user is resizing the window and the surface size is changed after calling AcquireNextImageKHR and before calling vkQueuePresentKHR.

The exception is handled in the try...catch block in `ServerCompositor.RenderCore` method and as far as I know it does not cause any harm to the app. Anyway, the exception prevents calling `VisualReadbackUpdatePass` and `ExecuteServerJobs(_receivedPostTargetJobQueue)` in the `RenderCore`. But I do not know how important that is.

## What does the pull request do?
The pull request handles the `VK_ERROR_OUT_OF_DATE_KHR`, `VK_SUBOPTIMAL_KHR` and `VK_ERROR_SURFACE_LOST_KHR` results that are expected when calling `vkQueuePresentKHR`. This is handled in the same way as after calling `AcquireNextImageKHR` (in `StartPresentation` method).