### PR TITLE
Fix BrowserDispatcherImpl never setting _signaled flag

### DIFF
--- a/src/Browser/Avalonia.Browser/BrowserDispatcherImpl.cs
+++ b/src/Browser/Avalonia.Browser/BrowserDispatcherImpl.cs
@@ -11,7 +11,7 @@ internal class BrowserDispatcherImpl : IDispatcherImpl
 {
     private readonly Thread _thread;
     private readonly Stopwatch _clock;
-    private bool _signaled;
+    private int _signaled;
     private int? _timerId;
 
     public BrowserDispatcherImpl()
@@ -26,7 +26,7 @@ internal class BrowserDispatcherImpl : IDispatcherImpl
         
         TimerHelper.Timeout = () =>
         {
-            _signaled = false;
+            Interlocked.Exchange(ref _signaled, 0);
             Signaled?.Invoke();
         };
     }
@@ -40,11 +40,11 @@ internal class BrowserDispatcherImpl : IDispatcherImpl
 
     public void Signal()
     {
-        if (_signaled)
+        if (Interlocked.CompareExchange(ref _signaled, 1, 0) != 0)
             return;
 
         // NOTE: by HTML5 spec minimal timeout is 4ms, but Chrome seems to work well with 1ms as well.
-        var interval = 1;
+        const int interval = 1;
         TimerHelper.SetTimeout(interval);
     }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
_signaled was only ever reset to false in the timeout callback and never
set to true in Signal(), so the coalescing guard never triggered.
Every Signal() call scheduled a brand-new setTimeout(1ms), instead of
reusing a single pending one. Use Interlocked.CompareExchange/Exchange
on an int flag, matching AndroidDispatcherImpl.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Excessive amounts of promises are created increasing memory usage over time. 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Should behave the same but not create excessive amounts of promises. 


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #22088
