### PR TITLE
fix(macos): prevent title bar flash on fullscreen exit

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -348,6 +348,10 @@
 
 - (void)windowWillExitFullScreen:(NSNotification *_Nonnull)notification
 {
+    // Prepare the destination appearance before AppKit starts the exit animation.
+    if (_isExtended)
+        [self setTitlebarAppearsTransparent:true];
+
     auto parent = _parent.tryGetWithCast<IWindowStateChanged>();
 
     if(parent != nullptr)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Prevents the native macOS title bar from briefly appearing when an extended-client-area window exits fullscreen.

I noticed this behavior while investigating #21119.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

On macOS, a window using `ExtendClientAreaToDecorationsHint="True"` with `WindowDecorations="Full"` can briefly display the opaque native title bar when exiting fullscreen.

This is especially noticeable when the extended client area is used to render a custom title bar. The flash disappears once Avalonia restores the transparent title bar after the transition.

https://github.com/user-attachments/assets/7260be28-76a2-4c8e-8900-cbe248e6af90

<img width="2560" height="1440" alt="before" src="https://github.com/user-attachments/assets/705a04d3-0e8a-41d2-8df9-45bc66a4bdc0" />


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

https://github.com/user-attachments/assets/463c1312-32e8-4ee3-ac7b-0223d51e42bd

<img width="2560" height="1440" alt="after" src="https://github.com/user-attachments/assets/fc6c4a5f-e48c-4be5-bc52-e6752ab8bfee" />


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

None.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

None.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

None.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

None.
