### PR TITLE
Fix focus being locked when restoring focus to a control thats detached from visual tree.

### DIFF
--- a/src/Avalonia.Base/Input/FocusManager.cs
+++ b/src/Avalonia.Base/Input/FocusManager.cs
@@ -84,6 +84,13 @@ namespace Avalonia.Input
                 {
                     // Previous effective focus is no longer part of the focus root's visual tree. We clear the focused element
                     _focusRoot.ClearValue(FocusedElementProperty);
+
+                    if (Current != null && GetFocusScope(Current) != _focusRoot)
+                    {
+                        _focusRoot = null;
+
+                        return false;
+                    }
                 }
                 else
                 {

--- a/src/Avalonia.Base/Input/FocusManager.cs
+++ b/src/Avalonia.Base/Input/FocusManager.cs
@@ -80,7 +80,15 @@ namespace Avalonia.Input
 
             if (_focusRoot?.GetValue(FocusedElementProperty) is { } restore && restore != Current)
             {
-                return FocusCore(keyboardDevice, restore, method, keyModifiers);
+                if (GetFocusScope(restore) != _focusRoot)
+                {
+                    // Previous effective focus is no longer part of the focus root's visual tree. We clear the focused element
+                    _focusRoot.ClearValue(FocusedElementProperty);
+                }
+                else
+                {
+                    return FocusCore(keyboardDevice, restore, method, keyModifiers);
+                }
             }
 
             _focusRoot = null;

--- a/src/Avalonia.Base/Input/FocusManager.cs
+++ b/src/Avalonia.Base/Input/FocusManager.cs
@@ -80,7 +80,7 @@ namespace Avalonia.Input
 
             if (_focusRoot?.GetValue(FocusedElementProperty) is { } restore && restore != Current)
             {
-                if (GetFocusScope(restore) != _focusRoot)
+                if (!CanFocus(restore))
                 {
                     // Previous effective focus is no longer part of the focus root's visual tree. We clear the focused element
                     _focusRoot.ClearValue(FocusedElementProperty);

--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -568,8 +568,8 @@ namespace Avalonia.Input
             if (IsFocused)
             {
                 var root = e.AttachmentPoint ?? e.RootVisual;
-                ((FocusManager?)e.PresentationSource.InputRoot.FocusManager)
-                    ?.ClearFocusOnElementRemoved(this, root);
+                (((FocusManager?)e.PresentationSource.InputRoot.FocusManager) ?? 
+                    FocusManager.GetFocusManager(this))?.ClearFocusOnElementRemoved(this, root);
             }
 
             IsKeyboardFocusWithin = false;

--- a/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
@@ -1,4 +1,7 @@
+using System.Linq;
+using Avalonia.Collections;
 using Avalonia.Controls;
+using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.UnitTests;
 using Xunit;
@@ -1628,6 +1631,67 @@ namespace Avalonia.Base.UnitTests.Input
             Assert.Same(first, KeyboardDevice.Instance?.FocusedElement);
             Assert.Same(first, window1.FocusManager.GetFocusedElement());
         }
+
+        [Fact]
+        public void Focus_Should_Not_Be_Restored_To_Detached_Control()
+        {
+            using var app = UnitTestApplication.Start(
+                TestServices.StyledWindow.With(keyboardDevice: () => new KeyboardDevice()));
+            var button = new Button { Name = "Button" };
+            MenuItem topLevelMenu;
+            MenuItem childMenu;
+            var menu = new Menu
+            {
+                Items =
+                    {
+                        (topLevelMenu = new MenuItem
+                        {
+                            Header = "Foo",
+                            Items =
+                            {
+                                (childMenu = new MenuItem { Header = "Bar" })
+                            }
+                        }),
+                    }
+            };
+            var panel = new StackPanel();
+            panel.Children.Add(button);
+            panel.Children.Add(menu);
+
+            var window = new Window
+            {
+                Content = panel,
+                Name = "Window1"
+            };
+
+            window.Show();
+
+            // Focus the button
+            button.Focus();
+            Assert.Same(button, KeyboardDevice.Instance?.FocusedElement);
+            Assert.Same(button, window.FocusManager.GetFocusedElement());
+
+
+            // Open the menu and focus the child menu
+            menu.Open();
+            topLevelMenu.IsSubMenuOpen = true;
+            childMenu.Focus();
+
+            // Remove the previously focused button.
+            panel.Children.Remove(button);
+
+
+            // Close the menus.
+            menu.Close();
+            topLevelMenu.Close();
+
+            window.PlatformImpl?.Activated?.Invoke();
+
+            // When window is activated, focus should be empty
+            Assert.Same(null, KeyboardDevice.Instance?.FocusedElement);
+            Assert.Same(null, window.FocusManager.GetFocusedElement());
+        }
+
 
         private class TestFocusScope : Panel, IFocusScope
         {

--- a/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
@@ -1633,6 +1633,53 @@ namespace Avalonia.Base.UnitTests.Input
         }
 
         [Fact]
+        public void Focus_Should_Stay_In_Active_Window()
+        {
+            using var app = UnitTestApplication.Start(
+                TestServices.StyledWindow.With(keyboardDevice: () => new KeyboardDevice()));
+            var first = new Button { Name = "FirstButton" };
+            var second = new Button { Name = "SecondButton" };
+
+            var window1 = new Window
+            {
+                Content = first
+            };
+
+            var window2 = new Window
+            {
+                Content = second
+            };
+
+            window1.Show();
+
+            // Focus the first button in the first window
+            first.Focus();
+            Assert.Same(first, KeyboardDevice.Instance?.FocusedElement);
+            Assert.Same(first, window1.FocusManager.GetFocusedElement());
+
+            window2.Show();
+
+            // Focus the second button in the second window
+            second.Focus();
+            Assert.Same(second, KeyboardDevice.Instance?.FocusedElement);
+            Assert.Same(second, window2.FocusManager.GetFocusedElement());
+
+            // Activate the first window again
+            window1.PlatformImpl?.Activated?.Invoke();
+
+            // Focus should have moved back to the first button in the first window
+            Assert.Same(first, KeyboardDevice.Instance?.FocusedElement);
+            Assert.Same(first, window1.FocusManager.GetFocusedElement());
+
+            // Close the second window
+            window2.Close();
+
+            // Focus should still be in the first window
+            Assert.Same(first, KeyboardDevice.Instance?.FocusedElement);
+            Assert.Same(first, window1.FocusManager.GetFocusedElement());
+        }
+
+        [Fact]
         public void Focus_Should_Not_Be_Restored_To_Detached_Control()
         {
             using var app = UnitTestApplication.Start(

--- a/tests/Avalonia.UnitTests/MockWindowingPlatform.cs
+++ b/tests/Avalonia.UnitTests/MockWindowingPlatform.cs
@@ -44,6 +44,7 @@ namespace Avalonia.UnitTests
 
             windowImpl.Setup(x => x.Dispose()).Callback(() =>
             {
+                windowImpl.Object.LostFocus?.Invoke();
                 windowImpl.Object.Closed?.Invoke();
             });
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
When focus changes between focus scopes, on restoring to a previous focus scope, if the restore element is not in the same scope, clears focus.


## What is the current behavior?
When focus changes from one focus scope, such as a window, that has a focused element to another focus scope hosted in a toplevel thats a child to the previous scope, the current focused element is saved in the previous scope in the `FocusedElement`
property. If that element is removed from the visual tree and then focus is restored to the main focus scope, the focus manager attempts to restore focus to the removed element. With the element no longer in tree, keyboard input won't be routed through the main focus scope until focus is manually set to an active element.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/21759 . 
This pr https://github.com/AvaloniaUI/Avalonia/pull/21800 doesn't fix it, nor does it have any effect on the issue.