### PR TITLE
Fix infinite loop when wrapping a line that produces no shaped runs

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -97,6 +97,12 @@ namespace Avalonia.Media.TextFormatting
                     case TextWrapping.WrapWithOverflow:
                     case TextWrapping.Wrap:
                         {
+                            if (shapedTextRuns.Count == 0)
+                            {
+                                return CreateUnshapedTextLine(firstTextSourceIndex, textSourceLength,
+                                    paragraphWidth, paragraphProperties, resolvedFlowDirection, nextLineBreak);
+                            }
+
                             return PerformTextWrapping(shapedTextRuns, false, firstTextSourceIndex, paragraphWidth,
                                 paragraphProperties, resolvedFlowDirection, nextLineBreak, objectPool);
                         }
@@ -143,6 +149,12 @@ namespace Avalonia.Media.TextFormatting
                 case TextWrapping.WrapWithOverflow:
                 case TextWrapping.Wrap:
                     {
+                        if (cached.ShapedRuns.Length == 0)
+                        {
+                            return CreateUnshapedTextLine(firstTextSourceIndex, cached.TextSourceLength,
+                                paragraphWidth, paragraphProperties, resolvedFlowDirection, nextLineBreak);
+                        }
+
                         var runs = new List<TextRun>(cached.ShapedRuns.Length);
 
                         for (var i = 0; i < cached.ShapedRuns.Length; i++)
@@ -159,6 +171,23 @@ namespace Avalonia.Media.TextFormatting
                 default:
                     throw new ArgumentOutOfRangeException(nameof(paragraphProperties.TextWrapping));
             }
+        }
+
+        /// <summary>
+        /// Creates a line for text that shaping produced no runs for, which happens when the
+        /// typeface has no glyphs for any of its characters. The line still consumes
+        /// <paramref name="textSourceLength"/> so that callers keep advancing through the text source.
+        /// </summary>
+        private static TextLineImpl CreateUnshapedTextLine(int firstTextSourceIndex, int textSourceLength,
+            double paragraphWidth, TextParagraphProperties paragraphProperties,
+            FlowDirection resolvedFlowDirection, TextLineBreak? textLineBreak)
+        {
+            var textLine = new TextLineImpl(Array.Empty<TextRun>(), firstTextSourceIndex, textSourceLength,
+                paragraphWidth, paragraphProperties, resolvedFlowDirection, textLineBreak);
+
+            textLine.FinalizeLine();
+
+            return textLine;
         }
 
         /// <summary>

