### PR TITLE
[Text] Snap a right-to-left buffer split to the cluster boundary

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/ShapedBuffer.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/ShapedBuffer.cs
@@ -731,20 +731,27 @@ namespace Avalonia.Media.TextFormatting
                 splitGlyphIndex = ~foundIndex;
             }
 
-            // Visual leading = glyphs [0, splitGlyphIndex) → logically text[textLength..]  (our "second")
-            // Visual trailing = glyphs [splitGlyphIndex, end) → logically text[0..textLength] (our "first")
+            // Visual leading = glyphs [0, splitGlyphIndex) → logically the trailing text (our "second")
+            // Visual trailing = glyphs [splitGlyphIndex, end) → logically the leading text (our "first")
             var secondGlyphs = _glyphInfos.Slice(sliceStart, splitGlyphIndex);
             var firstGlyphs = _glyphInfos.Slice(sliceStart + splitGlyphIndex, glyphInfosLength - splitGlyphIndex);
 
-            var firstText = Text.Slice(0, textLength);
-            var secondText = Text.Slice(textLength);
+            // The glyph boundary sits past the requested offset when it falls inside a cluster,
+            // because the whole cluster stays with "first". The text boundary has to follow it so
+            // each half's text matches its glyphs - the ascending path snaps the same way.
+            var splitCharCount = splitGlyphIndex > 0
+                ? Math.Min(glyphInfos[splitGlyphIndex - 1].GlyphCluster - baseCluster, Text.Length)
+                : Text.Length;
+
+            var firstText = Text.Slice(0, splitCharCount);
+            var secondText = Text.Slice(splitCharCount);
 
             // share the parent's cluster cache. The cache stores
             // clusters in logical order, so "first" (text[0..textLength]) gets the
             // leading slice and "second" gets the trailing slice — same indexing
             // as the LTR case.
             EnsureClusterCache();
-            var firstClusterCount = FindClusterOffsetForSplit(textLength);
+            var firstClusterCount = FindClusterOffsetForSplit(splitCharCount);
 
             var first = new ShapedBuffer(
                 firstText, firstGlyphs,

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextShaperTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextShaperTests.cs
@@ -72,6 +72,56 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
         }
 
         [Fact]
+        public void Should_Not_Split_RightToLeft_Cluster()
+        {
+            // Arabic letters carry their harakat in the same cluster, so the first cluster of this
+            // text spans two characters. Splitting inside it keeps the cluster's glyphs together in
+            // the leading half - the text boundary has to follow them, or the two halves disagree
+            // about which characters their glyphs cover.
+            const string text = "أَبْجَدِيَّة";
+
+            using (Start())
+            {
+                var codepoint = Codepoint.ReadAt(text, 0, out _);
+
+                Assert.True(FontManager.Current.TryMatchCharacter(codepoint, FontStyle.Normal, FontWeight.Normal,
+                    FontStretch.Normal, null, null, out var typeface));
+
+                var options = new TextShaperOptions(typeface.GlyphTypeface, 12, 1, CultureInfo.InvariantCulture);
+                var buffer = TextShaper.Current.ShapeText(text.AsMemory(), options);
+
+                // Precondition: the first cluster covers the first two characters.
+                Assert.False(buffer.IsLeftToRight);
+                Assert.Equal(0, buffer[buffer.Length - 1].GlyphCluster);
+                Assert.Equal(0, buffer[buffer.Length - 2].GlyphCluster);
+                Assert.Equal(2, buffer[buffer.Length - 3].GlyphCluster);
+
+                var splitResult = buffer.Split(1);
+
+                var first = splitResult.First;
+                var second = splitResult.Second;
+
+                Assert.NotNull(first);
+                Assert.NotNull(second);
+
+                // The split snaps forward past the cluster, exactly like the left-to-right path.
+                Assert.Equal(2, first!.Text.Length);
+                Assert.Equal(2, first.Length);
+
+                // No character and no glyph is lost or duplicated.
+                Assert.Equal(text.Length, first.Text.Length + second!.Text.Length);
+                Assert.Equal(buffer.Length, first.Length + second.Length);
+
+                // Every glyph of the trailing half belongs to the characters the trailing half owns.
+                for (var i = 0; i < second.Length; i++)
+                {
+                    Assert.True(second[i].GlyphCluster >= first.Text.Length,
+                        $"Glyph {i} has cluster {second[i].GlyphCluster}, which the leading half owns.");
+                }
+            }
+        }
+
+        [Fact]
         public void Should_Split_RightToLeft()
         {
             var text = "أَبْجَدِيَّة عَرَبِيَّة";


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Fixes `ShapedBuffer.Split` producing two halves whose character and glyph coverage disagree when the split point falls inside a cluster of a right-to-left buffer. Downstream, this crashes the bidi reorderer with a `NullReferenceException`.

Second layer of a stack; based on #22065.

## What is the current behavior?

A cluster straddling the split point keeps all of its glyphs in the leading half. This prevents breaking a cluster, which is correct; but the text is still cut at the requested offset. The leading half then claims fewer characters than its glyphs cover, and the trailing half claims characters whose glyphs it does not have. The left-to-right path (`SplitAscending`) already snaps the text boundary to the cluster; the right-to-left path did not.

```csharp
// "أَبْجَدِيَّة": each Arabic letter carries its harakat in the same cluster,
// so the first cluster spans two characters.
var split = buffer.Split(1);
// split.First.Text.Length == 1, but split.First holds 2 glyphs
```

Both halves share the parent's cluster cache, which now describes neither of them, so everything built on it misleads in turn: `FindTrailingCharCountWithinWidth` returns a count that cuts a cluster, and splitting the half at that count returns a leading half holding every glyph and **no trailing half at all**. That null run reaches `BidiReorderer.BidiReorder` and throws.

## What is the updated/expected behavior with this PR?

The text boundary follows the glyphs, so the halves stay consistent: no character and no glyph is lost or duplicated, and every glyph of the trailing half belongs to a character the trailing half owns. `Should_Not_Split_RightToLeft_Cluster` asserts exactly that. The `Collapse` crash disappears.

As with the left-to-right path, `Split(n)` may return a leading half slightly longer than `n` when `n` lands inside a cluster - that is the only way to keep a cluster whole.

## How was the solution implemented (if it's not obvious)?


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes? (no new API; the existing `SplitDescending` remarks describe the boundary and were updated in place)
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

`ShapedBuffer.Split(n)` on a right-to-left buffer can now return a leading half longer than `n` when `n` falls inside a cluster, where it previously returned exactly `n` characters with a glyph set that did not match them. This mirrors the existing left-to-right behaviour. No other public API changes.

## Obsoletions / Deprecations

None.

## Fixed issues

No tracked issues; found while fixing #14011.
