### PR TITLE
Remove shared pointer state from PenDevice

### DIFF
--- a/src/Avalonia.Base/Input/PenDevice.cs
+++ b/src/Avalonia.Base/Input/PenDevice.cs
@@ -17,12 +17,11 @@ namespace Avalonia.Input
     [PrivateApi]
     public class PenDevice : IPenDevice, IDisposable
     {
-        private readonly Dictionary<long, Pointer> _pointers = new();
+        private readonly Dictionary<long, PointerState> _pointers = new();
         private readonly bool _releasePointerOnPenUp;
         private int _clickCount;
         private Rect _lastClickRect;
         private ulong _lastClickTime;
-        private MouseButton _lastMouseDownButton;
 
         private bool _disposed;
 
@@ -41,15 +40,16 @@ namespace Avalonia.Input
         {
             e = e ?? throw new ArgumentNullException(nameof(e));
 
-            if (!_pointers.TryGetValue(e.RawPointerId, out var pointer))
+            if (!_pointers.TryGetValue(e.RawPointerId, out var state))
             {
                 if (e.Type == RawPointerEventType.LeftButtonUp
                     || e.Type == RawPointerEventType.TouchEnd)
                     return;
 
-                _pointers[e.RawPointerId] = pointer = new Pointer(Pointer.GetNextFreeId(),
-                    PointerType.Pen, _pointers.Count == 0);
+                _pointers[e.RawPointerId] = state = new PointerState();
             }
+
+            var pointer = state.Pointer;
             
             var props = new PointerPointProperties(e.InputModifiers, e.Type.ToUpdateKind(),
                 e.Point.Twist, e.Point.Pressure, e.Point.XTilt, e.Point.YTilt, e.Point.ContactRect);
@@ -71,7 +71,7 @@ namespace Avalonia.Input
                     case RawPointerEventType.MiddleButtonDown:
                     case RawPointerEventType.XButton1Down:
                     case RawPointerEventType.XButton2Down:
-                        e.Handled = PenDown(pointer, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult.firstEnabledAncestor, e.PlatformInputEventCookie);
+                        e.Handled = PenDown(state, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult.firstEnabledAncestor, e.PlatformInputEventCookie);
                         break;
                     case RawPointerEventType.LeftButtonUp:
                     case RawPointerEventType.RightButtonUp:
@@ -82,7 +82,7 @@ namespace Avalonia.Input
                         {
                             shouldReleasePointer = true;
                         }
-                        e.Handled = PenUp(pointer, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult.firstEnabledAncestor);
+                        e.Handled = PenUp(state, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult.firstEnabledAncestor);
                         break;
                     case RawPointerEventType.Move:
                         e.Handled = PenMove(pointer, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult.firstEnabledAncestor, e.IntermediatePoints);
@@ -99,10 +99,11 @@ namespace Avalonia.Input
             }
         }
 
-        private bool PenDown(Pointer pointer, ulong timestamp,
+        private bool PenDown(PointerState state, ulong timestamp,
             IInputRoot root, Point p, PointerPointProperties properties,
             KeyModifiers inputModifiers, IInputElement? hitTest, object? platformInputEventCookie)
         {
+            var pointer = state.Pointer;
             var source = pointer.Captured ?? hitTest;
 
             if (source != null)
@@ -125,7 +126,7 @@ namespace Avalonia.Input
                         .Inflate(new Thickness(doubleClickSize.Width / 2, doubleClickSize.Height / 2));
                 }
 
-                _lastMouseDownButton = properties.PointerUpdateKind.GetMouseButton();
+                state.LastMouseDownButton = properties.PointerUpdateKind.GetMouseButton();
                 var e = new PointerPressedEventArgs(source, pointer, root.RootElement, p, timestamp, properties, inputModifiers, _clickCount, platformInputEventCookie);
                 source.RaiseEvent(e);
                 return e.Handled;
@@ -156,16 +157,17 @@ namespace Avalonia.Input
             return false;
         }
 
