### PR TITLE
Add touch input simulation to the headless platform

### DIFF
--- a/src/Headless/Avalonia.Headless/HeadlessWindowExtensions.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
@@ -83,6 +84,9 @@ public static class HeadlessWindowExtensions
     /// <remarks>
     /// In the headless platform, there is a single mouse pointer. There are no helper methods for touch or pen input.
     /// </remarks>
+    /// <remarks>
+    /// In the headless platform, there is a single mouse pointer. For touch input use the TouchBegin method.
+    /// </remarks>
     public static void MouseDown(this TopLevel topLevel, Point point, MouseButton button,
         RawInputModifiers modifiers = RawInputModifiers.None) =>
         RunJobsOnImpl(topLevel, w => w.MouseDown(point, button, modifiers));
@@ -107,6 +111,46 @@ public static class HeadlessWindowExtensions
     public static void MouseWheel(this TopLevel topLevel, Point point, Vector delta,
         RawInputModifiers modifiers = RawInputModifiers.None) =>
         RunJobsOnImpl(topLevel, w => w.MouseWheel(point, delta, modifiers));
+
+    /// <summary>
+    /// Simulates a touch contact being pressed on the headless window/toplevel.
+    /// </summary>
+    /// <returns>
+    /// A touch pointer to pass to <see cref="TouchMove"/> and <see cref="TouchEnd"/>.
+    /// Disposing the pointer cancels the contact if it is still pressed.
+    /// </returns>
+    /// <remarks>
+    /// To simulate multi-touch, keep several returned touch pointers pressed at the same time.
+    /// </remarks>
+    public static IHeadlessTouchPointer TouchBegin(this TopLevel topLevel, Point point,
+        RawInputModifiers modifiers = RawInputModifiers.None)
+    {
+        var touchPointId = Interlocked.Increment(ref s_nextTouchPointId);
+        RunJobsOnImpl(topLevel, w => w.Touch(point, touchPointId, RawPointerEventType.TouchBegin, modifiers));
+        return new HeadlessTouchPointer(topLevel, touchPointId, point);
+    }
+
+    /// <summary>
+    /// Simulates a touch contact being moved on the headless window/toplevel.
+    /// </summary>
+    /// <param name="topLevel">The target headless top level. Must be the one the touch pointer was created on.</param>
+    /// <param name="touchPointer">The touch pointer returned from <see cref="TouchBegin"/>.</param>
+    /// <param name="point">The new contact position.</param>
+    /// <param name="modifiers">The optional key modifiers.</param>
+    public static void TouchMove(this TopLevel topLevel, IHeadlessTouchPointer touchPointer, Point point,
+        RawInputModifiers modifiers = RawInputModifiers.None) =>
+        GetTouchPointer(topLevel, touchPointer).Move(point, modifiers);
+
+    /// <summary>
+    /// Simulates a touch contact being released on the headless window/toplevel.
+    /// </summary>
+    /// <param name="topLevel">The target headless top level. Must be the one the touch pointer was created on.</param>
+    /// <param name="touchPointer">The touch pointer returned from <see cref="TouchBegin"/>.</param>
+    /// <param name="point">The position at which the contact is released.</param>
+    /// <param name="modifiers">The optional key modifiers.</param>
+    public static void TouchEnd(this TopLevel topLevel, IHeadlessTouchPointer touchPointer, Point point,
+        RawInputModifiers modifiers = RawInputModifiers.None) =>
+        GetTouchPointer(topLevel, touchPointer).End(point, modifiers);
 
     /// <summary>
     /// Simulates a drag and drop target event on the headless window/toplevel. This event simulates a user moving files from another app to the current app.
@@ -160,5 +204,63 @@ public static class HeadlessWindowExtensions
             IHeadlessWindow headless => headless,
             _ => throw new InvalidOperationException("TopLevel must be a headless window.")
         };
