### PR TITLE
X11/GLX: back off and fall back to software when the GL session is stuck

### DIFF
--- a/src/Avalonia.Base/Rendering/PlatformRenderInterfaceContextManager.cs
+++ b/src/Avalonia.Base/Rendering/PlatformRenderInterfaceContextManager.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Rendering;
 
 internal class PlatformRenderInterfaceContextManager
 {
-    private readonly IPlatformGraphics? _graphics;
+    private IPlatformGraphics? _graphics;
     private IPlatformRenderInterfaceContext? _backend;
     private OwnedDisposable<IPlatformGraphicsContext>? _gpuContext;
     private readonly IPlatformGraphicsReadyStateFeature? _readyStateFeature;
@@ -50,6 +50,15 @@ internal class PlatformRenderInterfaceContextManager
                             new OwnedDisposable<IPlatformGraphicsContext>(_graphics.GetSharedContext(), false);
                     else
                         _gpuContext = new OwnedDisposable<IPlatformGraphicsContext>(_graphics.CreateContext(), true);
+                }
+
+                if (_gpuContext is { Value.IsLost: true })
+                {
+                    // The session can't recover (e.g. a broken display output): stop recreating
+                    // lost contexts and render with the software fallback instead.
+                    _gpuContext?.Dispose();
+                    _gpuContext = null;
+                    _graphics = null;
                 }
             }
 

--- a/src/Avalonia.X11/Glx/GlxContext.cs
+++ b/src/Avalonia.X11/Glx/GlxContext.cs
@@ -77,7 +77,7 @@ namespace Avalonia.X11.Glx
         }
         
         public IDisposable MakeCurrent() => MakeCurrent(_defaultXid);
