### PR TITLE
Support nullable stream binding operator (?^)

### DIFF
--- a/src/Avalonia.Base/Data/CompiledBindingPath.cs
+++ b/src/Avalonia.Base/Data/CompiledBindingPath.cs
@@ -71,7 +71,7 @@ namespace Avalonia.Data
                         isRooted = true;
                         break;
                     case IStronglyTypedStreamElement stream:
-                        node = new StreamNode(stream.CreatePlugin());
+                        node = new StreamNode(stream.CreatePlugin(), stream.AcceptsNull);
                         break;
                     case ITypeCastElement typeCast:
                         node = new FuncTransformNode(typeCast.Cast);
@@ -152,7 +152,13 @@ namespace Avalonia.Data
 
         public CompiledBindingPathBuilder StreamTask<T>()
         {
-            _elements.Add(new TaskStreamPathElement<T>());
+            _elements.Add(new TaskStreamPathElement<T>(acceptsNull: false));
+            return this;
+        }
+
+        public CompiledBindingPathBuilder StreamTask<T>(bool acceptsNull)
+        {
+            _elements.Add(new TaskStreamPathElement<T>(acceptsNull));
             return this;
         }
 
@@ -163,9 +169,22 @@ namespace Avalonia.Data
             return this;
         }
 
+        [RequiresUnreferencedCode(TrimmingMessages.StreamPluginRequiresUnreferencedCodeMessage)]
+        public CompiledBindingPathBuilder StreamTask(bool acceptsNull)
+        {
+            _elements.Add(new TaskStreamPathElement(acceptsNull));
+            return this;
+        }
+
         public CompiledBindingPathBuilder StreamObservable<T>()
         {
-            _elements.Add(new ObservableStreamPathElement<T>());
+            _elements.Add(new ObservableStreamPathElement<T>(acceptsNull: false));
+            return this;
+        }
+
+        public CompiledBindingPathBuilder StreamObservable<T>(bool acceptsNull)
+        {
+            _elements.Add(new ObservableStreamPathElement<T>(acceptsNull));
             return this;
         }
 
@@ -173,6 +192,13 @@ namespace Avalonia.Data
         public CompiledBindingPathBuilder StreamObservable()
         {
             _elements.Add(new ObservableStreamPathElement());
+            return this;
+        }
+
+        [RequiresUnreferencedCode(TrimmingMessages.StreamPluginRequiresUnreferencedCodeMessage)]
+        public CompiledBindingPathBuilder StreamObservable(bool acceptsNull)
+        {
+            _elements.Add(new ObservableStreamPathElement(acceptsNull));
             return this;
         }
 
@@ -303,6 +329,8 @@ namespace Avalonia.Data
 
     internal interface IStronglyTypedStreamElement : ICompiledBindingPathElement
     {
+        bool AcceptsNull { get; }
+
         IStreamPlugin CreatePlugin();
     }
 
@@ -315,7 +343,14 @@ namespace Avalonia.Data
 
     internal class TaskStreamPathElement<T> : IStronglyTypedStreamElement
     {
-        public static readonly TaskStreamPathElement<T> Instance = new TaskStreamPathElement<T>();
+        public static readonly TaskStreamPathElement<T> Instance = new TaskStreamPathElement<T>(acceptsNull: false);
+
+        public TaskStreamPathElement(bool acceptsNull)
+        {
+            AcceptsNull = acceptsNull;
+        }
+
+        public bool AcceptsNull { get; }
 
         public IStreamPlugin CreatePlugin() => new TaskStreamPlugin<T>();
     }