+    }
+
+    private static long s_nextTouchPointId;
+
+    private static HeadlessTouchPointer GetTouchPointer(TopLevel topLevel, IHeadlessTouchPointer touchPointer)
+    {
+        if (touchPointer is not HeadlessTouchPointer headlessTouchPointer)
+            throw new ArgumentException("The touch pointer was not created by TouchBegin.", nameof(touchPointer));
+        if (headlessTouchPointer.TopLevel != topLevel)
+            throw new ArgumentException("The touch pointer belongs to a different toplevel.", nameof(touchPointer));
+        return headlessTouchPointer;
+    }
+
+    private sealed class HeadlessTouchPointer : IHeadlessTouchPointer
+    {
+        private readonly long _touchPointId;
+        private Point _position;
+        private bool _pressed = true;
+
+        public HeadlessTouchPointer(TopLevel topLevel, long touchPointId, Point position)
+        {
+            TopLevel = topLevel;
+            _touchPointId = touchPointId;
+            _position = position;
+        }
+
+        public TopLevel TopLevel { get; }
+
+        public void Move(Point point, RawInputModifiers modifiers)
+        {
+            ThrowIfReleased();
+            RunJobsOnImpl(TopLevel, w => w.Touch(point, _touchPointId, RawPointerEventType.TouchUpdate, modifiers));
+            _position = point;
+        }
+
+        public void End(Point point, RawInputModifiers modifiers)
+        {
+            ThrowIfReleased();
+            _pressed = false;
+            RunJobsOnImpl(TopLevel, w => w.Touch(point, _touchPointId, RawPointerEventType.TouchEnd, modifiers));
+        }
+
+        public void Dispose()
+        {
+            if (!_pressed)
+                return;
+            _pressed = false;
+
+            // The toplevel might have been closed already, cancelling all of its touch pointers.
+            if (TopLevel.PlatformImpl is IHeadlessWindow)
+                RunJobsOnImpl(TopLevel, w => w.Touch(_position, _touchPointId, RawPointerEventType.TouchCancel, RawInputModifiers.None));
+        }
+
+        private void ThrowIfReleased()
+        {
+            if (!_pressed)
+                throw new InvalidOperationException("The touch pointer has already been released.");
+        }
     }
 }

--- a/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -22,6 +22,7 @@ namespace Avalonia.Headless
         private readonly IKeyboardDevice _keyboard;
         private readonly IScreenImpl _screen;
         private readonly Stopwatch _st = Stopwatch.StartNew();
+        private readonly TouchDevice _touchDevice = new();
         private WriteableBitmap? _lastRenderedFrame;
         private readonly object _sync = new object();
         private readonly AvaloniaHeadlessPlatformOptions _options;
@@ -60,6 +61,7 @@ namespace Avalonia.Headless
         public void Dispose()
         {
             Closed?.Invoke();
+            _touchDevice.Dispose();
             _lastRenderedFrame?.Dispose();
             _lastRenderedFrame = null;
         }
@@ -367,6 +369,12 @@ namespace Avalonia.Headless
         {
             Input?.Invoke(new RawMouseWheelEventArgs(MouseDevice, Timestamp, InputRoot!,
                 point, delta, modifiers));
+        }
+
+        void IHeadlessWindow.Touch(Point point, long touchPointId, RawPointerEventType type, RawInputModifiers modifiers)
+        {
+            Input?.Invoke(new RawTouchEventArgs(_touchDevice, Timestamp, InputRoot!,
+                type, point, modifiers, touchPointId));
         }
 
         void IHeadlessWindow.DragDrop(Point point, RawDragEventType type, IDataTransfer data, DragDropEffects effects, RawInputModifiers modifiers)

--- a/src/Headless/Avalonia.Headless/IHeadlessTouchPointer.cs
+++ b/src/Headless/Avalonia.Headless/IHeadlessTouchPointer.cs
@@ -1,0 +1,16 @@
+using System;
+using Avalonia.Metadata;
+
+namespace Avalonia.Headless;
+
+/// <summary>
+/// Represents an active touch contact simulated on a headless window/toplevel.
+/// Use <see cref="HeadlessWindowExtensions.TouchMove"/> and <see cref="HeadlessWindowExtensions.TouchEnd"/> to drive the contact.
+/// </summary>
+/// <remarks>
+/// Disposing the touch pointer cancels the contact if it hasn't been released with <see cref="HeadlessWindowExtensions.TouchEnd"/> yet.
+/// </remarks>
+[NotClientImplementable]
+public interface IHeadlessTouchPointer : IDisposable
+{
+}

