### PR TITLE
Fix DWM maximize animation glitch when launching window extended into client area

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -103,6 +103,7 @@ namespace Avalonia.Win32
         private WindowImpl? _parent;
         private bool _isCloseRequested;
         private bool _shown;
+        private bool _isInitialShow = true;
         private bool _hiddenWindowIsParent;
         private uint _langid;
         internal bool _ignoreWmChar;
@@ -1237,7 +1238,11 @@ namespace Avalonia.Win32
                 DwmExtendFrameIntoClientArea(_hwnd, ref margins);
 
                 // Make sure that Windows still paints the non-client area so we get native borders and shadows.
-                SetNCRenderingPolicy(DwmNCRenderingPolicy.DWMNCRP_ENABLED);
+                // Bypass it during the startup maximize animation to fix Windows top border issue.
+                if (WindowState != WindowState.Maximized || !_isInitialShow)
+                {
+                    SetNCRenderingPolicy(DwmNCRenderingPolicy.DWMNCRP_ENABLED);
+                }
             }
             else
             {
@@ -1305,7 +1310,20 @@ namespace Avalonia.Win32
 
             if (command.HasValue)
             {
+                if (_isClientAreaExtended)
+                {
+                    if (state == WindowState.Maximized && _isInitialShow)
+                    {
+                        SetNCRenderingPolicy(DwmNCRenderingPolicy.DWMNCRP_DISABLED);
+                    }
+                    else
+                    {
+                        SetNCRenderingPolicy(DwmNCRenderingPolicy.DWMNCRP_ENABLED);
+                    }
+                }
+
                 UnmanagedMethods.ShowWindow(_hwnd, command.Value);
+                _isInitialShow = false;
             }
 
             if (!Design.IsDesignMode && activate)


### PR DESCRIPTION
## What does the pull request do?
Hello :)

I've had an issue with Avalonia for some time on Windows.
My app always had the window frame extended into the client area to render a custom title bar. In Avalonia v11, I used FluentAvalonia's AppWindow implementation, but now I was able to replace it with Avalonia's native Window.

The issue I encountered has been present on both implementations when testing on Windows 11.

When a Window opens with an initial Maximized state AND it has `ExtendClientAreaToDecorationsHint` set to True, its maximize animation incorrectly "leaves" the top of the screen, and then snaps into place after the animation completes.

https://github.com/user-attachments/assets/0ed51f20-10dd-4bf8-b71d-92b283ad84a1

I've tried to fix this in many different ways. I'm pretty sure it's just a Windows bug. Funnily enough, the PowerToys app, being written in WinUI3 by Microsoft, **has the exact same issue**, and that probably applies to all the other WinUI apps.

Eventually, I've found a [blog post](https://handmade.network/forums/articles/t/9073-custom_window_title_bar_and_almost_correctly_drawing_windows_10_borders) describing the exact same issue with a fix I've successfully ported to Avalonia.

Repro app: https://github.com/NotroDev/AvaloniaDwmMaximizeAnimIssue
I'd like to point out that the issue is difficult to notice during debug runs, so I suggest publishing the app first

## What is the updated/expected behavior with this PR?
The animation works fine now. Surprisingly, it seems even smoother than expected - I've noticed an opacity fade-in which I don't think was present previously. I have no idea why that's the case, but I guess that's a win :)

https://github.com/user-attachments/assets/52b73942-9232-45aa-86df-169c98c99554

## How was the solution implemented (if it's not obvious)?
We set the NC Rendering Policy to disabled when initially showing a maximized window.
Without the `_isInitialShow` flag (which was required, as the `_shown` flag didn't work in this case), all the subsequent maximize animations were flickering.

## Additional info
Initially, I added a 250 ms timer to re-enable the policy after disabling it. It seems redundant, though, as NC Rendering isn't needed in a maximized window anyway. When a user unmaximizes the window, Avalonia restores its NC rendering anyway.
I also didn't notice any issues when Windows animation effects were disabled.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

I don't think a test is possible for this issue.