### PR TITLE
Fix X11 LeaveWindow not raised with software rendering

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -605,13 +605,15 @@ namespace Avalonia.X11
             else if (ev.type == XEventName.MotionNotify)
                 MouseEvent(RawPointerEventType.Move, ref ev, ev.MotionEvent.state);
             else if (ev.type == XEventName.LeaveNotify)
-                MouseEvent(RawPointerEventType.LeaveWindow, ref ev, ev.CrossingEvent.state);
+            {
+                if (IsHandledLeaveEnterDetail(ev.CrossingEvent.detail))
+                {
+                    MouseEvent(RawPointerEventType.LeaveWindow, ref ev, ev.CrossingEvent.state);
+                }
+            }
             else if (ev.type == XEventName.EnterNotify)
             {
-                if (ev.CrossingEvent.detail is
-                    NotifyDetail.NotifyNonlinear or
-                    NotifyDetail.NotifyNonlinearVirtual or
-                    NotifyDetail.NotifyVirtual)
+                if (IsHandledLeaveEnterDetail(ev.CrossingEvent.detail))
                 {
                     MouseEvent(RawPointerEventType.Move, ref ev, ev.CrossingEvent.state);
                 }
@@ -757,6 +759,13 @@ namespace Avalonia.X11
                 HandleKeyEvent(ref ev);
             }
         }
+
+        private static bool IsHandledLeaveEnterDetail(NotifyDetail detail)
+            => detail is
+                NotifyDetail.NotifyNonlinear or
+                NotifyDetail.NotifyNonlinearVirtual or
+                NotifyDetail.NotifyVirtual or
+                NotifyDetail.NotifyAncestor;
 
         private void HandleActivation(bool active)
         {

--- a/src/Avalonia.X11/XI2Manager.cs
+++ b/src/Avalonia.X11/XI2Manager.cs
@@ -296,7 +296,8 @@ namespace Avalonia.X11
             var detail = ev.detail;
             if (detail != XiEnterLeaveDetail.XINotifyNonlinearVirtual &&
                 detail != XiEnterLeaveDetail.XINotifyNonlinear &&
-                detail != XiEnterLeaveDetail.XINotifyVirtual)
+                detail != XiEnterLeaveDetail.XINotifyVirtual &&
+                detail != XiEnterLeaveDetail.XINotifyAncestor)
                 return;
 
             var buttons = ParsedDeviceEvent.ParseButtonState(ev.buttons.MaskLen, ev.buttons.Mask);


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the raw `LeaveWindow` event not being raised correctly on X11 when the rendering mode is set to `Software`.

When the GPU is involved, Avalonia adds an extra render child window that receives input instead of the top-level one, so the pointer only moves between unrelated windows and the render window: it never goes through the actual top-level one. 

With the window missing in software mode, the pointer moves between other windows and the top-level one: events with `XINotifyAncestor` are received instead. Only `XINotifyInferior` is effectively rejected.

This PR applies the logic to both `Leave` and `Enter`. It also makes the non-xinput path symmetric.

## Fixed issues
 - Fixes #21946
