### PR TITLE
Drive Win32 composition effects from RenderTargetSceneInfo on the render thread

### DIFF
--- a/api/Avalonia.nupkg.xml
+++ b/api/Avalonia.nupkg.xml
@@ -45,6 +45,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.IRenderTarget.RenderTargetSceneInfo.#ctor(Avalonia.PixelSize,System.Double,Avalonia.Size,Avalonia.Rendering.Composition.CompositionTransparencyLevel)</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Platform.IRenderTarget.RenderTargetSceneInfo.#ctor(Avalonia.PixelSize,System.Double,Avalonia.Size)</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
@@ -52,6 +58,12 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Platform.IRenderTarget.RenderTargetSceneInfo.#ctor(Avalonia.PixelSize,System.Double)</Target>
+    <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.IRenderTarget.RenderTargetSceneInfo.Deconstruct(Avalonia.PixelSize@,System.Double@,Avalonia.Size@,Avalonia.Rendering.Composition.CompositionTransparencyLevel@)</Target>
     <Left>baseline/Avalonia/lib/net10.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net10.0/Avalonia.Base.dll</Right>
   </Suppression>
@@ -129,6 +141,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.IRenderTarget.RenderTargetSceneInfo.#ctor(Avalonia.PixelSize,System.Double,Avalonia.Size,Avalonia.Rendering.Composition.CompositionTransparencyLevel)</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Platform.IRenderTarget.RenderTargetSceneInfo.#ctor(Avalonia.PixelSize,System.Double,Avalonia.Size)</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
@@ -136,6 +154,12 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Avalonia.Platform.IRenderTarget.RenderTargetSceneInfo.#ctor(Avalonia.PixelSize,System.Double)</Target>
+    <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
+    <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Avalonia.Platform.IRenderTarget.RenderTargetSceneInfo.Deconstruct(Avalonia.PixelSize@,System.Double@,Avalonia.Size@,Avalonia.Rendering.Composition.CompositionTransparencyLevel@)</Target>
     <Left>baseline/Avalonia/lib/net8.0/Avalonia.Base.dll</Left>
     <Right>current/Avalonia/lib/net8.0/Avalonia.Base.dll</Right>
   </Suppression>

--- a/src/Avalonia.Base/Platform/IRenderTarget.cs
+++ b/src/Avalonia.Base/Platform/IRenderTarget.cs
@@ -33,7 +33,10 @@ namespace Avalonia.Platform
         /// </summary>
         PlatformRenderTargetState PlatformRenderTargetState => PlatformRenderTargetState.Ready;
         
