### PR TITLE
Use built-in float.Lerp/double.Lerp in transitions

### DIFF
--- a/samples/ControlCatalog/Pages/TabbedPage/FluidNavBar/FluidNavBar.cs
+++ b/samples/ControlCatalog/Pages/TabbedPage/FluidNavBar/FluidNavBar.cs
@@ -604,7 +604,7 @@ namespace ControlCatalog.Pages
                 while (measure.NextContour());
             }
 
-            private static float Lerp(float a, float b, float t) => a + (b - a) * t;
+            private static float Lerp(float a, float b, float t) => float.Lerp(a, b, t);
 
             private static double LinearPoint(double x, double pIn, double pOut)
             {

--- a/samples/ControlCatalog/Pages/Transitions/CardStackPageTransition.cs
+++ b/samples/ControlCatalog/Pages/Transitions/CardStackPageTransition.cs
@@ -424,10 +424,8 @@ public class CardStackPageTransition : PageSlide
         return sign * FarPeekAngle;
     }
 
-    private static double Lerp(double from, double to, double t)
-    {
-        return from + ((to - from) * Math.Clamp(t, 0.0, 1.0));
-    }
+    private static double Lerp(double from, double to, double t) =>
+        double.Lerp(from, to, Math.Clamp(t, 0.0, 1.0));
 
     private static int GetViewportZIndex(double offsetFromCenter, Visual visual, Visual? from, Visual? to)
     {

--- a/src/Avalonia.Base/Animation/CrossFade.cs
+++ b/src/Avalonia.Base/Animation/CrossFade.cs
@@ -260,9 +260,7 @@ namespace Avalonia.Animation
             return FarPeekOpacity;
         }
 
-        private static double Lerp(double from, double to, double t)
-        {
-            return from + ((to - from) * Math.Clamp(t, 0.0, 1.0));
-        }
+        private static double Lerp(double from, double to, double t) =>
+            double.Lerp(from, to, Math.Clamp(t, 0.0, 1.0));
     }
 }

--- a/src/Avalonia.Base/Animation/Transitions/Rotate3DTransition.cs
+++ b/src/Avalonia.Base/Animation/Transitions/Rotate3DTransition.cs
@@ -244,10 +244,8 @@ public class Rotate3DTransition : PageSlide
         return 1;
     }
 
-    private static double Lerp(double from, double to, double t)
-    {
-        return from + ((to - from) * Math.Clamp(t, 0.0, 1.0));
-    }
+    private static double Lerp(double from, double to, double t) =>
+        double.Lerp(from, to, Math.Clamp(t, 0.0, 1.0));
 
     /// <inheritdoc/>
     public override void Reset(Visual visual)

--- a/src/Avalonia.Base/Rendering/Composition/Animations/Interpolators.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Animations/Interpolators.cs
@@ -77,7 +77,7 @@ namespace Avalonia.Rendering.Composition.Animations
     
     class ColorInterpolator : IInterpolator<Avalonia.Media.Color>
     {
-        static byte Lerp(float a, float b, float p) => (byte) Math.Max(0, Math.Min(255, (p * (b - a) + a)));
+        static byte Lerp(float a, float b, float p) => (byte)Math.Clamp(float.Lerp(a, b, p), 0, 255);
 
         public static Avalonia.Media.Color
             LerpRGB(Avalonia.Media.Color to, Avalonia.Media.Color from, float progress) =>

--- a/src/Avalonia.Base/Rendering/Composition/Expressions/BuiltInExpressionFfi.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Expressions/BuiltInExpressionFfi.cs
@@ -13,8 +13,8 @@ namespace Avalonia.Rendering.Composition.Expressions
     {
         private readonly DelegateExpressionFfi _registry;
 
-        static float Lerp(float a, float b, float p) => p * (b - a) + a;
-        static double Lerp(double a, double b, double p) => p * (b - a) + a;
+        static float Lerp(float a, float b, float p) => float.Lerp(a, b, p);
+        static double Lerp(double a, double b, double p) => double.Lerp(a, b, p);
 
         static Matrix3x2 Inverse(Matrix3x2 m)
         {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Replace hand-written linear interpolation formulas with the .NET 8+ framework Lerp helpers across animation code and the composition expression FFI.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The behavior remains almost unchanged, but the floating-point precision may change slightly because the built-in helper function uses the formula form `value1 * (1 - amount) + value2 * amount` (https://github.com/dotnet/runtime/issues/80044) instead of `value1 + (value2 - value1) * amount`.

<details>

<summary>Wikipedia</summary>

[Linear_interpolation](https://en.wikipedia.org/wiki/Linear_interpolation):

```
// Imprecise method, which does not guarantee v = v1 when t = 1, due to floating-point arithmetic error.
// This method is monotonic. This form may be used when the hardware has a native fused multiply-add instruction.
float lerp(float v0, float v1, float t) {
  return v0 + t * (v1 - v0);
}

// Precise method, which guarantees v = v1 when t = 1. This method is monotonic only when v0 * v1 < 0.
// Lerping between same values might not produce the same value
float lerp(float v0, float v1, float t) {
  return (1 - t) * v0 + t * v1;
}
```
</details>

.NET 9+: https://github.com/dotnet/runtime/issues/98053
The built-in helper function uses `MultiplyAddEstimate(value1, 1.0 - amount, value2 * amount)` (https://github.com/dotnet/runtime/pull/103837).
The `MultiplyAddEstimate` is hardware-accelerated as fused multiply-add operation (`FusedMultiplyAdd(x, y, z)`) on CPUs with FMA instructions; elsewhere .NET falls back to a software estimate (`(x * y) + z`) whose result may differ by a few ulps, so animation values can vary slightly between platforms (with Native AOT the instruction set is fixed at compile time via [`IlcInstructionSet`](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md), e.g., `<IlcInstructionSet>x86-64-v3</IlcInstructionSet>`).

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Since .NET 8, the framework has provided Lerp methods for double/float (Avalonia has adjusted the minimum supported framework version to .NET 8). Therefore, this PR directly replaces hand-written formulas with calling the framework methods:
[`public static double Lerp(double value1, double value2, double amount);`](https://learn.microsoft.com/en-us/dotnet/api/system.double.lerp)
[`public static float Lerp(float value1, float value2, float amount);`](https://learn.microsoft.com/en-us/dotnet/api/system.single.lerp)

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