@@ -323,14 +358,32 @@ namespace Avalonia.Data
     [RequiresUnreferencedCode(TrimmingMessages.StreamPluginRequiresUnreferencedCodeMessage)]
     internal class TaskStreamPathElement : IStronglyTypedStreamElement
     {
-        public static readonly TaskStreamPathElement Instance = new TaskStreamPathElement();
+        public static readonly TaskStreamPathElement Instance = new TaskStreamPathElement(acceptsNull: false);
+
+        public TaskStreamPathElement() : this(acceptsNull: false)
+        {
+        }
+
+        public TaskStreamPathElement(bool acceptsNull)
+        {
+            AcceptsNull = acceptsNull;
+        }
+
+        public bool AcceptsNull { get; }
 
         public IStreamPlugin CreatePlugin() => new TaskStreamPlugin();
     }
 
     internal class ObservableStreamPathElement<T> : IStronglyTypedStreamElement
     {
-        public static readonly ObservableStreamPathElement<T> Instance = new ObservableStreamPathElement<T>();
+        public static readonly ObservableStreamPathElement<T> Instance = new ObservableStreamPathElement<T>(acceptsNull: false);
+
+        public ObservableStreamPathElement(bool acceptsNull)
+        {
+            AcceptsNull = acceptsNull;
+        }
+
+        public bool AcceptsNull { get; }
 
         public IStreamPlugin CreatePlugin() => new ObservableStreamPlugin<T>();
     }
@@ -338,7 +391,18 @@ namespace Avalonia.Data
     [RequiresUnreferencedCode(TrimmingMessages.StreamPluginRequiresUnreferencedCodeMessage)]
     internal class ObservableStreamPathElement : IStronglyTypedStreamElement
     {
-        public static readonly ObservableStreamPathElement Instance = new ObservableStreamPathElement();
+        public static readonly ObservableStreamPathElement Instance = new ObservableStreamPathElement(acceptsNull: false);
+
+        public ObservableStreamPathElement() : this(acceptsNull: false)
+        {
+        }
+
+        public ObservableStreamPathElement(bool acceptsNull)
+        {
+            AcceptsNull = acceptsNull;
+        }
+
+        public bool AcceptsNull { get; }
 
         public IStreamPlugin CreatePlugin() => new ObservableStreamPlugin();
     }