-        public record struct RenderTargetSceneInfo(PixelSize Size, double Scaling, Size LogicalSize, CompositionTransparencyLevel TransparencyLevel)
+        // TopLevelSpecificSceneInfo is an opaque immutable object provided by the platform's
+        // ITopLevelImpl.TopLevelSpecificSceneInfo.
+        public record struct RenderTargetSceneInfo(PixelSize Size, double Scaling, Size LogicalSize,
+            CompositionTransparencyLevel TransparencyLevel, object? TopLevelSpecificSceneInfo = null)
         {
             public RenderTargetSceneInfo(PixelSize size, double scaling, CompositionTransparencyLevel transparencyLevel) : this(size, scaling, size.ToSize(scaling), transparencyLevel)
             {

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -205,7 +205,9 @@ namespace Avalonia.Rendering.Composition.Server
             try
             {
                 renderTargetContext =
-                    _renderTarget.CreateDrawingContext(new(PixelSize, Scaling, Size, TransparencyLevel), out properties);
+                    _renderTarget.CreateDrawingContext(
+                        new(PixelSize, Scaling, Size, TransparencyLevel, TopLevelSpecificSceneInfo),
+                        out properties);
             }
             catch (RenderTargetNotReadyException)
             {

--- a/src/Avalonia.Base/composition-schema.xml
+++ b/src/Avalonia.Base/composition-schema.xml
@@ -11,6 +11,7 @@
     <Manual Name="Avalonia.Media.IImmutableBrush" Passthrough="true"/>
     <Manual Name="Avalonia.Media.IImmutableEffect" Passthrough="true"/>
     <Manual Name="Avalonia.Media.Immutable.ImmutableDashStyle" Passthrough="true"/>
+    <Manual Name="object" Passthrough="true"/>
     <Manual Name="CompositionSurface" />
     <Manual Name="CompositionDrawingSurface" />
     <Object Name="CompositionVisual" Abstract="true">
@@ -60,6 +61,7 @@
         <Property Name="Scaling" Type="double"/>
         <Property Name="Size" Type="Size" />
         <Property Name="TransparencyLevel" Type="CompositionTransparencyLevel" />
+        <Property Name="TopLevelSpecificSceneInfo" Type="object?" />
     </Object>
     <KeyFrameAnimation Name="Scalar" Type="float"/>
     <KeyFrameAnimation Name="Double" Type="double"/>

--- a/src/Avalonia.Controls/Platform/ITopLevelImpl.cs
+++ b/src/Avalonia.Controls/Platform/ITopLevelImpl.cs
@@ -77,6 +77,18 @@ namespace Avalonia.Platform
         Action<WindowTransparencyLevel>? TransparencyLevelChanged { get; set; }
 
         /// <summary>
+        /// Gets an opaque platform-specific object with extra information about the scene,
+        /// to be passed to the platform render target with each frame.
+        /// The object must be immutable; implementations must publish a new instance on change.
+        /// </summary>
+        object? TopLevelSpecificSceneInfo => null;
+
+        /// <summary>
+        /// Gets or sets a method called when <see cref="TopLevelSpecificSceneInfo"/> changes.
+        /// </summary>
+        Action<object?>? TopLevelSpecificSceneInfoChanged { get => null; set { } }
+
+        /// <summary>
         /// Gets the compositor that's compatible with the toplevel
         /// </summary>
         Compositor Compositor { get; }

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -223,6 +223,7 @@ namespace Avalonia.Controls
 
             _source.Renderer.CompositionTarget.TransparencyLevel =
                 ToCompositionTransparencyLevel(_actualTransparencyLevel);
+            _source.Renderer.CompositionTarget.TopLevelSpecificSceneInfo = impl.TopLevelSpecificSceneInfo;
 
 
             _accessKeyHandler = TryGetService<IAccessKeyHandler>(dependencyResolver);
@@ -240,6 +241,7 @@ namespace Avalonia.Controls
             impl.Resized = HandleResized;
             impl.ScalingChanged += HandleScalingChanged;
             impl.TransparencyLevelChanged = HandleTransparencyLevelChanged;
+            impl.TopLevelSpecificSceneInfoChanged = HandleTopLevelSpecificSceneInfoChanged;
 
             CreatePlatformImplBinding(TransparencyLevelHintProperty, hint => PlatformImpl.SetTransparencyLevelHint(hint ?? Array.Empty<WindowTransparencyLevel>()));
 
@@ -769,6 +771,11 @@ namespace Avalonia.Controls
             ActualTransparencyLevel = transparencyLevel;
             Renderer.CompositionTarget.TransparencyLevel =
                 ToCompositionTransparencyLevel(transparencyLevel);
+        }
+
+        private void HandleTopLevelSpecificSceneInfoChanged(object? sceneInfo)
+        {
+            Renderer.CompositionTarget.TopLevelSpecificSceneInfo = sceneInfo;
         }
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)

--- a/src/Windows/Avalonia.Win32/DComposition/DirectCompositedWindowSurface.cs
+++ b/src/Windows/Avalonia.Win32/DComposition/DirectCompositedWindowSurface.cs
@@ -16,7 +16,6 @@ internal class DirectCompositedWindowSurface : IDirect3D11TexturePlatformSurface
     private readonly EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo _info;
     private readonly DirectCompositionShared _shared;
     private DirectCompositedWindow? _window;
-    private BlurEffect _blurEffect;
 
     public DirectCompositedWindowSurface(DirectCompositionShared shared, EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo info)
     {
@@ -32,7 +31,6 @@ internal class DirectCompositedWindowSurface : IDirect3D11TexturePlatformSurface
     public IDirect3D11TextureRenderTarget2 CreateRenderTarget(IPlatformGraphicsContext context, IntPtr d3dDevice)
     {
         _window ??= new DirectCompositedWindow(_info, _shared);
-        SetBlur(_blurEffect);
 
         return new DirectCompositedWindowRenderTarget(context, d3dDevice, _shared, _window);
     }
@@ -43,14 +41,8 @@ internal class DirectCompositedWindowSurface : IDirect3D11TexturePlatformSurface
         _window = null;
     }
 
-    // TODO: we can implement BlurEffect.GaussianBlur in with IDCompositionDevice3.CreateGaussianBlurEffect. 
+    // TODO: we can implement BlurEffect.GaussianBlur in with IDCompositionDevice3.CreateGaussianBlurEffect.
     public bool IsBlurSupported(BlurEffect effect) => effect == BlurEffect.None;
-
-    public void SetBlur(BlurEffect enable)
-    {
-        _blurEffect = enable;
-        // _window?.SetBlur(enable);
-    }
 }
 
 internal class DirectCompositedWindowRenderTarget : IDirect3D11TextureRenderTarget, IDirect3D11TextureRenderTarget2

