### PR TITLE
Fix auto-sized VirtualizingStackPanel not rendering

### DIFF
--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -941,7 +941,9 @@ namespace Avalonia.Controls
             var horizontal = Orientation == Orientation.Horizontal;
             var u = viewport.anchorU;
             var viewportEnd = horizontal ? _viewport.Right : _viewport.Bottom;
+
             var anchorAtEnd = !_hasReachedEnd && index == items.Count - 1 &&
+                !MathUtilities.IsZero(viewport.viewportUStart) &&
                 MathUtilities.GreaterThanOrClose(viewportEnd, horizontal ? Bounds.Width : Bounds.Height);
 
             // Reset boundary flags

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -172,6 +172,28 @@ namespace Avalonia.Controls.UnitTests
                 horizontal ? target.GetRealizedElements().Last()!.Bounds.Right : target.GetRealizedElements().Last()!.Bounds.Bottom);
         }
 
+        [Fact]
+        public void Item_Of_Content_Sized_Panel_Is_Positioned_At_Start()
+        {
+            using var app = App();
+
+            var items = new ObservableCollection<string>();
+            var (target, _, itemsControl) = CreateUnrootedTarget<ItemsControl>(items: items);
+
+            // Size the control to its content rather than to the viewport.
+            itemsControl.VerticalAlignment = VerticalAlignment.Top;
+
+            CreateRoot(itemsControl).LayoutManager.ExecuteInitialLayoutPass();
+
+            items.Add("Item 0");
+            Layout(target);
+
+            var container = Assert.IsAssignableFrom<Control>(target.ContainerFromIndex(0));
+
+            Assert.Equal(0, container.Bounds.Y);
+            Assert.Equal(container.Bounds.Height, target.Bounds.Height);
+        }
+
         [Theory]
         [InlineData(0d, 10)]
         [InlineData(0.5d, 20)]


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a recent regression introduced in #22014: the anchor was placed at the end even when the viewport was at the beginning of the list. In other words, the first item was incorrectly placed at negative bounds, outside of the viewport.

Visually, this manifested as an empty list when a single item was present and the `VirtualizingStackPanel` was auto-sized (effectively disabling virtualization, but that's not a reason for it not to work correctly).

A matching unit test has been added.
