### PR TITLE
Fix iOS issue with creating files under app container Documents directory

### DIFF
--- a/src/iOS/Avalonia.iOS/Storage/IOSStorageItem.cs
+++ b/src/iOS/Avalonia.iOS/Storage/IOSStorageItem.cs
@@ -271,10 +271,7 @@ internal sealed class IOSStorageFolder : IOSStorageItem, IStorageBookmarkFolder
     {
         try
         {
-            if (!SecurityScopedAncestorUrl.StartAccessingSecurityScopedResource())
-            {
-                return Task.FromResult<IStorageFile?>(null);
-            }
+            SecurityScopedAncestorUrl.StartAccessingSecurityScopedResource();
 
             var path = System.IO.Path.Combine(FilePath, name);
             NSFileAttributes? attributes = null;


### PR DESCRIPTION
## What does the pull request do?
Fixes #19569. This is fixed by removing the short circuit return in the `CreateFileAsync` method when `SecurityScopedAncestorUrl.StartAccessingSecurityScopedResource()` returns false.

As per [apple's documentation](https://developer.apple.com/documentation/foundation/nsurl/startaccessingsecurityscopedresource()) and verified by local testing, when this method returns false it does not mean that the app doesn't have access to this directory, but rather that the boolean is a flag for when we should subsequently call `SecurityScopedAncestorUrl.StopAccessingSecurityScopedResource();`

So that short circuit was preventing files being saved against valid directory paths

## What is the current behavior?
The current behaviour is that this condition prematurely short-circuits and returns without creating the file if the directory is an app container subdirectory (Like with the `WellKnownFolder.Documents` example in the issue).

## What is the updated/expected behavior with this PR?
Files should able to be created under the Documents app container directory. As per the reproduction code snippet mentioned in that issue's author, you can add this snippet

```
var documents = await GetStorageProvider().TryGetWellKnownFolderAsync(WellKnownFolder.Documents);
var test = await documents.CreateFileAsync("test.txt");
```

to the [DialogsPage Save File button handler](https://github.com/AvaloniaUI/Avalonia/blob/37f3e607a6bc970354b70e3b7dfa817e2bd8cf88/samples/ControlCatalog/Pages/DialogsPage.xaml.cs#L213) and see that without this change the text file fails to save to that Documents directory (even though the app has access to this scope)

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
this if condition `if (NSFileManager.DefaultManager.CreateFile(path, new NSData(), attributes))` further down the `CreateFileAsync` should preserve the "return null on no file access" behaviour

## Obsoletions / Deprecations
No deprecations, but it'd be good to have iOS app integration tests with Appium so fixes like this can have accompanying platform tests

## Fixed issues
Fixes #19569