--- a/src/Avalonia.Base/Data/Core/ExpressionNodes/Reflection/DynamicPluginStreamNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNodes/Reflection/DynamicPluginStreamNode.cs
@@ -10,7 +10,13 @@ namespace Avalonia.Data.Core.ExpressionNodes.Reflection;
 [RequiresDynamicCode(TrimmingMessages.ExpressionNodeRequiresDynamicCodeMessage)]
 internal sealed class DynamicPluginStreamNode : ExpressionNode
 {
+    private readonly bool _acceptsNull;
     private IDisposable? _subscription;
+
+    public DynamicPluginStreamNode(bool acceptsNull)
+    {
+        _acceptsNull = acceptsNull;
+    }
 
     override public void BuildString(StringBuilder builder)
     {
@@ -19,8 +25,14 @@ internal sealed class DynamicPluginStreamNode : ExpressionNode
 
     protected override void OnSourceChanged(object? source, Exception? dataValidationError)
     {
-        if (!ValidateNonNullSource(source))
+        if (source is null)
+        {
+            if (_acceptsNull)
+                SetValue(null);
+            else
+                ValidateNonNullSource(source);
             return;
+        }
 
         var reference = new WeakReference<object?>(source);
 

--- a/src/Avalonia.Base/Data/Core/ExpressionNodes/StreamNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNodes/StreamNode.cs
@@ -6,12 +6,14 @@ namespace Avalonia.Data.Core.ExpressionNodes;
 
 internal sealed class StreamNode : ExpressionNode, IObserver<object?>
 {
+    private readonly bool _acceptsNull;
     private IStreamPlugin _plugin;
     private IDisposable? _subscription;
 
-    public StreamNode(IStreamPlugin plugin)
+    public StreamNode(IStreamPlugin plugin, bool acceptsNull)
     {
         _plugin = plugin;
+        _acceptsNull = acceptsNull;
     }
 
     public override void BuildString(StringBuilder builder)
@@ -25,8 +27,14 @@ internal sealed class StreamNode : ExpressionNode, IObserver<object?>
 
     protected override void OnSourceChanged(object? source, Exception? dataValidationError)
     {
-        if (!ValidateNonNullSource(source))
+        if (source is null)
+        {
+            if (_acceptsNull)
+                SetValue(null);
+            else
+                ValidateNonNullSource(source);
             return;
+        }
 
         if (_plugin.Start(new(source)) is { } accessor)
         {

--- a/src/Avalonia.Base/Data/Core/Parsers/BindingExpressionGrammar.cs
+++ b/src/Avalonia.Base/Data/Core/Parsers/BindingExpressionGrammar.cs
@@ -140,10 +140,10 @@ namespace Avalonia.Data.Core.Parsers
                 nodes.Add(new EmptyExpressionNode());
                 return State.AfterMember;
             }
-            else if (ParseStreamOperator(ref r))
+            else if (ParseStreamOperator(ref r, out var acceptsNull))
             {
                 nodes.Add(new EmptyExpressionNode());
-                nodes.Add(new StreamNode());
+                nodes.Add(new StreamNode { AcceptsNull = acceptsNull });
                 return State.AfterMember;
             }
             else
@@ -166,9 +166,9 @@ namespace Avalonia.Data.Core.Parsers
             {
                 return acceptsNull ? State.BeforeMemberNullable : State.BeforeMember;
             }
-            else if (ParseStreamOperator(ref r))
+            else if (ParseStreamOperator(ref r, out acceptsNull))
             {
-                nodes.Add(new StreamNode());
+                nodes.Add(new StreamNode { AcceptsNull = acceptsNull });
                 return State.AfterMember;
             }
             else if (PeekOpenBracket(ref r))
@@ -441,9 +441,26 @@ namespace Avalonia.Data.Core.Parsers
             return !r.End && r.Peek == '(';
         }
 
-        private static bool ParseStreamOperator(ref CharacterReader r)
+        private static bool ParseStreamOperator(ref CharacterReader r, out bool acceptsNull)
         {
-            return !r.End && r.TakeIf('^');
+            acceptsNull = false;
+
+            if (r.End)
+                return false;
+
+            if (r.Peek == '^')
+            {
+                r.Take();
+                return true;
+            }
+
+            if (r.TakeIf("?^"))
+            {
+                acceptsNull = true;
+                return true;
+            }
+
+            return false;
         }
 
         private static bool ParseDollarSign(ref CharacterReader r)
@@ -521,7 +538,10 @@ namespace Avalonia.Data.Core.Parsers
 
         public class NotNode : INode, ITransformNode { }
 
-        public class StreamNode : INode { }
+        public class StreamNode : INode
+        {
+            public bool AcceptsNull { get; set; }
+        }
 
         public class SelfNode : INode { }
 

--- a/src/Avalonia.Base/Data/Core/Parsers/ExpressionNodeFactory.cs
+++ b/src/Avalonia.Base/Data/Core/Parsers/ExpressionNodeFactory.cs
@@ -59,8 +59,8 @@ namespace Avalonia.Data.Core.Parsers
                         node = null;
                         isRooted = true;
                         break;
-                    case BindingExpressionGrammar.StreamNode:
-                        node = new DynamicPluginStreamNode();
+                    case BindingExpressionGrammar.StreamNode stream:
+                        node = new DynamicPluginStreamNode(stream.AcceptsNull);
                         break;
                     case BindingExpressionGrammar.TypeCastNode typeCast:
                         node = new ReflectionTypeCastNode(LookupType(typeResolver, typeCast.Namespace, typeCast.TypeName));

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
@@ -152,7 +152,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                     case BindingExpressionGrammar.NotNode _:
                         transformNodes.Add(new XamlIlNotPathElementNode(context.Configuration.WellKnownTypes.Boolean));
                         break;
-                    case BindingExpressionGrammar.StreamNode _:
+                    case BindingExpressionGrammar.StreamNode streamNode:
                         {
                             IXamlType targetType = targetTypeResolver();
                             IXamlType? observableType;
@@ -168,7 +168,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
 
                             if (observableType != null)
                             {
-                                nodes.Add(new XamlIlStreamObservablePathElementNode(observableType.GenericArguments[0]));
+                                nodes.Add(new XamlIlStreamObservablePathElementNode(observableType.GenericArguments[0], streamNode.AcceptsNull));
                                 break;
                             }
 
@@ -180,7 +180,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                                 if (currentType.GenericTypeDefinition?.Equals(taskType) == true)
                                 {
                                     foundTask = true;
-                                    nodes.Add(new XamlIlStreamTaskPathElementNode(currentType.GenericArguments[0]));
+                                    nodes.Add(new XamlIlStreamTaskPathElementNode(currentType.GenericArguments[0], streamNode.AcceptsNull));
                                     break;
                                 }
                             }
@@ -620,31 +620,57 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
 
         class XamlIlStreamObservablePathElementNode : IXamlIlBindingPathElementNode
         {
-            public XamlIlStreamObservablePathElementNode(IXamlType type)
+            private readonly bool _acceptsNull;
+
+            public XamlIlStreamObservablePathElementNode(IXamlType type, bool acceptsNull)
             {
                 Type = type;
+                _acceptsNull = acceptsNull;
             }
 
             public IXamlType Type { get; }
 
             public void Emit(XamlIlEmitContext context, IXamlILEmitter codeGen)
             {
-                codeGen.EmitCall(context.GetAvaloniaTypes().CompiledBindingPathBuilder.GetMethod(m => m is { Name: "StreamObservable", IsGenericMethod: true }).MakeGenericMethod(new[] { Type }));
+                var parameterCount = 0;
+
+                if (_acceptsNull)
+                {
+                    parameterCount = 1;
+                    codeGen.Ldc_I4(1);
+                }
+
+                codeGen.EmitCall(context.GetAvaloniaTypes().CompiledBindingPathBuilder.GetMethod(m =>
+                    m is { Name: "StreamObservable", IsGenericMethod: true } &&
+                    m.Parameters.Count == parameterCount).MakeGenericMethod(new[] { Type }));
             }
         }
 
         class XamlIlStreamTaskPathElementNode : IXamlIlBindingPathElementNode
         {
-            public XamlIlStreamTaskPathElementNode(IXamlType type)
+            private readonly bool _acceptsNull;
+
+            public XamlIlStreamTaskPathElementNode(IXamlType type, bool acceptsNull)
             {
                 Type = type;
+                _acceptsNull = acceptsNull;
             }
 
             public IXamlType Type { get; }
 
             public void Emit(XamlIlEmitContext context, IXamlILEmitter codeGen)
             {
-                codeGen.EmitCall(context.GetAvaloniaTypes().CompiledBindingPathBuilder.GetMethod(m => m is { Name: "StreamTask", IsGenericMethod: true }).MakeGenericMethod(new[] { Type }));
+                var parameterCount = 0;
+
+                if (_acceptsNull)
+                {
+                    parameterCount = 1;
+                    codeGen.Ldc_I4(1);
+                }
+
+                codeGen.EmitCall(context.GetAvaloniaTypes().CompiledBindingPathBuilder.GetMethod(m =>
+                    m is { Name: "StreamTask", IsGenericMethod: true } &&
+                    m.Parameters.Count == parameterCount).MakeGenericMethod(new[] { Type }));
             }
         }
 

--- a/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.Observable.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/BindingExpressionTests.Observable.cs
@@ -1,6 +1,11 @@
 using System;
 using System.Reactive.Subjects;
+using Avalonia.Data;
+using Avalonia.Data.Core;
+using Avalonia.Data.Core.ExpressionNodes;
+using Avalonia.Data.Core.Parsers;
 using Avalonia.UnitTests;
+using Avalonia.Utilities;
 using Xunit;
 
 namespace Avalonia.Base.UnitTests.Data.Core;
@@ -85,5 +90,49 @@ public partial class BindingExpressionTests
         Assert.Equal(42, target.Int);
 
         GC.KeepAlive(data);
+    }
+
+    public partial class Reflection
+    {
+        [Fact]
+        public void Should_Not_Error_When_Observable_Is_Null_With_Null_Conditional_Stream()
+        {
+            using var sync = UnitTestSynchronizationContext.Begin();
+            var data = new ViewModel { NextObservable = null };
+            var target = new TargetClass { DataContext = data };
+
+            var reader = new CharacterReader("NextObservable?^".AsSpan());
+            var (astNodes, _) = BindingExpressionGrammar.Parse(ref reader);
+            var nodes = ExpressionNodeFactory.CreateFromAst(astNodes, null, null, out _)!;
+            nodes.Insert(0, new DataContextNode());
+
+            var bindingExpression = new BindingExpression(target, nodes, AvaloniaProperty.UnsetValue);
+            target.GetValueStore().AddBinding(TargetClass.ObjectProperty, bindingExpression);
+
+            Assert.Equal(BindingErrorType.None, bindingExpression.ErrorType);
+            Assert.Null(target.Object);
+
+            GC.KeepAlive(data);
+        }
+
+        [Fact]
+        public void Should_Error_When_Observable_Is_Null_Without_Null_Conditional_Stream()
+        {
+            using var sync = UnitTestSynchronizationContext.Begin();
+            var data = new ViewModel { NextObservable = null };
+            var target = new TargetClass { DataContext = data };
+
+            var reader = new CharacterReader("NextObservable^".AsSpan());
+            var (astNodes, _) = BindingExpressionGrammar.Parse(ref reader);
+            var nodes = ExpressionNodeFactory.CreateFromAst(astNodes, null, null, out _)!;
+            nodes.Insert(0, new DataContextNode());
+
+            var bindingExpression = new BindingExpression(target, nodes, AvaloniaProperty.UnsetValue);
+            target.GetValueStore().AddBinding(TargetClass.ObjectProperty, bindingExpression);
+
+            Assert.Equal(BindingErrorType.Error, bindingExpression.ErrorType);
+
+            GC.KeepAlive(data);
+        }
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Data/Core/Parsers/BindingExpressionGrammarTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/Parsers/BindingExpressionGrammarTests.cs
@@ -221,7 +221,8 @@ namespace Avalonia.Base.UnitTests.Data.Core.Parsers
             var result = Parse("Foo^");
 
             Assert.Equal(2, result.Count);
-            Assert.IsType<BindingExpressionGrammar.StreamNode>(result[1]);
+            AssertIsProperty(result[0], "Foo");
+            AssertIsStream(result[1], acceptsNull: false);
         }
 
         [Fact]
@@ -244,6 +245,16 @@ namespace Avalonia.Base.UnitTests.Data.Core.Parsers
             Assert.IsType<BindingExpressionGrammar.StreamNode>(result[1]);
         }
 
+        [Fact]
+        public void Should_Parse_Null_Conditional_Stream_Node()
+        {
+            var result = Parse("Foo?^");
+
+            Assert.Equal(2, result.Count);
+            AssertIsProperty(result[0], "Foo");
+            AssertIsStream(result[1], acceptsNull: true);
+        }
+
         private static void AssertIsProperty(
             BindingExpressionGrammar.INode node,
             string name,
@@ -252,6 +263,14 @@ namespace Avalonia.Base.UnitTests.Data.Core.Parsers
             var p = Assert.IsType<BindingExpressionGrammar.PropertyNameNode>(node);
             Assert.Equal(name, p.PropertyName);
             Assert.Equal(acceptsNull, p.AcceptsNull);
+        }
+
+        private static void AssertIsStream(
+            BindingExpressionGrammar.INode node,
+            bool acceptsNull = false)
+        {
+            var s = Assert.IsType<BindingExpressionGrammar.StreamNode>(node);
+            Assert.Equal(acceptsNull, s.AcceptsNull);
         }
 
         private static void AssertIsAttachedProperty(

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -306,6 +306,32 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
 
         [Fact]
+        public void ResolvesNullConditionalStreamObservableBindingCorrectly()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        x:DataType='local:TestDataContext'>
+    <TextBlock Text='{CompiledBinding ObservableProperty?^}' Name='textBlock' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = window.GetControl<TextBlock>("textBlock");
+
+                var dataContext = new TestDataContext
+                {
+                    ObservableProperty = null
+                };
+
+                window.DataContext = dataContext;
+
+                Assert.Null(textBlock.Text);
+            }
+        }
+
+        [Fact]
         public void IndexerSetterBindsCorrectly()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))


### PR DESCRIPTION
Previously {Binding Header^} raised 'Value is null.' when the bound IObservable<T>/Task was null. Add support for the '?^' operator so that a null source is propagated as a null value instead of an error.

- BindingExpressionGrammar: parse '?^' and set StreamNode.AcceptsNull
- StreamNode/DynamicPluginStreamNode: handle null source when acceptsNull is set
- CompiledBindingPathBuilder: add acceptsNull overloads for StreamTask/StreamObservable
- XamlIlBindingPathHelper: emit acceptsNull argument for compiled bindings
- Add grammar, reflection and compiled binding tests

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [X] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
