### PR TITLE
Basic infra to use headless platform in "normal" unit tests

### DIFF
--- a/tests/Avalonia.Controls.UnitTests/HeadlessProbeTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/HeadlessProbeTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Linq;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
+using Avalonia.Platform;
+using Avalonia.Rendering;
+using Avalonia.Threading;
+using Avalonia.UnitTests;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests;
+
+public class HeadlessProbeTests : ScopedTestBase
+{
+    [Fact]
+    public void Can_Show_Window_And_Lay_Out()
+    {
+        using var _ = HeadlessUnitTestApplication.Start();
+
+        var button = new Button { Width = 100, Height = 30, Content = "hi" };
+        var window = new Window { Width = 400, Height = 300, Content = button };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(new Size(100, 30), button.Bounds.Size);
+        Assert.Equal(new Size(400, 300), window.ClientSize);
+    }
+
+    [Fact]
+    public void Can_Route_Real_Input_Through_Headless_Toplevel()
+    {
+        using var _ = HeadlessUnitTestApplication.Start();
+
+        var clicked = false;
+        var button = new Button { Width = 100, Height = 30, Content = "hi" };
+        button.Click += (_, _) => clicked = true;
+        var window = new Window { Width = 400, Height = 300, Content = button };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var pt = button.Bounds.Center;
+        window.MouseDown(pt, MouseButton.Left);
+        window.MouseUp(pt, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(clicked);
+    }
+
+    [Fact]
+    public void Keyboard_Input_Reaches_Focused_Control()
+    {
+        using var _ = HeadlessUnitTestApplication.Start();
+
+        var box = new TextBox { Width = 200, Height = 30 };
+        var window = new Window { Width = 400, Height = 300, Content = box };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        box.Focus();
+        Dispatcher.UIThread.RunJobs();
+        window.KeyTextInput("abc");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("abc", box.Text);
+    }
+
+    [Fact]
+    public void Popup_Opens_As_Real_PopupRoot()
+    {
+        using var _ = HeadlessUnitTestApplication.Start();
+
+        var popup = new Popup { Placement = PlacementMode.Pointer, Child = new Border { Width = 50, Height = 50 } };
+        var window = new Window { Width = 400, Height = 300, Content = new Panel { Children = { popup } } };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        popup.Open();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.IsType<PopupRoot>(popup.Host);
+    }
+
+    [Fact]
+    public void Popup_Uses_OverlayPopupHost_When_OverlayPopups_Enabled()
+    {
+        using var _ = HeadlessUnitTestApplication.Start(new AvaloniaHeadlessPlatformOptions { OverlayPopups = true });
+
+        var popup = new Popup { Placement = PlacementMode.Pointer, Child = new Border { Width = 50, Height = 50 } };
+        var window = new Window { Width = 400, Height = 300, Content = new Panel { Children = { popup } } };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        popup.Open();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.IsType<OverlayPopupHost>(popup.Host);
+    }
+
+    [Fact]
+    public void Overlay_Popup_Requires_An_Applied_Window_Template()
+    {
+        using var _ = HeadlessUnitTestApplication.Start(new AvaloniaHeadlessPlatformOptions { OverlayPopups = true });
+
+        // The overlay layer is looked up through the visual tree, so a window that was
+        // never shown has nothing to find.
+        var untemplated = new Popup { PlacementTarget = new Window() };
+        var ex = Assert.Throws<InvalidOperationException>(() => untemplated.Open());
+        Assert.Contains("no overlay layer is found", ex.Message);
+
+        var window = new Window();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(window.GetVisualDescendants().OfType<VisualLayerManager>().FirstOrDefault());
+
+        var templated = new Popup { PlacementTarget = window };
+        templated.Open();
+        Assert.IsType<OverlayPopupHost>(templated.Host);
+    }
+
+    [Fact]
+    public void Platform_Services_Are_Registered_Before_The_First_Window_And_Stay_Stable()
+    {
+        using var _ = HeadlessUnitTestApplication.Start();
+
+        object?[] Resolve() =>
+        [
+            AvaloniaLocator.Current.GetService<IKeyboardDevice>(),
+            AvaloniaLocator.Current.GetService<IPlatformSettings>(),
+            AvaloniaLocator.Current.GetService<ICursorFactory>(),
+            AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>(),
+            AvaloniaLocator.Current.GetService<IClipboard>(),
+            AvaloniaLocator.Current.GetService<IRenderLoop>(),
+            AvaloniaLocator.Current.GetService<IPlatformIconLoader>(),
+            AvaloniaLocator.Current.GetService<KeyGestureFormatInfo>(),
+        ];
+
+        var before = Resolve();
+        Assert.All(before, Assert.NotNull);
+
+        new Window().Show();
+        Dispatcher.UIThread.RunJobs();
+
+        // Initializing the platform lazily used to replace these mid-test, leaving anything that
+        // resolved early holding a different instance than the window does.
+        Assert.Equal(before, Resolve(), System.Collections.Generic.ReferenceEqualityComparer.Instance);
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/HeadlessProbeTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/HeadlessProbeTests.cs
@@ -18,12 +18,12 @@ public class HeadlessProbeTests : ScopedTestBase
     [Fact]
     public void Can_Show_Window_And_Lay_Out()
     {
-        using var _ = HeadlessUnitTestApplication.Start();
+        using var app = HeadlessUnitTestApplication.Start();
 
         var button = new Button { Width = 100, Height = 30, Content = "hi" };
         var window = new Window { Width = 400, Height = 300, Content = button };
         window.Show();
-        Dispatcher.UIThread.RunJobs();
+        app.RunJobs();
 
         Assert.Equal(new Size(100, 30), button.Bounds.Size);
         Assert.Equal(new Size(400, 300), window.ClientSize);
@@ -32,19 +32,19 @@ public class HeadlessProbeTests : ScopedTestBase
     [Fact]
     public void Can_Route_Real_Input_Through_Headless_Toplevel()
     {
-        using var _ = HeadlessUnitTestApplication.Start();
+        using var app = HeadlessUnitTestApplication.Start();
 
         var clicked = false;
         var button = new Button { Width = 100, Height = 30, Content = "hi" };
         button.Click += (_, _) => clicked = true;
         var window = new Window { Width = 400, Height = 300, Content = button };
         window.Show();
-        Dispatcher.UIThread.RunJobs();
+        app.RunJobs();
 
         var pt = button.Bounds.Center;
         window.MouseDown(pt, MouseButton.Left);
         window.MouseUp(pt, MouseButton.Left);
-        Dispatcher.UIThread.RunJobs();
+        app.RunJobs();
 
         Assert.True(clicked);
     }
@@ -52,17 +52,17 @@ public class HeadlessProbeTests : ScopedTestBase
     [Fact]
     public void Keyboard_Input_Reaches_Focused_Control()
     {
-        using var _ = HeadlessUnitTestApplication.Start();
+        using var app = HeadlessUnitTestApplication.Start();
 
         var box = new TextBox { Width = 200, Height = 30 };
         var window = new Window { Width = 400, Height = 300, Content = box };
         window.Show();
-        Dispatcher.UIThread.RunJobs();
+        app.RunJobs();
 
         box.Focus();
-        Dispatcher.UIThread.RunJobs();
+        app.RunJobs();
         window.KeyTextInput("abc");
-        Dispatcher.UIThread.RunJobs();
+        app.RunJobs();
 
         Assert.Equal("abc", box.Text);
     }
@@ -70,15 +70,15 @@ public class HeadlessProbeTests : ScopedTestBase
     [Fact]
     public void Popup_Opens_As_Real_PopupRoot()
     {
-        using var _ = HeadlessUnitTestApplication.Start();
+        using var app = HeadlessUnitTestApplication.Start();
 
         var popup = new Popup { Placement = PlacementMode.Pointer, Child = new Border { Width = 50, Height = 50 } };
         var window = new Window { Width = 400, Height = 300, Content = new Panel { Children = { popup } } };
         window.Show();
-        Dispatcher.UIThread.RunJobs();
+        app.RunJobs();
 
         popup.Open();
-        Dispatcher.UIThread.RunJobs();
+        app.RunJobs();
 
         Assert.IsType<PopupRoot>(popup.Host);
     }
@@ -86,15 +86,15 @@ public class HeadlessProbeTests : ScopedTestBase
     [Fact]
     public void Popup_Uses_OverlayPopupHost_When_OverlayPopups_Enabled()
     {
-        using var _ = HeadlessUnitTestApplication.Start(new AvaloniaHeadlessPlatformOptions { OverlayPopups = true });
+        using var app = HeadlessUnitTestApplication.Start(new AvaloniaHeadlessPlatformOptions { OverlayPopups = true });
 
         var popup = new Popup { Placement = PlacementMode.Pointer, Child = new Border { Width = 50, Height = 50 } };
         var window = new Window { Width = 400, Height = 300, Content = new Panel { Children = { popup } } };
         window.Show();
-        Dispatcher.UIThread.RunJobs();
+        app.RunJobs();
 
         popup.Open();
-        Dispatcher.UIThread.RunJobs();
+        app.RunJobs();
 
         Assert.IsType<OverlayPopupHost>(popup.Host);
     }
@@ -102,7 +102,7 @@ public class HeadlessProbeTests : ScopedTestBase
     [Fact]
     public void Overlay_Popup_Requires_An_Applied_Window_Template()
     {
-        using var _ = HeadlessUnitTestApplication.Start(new AvaloniaHeadlessPlatformOptions { OverlayPopups = true });
+        using var app = HeadlessUnitTestApplication.Start(new AvaloniaHeadlessPlatformOptions { OverlayPopups = true });
 
         // The overlay layer is looked up through the visual tree, so a window that was
         // never shown has nothing to find.
@@ -112,7 +112,7 @@ public class HeadlessProbeTests : ScopedTestBase
 
         var window = new Window();
         window.Show();
-        Dispatcher.UIThread.RunJobs();
+        app.RunJobs();
         Assert.NotNull(window.GetVisualDescendants().OfType<VisualLayerManager>().FirstOrDefault());
 
         var templated = new Popup { PlacementTarget = window };
@@ -123,7 +123,7 @@ public class HeadlessProbeTests : ScopedTestBase
     [Fact]
     public void Platform_Services_Are_Registered_Before_The_First_Window_And_Stay_Stable()
     {
-        using var _ = HeadlessUnitTestApplication.Start();
+        using var app = HeadlessUnitTestApplication.Start();
 
         object?[] Resolve() =>
         [
@@ -141,7 +141,7 @@ public class HeadlessProbeTests : ScopedTestBase
         Assert.All(before, Assert.NotNull);
 
         new Window().Show();
-        Dispatcher.UIThread.RunJobs();
+        app.RunJobs();
 
         // Initializing the platform lazily used to replace these mid-test, leaving anything that
         // resolved early holding a different instance than the window does.

--- a/tests/Avalonia.UnitTests/HeadlessUnitTestApplication.cs
+++ b/tests/Avalonia.UnitTests/HeadlessUnitTestApplication.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Reactive.Disposables;
+using System.Threading;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Platform;
+using Avalonia.Themes.Simple;
+using Avalonia.Threading;
+
+namespace Avalonia.UnitTests;
+
+/// <summary>
+/// Test application running on the real headless platform, set up through <see cref="AppBuilder"/>
+/// so that the platform owns its own slice of the locator.
+/// </summary>
+/// <remarks>
+/// This is deliberately not a <see cref="TestServices"/> flavour: the headless platform registers
+/// services of its own (keyboard device, clipboard, render loop, platform settings, hotkey config),
+/// and <see cref="UnitTestApplication"/> binds the same keys from its service bag, so the two
+/// overwrite each other depending on when the platform happens to initialize.
+/// </remarks>
+public class HeadlessUnitTestApplication : Application
+{
+    public HeadlessUnitTestApplication()
+    {
+        Styles.Add(new SimpleTheme());
+    }
+
+    public static IDisposable Start(AvaloniaHeadlessPlatformOptions? options = null)
+    {
+        var scope = AvaloniaLocator.EnterScope();
+        var oldContext = SynchronizationContext.Current;
+
+        try
+        {
+            Dispatcher.ResetBeforeUnitTests();
+
+            AppBuilder.Configure<HeadlessUnitTestApplication>()
+                // Popups default to dedicated top-levels here, matching the desktop platforms
+                // and the app used by Avalonia.Headless.UnitTests.
+                .UseHeadless(options ?? new AvaloniaHeadlessPlatformOptions { OverlayPopups = false })
+                .AfterPlatformServicesSetup(_ => AvaloniaLocator.CurrentMutable
+                    .Bind<IFontManagerImpl>().ToConstant(new TestFontManager()))
+                .SetupUnsafe();
+        }
+        catch
+        {
+            scope.Dispose();
+            throw;
+        }
+
+        return Disposable.Create(() =>
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.RunJobs();
+            }
+
+            (AvaloniaLocator.Current.GetService<IToolTipService>() as ToolTipService)?.Dispose();
+            (AvaloniaLocator.Current.GetService<FontManager>() as IDisposable)?.Dispose();
+            (AvaloniaLocator.Current.GetService<IInputManager>() as IDisposable)?.Dispose();
+
+            Dispatcher.ResetForUnitTests();
+            scope.Dispose();
+            Dispatcher.ResetBeforeUnitTests();
+            SynchronizationContext.SetSynchronizationContext(oldContext);
+        });
+    }
+}

--- a/tests/Avalonia.UnitTests/HeadlessUnitTestApplication.cs
+++ b/tests/Avalonia.UnitTests/HeadlessUnitTestApplication.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reactive.Disposables;
 using System.Threading;
 using Avalonia.Controls;
 using Avalonia.Headless;
@@ -8,6 +7,7 @@ using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Themes.Simple;
 using Avalonia.Threading;
+using Xunit;
 
 namespace Avalonia.UnitTests;
 
@@ -28,7 +28,7 @@ public class HeadlessUnitTestApplication : Application
         Styles.Add(new SimpleTheme());
     }
 
-    public static IDisposable Start(AvaloniaHeadlessPlatformOptions? options = null)
+    public static Scope Start(AvaloniaHeadlessPlatformOptions? options = null)
     {
         var scope = AvaloniaLocator.EnterScope();
         var oldContext = SynchronizationContext.Current;
@@ -51,7 +51,19 @@ public class HeadlessUnitTestApplication : Application
             throw;
         }
 
-        return Disposable.Create(() =>
+        return new Scope(scope, oldContext);
+    }
+
+    public sealed class Scope(IDisposable locatorScope, SynchronizationContext? oldContext) : IDisposable
+    {
+        /// <summary>
+        /// Runs pending dispatcher jobs, tied to the test's cancellation token. Headless top-levels
+        /// post activation, resizes and rendering, so tests have to let those settle between acts.
+        /// </summary>
+        public void RunJobs(DispatcherPriority? priority = null) =>
+            Dispatcher.UIThread.RunJobs(priority, TestContext.Current.CancellationToken);
+
+        public void Dispose()
         {
             if (Dispatcher.UIThread.CheckAccess())
             {
@@ -63,9 +75,9 @@ public class HeadlessUnitTestApplication : Application
             (AvaloniaLocator.Current.GetService<IInputManager>() as IDisposable)?.Dispose();
 
             Dispatcher.ResetForUnitTests();
-            scope.Dispose();
+            locatorScope.Dispose();
             Dispatcher.ResetBeforeUnitTests();
             SynchronizationContext.SetSynchronizationContext(oldContext);
-        });
+        }
     }
 }


### PR DESCRIPTION
PR adds `TestServices.HeadlessStyledWindow` that enables full headless backend instead of simplified mocks we have in UnitTestApplication.


The general plan was to switch to headless platform for most of the test suite, but it was never started.