### PR TITLE
Short-circuit the binding chain on a null-conditional operator

### DIFF
--- a/src/Avalonia.Base/Data/Core/BindingExpression.cs
+++ b/src/Avalonia.Base/Data/Core/BindingExpression.cs
@@ -240,6 +240,27 @@ internal class BindingExpression : UntypedBindingExpressionBase, IDescription, I
     }
 
     /// <summary>
+    /// Called by an <see cref="ExpressionNode"/> belonging to this binding when a
+    /// null-conditional operator applied to the node encounters a null source.
+    /// </summary>
+    /// <param name="nodeIndex">The <see cref="ExpressionNode.Index"/>.</param>
+    /// <remarks>
+    /// A null-conditional operator short-circuits the remainder of the binding path, just as it
+    /// does in C#. The nodes after <paramref name="nodeIndex"/> are unsubscribed and their values
+    /// set to null, and null is published as the value of the binding.
+    /// </remarks>
+    internal void OnNodeNullShortCircuit(int nodeIndex)
+    {
+        Debug.Assert(nodeIndex >= 0 && nodeIndex < _nodes.Count);
+
+        for (var i = nodeIndex + 1; i < _nodes.Count; ++i)
+            _nodes[i].PropagateNullShortCircuitValue();
+
+        // Publish the null value as if it were produced by the leaf node.
+        OnNodeValueChanged(_nodes.Count - 1, null, null);
+    }
+
+    /// <summary>
     /// Called by an <see cref="ExpressionNode"/> belonging to this binding when an error occurs
     /// reading its value.
     /// </summary>

