### PR TITLE
Fix undisposed PointerEvent JSObject on browser pointer move

### DIFF
--- a/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
+++ b/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
@@ -107,15 +107,8 @@ internal class BrowserInputHandler
         }
         finally
         {
-            // The JSObject wraps the native PointerEvent. Disposing it here releases the JS-side handle
-            // deterministically instead of relying on the .NET GC to collect the wrapper first (which,
-            // without a dispose, isn't guaranteed to run promptly under continuous allocation pressure) -
-            // regardless of whether the Lazy above was ever evaluated (most consumers never call
-            // GetIntermediatePoints()).
-
-            // It is safe to dispose, because when _rawEventGrouper is null the event is processed synchronously. 
-            // At least as long as RawPointerEvent.ImmediatePoints is only accessed synchronously within the 
-            // scope of this method.
+            // Release the JS handle after processing the event.
+            // ImmediatePoints is only expected to be accessed synchronously during event processing.
             argsObj.Dispose();
         }
     }

--- a/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
+++ b/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
@@ -102,11 +102,6 @@ internal class BrowserInputHandler
 
         try
         {
-            // Note: routing here is only synchronous when _rawEventGrouper is null (the branch above
-            // that creates the Lazy referencing argsObj). When _rawEventGrouper is set, ScheduleInput
-            // enqueues the event for later dispatch on the managed dispatcher - but coalescedEvents is
-            // never created (stays null) in that branch, so disposing argsObj below is still safe even
-            // though the deferred dispatch/merge logic (RawEventGrouper.MergeEvents) never touches it.
             return RawPointerEvent(type, pointerType!, point, (RawInputModifiers)modifier, pointerId,
                 coalescedEvents);
         }
@@ -117,6 +112,10 @@ internal class BrowserInputHandler
             // without a dispose, isn't guaranteed to run promptly under continuous allocation pressure) -
             // regardless of whether the Lazy above was ever evaluated (most consumers never call
             // GetIntermediatePoints()).
+
+            // It is safe to dispose, because when _rawEventGrouper is null the event is processed synchronously. 
+            // At least as long as RawPointerEvent.ImmediatePoints is only accessed synchronously within the 
+            // scope of this method.
             argsObj.Dispose();
         }
     }

--- a/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
+++ b/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
@@ -82,7 +82,6 @@ internal class BrowserInputHandler
                 // To minimize JS interop usage, we resolve all points properties in a single call.
                 const int itemsPerPoint = 6;
                 var pointsProps = InputHelper.GetCoalescedEvents(argsObj);
-                argsObj.Dispose();
                 s_intermediatePointsPooledList.Clear();
 
                 var pointsCount = pointsProps.Length / itemsPerPoint;
@@ -101,8 +100,25 @@ internal class BrowserInputHandler
             });
         }
 
-        return RawPointerEvent(type, pointerType!, point, (RawInputModifiers)modifier, pointerId,
-            coalescedEvents);
+        try
+        {
+            // Note: routing here is only synchronous when _rawEventGrouper is null (the branch above
+            // that creates the Lazy referencing argsObj). When _rawEventGrouper is set, ScheduleInput
+            // enqueues the event for later dispatch on the managed dispatcher - but coalescedEvents is
+            // never created (stays null) in that branch, so disposing argsObj below is still safe even
+            // though the deferred dispatch/merge logic (RawEventGrouper.MergeEvents) never touches it.
+            return RawPointerEvent(type, pointerType!, point, (RawInputModifiers)modifier, pointerId,
+                coalescedEvents);
+        }
+        finally
+        {
+            // The JSObject wraps the native PointerEvent. Disposing it here releases the JS-side handle
+            // deterministically instead of relying on the .NET GC to collect the wrapper first (which,
+            // without a dispose, isn't guaranteed to run promptly under continuous allocation pressure) -
+            // regardless of whether the Lazy above was ever evaluated (most consumers never call
+            // GetIntermediatePoints()).
+            argsObj.Dispose();
+        }
     }
 
     public bool OnPointerDown(string pointerType, long pointerId, int buttons, double offsetX, double offsetY,

--- a/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
+++ b/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
@@ -79,6 +79,9 @@ internal class BrowserInputHandler
         {
             coalescedEvents = new Lazy<IReadOnlyList<RawPointerPoint>?>(() =>
             {
+                if (argsObj.IsDisposed)
+                    return [];
+
                 // To minimize JS interop usage, we resolve all points properties in a single call.
                 const int itemsPerPoint = 6;
                 var pointsProps = InputHelper.GetCoalescedEvents(argsObj);


### PR DESCRIPTION
OnPointerMove dropped argsObj (the JSObject wrapping the native DOM PointerEvent) without disposing it, except inside a Lazy factory only evaluated when GetIntermediatePoints() is called - which doesn't happen for ordinary moves/hover.

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix by disposing argsObj in a finally block after routing, guaranteeing deterministic release instead of depending on GC timing. Coalesced-event resolution (GetCoalescedEvents) is unaffected since it only runs synchronously within the same call when a consumer needs it.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Without explicit Dispose(), release requires two steps: Mono GC must collect the abandoned JSObject wrapper to release its JS handle, then V8 can reclaim the underlying JS object. Verified with a standalone FinalizationRegistry-based repro that Mono GC does not trigger on its own under continuous pointermove-like allocation pressure, so undisposed objects pile up - not a permanent leak though.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Reduced memory pressure. 