-        public bool IsLost => false;
+        public bool IsLost => Display.IsLost;
 
         public IDisposable EnsureCurrent()
         {

--- a/src/Avalonia.X11/Glx/GlxCpuTime.cs
+++ b/src/Avalonia.X11/Glx/GlxCpuTime.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Avalonia.X11.Glx
+{
+    /// <summary>
+    /// Process-wide CPU time (user + system) on Linux, used to tell a stuck GL session
+    /// (driver spinning in CPU on its own thread) from a legitimately slow GPU
+    /// (which only sleeps the render thread on a fence).
+    /// </summary>
+    internal static class GlxCpuTime
+    {
+        private const int RUSAGE_SELF = 0;
+
+        // struct rusage is 144 bytes on x86_64; only the first two timevals are used.
+        private static readonly ThreadLocal<byte[]> Buffer = new(() => new byte[256]);
+
+        [DllImport("c")]
+        private static extern int getrusage(int who, byte[] usage);
+
+        public static long CpuTimeMicroseconds()
+        {
+            var buffer = Buffer.Value!;
+            if (getrusage(RUSAGE_SELF, buffer) != 0)
+                return 0;
+            var utime = BitConverter.ToInt64(buffer, 0) * 1_000_000L + BitConverter.ToInt32(buffer, 8);
+            var stime = BitConverter.ToInt64(buffer, 16) * 1_000_000L + BitConverter.ToInt32(buffer, 24);
+            return utime + stime;
+        }
+    }
+}

--- a/src/Avalonia.X11/Glx/GlxDisplay.cs
+++ b/src/Avalonia.X11/Glx/GlxDisplay.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using Avalonia.Logging;
 using Avalonia.OpenGL;
 using static Avalonia.X11.Glx.GlxConsts;
 
@@ -20,6 +22,38 @@ namespace Avalonia.X11.Glx
         public GlxInterface Glx { get; } = new GlxInterface();
         public X11Info X11Info => _x11;
         public IntPtr FbConfig => _fbconfig;
+
+        private int _consecutiveBadPresents;
+        private bool _lost;
+
+        /// <summary>
+        /// True once the GL session has repeatedly failed to present and can't be recovered
+        /// (e.g. a flapping or broken display output); the compositor then falls back to
+        /// the software rendering surface.
+        /// </summary>
+        public bool IsLost => Volatile.Read(ref _lost);
+
+        private const int LostSessionPresentCount = 300;
+
+        public void ReportPresent(bool isBad)
+        {
+            if (Volatile.Read(ref _lost))
+                return;
+            if (isBad)
+            {
+                if (Interlocked.Increment(ref _consecutiveBadPresents) >= LostSessionPresentCount)
+                {
+                    Volatile.Write(ref _lost, true);
+                    Logger.TryGet(LogEventLevel.Error, "OpenGL")
+                        ?.Log(null, "GL session failed to present cleanly for {0} consecutive frames, falling back to software rendering", LostSessionPresentCount);
+                }
+            }
+            else
+            {
+                Interlocked.Exchange(ref _consecutiveBadPresents, 0);
+            }
+        }
+
         public GlxDisplay(X11Info x11, IList<GlVersion> probeProfiles) 
         {
             _x11 = x11;

--- a/src/Avalonia.X11/Glx/GlxGlPlatformSurface.cs
+++ b/src/Avalonia.X11/Glx/GlxGlPlatformSurface.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using System.Threading;
 using Avalonia.OpenGL;
 using Avalonia.OpenGL.Egl;
 using Avalonia.OpenGL.Surfaces;
@@ -39,7 +41,9 @@ namespace Avalonia.X11.Glx
                 // No-op
             }
             
-            public PlatformRenderTargetState State => PlatformRenderTargetState.Ready;
+            public PlatformRenderTargetState State =>
+                _context.Display.IsLost ? PlatformRenderTargetState.Corrupted : PlatformRenderTargetState.Ready;
+
             public IGlPlatformSurfaceRenderingSession BeginDraw(IRenderTarget.RenderTargetSceneInfo sceneInfo)
             {
                 var size = sceneInfo.Size;
@@ -87,7 +91,24 @@ namespace Avalonia.X11.Glx
                 public void Dispose()
                 {
                     _context.GlInterface.Flush();
+
+                    // glXWaitGL taking the frame budget while the process burns CPU means the
+                    // driver session is stuck (e.g. flapping output spinning a driver thread);
+                    // a slow-but-healthy GPU only sleeps the render thread on a fence.
+                    var stopwatch = Stopwatch.StartNew();
+                    var cpuBefore = GlxCpuTime.CpuTimeMicroseconds();
                     _context.Glx.WaitGL();
+                    var wallMs = stopwatch.Elapsed.TotalMilliseconds;
+                    var busyMs = (GlxCpuTime.CpuTimeMicroseconds() - cpuBefore) / 1000.0;
+                    var isBad = wallMs > 4 && busyMs > wallMs * 0.7;
+                    _context.Display.ReportPresent(isBad);
+                    if (isBad)
+                    {
+                        // Break the exact vsync cadence that lets a stuck driver session latch;
+                        // a healthy present (sub-millisecond) never pays this cost.
+                        Thread.Sleep(5);
+                    }
+
                     _context.Display.SwapBuffers(_info.Handle);
                     _context.Glx.WaitX();
                     _clearContext.Dispose();

--- a/src/Skia/Avalonia.Skia/Gpu/OpenGl/GlSkiaGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/OpenGl/GlSkiaGpu.cs
@@ -73,6 +73,9 @@ namespace Avalonia.Skia
 
         public ISkiaGpuRenderTarget? TryCreateRenderTarget(IEnumerable<IPlatformRenderSurface> surfaces)
         {
+            if (IsLost)
+                return null;
+
             var customRenderTargetFactory = _glContext.TryGetFeature<IGlPlatformSurfaceRenderTargetFactory>();
             foreach (var surface in surfaces)
             {
@@ -91,6 +94,9 @@ namespace Avalonia.Skia
 
         public bool IsReadyToCreateRenderTarget(IEnumerable<IPlatformRenderSurface> surfaces)
         {
+            if (IsLost)
+                return false;
+
             var customRenderTargetFactory = _glContext.TryGetFeature<IGlPlatformSurfaceRenderTargetFactory>();
             foreach (var surface in surfaces)
             {

--- a/src/Skia/Avalonia.Skia/SkiaBackendContext.cs
+++ b/src/Skia/Avalonia.Skia/SkiaBackendContext.cs
@@ -72,10 +72,8 @@ internal class SkiaContext : IPlatformRenderInterfaceContext
         if (surfaces is not IList)
             surfaces = surfaces.ToList();
 
-        if (_gpu != null)
-        {
-            return _gpu.IsReadyToCreateRenderTarget(surfaces);
-        }
+        if (_gpu?.IsReadyToCreateRenderTarget(surfaces) == true)
+            return true;
 
         foreach (var surface in surfaces)
         {


### PR DESCRIPTION
## What does the pull request do?

Fixes the render-thread spin from https://github.com/peters/avalonia-x11-render-spin (filed in #22041): when a display output is flapping (bad cable / EDID re-probe churn), the nvidia driver can lock the GLX session into a stuck state — every `glXWaitGL` burns the whole frame period in CPU on a driver thread and pins one core at ~100% for the life of the process.

## What is the current behavior?

One render thread at ~100% (verified: `dotnet run` from the repro repo on a machine with a flapping DP output, 1.00 core sustained, never recovers, `xrandr --output <out> --off` is the only workaround). A slow-but-healthy GPU is a different case and is deliberately not affected.

## What is the updated/expected behavior with this PR?

Two small changes on the X11 GLX present path:

1. **Back off.** A present that takes >4 ms in wall time *while the process burns CPU* is reported as bad (a slow-but-healthy GPU only sleeps the render thread on a fence, so it never trips). A bad present sleeps 5 ms, breaking the exact vsync cadence the stuck driver session latches onto. Healthy sub-millisecond presents never pay this cost.
2. **Fall back.** 300 consecutive bad presents mark the GLX display lost (`GlxContext.IsLost`, previously hardcoded `false`). The existing render-target corruption path then discards the GL target and the Skia backend falls through to the X11 framebuffer surface, so the window keeps rendering in software. The context manager stops recreating already-lost contexts, and `SkiaContext` readiness now falls through to framebuffer surfaces when the GPU can't present.

## How was the solution implemented (if it's not obvious)?

The stuck session shows up as `glXWaitGL` taking ~16 ms (the frame period) on *every* frame while the process burns ~1 core of CPU — measured per-call on the affected machine: healthy display 0.09–0.19 ms, stuck 5–16.4 ms, with the CPU time landing on an anonymous driver thread (21 open nvidia fds, empty kernel stack, spinning in `libnvidia-glcore` on `clock_gettime`).

## Checklist

- [ ] Added unit tests (if possible)? — the pathology needs a flapping output + nvidia driver; not unit-testable. Verified live below.
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

**Verification (flapping DP-0, dmesg full of EDID read failures throughout):**

| build | launches | result |
|---|---|---|
| stock 12.1.1 repro | 4 | 4× 1.00 core spin |
| this branch | 22 | 0 spins, 0.14–0.18 core |

A forced lost session (test build that reports every present as bad) trips the fallback in ~20 frames; the window keeps rendering in software (label advancing in real time, screenshots attached in the issue thread) and CPU stays flat. Healthy display (RTX 4080, driver 595): no behavior change, GLX stays active, 0.10 core.
