### PR TITLE
Fix memory leak when binding to observables (#5872, #18176)

### DIFF
--- a/src/Avalonia.Base/Data/Core/ExpressionNodes/StreamNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNodes/StreamNode.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using Avalonia.Data.Core.Plugins;
+using Avalonia.Reactive;
 
 namespace Avalonia.Data.Core.ExpressionNodes;
 
@@ -30,7 +31,8 @@ internal sealed class StreamNode : ExpressionNode, IObserver<object?>
 
         if (_plugin.Start(new(source)) is { } accessor)
         {
-            _subscription = accessor.Subscribe(this);
+            // Subscribe weakly so a long-lived source doesn't keep the binding target alive (#5872).
+            _subscription = WeakObserverSubscription<object?>.Subscribe(accessor, this);
         }
         else
         {

--- a/src/Avalonia.Base/Data/Core/ExpressionNodes/StreamNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNodes/StreamNode.cs
@@ -31,7 +31,6 @@ internal sealed class StreamNode : ExpressionNode, IObserver<object?>
 
         if (_plugin.Start(new(source)) is { } accessor)
         {
-            // Subscribe weakly so a long-lived source doesn't keep the binding target alive (#5872).
             _subscription = WeakObserverSubscription<object?>.Subscribe(accessor, this);
         }
         else

--- a/src/Avalonia.Base/Data/Core/UntypedObservableBindingExpression.cs
+++ b/src/Avalonia.Base/Data/Core/UntypedObservableBindingExpression.cs
@@ -20,7 +20,6 @@ internal class UntypedObservableBindingExpression : UntypedBindingExpressionBase
 
     protected override void StartCore()
     {
-        // Subscribe weakly so a long-lived source doesn't keep the binding target alive (#5872, #18176).
         _subscription = WeakObserverSubscription<object?>.Subscribe(_observable, this);
     }
 

--- a/src/Avalonia.Base/Data/Core/UntypedObservableBindingExpression.cs
+++ b/src/Avalonia.Base/Data/Core/UntypedObservableBindingExpression.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Avalonia.Reactive;
 
 namespace Avalonia.Data.Core;
 
@@ -19,7 +20,8 @@ internal class UntypedObservableBindingExpression : UntypedBindingExpressionBase
 
     protected override void StartCore()
     {
-        _subscription = _observable.Subscribe(this);
+        // Subscribe weakly so a long-lived source doesn't keep the binding target alive (#5872, #18176).
+        _subscription = WeakObserverSubscription<object?>.Subscribe(_observable, this);
     }
 
     protected override void StopCore()

--- a/src/Avalonia.Base/Reactive/WeakObserverSubscription.cs
+++ b/src/Avalonia.Base/Reactive/WeakObserverSubscription.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace Avalonia.Reactive;
+
+/// <summary>
+/// Subscribes an <see cref="IObserver{T}"/> to an <see cref="IObservable{T}"/> such that the
+/// observable holds only a weak reference to the observer, disposing the subscription once the
+/// observer has been collected.
+/// </summary>
+/// <typeparam name="T">The type of the elements in the sequence.</typeparam>
+internal sealed class WeakObserverSubscription<T> : IObserver<T>, IDisposable
+{
+    private readonly WeakReference<IObserver<T>> _observer;
+    private IDisposable? _subscription;
+
+    private WeakObserverSubscription(IObserver<T> observer)
+    {
+        _observer = new WeakReference<IObserver<T>>(observer);
+    }
+
+    /// <summary>
+    /// Subscribes <paramref name="observer"/> to <paramref name="observable"/> via a weak reference.
+    /// </summary>
+    /// <returns>
+    /// A disposable which unsubscribes from the observable when disposed. The caller must keep it
+    /// alive for as long as the subscription is required.
+    /// </returns>
+    public static IDisposable Subscribe(IObservable<T> observable, IObserver<T> observer)
+    {
+        var subscription = new WeakObserverSubscription<T>(observer);
+        subscription._subscription = observable.Subscribe(subscription);
+        return subscription;
+    }
+
+    public void OnCompleted()
+    {
+        if (TryGetObserver(out var observer))
+            observer.OnCompleted();
+    }
+
+    public void OnError(Exception error)
+    {
+        if (TryGetObserver(out var observer))
+            observer.OnError(error);
+    }
+
+    public void OnNext(T value)
+    {
+        if (TryGetObserver(out var observer))
+            observer.OnNext(value);
+    }
+
+    public void Dispose()
+    {
+        _subscription?.Dispose();
+        _subscription = null;
+    }
+
+    private bool TryGetObserver(out IObserver<T> observer)
+    {
+        if (_observer.TryGetTarget(out observer!))
+            return true;
+
+        // The observer has been collected; unsubscribe from the observable.
+        Dispose();
+        return false;
+    }
+}

--- a/src/Avalonia.Base/Reactive/WeakObserverSubscription.cs
+++ b/src/Avalonia.Base/Reactive/WeakObserverSubscription.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Avalonia.Reactive;
 
@@ -56,9 +57,9 @@ internal sealed class WeakObserverSubscription<T> : IObserver<T>, IDisposable
         _subscription = null;
     }
 
-    private bool TryGetObserver(out IObserver<T> observer)
+    private bool TryGetObserver([NotNullWhen(true)] out IObserver<T>? observer)
     {
-        if (_observer.TryGetTarget(out observer!))
+        if (_observer.TryGetTarget(out observer))
             return true;
 
         // The observer has been collected; unsubscribe from the observable.

--- a/tests/Avalonia.LeakTests/AvaloniaObjectTests.cs
+++ b/tests/Avalonia.LeakTests/AvaloniaObjectTests.cs
@@ -228,6 +228,51 @@ namespace Avalonia.LeakTests
         }
 
         [Fact]
+        public void StreamObservable_Binding_With_Alive_Target_Keeps_Source_Alive()
+        {
+            // The weak subscription introduced for #5872 must not collect the source observable
+            // while the binding target is still alive: an active binding still needs its source.
+            var target = new TextBlock();
+
+            WeakReference SetupBinding()
+            {
+                var observable = new Subject<string>();
+                var source = new Class3 { Observable = observable };
+
+                var path = new CompiledBindingPathBuilder()
+                    .Property(
+                        new ClrPropertyInfo(
+                            nameof(Class3.Observable),
+                            o => ((Class3)o).Observable,
+                            null,
+                            typeof(IObservable<string>)),
+                        PropertyInfoAccessorFactory.CreateInpcPropertyAccessor)
+                    .StreamObservable<string>()
+                    .Build();
+
+                target.Bind(TextBlock.TextProperty, new CompiledBindingExtension
+                {
+                    Source = source,
+                    Path = path
+                });
+
+                observable.OnNext("foo");
+                Assert.Equal("foo", target.Text);
+
+                return new WeakReference(observable);
+            }
+
+            var weakObservable = SetupBinding();
+
+            CollectGarbage();
+
+            // The target is still alive, so its binding must keep the source observable alive.
+            Assert.True(weakObservable.IsAlive);
+
+            GC.KeepAlive(target);
+        }
+
+        [Fact]
         public void Binding_To_AttachedProperty_With_Alive_Source_Does_Not_Keep_Target_Alive()
         {
             var source = new StyledElement { Name = "foo" };

--- a/tests/Avalonia.LeakTests/AvaloniaObjectTests.cs
+++ b/tests/Avalonia.LeakTests/AvaloniaObjectTests.cs
@@ -155,6 +155,79 @@ namespace Avalonia.LeakTests
         }
 
         [Fact]
+        public void CompiledBinding_StreamObservable_With_Alive_Source_Does_Not_Keep_Target_Alive()
+        {
+            // Issue #5872: a binding to a long-lived observable via the '^' stream operator should
+            // not keep the target alive, in the same way as every other binding type above.
+            var observable = new Subject<string>();
+            var source = new Class3 { Observable = observable };
+
+            WeakReference SetupBinding()
+            {
+                var path = new CompiledBindingPathBuilder()
+                    .Property(
+                        new ClrPropertyInfo(
+                            nameof(Class3.Observable),
+                            target => ((Class3)target).Observable,
+                            null,
+                            typeof(IObservable<string>)),
+                        PropertyInfoAccessorFactory.CreateInpcPropertyAccessor)
+                    .StreamObservable<string>()
+                    .Build();
+
+                var target = new TextBlock();
+
+                target.Bind(TextBlock.TextProperty, new CompiledBindingExtension
+                {
+                    Source = source,
+                    Path = path
+                });
+
+                observable.OnNext("foo");
+                Assert.Equal("foo", target.Text);
+
+                return new WeakReference(target);
+            }
+
+            var weakTarget = SetupBinding();
+
+            CollectGarbage();
+            Assert.False(weakTarget.IsAlive);
+
+            // Keep the source and its observable alive to simulate a resource that outlives the target.
+            GC.KeepAlive(source);
+            GC.KeepAlive(observable);
+        }
+
+        [Fact]
+        public void ToBinding_Observable_With_Alive_Source_Does_Not_Keep_Target_Alive()
+        {
+            // Issue #18176 (duplicate of #5872): a binding created from an observable via
+            // ToBinding() should not keep the target alive while the observable is alive.
+            var observable = new Subject<string>();
+
+            WeakReference SetupBinding()
+            {
+                var target = new TextBlock();
+
+                target.Bind(TextBlock.TextProperty, observable.ToBinding());
+
+                observable.OnNext("foo");
+                Assert.Equal("foo", target.Text);
+
+                return new WeakReference(target);
+            }
+
+            var weakTarget = SetupBinding();
+
+            CollectGarbage();
+            Assert.False(weakTarget.IsAlive);
+
+            // Keep the observable alive to simulate a resource that outlives the target.
+            GC.KeepAlive(observable);
+        }
+
+        [Fact]
         public void Binding_To_AttachedProperty_With_Alive_Source_Does_Not_Keep_Target_Alive()
         {
             var source = new StyledElement { Name = "foo" };
@@ -211,6 +284,11 @@ namespace Avalonia.LeakTests
             public void DoSomething()
             {
             }
+        }
+
+        private sealed class Class3
+        {
+            public IObservable<string>? Observable { get; set; }
         }
 
         private sealed class Class2 : INotifyPropertyChanged


### PR DESCRIPTION
## What does the pull request do?

(Real @grokys here: this is a really old one that I never had the time to get to the bottom of before. Claude looks like it's worked it out though; it's it's pretty obvious now I see the fix. My main input here was stopping the bloody thing waffling on interminably in comments.)

Fixes a memory leak where binding to a long-lived observable keeps the binding target alive for the lifetime of the observable.

Bindings hold their target weakly so a control can be collected even while a binding to a long-lived source is still active; normal property bindings preserve this by subscribing to their source via weak events. Observable sources broke the invariant: `observable.Subscribe(this)` let the observable hold the observer strongly, which transitively rooted the `ValueStore` and therefore the target, so a long-lived observable pinned the control for the observables lifetime.

This affects:
- the `^` stream binding operator (`StreamNode`) — #5872
- `Observable.ToBinding()` (`UntypedObservableBindingExpression`) — #18176

## How was the solution implemented?

Added `WeakObserverSubscription<T>` (in `Avalonia.Reactive`), which subscribes an observer to an observable via a weak reference and disposes the subscription once the observer has been collected. Wired it into `StreamNode` and `UntypedObservableBindingExpression`.

Leak tests were added alongside the existing `_With_Alive_Source_Does_Not_Keep_Target_Alive` invariant tests in `Avalonia.LeakTests`, covering both the `^` operator and `ToBinding()`. They fail without the fix and pass with it.

Fixes #5872
Fixes #18176

🤖 Generated with [Claude Code](https://claude.com/claude-code)