--- a/src/Windows/Avalonia.Win32/IBlurHost.cs
+++ b/src/Windows/Avalonia.Win32/IBlurHost.cs
@@ -12,6 +12,4 @@ internal enum BlurEffect
 internal interface ICompositionEffectsSurface
 {
     bool IsBlurSupported(BlurEffect effect);
-
-    void SetBlur(BlurEffect enable);
 }

--- a/src/Windows/Avalonia.Win32/Win32TopLevelSceneInfo.cs
+++ b/src/Windows/Avalonia.Win32/Win32TopLevelSceneInfo.cs
@@ -1,0 +1,10 @@
+using Avalonia.Platform;
+
+namespace Avalonia.Win32;
+
+/// <summary>
+/// An immutable bag with Win32-specific per-frame scene information, published via
+/// <see cref="ITopLevelImpl.TopLevelSpecificSceneInfo"/> and consumed by render targets
+/// on the render thread.
+/// </summary>
+internal sealed record Win32TopLevelSceneInfo(PlatformThemeVariant ThemeVariant);

--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositedWindow.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositedWindow.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Numerics;
 using System.Threading;
 using Avalonia.OpenGL.Egl;
+using Avalonia.Platform;
 using Avalonia.Reactive;
+using Avalonia.Rendering.Composition;
 using MicroCom.Runtime;
 
 namespace Avalonia.Win32.WinRT.Composition;
@@ -17,6 +20,7 @@ internal class WinUiCompositedWindow : IDisposable
     private readonly IVisual _blur;
     private readonly IVisual _visual;
     private PixelSize _size;
+    private BlurEffect? _appliedBlurEffect;
     private readonly ICompositionSurfaceBrush _surfaceBrush;
     private readonly ICompositionTarget _target;
 
@@ -80,18 +84,30 @@ internal class WinUiCompositedWindow : IDisposable
 
     public void SetSurface(ICompositionSurface surface) => _surfaceBrush.SetSurface(surface);
 