--- a/src/Headless/Avalonia.Headless/IHeadlessWindow.cs
+++ b/src/Headless/Avalonia.Headless/IHeadlessWindow.cs
@@ -17,6 +17,7 @@ namespace Avalonia.Headless
         void MouseMove(Point point, RawInputModifiers modifiers = RawInputModifiers.None);
         void MouseUp(Point point, MouseButton button, RawInputModifiers modifiers = RawInputModifiers.None);
         void MouseWheel(Point point, Vector delta, RawInputModifiers modifiers = RawInputModifiers.None);
+        void Touch(Point point, long touchPointId, RawPointerEventType type, RawInputModifiers modifiers = RawInputModifiers.None);
         void DragDrop(Point point, RawDragEventType type, IDataTransfer data, DragDropEffects effects, RawInputModifiers modifiers = RawInputModifiers.None);
         void SetRenderScaling(double scaling);
     }

--- a/tests/Avalonia.Headless.UnitTests/InputTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/InputTests.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Avalonia.Threading;
 
 namespace Avalonia.Headless.UnitTests;
@@ -101,6 +103,88 @@ public class InputTests
         _window.MouseUp(translatePoint.Value, MouseButton.Left, RawInputModifiers.None);
 
         AssertHelper.Equal(1, clickCount);
+    }
+
+#if NUNIT
+    [AvaloniaTest]
+#elif XUNIT
+    [AvaloniaFact]
+#endif
+    public void Touch_Contact_Raises_Touch_Pointer_Events()
+    {
+        var pressedCount = 0;
+        var movedCount = 0;
+        var releasedCount = 0;
+        PointerType pressedPointerType = default;
+
+        var border = new Border { Background = Brushes.Red };
+        border.PointerPressed += (_, e) =>
+        {
+            pressedCount++;
+            pressedPointerType = e.Pointer.Type;
+        };
+        border.PointerMoved += (_, _) => movedCount++;
+        border.PointerReleased += (_, _) => releasedCount++;
+
+        _window.Content = border;
+        _window.Show();
+
+        var touch = _window.TouchBegin(new Point(50, 50));
+        _window.TouchMove(touch, new Point(60, 60));
+        _window.TouchEnd(touch, new Point(60, 60));
+
+        AssertHelper.Equal(1, pressedCount);
+        AssertHelper.Equal(1, movedCount);
+        AssertHelper.Equal(1, releasedCount);
+        AssertHelper.Equal(PointerType.Touch, pressedPointerType);
+    }
+
+#if NUNIT
+    [AvaloniaTest]
+#elif XUNIT
+    [AvaloniaFact]
+#endif
+    public void Multiple_Touch_Contacts_Are_Distinct_Pointers()
+    {
+        var pointerIds = new HashSet<int>();
+
+        var border = new Border { Background = Brushes.Red };
+        border.PointerPressed += (_, e) => pointerIds.Add(e.Pointer.Id);
+
+        _window.Content = border;
+        _window.Show();
+
+        var touch1 = _window.TouchBegin(new Point(30, 30));
+        var touch2 = _window.TouchBegin(new Point(70, 70));
+        _window.TouchEnd(touch1, new Point(30, 30));
+        _window.TouchEnd(touch2, new Point(70, 70));
+
+        AssertHelper.Equal(2, pointerIds.Count);
+    }
+
+#if NUNIT
+    [AvaloniaTest]
+#elif XUNIT
+    [AvaloniaFact]
+#endif
+    public void Disposing_Touch_Pointer_Cancels_Contact()
+    {
+        var captureLostCount = 0;
+        var releasedCount = 0;
+
+        var border = new Border { Background = Brushes.Red };
+        border.PointerCaptureLost += (_, _) => captureLostCount++;
+        border.PointerReleased += (_, _) => releasedCount++;
+
+        _window.Content = border;
+        _window.Show();
+
+        using (_window.TouchBegin(new Point(50, 50)))
+        {
+        }
+
+        AssertHelper.Equal(1, captureLostCount);
+        AssertHelper.Equal(0, releasedCount);
     }
 
 #if NUNIT


### PR DESCRIPTION
Touch only changes from https://github.com/AvaloniaUI/Avalonia/pull/21888 since pen work has opened a can of worms that won't be backportable.

API already approved for the original PR.