-        private bool PenUp(Pointer pointer, ulong timestamp,
+        private bool PenUp(PointerState state, ulong timestamp,
             IInputRoot root, Point p, PointerPointProperties properties,
             KeyModifiers inputModifiers, IInputElement? hitTest)
         {
+            var pointer = state.Pointer;
             var source = pointer.CapturedGestureRecognizer?.Target ?? pointer.Captured ?? hitTest;
             
             if (source is not null)
             {
                 var e = new PointerReleasedEventArgs(source, pointer, root.RootElement, p, timestamp, properties, inputModifiers,
-                    _lastMouseDownButton);
+                    state.LastMouseDownButton);
 
                 try
                 {
@@ -177,7 +179,7 @@ namespace Avalonia.Input
                 finally
                 {
                     pointer.CaptureLost(CaptureSource.Implicit);
-                    _lastMouseDownButton = default;
+                    state.LastMouseDownButton = default;
                 }
 
                 return e.Handled;
@@ -194,14 +196,25 @@ namespace Avalonia.Input
             _pointers.Clear();
             _disposed = true;
             foreach (var p in values)
-                p.Dispose();
+                p.Pointer.Dispose();
         }
 
         public IPointer? TryGetPointer(RawPointerEventArgs ev)
         {
-            return _pointers.TryGetValue(ev.RawPointerId, out var pointer)
-                ? pointer
+            return _pointers.TryGetValue(ev.RawPointerId, out var state)
+                ? state.Pointer
                 : null;
+        }
+
+        private sealed class PointerState
+        {
+            public PointerState()
+            {
+                Pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Pen, true);
+            }
+
+            public Pointer Pointer { get; }
+            public MouseButton LastMouseDownButton { get; set; }
         }
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Input/PenDeviceTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/PenDeviceTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Input.Raw;
+using Avalonia.Platform;
+using Avalonia.Rendering;
+using Avalonia.UnitTests;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Input;
+
+public class PenDeviceTests : PointerTestsBase
+{
+    [Fact]
+    public void Pen_Pointers_Should_Share_Click_Counts()
+    {
+        using var scope = AvaloniaLocator.EnterScope();
+        var settings = new Mock<IPlatformSettings>();
+        settings.Setup(x => x.GetDoubleTapTime(PointerType.Pen)).Returns(TimeSpan.FromMilliseconds(500));
+        settings.Setup(x => x.GetDoubleTapSize(PointerType.Pen)).Returns(new Size(16, 16));
+        AvaloniaLocator.CurrentMutable.Bind<IPlatformSettings>().ToConstant(settings.Object);
+
+        using var app = UnitTestApplication.Start(new TestServices(inputManager: new InputManager()));
+
+        var renderer = new Mock<IHitTester>();
+        var device = new PenDevice();
+        var impl = CreateTopLevelImplMock();
+        var control = new Border();
+        var root = CreateInputRoot(impl.Object, control, renderer.Object);
+        var clickCounts = new List<int>();
+
+        root.PointerPressed += (_, e) => clickCounts.Add(e.ClickCount);
+        SetHit(renderer, control);
+
+        Send(device, root, RawPointerEventType.LeftButtonDown, 1);
+        Send(device, root, RawPointerEventType.LeftButtonDown, 2);
+
+        Assert.Equal(new[] { 1, 2 }, clickCounts);
+    }
+
+    [Fact]
+    public void Pen_Pointers_Should_Have_Separate_Initial_Buttons()
+    {
+        using var app = UnitTestApplication.Start(new TestServices(inputManager: new InputManager()));
+
+        var renderer = new Mock<IHitTester>();
+        var device = new PenDevice();
+        var impl = CreateTopLevelImplMock();
+        var control = new Border();
+        var root = CreateInputRoot(impl.Object, control, renderer.Object);
+        var buttons = new List<MouseButton>();
+
+        root.PointerReleased += (_, e) => buttons.Add(e.InitialPressMouseButton);
+        SetHit(renderer, control);
+
+        Send(device, root, RawPointerEventType.LeftButtonDown, 1);
+        Send(device, root, RawPointerEventType.RightButtonDown, 2);
+        Send(device, root, RawPointerEventType.LeftButtonUp, 1);
+        Send(device, root, RawPointerEventType.RightButtonUp, 2);
+
+        Assert.Equal(new[] { MouseButton.Left, MouseButton.Right }, buttons);
+    }
+
+    [Fact]
+    public void Pen_Pointers_Should_Always_Be_Primary()
+    {
+        using var app = UnitTestApplication.Start(new TestServices(inputManager: new InputManager()));
+
+        var renderer = new Mock<IHitTester>();
+        var device = new PenDevice();
+        var impl = CreateTopLevelImplMock();
+        var root = CreateInputRoot(impl.Object, new Border(), renderer.Object);
+
+        var first = Send(device, root, RawPointerEventType.Move, 1);
+        var second = Send(device, root, RawPointerEventType.Move, 2);
+
+        Assert.True(device.TryGetPointer(first)!.IsPrimary);
+        Assert.True(device.TryGetPointer(second)!.IsPrimary);
+    }
+
+    private static RawPointerEventArgs Send(PenDevice device, TopLevel root, RawPointerEventType type, long pointerId)
+    {
+        var args = CreateRawPointerArgs(device, root, type);
+        args.RawPointerId = pointerId;
+        root.PlatformImpl!.Input!(args);
+        return args;
+    }
+}


### PR DESCRIPTION
Pen pointers each represent a separate pen. Pens are independent. They have their own buttons. They should also be treated as primary pointers, there is no such thing as multi-pen gesture.

~Draft, because IsPrimary behavior is being verified against UWP.~


Fun - https://github.com/AvaloniaUI/Avalonia/issues/22085