-    public void SetBlur(BlurEffect blurEffect)
+    // Called from the render thread with the transaction (SyncRoot) held, so effect changes
+    // are applied within the same composition batch as the frame they belong to.
+    public void ApplyEffects(CompositionTransparencyLevel transparencyLevel, PlatformThemeVariant themeVariant)
     {
-        lock (_shared.SyncRoot)
+        Debug.Assert(Monitor.IsEntered(_shared.SyncRoot));
+
+        var blurEffect = transparencyLevel switch
         {
-            _blur.SetIsVisible(blurEffect == BlurEffect.Acrylic
-                               || (blurEffect == BlurEffect.MicaLight && _micaLight == null) ||
-                               (blurEffect == BlurEffect.MicaDark && _micaDark == null) ?
-                1 :
-                0);
-            _micaLight?.SetIsVisible(blurEffect == BlurEffect.MicaLight ? 1 : 0);
-            _micaDark?.SetIsVisible(blurEffect == BlurEffect.MicaDark ? 1 : 0);
-        }
+            CompositionTransparencyLevel.AcrylicBlur => BlurEffect.Acrylic,
+            CompositionTransparencyLevel.Mica when themeVariant == PlatformThemeVariant.Dark => BlurEffect.MicaDark,
+            CompositionTransparencyLevel.Mica => BlurEffect.MicaLight,
+            _ => BlurEffect.None
+        };
+        if (_appliedBlurEffect == blurEffect)
+            return;
+
+        _blur.SetIsVisible(blurEffect == BlurEffect.Acrylic
+                           || (blurEffect == BlurEffect.MicaLight && _micaLight == null) ||
+                           (blurEffect == BlurEffect.MicaDark && _micaDark == null) ?
+            1 :
+            0);
+        _micaLight?.SetIsVisible(blurEffect == BlurEffect.MicaLight ? 1 : 0);
+        _micaDark?.SetIsVisible(blurEffect == BlurEffect.MicaDark ? 1 : 0);
+        _appliedBlurEffect = blurEffect;
     }
 
     public IDisposable BeginTransaction()
@@ -102,14 +118,13 @@ internal class WinUiCompositedWindow : IDisposable
 
     public void ResizeIfNeeded(PixelSize size)
     {
-        lock (_shared.SyncRoot)
+        Debug.Assert(Monitor.IsEntered(_shared.SyncRoot));
+
+        if (_size != size)
         {
-            if (_size != size)
-            {
-                _visual.SetSize(new Vector2(size.Width, size.Height));
-                _compositionRoundedRectangleGeometry?.SetSize(new Vector2(size.Width, size.Height));
-                _size = size;
-            }
+            _visual.SetSize(new Vector2(size.Width, size.Height));
+            _compositionRoundedRectangleGeometry?.SetSize(new Vector2(size.Width, size.Height));
+            _size = size;
         }
     }
 }

--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositedWindowSurface.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositedWindowSurface.cs
@@ -14,7 +14,6 @@ namespace Avalonia.Win32.WinRT.Composition
         private readonly WinUiCompositionShared _shared;
         private readonly EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo _info;
         private WinUiCompositedWindow? _window;
-        private BlurEffect _blurEffect;
 
         public WinUiCompositedWindowSurface(WinUiCompositionShared shared, EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo info)
         {
@@ -32,7 +31,6 @@ namespace Avalonia.Win32.WinRT.Composition
             var cornerRadius = AvaloniaLocator.Current.GetService<Win32PlatformOptions>()
                 ?.WinUICompositionBackdropCornerRadius;
             _window ??= new WinUiCompositedWindow(_info, _shared, cornerRadius);
-            _window.SetBlur(_blurEffect);
 
             return new WinUiCompositedWindowRenderTarget(context, _window, d3dDevice, _shared.Compositor);
         }
@@ -51,12 +49,6 @@ namespace Avalonia.Win32.WinRT.Composition
             BlurEffect.MicaDark => Win32Platform.WindowsVersion >= WinUiCompositionShared.MinHostBackdropVersion,
             _ => false
         };
-
-        public void SetBlur(BlurEffect enable)
-        {
-            _blurEffect = enable;
-            _window?.SetBlur(enable);
-        }
     }
 
     internal class WinUiCompositedWindowRenderTarget : IDirect3D11TextureRenderTarget, IDirect3D11TextureRenderTarget2
@@ -171,6 +163,9 @@ namespace Avalonia.Win32.WinRT.Composition
                 var size = sceneInfo.Size;
                 var scale = sceneInfo.Scaling;
                 _window.ResizeIfNeeded(size);
