### PR TITLE
Android: fix crash on a stale accessibility virtual view id

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
+++ b/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
@@ -254,15 +254,8 @@ namespace Avalonia.Android
 
             if (!_peers.TryGetValue(virtualViewId, out AutomationPeer? peer))
             {
-                // Stale ID: the peer was unregistered when its control left the visual tree,
-                // but the platform can still ask for a node it obtained earlier - it caches
-                // them, and it re-queries the accessibility focused one. Leaving the node
-                // untouched is not an option: ExploreByTouchHelper.createNodeForChild rejects a
-                // node whose text and content description are both null, and throws "Callbacks
-                // must add text or a content description in populateNodeForVirtualViewId()" -
-                // then again for the bounds. That happens inside an accessibility callback, so
-                // the application cannot recover from it and goes down.
-                // There is no peer here, so there is nothing to describe: report an inert node.
+                // The node must still be populated: ExploreByTouchHelper rejects one whose text,
+                // content description or bounds are unset.
                 nodeInfo.ContentDescription = string.Empty;
                 nodeInfo.Enabled = false;
                 nodeInfo.Focusable = false;
@@ -324,17 +317,8 @@ namespace Avalonia.Android
             nodeInfo.Text ??= peer.GetName();
             nodeInfo.ContentDescription ??= peer.GetHelpText();
 
-            // AutomationPeer.GetName()/GetHelpText() never return null - they collapse a missing
-            // value to string.Empty - so the two assignments above always run, and both can assign
-            // an empty string. That is the case for any peer that is a pure container: a Panel, a
-            // Border, the TextSelectorLayer added when a text selection starts. Such a node reaches
-            // the platform carrying no label at all, and a screen reader has nothing to announce
-            // for it.
-            //
-            // Default to the type name, which is what nodeInfo.ClassName already carries:
-            // GetClassNameCore() is abstract and ControlAutomationPeer returns Owner.GetType().Name,
-            // so a peer always has one. It keeps an unnamed control visible as a gap to be fixed
-            // rather than leaving it silent.
+            // GetName() and GetHelpText() collapse a missing value to string.Empty, so a pure
+            // container ends up with no label at all. Fall back to the type name.
             if (string.IsNullOrEmpty(nodeInfo.Text) && string.IsNullOrEmpty(nodeInfo.ContentDescription))
             {
                 nodeInfo.ContentDescription = peer.GetClassName();

--- a/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
+++ b/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
@@ -245,11 +245,40 @@ namespace Avalonia.Android
             }
         }
 
+        /// <summary>
+        /// Placeholder used when a node would otherwise carry neither text nor content description.
+        /// </summary>
+        /// <remarks>
+        /// A single space, deliberately: <c>ExploreByTouchHelper.createNodeForChild</c> rejects a
+        /// node whose text and content description are both empty, and <c>TextUtils.isEmpty</c>
+        /// treats <c>""</c> as empty - so an empty string does not satisfy the contract. A space
+        /// does, without inventing a label that screen readers would announce.
+        /// </remarks>
+        private const string EmptyNodeDescription = " ";
+
         protected override void OnPopulateNodeForVirtualView(int virtualViewId, AccessibilityNodeInfoCompat? nodeInfo)
         {
-            if (nodeInfo is null || !_peers.TryGetValue(virtualViewId, out AutomationPeer? peer))
+            if (nodeInfo is null)
             {
                 return; // BAIL!! No work to be done
+            }
+
+            if (!_peers.TryGetValue(virtualViewId, out AutomationPeer? peer))
+            {
+                // Stale ID: the peer was unregistered when its control left the visual tree,
+                // but the platform can still ask for a node it obtained earlier - it caches
+                // them, and it re-queries the accessibility focused one. Leaving the node
+                // untouched is not an option: ExploreByTouchHelper.createNodeForChild
+                // validates what the callback produced and throws "Callbacks must add text or
+                // a content description in populateNodeForVirtualViewId()" when both are empty,
+                // then again for the bounds - from inside an accessibility callback, which
+                // takes the whole application down. Describe an inert node instead.
+                nodeInfo.ContentDescription = EmptyNodeDescription;
+                nodeInfo.Enabled = false;
+                nodeInfo.Focusable = false;
+                nodeInfo.ScreenReaderFocusable = false;
+                nodeInfo.SetBoundsInScreen(new(0, 0, 0, 0));
+                return;
             }
 
             // UI logical structure
@@ -304,6 +333,18 @@ namespace Avalonia.Android
             // Control text contents
             nodeInfo.Text ??= peer.GetName();
             nodeInfo.ContentDescription ??= peer.GetHelpText();
+
+            // AutomationPeer.GetName()/GetHelpText() never return null - they collapse a missing
+            // value to string.Empty - so the two assignments above always run, and they can both
+            // assign an empty string. That happens for any peer that is a pure container: a Panel,
+            // a Border, the TextSelectorLayer added when a text selection starts... Such a node is
+            // rejected by ExploreByTouchHelper.createNodeForChild, which throws "Callbacks must add
+            // text or a content description in populateNodeForVirtualViewId()" from inside an
+            // accessibility callback - taking the whole application down.
+            if (string.IsNullOrEmpty(nodeInfo.Text) && string.IsNullOrEmpty(nodeInfo.ContentDescription))
+            {
+                nodeInfo.ContentDescription = EmptyNodeDescription;
+            }
         }
     }
 }

--- a/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
+++ b/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
@@ -245,17 +245,6 @@ namespace Avalonia.Android
             }
         }
 
