### PR TITLE
Don't build the selected text just to check whether a selection exists

### DIFF
--- a/src/Avalonia.Controls/SelectableTextBlock.cs
+++ b/src/Avalonia.Controls/SelectableTextBlock.cs
@@ -539,9 +539,26 @@ namespace Avalonia.Controls
 
         private void UpdateCommandStates()
         {
-            var text = GetSelection();
+            CanCopy = HasSelection();
+        }
 
-            CanCopy = !string.IsNullOrEmpty(text);
+        /// <summary>
+        /// Reports the same emptiness conditions as <see cref="GetSelection"/>, without building
+        /// the selected string.
+        /// </summary>
+        private bool HasSelection()
+        {
+            var start = Math.Min(SelectionStart, SelectionEnd);
+            var end = Math.Max(SelectionStart, SelectionEnd);
+
+            if (start == end)
+            {
+                return false;
+            }
+
+            var textLength = (HasComplexContent ? Inlines?.Text : Text)?.Length ?? 0;
+
+            return textLength > 0 && end <= textLength;
         }
 
         private string GetSelection()

--- a/src/Avalonia.Controls/SelectableTextBlock.cs
+++ b/src/Avalonia.Controls/SelectableTextBlock.cs
@@ -548,8 +548,10 @@ namespace Avalonia.Controls
         /// </summary>
         private bool HasSelection()
         {
-            var start = Math.Min(SelectionStart, SelectionEnd);
-            var end = Math.Max(SelectionStart, SelectionEnd);
+            var selectionStart = SelectionStart;
+            var selectionEnd = SelectionEnd;
+            var start = Math.Min(selectionStart, selectionEnd);
+            var end = Math.Max(selectionStart, selectionEnd);
 
             if (start == end)
             {

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1112,10 +1112,9 @@ namespace Avalonia.Controls
 
         private void UpdateCommandStates()
         {
-            var text = GetSelection();
-            var isSelectionNullOrEmpty = string.IsNullOrEmpty(text);
-            CanCopy = !IsPasswordBox && !isSelectionNullOrEmpty;
-            CanCut = !IsPasswordBox && !isSelectionNullOrEmpty && !IsReadOnly;
+            var hasSelection = HasSelection();
+            CanCopy = !IsPasswordBox && hasSelection;
+            CanCut = !IsPasswordBox && hasSelection && !IsReadOnly;
             CanPaste = !IsReadOnly;
         }
 
@@ -2448,6 +2447,25 @@ namespace Avalonia.Controls
             SetCurrentValue(CaretIndexProperty, SelectionStart);
 
             return false;
+        }
+
+        /// <summary>
+        /// Reports the same emptiness conditions as <see cref="GetSelection"/>, without building
+        /// the selected string.
+        /// </summary>
+        private bool HasSelection()
+        {
+            var start = Math.Min(SelectionStart, SelectionEnd);
+            var end = Math.Max(SelectionStart, SelectionEnd);
+
+            if (start == end)
+            {
+                return false;
+            }
+
+            var textLength = Text?.Length ?? 0;
+
+            return textLength > 0 && end <= textLength;
         }
 
         private string GetSelection()

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -2455,8 +2455,7 @@ namespace Avalonia.Controls
         /// </summary>
         private bool HasSelection()
         {
-            var start = Math.Min(SelectionStart, SelectionEnd);
-            var end = Math.Max(SelectionStart, SelectionEnd);
+            var (start, end) = GetSelectionRange();
 
             if (start == end)
             {

--- a/tests/Avalonia.Controls.UnitTests/SelectableTextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SelectableTextBlockTests.cs
@@ -273,6 +273,51 @@ namespace Avalonia.Controls.UnitTests
             Assert.IsType<InvalidOperationException>(Record.Exception(syncContext.ExecutePostedCallbacks));
         }
 
+        [Theory]
+        [InlineData(2, 2, false)]
+        [InlineData(1, 3, true)]
+        [InlineData(3, 1, true)]
+        [InlineData(0, 4, true)]
+        public void CanCopy_Tracks_Whether_Selection_Covers_Any_Character(int start, int end, bool expected)
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var target = new SelectableTextBlock { Text = "abcd" };
+
+                target.Measure(Size.Infinity);
+
+                target.SelectionStart = start;
+                target.SelectionEnd = end;
+
+                Assert.Equal(expected, target.CanCopy);
+            }
+        }
+
+        [Fact]
+        public void CanCopy_Tracks_Selection_Over_Inlines()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var target = new SelectableTextBlock();
+
+                target.Inlines!.Add(new Run("foo"));
+                target.Inlines!.Add(new Run("bar"));
+
+                target.Measure(Size.Infinity);
+
+                Assert.False(target.CanCopy);
+
+                target.SelectionStart = 2;
+                target.SelectionEnd = 5;
+
+                Assert.True(target.CanCopy);
+
+                target.ClearSelection();
+
+                Assert.False(target.CanCopy);
+            }
+        }
+
         private static TestServices ClipboardServices
             => TestServices.MockThreadingInterface.With(
                 assetLoader: new StandardAssetLoader(),


### PR DESCRIPTION
## What does the pull request do?

Stops `UpdateCommandStates` from building the selected text on every selection change, as requested by @Gillibald in #21492.

## What is the current behavior?

`TextBox.UpdateCommandStates` and `SelectableTextBlock.UpdateCommandStates` only need to know whether the selection is empty, but they call `GetSelection`, which allocates a substring. `UpdateCommandStates` runs on every `SelectionStart`/`SelectionEnd` change, so dragging a selection or moving the caret allocates a string per event that is immediately discarded.

## What is the updated/expected behavior with this PR?

No behavioral change. A selection change no longer allocates in `TextBox`, nor in `SelectableTextBlock` that uses `Text`.

## How was the solution implemented (if it's not obvious)?

`HasSelection` replicates the emptiness conditions of `GetSelection` from the selection indices and the text length, so `CanCopy`/`CanCut` are unchanged for every reachable state. `SelectableTextBlock` checks the indices before it reads the content, so an empty selection over `Inlines` no longer builds the inline text either.

Not covered here: a `SelectableTextBlock` with a non-empty selection over `Inlines` still needs the content length, and `Inlines.Text` is the only way to get it. `TextBox.CoerceCaretIndex` builds that same string on the same path, so removing it from one of the two alone buys nothing — both want a non-allocating inline length, which is a separate change.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Related issues

Related to #21461 — this addresses the allocation concern raised while reviewing #21492, not the `SelectedText` notification values themselves.
