### PR TITLE
Fix infinite loop when a text run shapes to no glyphs

### DIFF
--- a/src/Avalonia.Base/Media/GlyphRun.cs
+++ b/src/Avalonia.Base/Media/GlyphRun.cs
@@ -160,7 +160,11 @@ namespace Avalonia.Media
         public Rect Bounds => new Rect(new Point(BaselineOrigin.X, 0),
             new Size(Metrics.WidthIncludingTrailingWhitespace, Metrics.Height));
 
-        public Rect InkBounds => PlatformImpl.Item.Bounds;
+        // A run with no glyphs marks nothing, so its ink bounds are empty by definition. Answering
+        // from here keeps a run that draws nothing from building a platform glyph run - and the
+        // platform side is not free: the Skia implementation allocates an SKFont and measures glyph
+        // widths in its constructor. TextLineImpl reads InkBounds for every shaped run in a line.
+        public Rect InkBounds => _glyphInfos.Count == 0 ? default : PlatformImpl.Item.Bounds;
 
         /// <summary>
         /// 
@@ -246,6 +250,11 @@ namespace Avalonia.Media
         /// </returns>
         public double GetDistanceFromCharacterHit(CharacterHit characterHit)
         {
+            if (_glyphInfos.Count == 0)
+            {
+                return 0;
+            }
+
             var characterIndex = characterHit.FirstCharacterIndex + characterHit.TrailingLength;
             var isTrailingHit = characterHit.TrailingLength > 0;
 
@@ -473,6 +482,11 @@ namespace Avalonia.Media
         /// </returns>
         public int FindGlyphIndex(int characterIndex)
         {
+            if (_glyphInfos.Count == 0)
+            {
+                return 0;
+            }
+
             if (_hasOneCharPerCluster)
             {
                 return characterIndex;
@@ -558,6 +572,14 @@ namespace Avalonia.Media
         public CharacterHit FindNearestCharacterHit(int index, out double width)
         {
             width = 0.0;
+
+            // A run can hold characters and no glyphs at all - a line break in a font that gives the
+            // shaper no way to hide it shapes to nothing. There is no cluster to snap to, and the
+            // whole run sits at one position, so treat it as a single zero-width cluster.
+            if (_glyphInfos.Count == 0)
+            {
+                return new CharacterHit(Metrics.FirstCluster, _characters.Length);
+            }
 
             var glyphIndex = FindGlyphIndex(index);
 

--- a/src/Avalonia.Base/Media/GlyphRun.cs
+++ b/src/Avalonia.Base/Media/GlyphRun.cs
@@ -160,10 +160,9 @@ namespace Avalonia.Media
         public Rect Bounds => new Rect(new Point(BaselineOrigin.X, 0),
             new Size(Metrics.WidthIncludingTrailingWhitespace, Metrics.Height));
 
-        // A run with no glyphs marks nothing, so its ink bounds are empty by definition. Answering
-        // from here keeps a run that draws nothing from building a platform glyph run - and the
-        // platform side is not free: the Skia implementation allocates an SKFont and measures glyph
-        // widths in its constructor. TextLineImpl reads InkBounds for every shaped run in a line.
+        /// <summary>
+        ///     Gets the conservative bounding box of the inked area of the <see cref="GlyphRun"/>.
+        /// </summary>
         public Rect InkBounds => _glyphInfos.Count == 0 ? default : PlatformImpl.Item.Bounds;
 
         /// <summary>

--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -541,7 +541,12 @@ namespace Avalonia.Media.TextFormatting
 
                 var splitResult = shapedBuffer.Split(previousLength + currentRun.Length);
 
-                if (splitResult.First is null || splitResult.First.Length == 0)
+                // Split by text, not by glyph count: a run can legitimately shape to no glyphs at
+                // all and still own its characters. Shapers drop default ignorables that the font
+                // cannot hide behind a space glyph, so a run holding nothing but a line break can
+                // come back empty. Skipping it there would delete its characters from the line and
+                // leave the caller stuck at the same text position.
+                if (splitResult.First is null || splitResult.First.Text.Length == 0)
                 {
                     previousLength += currentRun.Length;
                 }

--- a/tests/Avalonia.Base.UnitTests/Media/GlyphRunTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/GlyphRunTests.cs
@@ -170,6 +170,39 @@ namespace Avalonia.Base.UnitTests.Media
             }
         }
 
+        // A run can hold characters and no glyphs at all: a line break in a font that gives the shaper
+        // no way to hide it shapes to nothing. Hit-testing has no cluster to snap to there, so it must
+        // degenerate to the run's single zero-width position instead of indexing an empty glyph list.
+        [Fact]
+        public void Should_Hit_Test_Run_Without_Glyphs()
+        {
+            using (Start())
+            using (var glyphRun = new GlyphRun(Typeface.Default.GlyphTypeface, 10, "\r\n".AsMemory(),
+                       Array.Empty<GlyphInfo>()))
+            {
+                Assert.Equal(0, glyphRun.Bounds.Width);
+
+                // Answered without building a platform glyph run for something that marks nothing.
+                Assert.Equal(default, glyphRun.InkBounds);
+
+                Assert.Equal(0, glyphRun.GetDistanceFromCharacterHit(new CharacterHit(0)));
+                Assert.Equal(0, glyphRun.GetDistanceFromCharacterHit(new CharacterHit(0, 2)));
+
+                Assert.Equal(0, glyphRun.FindGlyphIndex(0));
+
+                var nearestHit = glyphRun.FindNearestCharacterHit(0, out var width);
+
+                Assert.Equal(0, nearestHit.FirstCharacterIndex);
+                Assert.Equal(2, nearestHit.TrailingLength);
+                Assert.Equal(0, width);
+
+                var hitFromDistance = glyphRun.GetCharacterHitFromDistance(0, out var isInside);
+
+                Assert.False(isInside);
+                Assert.Equal(0, hitFromDistance.FirstCharacterIndex);
+            }
+        }
+
         private static GlyphRun CreateGlyphRun(double[] glyphAdvances, int[] glyphClusters, int bidiLevel = 0)
         {
             var count = glyphAdvances.Length;

--- a/tests/Avalonia.Skia.UnitTests/Avalonia.Skia.UnitTests.csproj
+++ b/tests/Avalonia.Skia.UnitTests/Avalonia.Skia.UnitTests.csproj
@@ -17,6 +17,8 @@
     <EmbeddedResource Include="..\Avalonia.RenderTests\Assets\**\*.ttf" LinkBase="Assets" />
     <None Remove="Fonts\**\*.ttf" />
     <EmbeddedResource Include="Fonts\**\*.ttf" />
+    <!-- The headless platform's default font, reused here to cover fonts without a space glyph. -->
+    <EmbeddedResource Include="..\..\src\Headless\Avalonia.Headless\BareMinimum.ttf" LinkBase="Fonts" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Avalonia.Base\Avalonia.Base.csproj" />

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/EmptyShapedBufferTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/EmptyShapedBufferTests.cs
@@ -1,0 +1,97 @@
+#nullable enable
+
+using System;
+using Avalonia.Media;
+using Avalonia.Media.Fonts;
+using Avalonia.Media.TextFormatting;
+using Avalonia.Platform;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Skia.UnitTests.Media.TextFormatting
+{
+    /// <summary>
+    /// A shaper hides the default ignorables it substitutes for line breaks behind the font's space
+    /// glyph. A font that has no space glyph leaves it no way to do that, so those glyphs are deleted
+    /// instead and a run holding nothing but a line break shapes to an empty glyph buffer. The run
+    /// still owns its characters and has to survive, otherwise the line covers no text at all.
+    /// </summary>
+    public class EmptyShapedBufferTests
+    {
+        // The headless platform's default font: four glyphs, no space, no coverage for anything else.
+        private const string GlyphlessFont = "Avalonia.Skia.UnitTests.Fonts.BareMinimum.ttf";
+
+        private static readonly Typeface s_typeface = new("fonts:SystemFonts#BareMinimum");
+
+        [Fact]
+        public void Line_Break_That_Shapes_To_No_Glyphs_Keeps_Its_Characters()
+        {
+            using (Start())
+            {
+                var defaultProperties = new GenericTextRunProperties(s_typeface, 12);
+
+                var formatter = new TextFormatterImpl();
+
+                var textLine = formatter.FormatLine(new SingleBufferTextSource("\r\nfoo", defaultProperties), 0, 100,
+                    new GenericTextParagraphProperties(defaultProperties, textWrapping: TextWrapping.Wrap));
+
+                Assert.NotNull(textLine);
+
+                var run = Assert.IsType<ShapedTextRun>(Assert.Single(textLine.TextRuns));
+
+                Assert.Equal(2, run.Length);
+                Assert.Equal(2, textLine.Length);
+
+                // The premise of the test: shaping really did produce nothing for these characters.
+                Assert.Empty(run.ShapedBuffer);
+            }
+        }
+
+        [Fact]
+        public void Should_Wrap_Text_That_Starts_With_A_Line_Break()
+        {
+            using (Start())
+            {
+                // MaxLines bounds the layout loop: a line that covers no text never advances the text
+                // source, so without it a regression here hangs the test run instead of failing it.
+                var layout = new TextLayout("\r\nPassword update failed", s_typeface, 12, Brushes.Black,
+                    textWrapping: TextWrapping.Wrap, maxWidth: 290, maxLines: 5);
+
+                Assert.Equal(2, layout.TextLines.Count);
+
+                Assert.Equal(2, layout.TextLines[0].Length);
+                Assert.Equal(22, layout.TextLines[1].Length);
+            }
+        }
+
+        private static IDisposable Start()
+        {
+            var disposable = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface
+                .With(renderInterface: new PlatformRenderInterface()));
+
+            var fontManagerImpl = new CustomFontManagerImpl();
+
+            AvaloniaLocator.CurrentMutable
+                .Bind<IFontManagerImpl>().ToConstant(fontManagerImpl);
+
+            var fontManager = new FontManager(fontManagerImpl);
+
+            AvaloniaLocator.CurrentMutable
+                .Bind<FontManager>().ToConstant(fontManager);
+
+            fontManager.AddFontCollection(new GlyphlessSystemFontCollection());
+
+            return disposable;
+        }
+
+        private sealed class GlyphlessSystemFontCollection : FontCollectionBase
+        {
+            public GlyphlessSystemFontCollection()
+            {
+                TryAddFontSource(new Uri($"resm:{GlyphlessFont}?assembly=Avalonia.Skia.UnitTests"));
+            }
+
+            public override Uri Key => FontManager.SystemFontsKey;
+        }
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Fixes an infinite loop and unbounded allocation in `TextLayout` when a text run shapes to no glyphs.

## What is the current behavior?

A shaper hides the default ignorables it substitutes for line breaks behind the font's space glyph, and deletes them when the font has none. A run holding nothing but a line break then shapes to an empty glyph buffer while still owning its characters.

`TextFormatterImpl.ShapeTogether` splits the shaped buffer by glyph count, so it skips that run and rolls its characters into `previousLength` for a following run to absorb. When no such run follows they are lost: the line reports a length of 0 with no line break, `TextLayout.CreateTextLines` never advances `_textSourceLength`, and it formats the same line forever until the process runs out of memory.

Line breaks are the common trigger, not the only one. Any run that is entirely default-ignorable takes the same path - with the headless `BareMinimum.ttf`, `U+200D`, `U+200B` and `U+FE0F` each shape to a run of length 1 with zero glyphs.

`GlyphRun` also indexes its glyph list without checking it is non-empty, so hit-testing a run with characters and no glyphs throws `IndexOutOfRangeException`.

## What is the updated/expected behavior with this PR?

- `ShapeTogether` splits on text length, so a run that shapes to no glyphs keeps its characters and the layout advances. Text starting with a line break lays out as an empty first line followed by the wrapped text.
- `GlyphRun` hit-testing handles an empty glyph list, degenerating to a single zero-width cluster.
- `GlyphRun.InkBounds` answers empty without building a platform glyph run. `TextLineImpl` reads it for every shaped run in a line, and the Skia implementation creates an `SKFont` and measures glyph widths in its constructor.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None. No public API is added or changed.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #22004

🤖 Generated with [Claude Code](https://claude.com/claude-code)