--- a/src/Avalonia.Base/Data/Core/ExpressionNodes/AvaloniaPropertyAccessorNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNodes/AvaloniaPropertyAccessorNode.cs
@@ -10,9 +10,12 @@ internal sealed class AvaloniaPropertyAccessorNode :
     ISettableNode,
     IWeakEventSubscriber<AvaloniaPropertyChangedEventArgs>
 {
-    public AvaloniaPropertyAccessorNode(AvaloniaProperty property)
+    private readonly bool _acceptsNull;
+
+    public AvaloniaPropertyAccessorNode(AvaloniaProperty property, bool acceptsNull)
     {
         Property = property;
+        _acceptsNull = acceptsNull;
     }
 
     public AvaloniaProperty Property { get; }
@@ -38,8 +41,14 @@ internal sealed class AvaloniaPropertyAccessorNode :
 
     protected override void OnSourceChanged(object? source, Exception? dataValidationError)
     {
-        if (!ValidateNonNullSource(source))
+        if (source is null)
+        {
+            if (_acceptsNull)
+                ShortCircuitNull();
+            else
+                ValidateNonNullSource(source);
             return;
+        }
 
         if (source is AvaloniaObject newObject)
         {

--- a/src/Avalonia.Base/Data/Core/ExpressionNodes/ExpressionNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNodes/ExpressionNode.cs
@@ -118,9 +118,40 @@ internal abstract class ExpressionNode
     }
 
     /// <summary>
+    /// Sets the value of the node to null without notifying the <see cref="Owner"/>, and
+    /// unsubscribes from the current source.
+    /// </summary>
+    /// <remarks>
+    /// Called on the nodes which follow a short-circuited null-conditional operator.
+    /// </remarks>
+    internal void PropagateNullShortCircuitValue()
+    {
+        // Setting the source to unset unsubscribes from the old source without raising errors
+        // for this or subsequent nodes.
+        SetSource(AvaloniaProperty.UnsetValue, null);
+        _value = null;
+    }
+
+    /// <summary>
     /// Sets the current value to <see cref="AvaloniaProperty.UnsetValue"/>.
     /// </summary>
     protected void ClearValue() => SetValue(AvaloniaProperty.UnsetValue);
+
+    /// <summary>
+    /// Called by a node which has a null-conditional operator applied to it when its source is
+    /// null.
+    /// </summary>
+    /// <remarks>
+    /// The C# null-conditional operator short-circuits the remainder of the expression, so
+    /// <c>a?.b.c</c> evaluates to null when <c>a</c> is null. This method does the same for a
+    /// binding path: the value of this node and all subsequent nodes is set to null and the
+    /// binding produces a null value rather than an error.
+    /// </remarks>
+    protected void ShortCircuitNull()
+    {
+        _value = null;
+        Owner?.OnNodeNullShortCircuit(Index);
+    }
 
     /// <summary>
     /// Notifies the <see cref="Owner"/> of a data validation error.

--- a/src/Avalonia.Base/Data/Core/ExpressionNodes/PropertyAccessorNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNodes/PropertyAccessorNode.cs
@@ -55,7 +55,7 @@ internal sealed class PropertyAccessorNode : ExpressionNode, IPropertyAccessorNo
         if (source is null)
         {
             if (_acceptsNull)
-                SetValue(null);
+                ShortCircuitNull();
             else
                 ValidateNonNullSource(source);
             return;

--- a/src/Avalonia.Base/Data/Core/ExpressionNodes/Reflection/DynamicPluginPropertyAccessorNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNodes/Reflection/DynamicPluginPropertyAccessorNode.cs
@@ -49,7 +49,7 @@ internal sealed class DynamicPluginPropertyAccessorNode : ExpressionNode, IPrope
         if (source is null)
         {
             if (_acceptsNull)
-                SetValue(null);
+                ShortCircuitNull();
             else
                 ValidateNonNullSource(source);
             return;

--- a/src/Avalonia.Base/Data/Core/Parsers/ExpressionNodeFactory.cs
+++ b/src/Avalonia.Base/Data/Core/Parsers/ExpressionNodeFactory.cs
@@ -115,7 +115,7 @@ namespace Avalonia.Data.Core.Parsers
             var type = LookupType(typeResolver, attached.Namespace, attached.TypeName);
             var property = AvaloniaPropertyRegistry.Instance.FindRegistered(type, attached.PropertyName) ??
                 throw new InvalidOperationException($"Cannot find property {type}.{attached.PropertyName}.");
-            return new AvaloniaPropertyAccessorNode(property);
+            return new AvaloniaPropertyAccessorNode(property, attached.AcceptsNull);
         }
 
         private static LogicalAncestorElementNode LogicalAncestorNode(

--- a/tests/Avalonia.Base.UnitTests/Data/Core/NullConditionalBindingTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/NullConditionalBindingTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Logging;
@@ -127,6 +128,32 @@ public class NullConditionalBindingTests
                       </Window>
                       """;
         var data = new First { StyledSecond = new Second() };
+        var window = CreateTarget(xaml, data);
+        var textBox = Assert.IsType<ErrorCollectingTextBox>(window.Content);
+
+        Assert.Null(textBox.Text);
+        Assert.Null(textBox.Error);
+        Assert.Equal(BindingValueType.Value, textBox.ErrorState);
+        Assert.Empty(log.Messages);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Should_Not_Report_Error_With_Null_Conditional_Operator_For_Stream(bool compileBindings)
+    {
+        using var app = Start();
+        using var log = TestLogger.Create();
+        var xaml = $$$"""
+            <Window xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                    xmlns:local='using:Avalonia.Base.UnitTests.Data.Core'
+                    x:DataType='local:NullConditionalBindingTests+First'
+                    x:CompileBindings='{{{compileBindings}}}'>
+                <local:ErrorCollectingTextBox Text='{Binding Second?.Task^}'/>
+            </Window>
+            """;
+        var data = new First { Second = null };
         var window = CreateTarget(xaml, data);
         var textBox = Assert.IsType<ErrorCollectingTextBox>(window.Content);
 
@@ -271,6 +298,8 @@ public class NullConditionalBindingTests
     {
         public static readonly StyledProperty<Third?> StyledThirdProperty =
             AvaloniaProperty.Register<Second, Third?>(nameof(StyledThird));
+
+        public Task<string>? Task { get; set; }
 
         public Third? Third { get; set; }
 

--- a/tests/Avalonia.Base.UnitTests/Data/Core/NullConditionalBindingTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/NullConditionalBindingTests.cs
@@ -319,6 +319,58 @@ public class NullConditionalBindingTests
         Assert.Empty(log.Messages);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Should_Use_TargetNullValue_With_Short_Circuited_Null_Conditional_Operator_For_Clr_Property(bool compileBindings)
+    {
+        using var app = Start();
+        using var log = TestLogger.Create();
+        var xaml = $$$"""
+            <Window xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                    xmlns:local='using:Avalonia.Base.UnitTests.Data.Core'
+                    x:DataType='local:NullConditionalBindingTests+First'
+                    x:CompileBindings='{{{compileBindings}}}'>
+                <local:ErrorCollectingTextBox Text='{Binding Second?.Third.Final, TargetNullValue=ItsNull}'/>
+            </Window>
+            """;
+        var data = new First { Second = null };
+        var window = CreateTarget(xaml, data);
+        var textBox = Assert.IsType<ErrorCollectingTextBox>(window.Content);
+
+        Assert.Equal("ItsNull", textBox.Text);
+        Assert.Null(textBox.Error);
+        Assert.Equal(BindingValueType.Value, textBox.ErrorState);
+        Assert.Empty(log.Messages);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Should_Use_TargetNullValue_With_Short_Circuited_Null_Conditional_Operator_For_Avalonia_Property(bool compileBindings)
+    {
+        using var app = Start();
+        using var log = TestLogger.Create();
+        var xaml = $$$"""
+                      <Window xmlns='https://github.com/avaloniaui'
+                              xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                              xmlns:local='using:Avalonia.Base.UnitTests.Data.Core'
+                              x:DataType='local:NullConditionalBindingTests+First'
+                              x:CompileBindings='{{{compileBindings}}}'>
+                          <local:ErrorCollectingTextBox Text='{Binding StyledSecond?.StyledThird.StyledFinal, TargetNullValue=ItsNull}'/>
+                      </Window>
+                      """;
+        var data = new First { StyledSecond = null };
+        var window = CreateTarget(xaml, data);
+        var textBox = Assert.IsType<ErrorCollectingTextBox>(window.Content);
+
+        Assert.Equal("ItsNull", textBox.Text);
+        Assert.Null(textBox.Error);
+        Assert.Equal(BindingValueType.Value, textBox.ErrorState);
+        Assert.Empty(log.Messages);
+    }
+
     private Window CreateTarget(string xaml, object? data)
     {
         var result = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);

--- a/tests/Avalonia.Base.UnitTests/Data/Core/NullConditionalBindingTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/NullConditionalBindingTests.cs
@@ -192,6 +192,32 @@ public class NullConditionalBindingTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
+    public void Should_Not_Report_Error_With_Null_Conditional_Operator_For_Attached_Property(bool compileBindings)
+    {
+        using var app = Start();
+        using var log = TestLogger.Create();
+        var xaml = $$$"""
+            <Window xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                    xmlns:local='using:Avalonia.Base.UnitTests.Data.Core'
+                    x:DataType='local:NullConditionalBindingTests+First'
+                    x:CompileBindings='{{{compileBindings}}}'>
+                <local:ErrorCollectingTextBox Text='{Binding Second?.(Grid.Row)}'/>
+            </Window>
+            """;
+        var data = new First { Second = null };
+        var window = CreateTarget(xaml, data);
+        var textBox = Assert.IsType<ErrorCollectingTextBox>(window.Content);
+
+        Assert.Null(textBox.Text);
+        Assert.Null(textBox.Error);
+        Assert.Equal(BindingValueType.Value, textBox.ErrorState);
+        Assert.Empty(log.Messages);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
     public void Should_Not_Report_Error_With_Null_Conditional_Operator_Before_Method_For_Clr_Property(bool compileBindings)
     {
         using var app = Start();

--- a/tests/Avalonia.Base.UnitTests/Data/Core/NullConditionalBindingTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/NullConditionalBindingTests.cs
@@ -88,7 +88,33 @@ public class NullConditionalBindingTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public void Should_Not_Report_Error_With_Null_Conditional_Operator_For_Clr_Property(bool compileBindings)
+    public void Should_Not_Report_Error_With_Null_Conditional_Operator_For_Clr_Property_1(bool compileBindings)
+    {
+        using var app = Start();
+        using var log = TestLogger.Create();
+        var xaml = $$$"""
+            <Window xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                    xmlns:local='using:Avalonia.Base.UnitTests.Data.Core'
+                    x:DataType='local:NullConditionalBindingTests+First'
+                    x:CompileBindings='{{{compileBindings}}}'>
+                <local:ErrorCollectingTextBox Text='{Binding Second?.Third.Final}'/>
+            </Window>
+            """;
+        var data = new First { Second = null };
+        var window = CreateTarget(xaml, data);
+        var textBox = Assert.IsType<ErrorCollectingTextBox>(window.Content);
+
+        Assert.Null(textBox.Text);
+        Assert.Null(textBox.Error);
+        Assert.Equal(BindingValueType.Value, textBox.ErrorState);
+        Assert.Empty(log.Messages);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Should_Not_Report_Error_With_Null_Conditional_Operator_For_Clr_Property_2(bool compileBindings)
     {
         using var app = Start();
         using var log = TestLogger.Create();


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Makes the [null-conditional operator](https://github.com/AvaloniaUI/Avalonia/pull/18270) in a binding path short-circuit the rest of the chain, as it does in C#.

This came out of the discussion in #22069, which proposed a new `?^` operator for null tasks/observables. The underlying problem there turned out to be the same one already reported in #18949: `?.` doesn't short-circuit, so any node after it still sees a null and reports an error.

## What is the current behavior?

The null-conditional operator only applies to the node it's attached to. A null source produces a null value, which is then handed to the next node in the chain, which raises `Value is null.`.

Given the viewmodel from #18949, where `Model` is null and `Info` is never null:

```xml
<TextBlock Text="{Binding Model?.Info.Name, TargetNullValue=Unknown}" />
```

reports:

> An error occurred binding 'Text' to 'Model.Info.Name' at 'Info': 'Value is null.'

`Info` is never null, so the error names a confusing node. The binding then falls back to `FallbackValue` instead of using `TargetNullValue`.

The same thing happens with a stream operator, which is the case from #22069:

```xml
<TextBox Text="{Binding Second?.Task^}" />
```

errors at `Task` when `Second` is null.

Separately, attached properties in reflection bindings never honoured the operator at all. `{Binding Second?.(Grid.Row)}` reports `Value is null.` even though the grammar parses the `?.` correctly.

## What is the updated/expected behavior with this PR?

`a?.b.c` evaluates to null when `a` is null, and no error is reported. This matches C#, where the null-conditional operator short-circuits the remainder of the expression.

Because the short-circuited chain publishes null rather than `UnsetValue`, `TargetNullValue` applies as one would expect.

Note this does not make a null value *at* the stream operator legal: `Second?.Task^` still errors if `Second` is non-null and `Task` is null, in the same way that C# won't let you await a null task. The `?.` guards `Second` only.

## How was the solution implemented (if it's not obvious)?

`ExpressionNode` gains two methods:

- `ShortCircuitNull()`, called by a node with a null-conditional operator when its source is null.
- `PropagateNullShortCircuitValue()`, called on each node after it.

The first notifies the owning `BindingExpression` via the new `OnNodeNullShortCircuit`, which unsubscribes every subsequent node, sets their values to null, and publishes null as the value of the binding.

The three property accessor nodes then call `ShortCircuitNull()` instead of `SetValue(null)` on a null source:

- `PropertyAccessorNode` (compiled bindings)
- `DynamicPluginPropertyAccessorNode` (reflection bindings)
- `AvaloniaPropertyAccessorNode` (attached properties in reflection bindings)

The last of those had no `acceptsNull` at all. The grammar parses `?.(Foo.Bar)` and sets `AttachedPropertyNameNode.AcceptsNull` — there's an existing grammar test for it — but `ExpressionNodeFactory` discarded the flag. It's now passed through. Compiled bindings were already correct here as they route attached properties through `PropertyAccessorNode`.

No other node has a null-conditional form to honour: `^` has no `?^`, and the indexer nodes have no `?[]` because the grammar doesn't parse one.

The tests were added as separate commits ahead of the fix, so they can be checked out to see the failures.

## Checklist

- [X] Added unit tests (if possible)?
- [X] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

A binding path that previously produced a binding error will now produce a null value, if the path contains a null-conditional operator before the point at which the null was encountered. Any binding relying on `FallbackValue` being applied in that case will now get `TargetNullValue` (or null) instead.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #18949

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Atuuu4jtp14QXXoCzkp2A6