+                _window.ApplyEffects(sceneInfo.TransparencyLevel,
+                    (sceneInfo.TopLevelSpecificSceneInfo as Win32TopLevelSceneInfo)?.ThemeVariant ??
+                    PlatformThemeVariant.Light);
                 _window.SetSurface(_surface);
                 
                 void* pTexture;

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -118,6 +118,7 @@ namespace Avalonia.Win32
         private static POINTER_INFO[]? s_historyInfos;
         private static MOUSEMOVEPOINT[]? s_mouseHistoryInfos;
         private PlatformThemeVariant _currentThemeVariant;
+        private Win32TopLevelSceneInfo _sceneInfo = new(PlatformThemeVariant.Light);
 
         public WindowImpl()
         {
@@ -215,6 +216,10 @@ namespace Avalonia.Win32
         public Action? LostFocus { get; set; }
 
         public Action<WindowTransparencyLevel>? TransparencyLevelChanged { get; set; }
+
+        public object? TopLevelSpecificSceneInfo => _sceneInfo;
+
+        public Action<object?>? TopLevelSpecificSceneInfoChanged { get; set; }
 
         public Thickness BorderThickness
         {
@@ -437,43 +442,29 @@ namespace Avalonia.Win32
             return false;
         }
 
+        // The composition effects themselves are applied by the render target on the render thread,
+        // based on the transparency level and theme variant it receives with RenderTargetSceneInfo.
+        // Here we only adjust the DWM window attributes that have to be set from the UI thread.
+
         private bool SetTransparencyTransparent()
         {
-            if (CompositionEffectsSurface is { } surface)
-            {
-                surface.SetBlur(BlurEffect.None);
+            if (CompositionEffectsSurface is not null)
                 return true;
-            }
-            else
-            {
-                return SetLegacyTransparency(true);
-            }
+
+            return SetLegacyTransparency(true);
         }
 
         private bool SetTransparencyAcrylicBlur()
         {
             SetUseHostBackdropBrush(true);
             SetLegacyTransparency(false);
-
-            CompositionEffectsSurface!.SetBlur(BlurEffect.Acrylic);
             return true;
         }
 
-        /// <summary>
-        /// Sets the transparency mica
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
         private bool SetTransparencyMica()
         {
             SetUseHostBackdropBrush(false);
             SetLegacyTransparency(false);
-
-            CompositionEffectsSurface!.SetBlur(_currentThemeVariant switch
-            {
-                PlatformThemeVariant.Light => BlurEffect.MicaLight,
-                PlatformThemeVariant.Dark => BlurEffect.MicaDark,
-                _ => throw new ArgumentOutOfRangeException()
-            });
             return true;
         }
 
@@ -951,6 +942,11 @@ namespace Avalonia.Win32
         public unsafe void SetFrameThemeVariant(PlatformThemeVariant? themeVariant)
         {
             _currentThemeVariant = themeVariant ?? Win32Platform.Instance.PlatformSettings.GetColorValues().ThemeVariant;
+            if (_sceneInfo.ThemeVariant != _currentThemeVariant)
+            {
+                _sceneInfo = new Win32TopLevelSceneInfo(_currentThemeVariant);
+                TopLevelSpecificSceneInfoChanged?.Invoke(_sceneInfo);
+            }
             if (Win32Platform.WindowsVersion.Build >= 22000)
             {
                 var pvUseBackdropBrush = _currentThemeVariant == PlatformThemeVariant.Dark ? 1 : 0;


### PR DESCRIPTION
Right now we can present frames in a torn state:
1) frame gets committed and scheduled for render with some transparency level enabled (and assumes semi-transparent background)
2) UI thread flips transparency hint to non-transparent or switches theme variant from light to dark, it's propagated to render surfaces, WinUI visuals immediately get updated (for frame -1 that's currently on-screen), new frame with correct content is committed
3) render thread renders a new frame with transparency level and theme variant from (1)
4) render thread finally gets a correct matching frame from (2)


The PR makes win32 backend to derive state from RenderTargetSceneInfo passed by compositor that now also holds the theme variant hint needed for mica theme selection. Since theme variant isn't something we care about across platforms, it's carried via new opaque platform-speciic RenderTargetSceneInfo field.

