### PR TITLE
Revert "fix(controls): Stop HotKeyManager from triggering on hidden controls (#21708)"

### DIFF
--- a/src/Avalonia.Controls/HotkeyManager.cs
+++ b/src/Avalonia.Controls/HotkeyManager.cs
@@ -38,18 +38,8 @@ namespace Avalonia.Controls
 
             public bool CanExecute(object? parameter)
             {
-                if (reference.Target is InputElement target)
+                if (reference.Target is { } target)
                 {
-                    var current = target as Visual;
-                    while (current != null && current is not TopLevel)
-                    {
-                        if (!current.IsVisible)
-                        {
-                            return false;
-                        }
-                        current = current.VisualParent;
-                    }
-                    
                     if (target is ICommandSource commandSource && commandSource.Command is { } command)
                     {
                         return commandSource.IsEffectivelyEnabled

--- a/tests/Avalonia.Controls.UnitTests/HotKeyedControlsTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/HotKeyedControlsTests.cs
@@ -119,36 +119,5 @@ namespace Avalonia.Controls.UnitTests
             
             Assert.True(hotKeyedTextBox.IsFocused);
         }
-        
-        [Fact]
-        public void Hidden_Button_HotKey_Should_Not_Swallow_Input()
-        {
-            using var _ = CreateServicesWithFocus();
-            
-            var keyboardDevice = new KeyboardDevice();
-            var root = PreparedWindow();
-            var panel = new StackPanel { IsVisible = false };
-            var button = new Button { HotKey = KeyGesture.Parse("Escape") };
-    
-            bool buttonClicked = false;
-            button.Click += (s, e) => buttonClicked = true;
-
-            panel.Children.Add(button);
-            root.Content = panel;
-            root.Show();
-
-            keyboardDevice.ProcessRawEvent(
-                new RawKeyEventArgs(
-                    keyboardDevice,
-                    0,
-                    root.InputRoot,
-                    RawKeyEventType.KeyDown,
-                    Key.Escape,
-                    RawInputModifiers.None,
-                    PhysicalKey.Escape,
-                    ""));
-    
-            Assert.False(buttonClicked);
-        }
     }
 }


### PR DESCRIPTION
Reverts AvaloniaUI/Avalonia#21714

HotKey is similar to WinUI's [KeyboardAccelerator](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.keyboardaccelerator?view=windows-app-sdk-2.0) which explicitly says:

> An accelerator can be executed even if the element associated with the accelerator is not visible. For example, an item in the `SecondaryCommands` collection of the `CommandBar` can be invoked using an accelerator without expanding the overflow menu and displaying the element.

The example given in the WinUI docs make sense: a control with `IsVisible="false"` should be considered in this scenario to be collapsed, not disabled.

I think that there is actually a problem here, but the issue is around `HotKey` priority. Hot keys should not be stealing keypresses from other parts of the application. Related: https://github.com/AvaloniaUI/Avalonia/issues/21871#issuecomment-5423733917