--- a/tests/Avalonia.Base.UnitTests/Media/TextFormatting/TextFormatterTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/TextFormatting/TextFormatterTests.cs
@@ -1,0 +1,108 @@
+using System;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+using Avalonia.Platform;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Media.TextFormatting
+{
+    public class TextFormatterTests : ScopedTestBase
+    {
+        [Fact]
+        public void Should_Consume_Line_Break_That_Produces_No_Shaped_Runs()
+        {
+            using (Start())
+            {
+                var defaultRunProperties = new GenericTextRunProperties(Typeface.Default);
+                var paragraphProperties = new GenericTextParagraphProperties(defaultRunProperties,
+                    textWrapping: TextWrapping.Wrap);
+                var textSource = new SingleBufferTextSource("\r\nABC", defaultRunProperties);
+
+                var textLine = TextFormatter.Current.FormatLine(textSource, 0, 200, paragraphProperties);
+
+                Assert.NotNull(textLine);
+
+                Assert.Equal(2, textLine.Length);
+            }
+        }
+
+        [Fact]
+        public void Should_Wrap_Text_Starting_With_A_Line_Break_That_Produces_No_Shaped_Runs()
+        {
+            using (Start())
+            {
+                var textLayout = new TextLayout("\r\nABC", Typeface.Default, 12, Brushes.Black,
+                    textWrapping: TextWrapping.Wrap, maxWidth: 200);
+
+                Assert.Equal(2, textLayout.TextLines.Count);
+
+                Assert.Equal(2, textLayout.TextLines[0].Length);
+
+                Assert.Equal(3, textLayout.TextLines[1].Length);
+            }
+        }
+
+        [Fact]
+        public void Should_Reuse_Cached_Line_Break_That_Produces_No_Shaped_Runs()
+        {
+            using (Start())
+            {
+                var defaultRunProperties = new GenericTextRunProperties(Typeface.Default);
+                var paragraphProperties = new GenericTextParagraphProperties(defaultRunProperties,
+                    textWrapping: TextWrapping.Wrap);
+                var textSource = new SingleBufferTextSource("\r\nABC", defaultRunProperties);
+
+                using var textRunCache = new TextRunCache();
+
+                _ = new TextLayout(textSource, paragraphProperties, maxWidth: 200, textRunCache: textRunCache);
+
+                var textLayout = new TextLayout(textSource, paragraphProperties, maxWidth: 200,
+                    textRunCache: textRunCache);
+
+                Assert.Equal(2, textLayout.TextLines.Count);
+
+                Assert.Equal(2, textLayout.TextLines[0].Length);
+
+                Assert.Equal(3, textLayout.TextLines[1].Length);
+            }
+        }
+
+        // The headless font has no glyphs for CR/LF, so shaping a line break produces no runs.
+        private static IDisposable Start()
+        {
+            var fontManagerImpl = new HeadlessFontManagerStub();
+
+            var disposable = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface
+                .With(fontManagerImpl: fontManagerImpl));
+
+            AvaloniaLocator.CurrentMutable
+                .Bind<FontManager>().ToConstant(new FontManager(fontManagerImpl));
+
+            return disposable;
+        }
+
+        private class SingleBufferTextSource : ITextSource
+        {
+            private readonly string _text;
+            private readonly TextRunProperties _defaultProperties;
+
+            public SingleBufferTextSource(string text, TextRunProperties defaultProperties)
+            {
+                _text = text;
+                _defaultProperties = defaultProperties;
+            }
+
+            public TextRun? GetTextRun(int textSourceIndex)
+            {
+                if (textSourceIndex >= _text.Length)
+                {
+                    return null;
+                }
+
+                return new TextCharacters(_text.AsMemory(textSourceIndex), _defaultProperties);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Fixes an infinite loop in `TextLayout` when wrapping text whose first line produces no shaped runs.

## What is the current behavior?

`TextFormatterImpl.FormatLine` fetches the text up to the first line break, shapes it, and then wraps it. Shaping drops a run when the typeface has no glyphs for its characters, so a line that consists only of a line break can come back with zero shaped runs. `PerformTextWrapping` then returns an empty line of length 0 with no line break, and `TextLayout.CreateTextLines` never advances `_textSourceLength` nor sees a `TextEndOfParagraph`, so it formats the same line forever and allocates a `TextLineImpl` per iteration until the process runs out of memory.

The headless font (`BareMinimum.ttf`) has no glyphs for CR/LF, so this reproduces on the default headless platform. Measuring a `TextBlock` with `TextWrapping="Wrap"`, a finite width, and text starting with a line break hangs and OOMs the test host:

```csharp
[AvaloniaFact]
public void TextBlock_LeadingNewline_Wrap_MeasureNeverReturns()
{
    var textBlock = new TextBlock
    {
        TextWrapping = TextWrapping.Wrap,
        Width = 290,
        Text = "\r\nPassword update failed",
    };

    textBlock.Measure(new Size(290, double.PositiveInfinity)); // never returns
}
```

## What is the updated/expected behavior with this PR?

The line break is consumed and the text lays out as an empty first line followed by the rest of the text. The repro above returns with two lines.

## How was the solution implemented (if it's not obvious)?

The `NoWrap` path already builds its line from the fetched source length, so it advances even when every run is dropped. The two wrapping paths (`FormatLine` and `FormatLineFromCache`) now do the same through `CreateUnshapedTextLine` instead of falling through to `PerformTextWrapping`, which has no source length to consume.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Fixed issues

Fixes #22004
