### PR TITLE
Fix TrayIcon attachment lifecycle

### DIFF
--- a/src/Avalonia.Controls/TrayIcon.cs
+++ b/src/Avalonia.Controls/TrayIcon.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Windows.Input;
 using Avalonia.Collections;
@@ -13,35 +14,19 @@ namespace Avalonia.Controls
 {
     public sealed class TrayIcons : AvaloniaList<TrayIcon>
     {
+        public TrayIcons()
+        {
+            ResetBehavior = ResetBehavior.Remove;
+        }
     }
 
     public class TrayIcon : AvaloniaObject, INativeMenuExporterProvider, IDisposable
     {
-        private readonly ITrayIconImpl? _impl;
+        private ITrayIconImpl? _impl;
+        private bool _isAttached;
+        private bool _isDisposed;
 
-        private TrayIcon(ITrayIconImpl? impl)
-        {
-            if (impl != null)
-            {
-                _impl = impl;
-
-                _impl.SetIsVisible(IsVisible);
-
-                _impl.OnClicked = () =>
-                {
-                    Clicked?.Invoke(this, EventArgs.Empty);
-                    
-                    if (Command?.CanExecute(CommandParameter) == true)
-                    {
-                        Command.Execute(CommandParameter);
-                    }
-                };
-            }
-        }
-
-        public TrayIcon() : this(PlatformManager.CreateTrayIcon())
-        {
-        }
+        public TrayIcon() { }
 
         static TrayIcon()
         {
@@ -51,12 +36,14 @@ namespace Avalonia.Controls
                 {
                     if (args.OldValue.Value != null)
                     {
-                        RemoveIcons(args.OldValue.Value);
+                        args.OldValue.Value.CollectionChanged -= Icons_CollectionChanged;
+                        DetachIcons(args.OldValue.Value);
                     }
 
                     if (args.NewValue.Value != null)
                     {
                         args.NewValue.Value.CollectionChanged += Icons_CollectionChanged;
+                        AttachIcons(args.NewValue.Value);
                     }
                 }
                 else
@@ -187,22 +174,85 @@ namespace Avalonia.Controls
 
             if (trayIcons != null)
             {
-                RemoveIcons(trayIcons);
+                DisposeIcons(trayIcons);
             }
         }
 
-        private static void Icons_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        private static void Icons_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
+            if (e.Action == NotifyCollectionChangedAction.Move)
+                return;
+
             if (e.OldItems is not null)
-                RemoveIcons(e.OldItems.Cast<TrayIcon>());
+                DetachIcons(e.OldItems.Cast<TrayIcon>());
+
+            if (e.NewItems is not null)
+                AttachIcons(e.NewItems.Cast<TrayIcon>());
         }
 
-        private static void RemoveIcons(IEnumerable<TrayIcon> icons)
+        private static void AttachIcons(IEnumerable<TrayIcon> icons)
+        {
+            foreach (var icon in icons)
+            {
+                icon.Attach();
+            }
+        }
+
+        private static void DetachIcons(IEnumerable<TrayIcon> icons)
+        {
+            foreach (var icon in icons)
+            {
+                icon.Detach();
+            }
+        }
+
+        private static void DisposeIcons(IEnumerable<TrayIcon> icons)
         {
             foreach (var icon in icons)
             {
                 icon.Dispose();
             }
+        }
+
+        private void Attach()
+        {
+            if (_isAttached || _isDisposed) return;
+            _isAttached = true;
+            
+            _impl = PlatformManager.CreateTrayIcon();
+            if (_impl is null) return;
+
+            // Keep the native icon hidden until all properties have been initialized.
+            _impl.SetIsVisible(false);
+            _impl.OnClicked = () =>
+            {
+                Clicked?.Invoke(this, EventArgs.Empty);
+
+                if (Command?.CanExecute(CommandParameter) == true)
+                {
+                    Command.Execute(CommandParameter);
+                }
+            };
+
+            _impl.SetIcon(Icon?.PlatformImpl);
+            _impl.SetToolTipText(ToolTipText);
+            _impl.MenuExporter?.SetNativeMenu(Menu);
+
+            if (_impl is ITrayIconWithIsTemplateImpl templateImpl)
+            {
+                templateImpl.SetIsTemplateIcon(MacOSProperties.GetIsTemplateIcon(this));
+            }
+
+            _impl.SetIsVisible(IsVisible);
+        }
+
+        private void Detach()
+        {
+            if (!_isAttached) return;
+
+            _isAttached = false;
+            _impl?.Dispose();
+            _impl = null;
         }
 
         /// <inheritdoc />
@@ -231,6 +281,13 @@ namespace Avalonia.Controls
         /// <summary>
         /// Disposes the tray icon (removing it from the tray area).
         /// </summary>
-        public void Dispose() => _impl?.Dispose();
+        public void Dispose()
+        {
+            if (_isDisposed) return;
+
+            _isDisposed = true;
+            Detach();
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/src/Avalonia.Controls/TrayIcon.cs
+++ b/src/Avalonia.Controls/TrayIcon.cs
@@ -222,8 +222,6 @@ namespace Avalonia.Controls
             _impl = PlatformManager.CreateTrayIcon();
             if (_impl is null) return;
 
-            // Keep the native icon hidden until all properties have been initialized.
-            _impl.SetIsVisible(false);
             _impl.OnClicked = () =>
             {
                 Clicked?.Invoke(this, EventArgs.Empty);

--- a/src/Avalonia.Controls/TrayIcon.cs
+++ b/src/Avalonia.Controls/TrayIcon.cs
@@ -224,6 +224,8 @@ namespace Avalonia.Controls
             if (_impl is null) 
                 return;
 
+            // Keep the native icon hidden until all properties have been initialized.
+            _impl.SetIsVisible(false);
             _impl.OnClicked = () =>
             {
                 Clicked?.Invoke(this, EventArgs.Empty);

--- a/src/Avalonia.Controls/TrayIcon.cs
+++ b/src/Avalonia.Controls/TrayIcon.cs
@@ -216,11 +216,13 @@ namespace Avalonia.Controls
 
         private void Attach()
         {
-            if (_isAttached || _isDisposed) return;
+            if (_isAttached || _isDisposed) 
+                return;
             _isAttached = true;
             
             _impl = PlatformManager.CreateTrayIcon();
-            if (_impl is null) return;
+            if (_impl is null) 
+                return;
 
             _impl.OnClicked = () =>
             {
@@ -246,7 +248,8 @@ namespace Avalonia.Controls
 
         private void Detach()
         {
-            if (!_isAttached) return;
+            if (!_isAttached) 
+                return;
 
             _isAttached = false;
             _impl?.Dispose();
@@ -281,7 +284,8 @@ namespace Avalonia.Controls
         /// </summary>
         public void Dispose()
         {
-            if (_isDisposed) return;
+            if (_isDisposed) 
+                return;
 
             _isDisposed = true;
             Detach();

--- a/tests/Avalonia.Controls.UnitTests/TrayIconTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TrayIconTests.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using Avalonia.Platform;
+using Avalonia.UnitTests;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests;
+
+public class TrayIconTests : ScopedTestBase
+{
+    [Fact]
+    public void Platform_Impl_Should_Be_Created_Only_After_Icon_Is_Attached_To_Application()
+    {
+        var impl = new Mock<ITrayIconImpl>();
+        var createCount = 0;
+        var platform = new MockWindowingPlatform(trayIconImpl: () =>
+        {
+            createCount++;
+            return impl.Object;
+        });
+
+        using (UnitTestApplication.Start(new TestServices(windowingPlatform: platform)))
+        {
+            var target = new TrayIcon { ToolTipText = "Test icon" };
+            var icons = new TrayIcons { target };
+
+            Assert.Equal(0, createCount);
+
+            TrayIcon.SetIcons(UnitTestApplication.Current, icons);
+
+            Assert.Equal(1, createCount);
+            impl.Verify(x => x.SetToolTipText("Test icon"), Times.Once);
+            impl.Verify(x => x.SetIsVisible(true), Times.Once);
+
+            TrayIcon.SetIcons(UnitTestApplication.Current, null);
+
+            impl.Verify(x => x.Dispose(), Times.Once);
+        }
+    }
+
+    [Fact]
+    public void Collection_Changes_Should_Attach_And_Detach_Icons()
+    {
+        var implementations = new List<Mock<ITrayIconImpl>>();
+        var platform = new MockWindowingPlatform(trayIconImpl: () =>
+        {
+            var impl = new Mock<ITrayIconImpl>();
+            implementations.Add(impl);
+            return impl.Object;
+        });
+
+        using (UnitTestApplication.Start(new TestServices(windowingPlatform: platform)))
+        {
+            var target = new TrayIcon();
+            var icons = new TrayIcons();
+            TrayIcon.SetIcons(UnitTestApplication.Current, icons);
+
+            icons.Add(target);
+
+            Assert.Single(implementations);
+
+            icons.Clear();
+
+            implementations[0].Verify(x => x.Dispose(), Times.Once);
+
+            icons.Add(target);
+
+            Assert.Equal(2, implementations.Count);
+        }
+    }
+
+    [Fact]
+    public void Replaced_Collection_Should_No_Longer_Attach_Icons()
+    {
+        var createCount = 0;
+        var platform = new MockWindowingPlatform(trayIconImpl: () =>
+        {
+            ++createCount;
+            return new Mock<ITrayIconImpl>().Object;
+        });
+
+        using (UnitTestApplication.Start(new TestServices(windowingPlatform: platform)))
+        {
+            var oldIcons = new TrayIcons();
+            var newIcons = new TrayIcons();
+
+            TrayIcon.SetIcons(UnitTestApplication.Current, oldIcons);
+            TrayIcon.SetIcons(UnitTestApplication.Current, newIcons);
+            oldIcons.Add(new TrayIcon());
+
+            Assert.Equal(0, createCount);
+
+            newIcons.Add(new TrayIcon());
+
+            Assert.Equal(1, createCount);
+        }
+    }
+}

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
@@ -25,9 +25,9 @@ namespace Avalonia.IntegrationTests.Appium
             {
                 mainWindow.Click();
 
-                var secondaryWindowIndex = GetWindowOrder("SecondaryWindow");
-
                 Thread.Sleep(300); // sync with timer
+                
+                var secondaryWindowIndex = GetWindowOrder("SecondaryWindow");
 
                 Assert.Equal(1, secondaryWindowIndex);
             }

--- a/tests/Avalonia.UnitTests/MockWindowingPlatform.cs
+++ b/tests/Avalonia.UnitTests/MockWindowingPlatform.cs
@@ -13,13 +13,16 @@ namespace Avalonia.UnitTests
         private static readonly Size s_screenSize = new Size(1280, 1024);
         private readonly Func<IWindowImpl>? _windowImpl;
         private readonly Func<IWindowBaseImpl, IPopupImpl?>? _popupImpl;
+        private readonly Func<ITrayIconImpl?>? _trayIconImpl;
 
         public MockWindowingPlatform(
             Func<IWindowImpl>? windowImpl = null,
-            Func<IWindowBaseImpl, IPopupImpl?>? popupImpl = null )
+            Func<IWindowBaseImpl, IPopupImpl?>? popupImpl = null,
+            Func<ITrayIconImpl?>? trayIconImpl = null)
         {
             _windowImpl = windowImpl;
             _popupImpl = popupImpl;
+            _trayIconImpl = trayIconImpl;
         }
 
         public static Mock<IWindowImpl> CreateWindowMock(double initialWidth = 800, double initialHeight = 600, Compositor? compositor = null)
@@ -161,7 +164,7 @@ namespace Avalonia.UnitTests
 
         public ITrayIconImpl? CreateTrayIcon()
         {
-            return null;
+            return _trayIconImpl?.Invoke();
         }
 
         public void GetWindowsZOrder(ReadOnlySpan<IWindowImpl> windows, Span<long> zOrder)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Changes the `TrayIcon` lifecycle so that constructing a `TrayIcon` does not immediately register it with the operating system.

A native tray icon is now created only after the `TrayIcon` is attached to an `Application` through `TrayIcon.Icons`.

## What is the current behavior?

Constructing a `TrayIcon` immediately creates its platform implementation.

On macOS, creating the platform implementation also creates an `NSStatusItem`, causing the icon to appear in the menu bar even when `TrayIcon.SetIcons` has not been called and the icon has not been added to a `TrayIcons` collection.

Because `IsVisible` defaults to `true`, a tray icon may also be displayed before all of its properties have been initialized.

Additionally:

- Replaced `TrayIcons` collections remain subscribed to `CollectionChanged`.
- Adding items to an attached `TrayIcons` collection does not explicitly attach them.
- Clearing a `TrayIcons` collection does not expose the removed items through `OldItems`, so their platform implementations cannot be detached.
- Tray icons created outside the application-owned collection can escape application shutdown cleanup.

## What is the updated/expected behavior with this PR?

Constructing a `TrayIcon` only creates the managed object. It does not create or display a native tray icon.

The native platform implementation is created only when the `TrayIcon` is:

- Included in a `TrayIcons` collection assigned through `TrayIcon.SetIcons`.
- Added to an already attached `TrayIcons` collection.

When attached, the previously configured icon, tooltip, menu, visibility, and macOS template-icon properties are synchronized with the newly created platform implementation.

When a tray icon is removed, the collection is cleared, or the collection is replaced, its platform implementation is detached and disposed.

All tray icons attached to the application are disposed during dispatcher shutdown.

## How was the solution implemented (if it's not obvious)?

An explicit attach/detach lifecycle was added to `TrayIcon`.

- Platform implementation creation was moved from the constructor to the attach operation.
- `TrayIcon.Icons` property changes attach icons from the new collection and detach icons from the previous collection.
- Collection changes now handle both added and removed icons.
- Previous collections are unsubscribed from `CollectionChanged` when replaced.
- `TrayIcons` uses remove notifications when cleared so the removed icons are available for cleanup.
- Configured properties are synchronized when the platform implementation is created.
- Shutdown cleanup is registered against the active UI dispatcher.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #18548