-        /// <summary>
-        /// Placeholder used when a node would otherwise carry neither text nor content description.
-        /// </summary>
-        /// <remarks>
-        /// A single space, deliberately: <c>ExploreByTouchHelper.createNodeForChild</c> rejects a
-        /// node whose text and content description are both empty, and <c>TextUtils.isEmpty</c>
-        /// treats <c>""</c> as empty - so an empty string does not satisfy the contract. A space
-        /// does, without inventing a label that screen readers would announce.
-        /// </remarks>
-        private const string EmptyNodeDescription = " ";
-
         protected override void OnPopulateNodeForVirtualView(int virtualViewId, AccessibilityNodeInfoCompat? nodeInfo)
         {
             if (nodeInfo is null)
@@ -268,12 +257,13 @@ namespace Avalonia.Android
                 // Stale ID: the peer was unregistered when its control left the visual tree,
                 // but the platform can still ask for a node it obtained earlier - it caches
                 // them, and it re-queries the accessibility focused one. Leaving the node
-                // untouched is not an option: ExploreByTouchHelper.createNodeForChild
-                // validates what the callback produced and throws "Callbacks must add text or
-                // a content description in populateNodeForVirtualViewId()" when both are empty,
-                // then again for the bounds - from inside an accessibility callback, which
-                // takes the whole application down. Describe an inert node instead.
-                nodeInfo.ContentDescription = EmptyNodeDescription;
+                // untouched is not an option: ExploreByTouchHelper.createNodeForChild rejects a
+                // node whose text and content description are both null, and throws "Callbacks
+                // must add text or a content description in populateNodeForVirtualViewId()" -
+                // then again for the bounds. That happens inside an accessibility callback, so
+                // the application cannot recover from it and goes down.
+                // There is no peer here, so there is nothing to describe: report an inert node.
+                nodeInfo.ContentDescription = string.Empty;
                 nodeInfo.Enabled = false;
                 nodeInfo.Focusable = false;
                 nodeInfo.ScreenReaderFocusable = false;
@@ -335,15 +325,19 @@ namespace Avalonia.Android
             nodeInfo.ContentDescription ??= peer.GetHelpText();
 
             // AutomationPeer.GetName()/GetHelpText() never return null - they collapse a missing
-            // value to string.Empty - so the two assignments above always run, and they can both
-            // assign an empty string. That happens for any peer that is a pure container: a Panel,
-            // a Border, the TextSelectorLayer added when a text selection starts... Such a node is
-            // rejected by ExploreByTouchHelper.createNodeForChild, which throws "Callbacks must add
-            // text or a content description in populateNodeForVirtualViewId()" from inside an
-            // accessibility callback - taking the whole application down.
+            // value to string.Empty - so the two assignments above always run, and both can assign
+            // an empty string. That is the case for any peer that is a pure container: a Panel, a
+            // Border, the TextSelectorLayer added when a text selection starts. Such a node reaches
+            // the platform carrying no label at all, and a screen reader has nothing to announce
+            // for it.
+            //
+            // Default to the type name, which is what nodeInfo.ClassName already carries:
+            // GetClassNameCore() is abstract and ControlAutomationPeer returns Owner.GetType().Name,
+            // so a peer always has one. It keeps an unnamed control visible as a gap to be fixed
+            // rather than leaving it silent.
             if (string.IsNullOrEmpty(nodeInfo.Text) && string.IsNullOrEmpty(nodeInfo.ContentDescription))
             {
-                nodeInfo.ContentDescription = EmptyNodeDescription;
+                nodeInfo.ContentDescription = peer.GetClassName();
             }
         }
     }

--- a/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
+++ b/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
@@ -316,13 +316,6 @@ namespace Avalonia.Android
             // Control text contents
             nodeInfo.Text ??= peer.GetName();
             nodeInfo.ContentDescription ??= peer.GetHelpText();
-
-            // GetName() and GetHelpText() collapse a missing value to string.Empty, so a pure
-            // container ends up with no label at all. Fall back to the type name.
-            if (string.IsNullOrEmpty(nodeInfo.Text) && string.IsNullOrEmpty(nodeInfo.ContentDescription))
-            {
-                nodeInfo.ContentDescription = peer.GetClassName();
-            }
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Fixes a crash on Android when the accessibility framework asks for a virtual view whose peer is no longer registered.

## What is the current behavior?

ExploreByTouchHelper.createNodeForChild rejects a node whose text and content description are both null, and throws: "Callbacks must add text or a content description in populateNodeForVirtualViewId()"

OnPopulateNodeForVirtualView returns without touching the node when the id is not found, so androidx gets an empty node and throws. It throws inside an accessibility callback, so the app cannot catch it and the process dies.

That path became reachable with #22024, which unregisters a peer when its control leaves the visual tree. The platform caches nodes it obtained earlier and re-queries the accessibility focused one, so a lookup can fail after a detach.

## What is the updated/expected behavior with this PR?

An unknown id gets an inert node: empty description, disabled, not focusable, empty bounds. The traversal completes instead of killing the process.

## How was the solution implemented (if it's not obvious)?

The guard in androidx.customview 1.1.0 and 1.2.0 is a strict null check, so string.Empty satisfies it.

## Checklist

- [ ] Added unit tests (if possible)? Not possible, the path needs a device with an
      accessibility service running.
- [x] Added XML documentation to any related classes? No public API added.
- [ ] Consider submitting a PR to avalonia-docs. Not applicable.

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

The type name default discussed earlier has been removed from this PR.