### PR TITLE
Support `TextInputOptions.IsSensitive` and ContentType Pin on Android

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AndroidInputMethod.cs
@@ -174,11 +174,14 @@ namespace Avalonia.Android.Platform.Input
 
                 outAttrs.InputType = options.ContentType switch
                 {
-                    TextInputContentType.Email => InputTypes.TextVariationEmailAddress,
-                    TextInputContentType.Number => InputTypes.ClassNumber,
-                    TextInputContentType.Password => InputTypes.TextVariationPassword,
+                    TextInputContentType.Email => InputTypes.ClassText | InputTypes.TextVariationEmailAddress,
+                    TextInputContentType.Number => InputTypes.ClassNumber | InputTypes.NumberFlagDecimal | InputTypes.NumberFlagSigned,
+                    TextInputContentType.Password => InputTypes.ClassText | InputTypes.TextVariationPassword,
+                    TextInputContentType.Pin => InputTypes.ClassNumber | InputTypes.NumberVariationPassword,
                     TextInputContentType.Digits => InputTypes.ClassPhone,
-                    TextInputContentType.Url => InputTypes.TextVariationUri,
+                    TextInputContentType.Url => InputTypes.ClassText | InputTypes.TextVariationUri,
+                    TextInputContentType.Name => InputTypes.ClassText | InputTypes.TextVariationPersonName,
+                    // Alpha/Normal/Social/Search have no dedicated Android keyboard
                     _ => InputTypes.ClassText
                 };
 
@@ -191,9 +194,6 @@ namespace Avalonia.Android.Platform.Input
                 if (options.Multiline)
                     outAttrs.InputType |= InputTypes.TextFlagMultiLine;
 
-                if (outAttrs.InputType is InputTypes.ClassText && options.ShowSuggestions == false)
-                    outAttrs.InputType |= InputTypes.TextVariationPassword | InputTypes.TextFlagNoSuggestions;
-                    
                 outAttrs.ImeOptions = options.ReturnKeyType switch
                 {
                     TextInputReturnKeyType.Return => ImeFlags.NoEnterAction,
@@ -207,6 +207,23 @@ namespace Avalonia.Android.Platform.Input
                 };
 
                 outAttrs.ImeOptions |= ImeFlags.NoFullscreen | ImeFlags.NoExtractUi;
+
+                if (options.ShowSuggestions == false &&
+                    (outAttrs.InputType & InputTypes.MaskClass) == InputTypes.ClassText)
+                {
+                    outAttrs.InputType |= InputTypes.TextFlagNoSuggestions;
+
+                    if ((outAttrs.InputType & InputTypes.MaskVariation) == InputTypes.TextVariationNormal)
+                        outAttrs.InputType |= InputTypes.TextVariationVisiblePassword;
+                }
+
+                if (options.IsSensitive)
+                {
+                    outAttrs.InputType |= InputTypes.TextFlagNoSuggestions;
+
+                    if (OperatingSystem.IsAndroidVersionAtLeast(26))
+                        outAttrs.ImeOptions |= ImeFlags.NoPersonalizedLearning;
+                }
 
                 if (options.LocaleHints?.Count > 0)
                     outAttrs.HintLocales = new LocaleList(options.LocaleHints.Select(Java.Util.Locale.ForLanguageTag).ToArray());


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes some quirks with `TextInputOptions` on Android (keyboard behavior)

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Setting TextInputOptions.ContentType to Pin has no effect on android
Setting TextInputOptions.IsSensitive to True has no effect on android
TextInputOptions.ShowSuggestions=False does not work if TextInputOptions.Multiline is true

- See the video attached in the issue

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
- Setting TextInputOptions.ContentType to Pin shows a keyboard with digits only on Android
- Setting TextInputOptions.IsSensitive to True makes it so that words you type into that TextBox are not learned and later suggested when you type.
- Setting TextInputOptions.ShowSuggestions to False and TextInputOptions.Multiline to true does not show suggestions

In the video below you can see that if I type "xamarin" into a non-sensitive TextBox, it would suggest me that word in another TextBox whereas if I type "xamarin" into the sensitive TextBox, it won't suggest me that word in another TextBox
<img width="360" height="640" alt="output" src="https://github.com/user-attachments/assets/1b0f5386-f5f7-4f1a-bf42-911d7fcd46d9" />

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
1. The InputTypes (and ImeOptions) enums are now correctly built by "OR-ing" in a class and variations (each TextInputContentType maps to a Class, e.g. ClassText, with the Variation OR-ed in)
    - For example: `TextInputContentType.Pin => InputTypes.ClassNumber | InputTypes.NumberVariationPassword`

2. The Ime flag "NoPersonalizedLearning" is OR-ed into the ImeOptions if `TextInputOptions.IsSensitive` is true (only supported on Android SDK 26+)

## Checklist

- [ ] Added unit tests (if possible)? - not possible, I tested it on my Google Pixel 8a
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #22108
