### PR TITLE
Fix #7536: crash when changing source during SelectionChanged

### DIFF
--- a/src/Avalonia.Controls/Selection/SelectionModel.cs
+++ b/src/Avalonia.Controls/Selection/SelectionModel.cs
@@ -665,8 +665,13 @@ namespace Avalonia.Controls.Selection
 
                 if (operation.SelectedIndex == -1 && LostSelection is not null && !operation.SkipLostSelection)
                 {
+                    // Bump the update count so that any selection change made by a LostSelection
+                    // handler is batched into the current operation. Decrement it again afterwards
+                    // so that the rest of the commit (in particular the SelectionChanged event) runs
+                    // with an update count of 0, allowing handlers to change the source (see #7536).
                     operation.UpdateCount++;
                     LostSelection?.Invoke(this, EventArgs.Empty);
+                    operation.UpdateCount--;
                 }
 
                 _selectedIndex = operation.SelectedIndex;

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -1111,15 +1111,17 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 ItemsSource = new ObservableCollection<Item> { new(), new(), new() },
                 SelectedIndex = 0,
             };
+            var raised = 0;
 
             target.SelectionChanged += (s, e) =>
             {
                 target.ItemsSource = new ObservableCollection<Item> { new(), new() };
+                ++raised;
             };
 
-            var ex = Record.Exception(() => target.SelectedIndex = -1);
+            target.SelectedIndex = -1;
 
-            Assert.Null(ex);
+            Assert.Equal(1, raised);
         }
 
         [Fact]

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -1103,6 +1103,26 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void Changing_ItemsSource_During_SelectionChanged_When_Selection_Lost_Does_Not_Throw()
+        {
+            // Issue #7536.
+            var target = new SelectingItemsControl
+            {
+                ItemsSource = new ObservableCollection<Item> { new(), new(), new() },
+                SelectedIndex = 0,
+            };
+
+            target.SelectionChanged += (s, e) =>
+            {
+                target.ItemsSource = new ObservableCollection<Item> { new(), new() };
+            };
+
+            var ex = Record.Exception(() => target.SelectedIndex = -1);
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
         public void Setting_SelectedIndex_Should_Raise_PropertyChanged_Events()
         {
             var items = new ObservableCollection<string> { "foo", "bar", "baz" };

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_AutoSelect.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_AutoSelect.cs
@@ -84,6 +84,35 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void Can_Change_Selection_From_SelectionChanged_When_AlwaysSelected_Reselects()
+        {
+            // Regression test for the #7536 fix: clearing the selection makes AlwaysSelected
+            // reselect the first item (via LostSelection), which raises SelectionChanged. A
+            // handler that changes the selection from there must be honoured rather than
+            // swallowed by the batch update that wraps the LostSelection handler.
+            var target = new TestSelector
+            {
+                ItemsSource = new[] { "foo", "bar", "baz" },
+                Template = Template(),
+            };
+
+            target.ApplyTemplate();
+            target.SelectedIndex = 1;
+
+            var raised = 0;
+            target.SelectionChanged += (s, e) =>
+            {
+                if (++raised == 1)
+                    target.SelectedIndex = 2;
+            };
+
+            target.SelectedIndex = -1;
+
+            Assert.Equal(2, target.SelectedIndex);
+            Assert.Equal("baz", target.SelectedItem);
+        }
+
+        [Fact]
         public void Selection_Should_Be_Cleared_When_No_Items_Left()
         {
             var items = new AvaloniaList<string>(new[] { "foo", "bar" });


### PR DESCRIPTION
## What

Fixes #7536: an `InvalidOperationException` ("Cannot change source while update is in progress.") when a `SelectingItemsControl`'s source is changed from within its own `SelectionChanged` handler while the selection is being lost.

## Cause

In `SelectionModel.CommitOperation`, when the selection is lost the code bumps the operation's `UpdateCount` before raising `LostSelection` so that any selection change made by the `LostSelection` handler (e.g. `AlwaysSelected` re-selecting the first item) folds into the current operation. However it never decremented the count again, so the rest of the commit — including the `SelectionChanged` event — ran with `UpdateCount > 0`.

As a result:

- A `SelectionChanged` handler that changed the control's source (as StructuredLogViewer's `UpdateBreadcrumb` does) hit the `UpdateCount > 0` guard in `SetSource` and threw.
- A `SelectionChanged` handler that changed the *selection* had its change batched into the outer operation and then silently discarded when the commit finished.

Note the non-lost-selection path already ran `SelectionChanged` at `UpdateCount == 0`; this only brings the lost-selection path in line with it.

## Fix

Decrement `UpdateCount` again once the `LostSelection` handler returns, so the batching only wraps that handler and the subsequent `SelectionChanged` event runs at `UpdateCount == 0`.

## Tests

- `Changing_ItemsSource_During_SelectionChanged_When_Selection_Lost_Does_Not_Throw` — reproduces the original crash.
- `Can_Change_Selection_From_SelectionChanged_When_AlwaysSelected_Reselects` — pins the interaction with `AlwaysSelected`: the re-selection still folds into the operation, and an in-handler selection change is now honoured instead of being swallowed. Both fail before the fix and pass after.

Full `SelectingItemsControlTests*` (540), `SelectionModelTests*` (122), `ListBoxTests` and `TreeViewTests` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
