### PR TITLE
Android: never walk an InteropAutomationPeer during accessibility traversal

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
+++ b/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
@@ -8,6 +8,7 @@ using Avalonia.Android.Automation;
 using Avalonia.Automation;
 using Avalonia.Automation.Peers;
 using Avalonia.Automation.Provider;
+using Avalonia.Controls.Automation.Peers;
 using Java.Lang;
 
 namespace Avalonia.Android
@@ -83,6 +84,28 @@ namespace Avalonia.Android
                 return null;
             }
         }
+
+        /// <summary>
+        /// Peers of native interop controls (<see cref="Avalonia.Controls.NativeControlHost"/>) must
+        /// never be walked: <c>InteropAutomationPeer</c> throws
+        /// <see cref="System.NotImplementedException"/> from almost every member, because it is meant
+        /// to be special-cased by each platform backend. The other backends already do so
+        /// (<c>AvnAutomationPeer.IsInteropPeer</c>, <c>AutomationNode.InteropAutomationNode</c>);
+        /// Android did not, so any accessibility traversal reaching a native control threw from
+        /// inside an accessibility callback and took the application down.
+        /// <para>
+        /// Skipping is the correct behaviour here, not merely the safe one: a native control is a
+        /// real Android <c>View</c>, already exposed to the accessibility framework on its own.
+        /// Presenting it a second time as an Avalonia virtual view would duplicate it.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Interop peers are filtered at every point where a virtual view ID could be handed out, so
+        /// that one is never allocated for them. <c>OnPopulateNodeForVirtualView</c> therefore never
+        /// has to deal with one - which matters, because it may not answer with an unpopulated node:
+        /// <c>ExploreByTouchHelper.createNodeForChild</c> rejects that and throws.
+        /// </remarks>
+        private static bool IsInteropPeer(AutomationPeer peer) => peer is InteropAutomationPeer;
 
         private HashSet<INodeInfoProvider> GetOrCreateNodeInfoProvidersFromPeer(AutomationPeer peer, out int virtualViewId)
         {
@@ -175,6 +198,12 @@ namespace Avalonia.Android
             AutomationPeer? peer = embeddedRootProvider?.GetPeerFromPoint(p);
             if (peer is not null)
             {
+                if (IsInteropPeer(peer))
+                {
+                    // The point lands on a native control, which Android already exposes itself.
+                    return InvalidId;
+                }
+
                 int virtualViewId;
                 if (peer.GetParent() is AutomationPeer parent && 
                     !s_containerTypes.Contains(parent.GetAutomationControlType()))
@@ -191,7 +220,7 @@ namespace Avalonia.Android
             else
             {
                 peer = embeddedRootProvider?.GetFocus();
-                return peer is null ? InvalidId : _peerIds[peer];
+                return peer is null || IsInteropPeer(peer) ? InvalidId : _peerIds[peer];
             }
         }
 
@@ -204,6 +233,11 @@ namespace Avalonia.Android
 
             foreach (AutomationPeer peer in _peers[0].GetChildren())
             {
+                if (IsInteropPeer(peer))
+                {
+                    continue;
+                }
+
                 GetOrCreateNodeInfoProvidersFromPeer(peer, out int virtualViewId);
                 virtualViewIds.Add(Integer.ValueOf(virtualViewId));
             }
@@ -255,6 +289,11 @@ namespace Avalonia.Android
             // UI logical structure
             foreach (AutomationPeer child in peer.GetChildren())
             {
+                if (IsInteropPeer(child))
+                {
+                    continue;
+                }
+
                 GetOrCreateNodeInfoProvidersFromPeer(child, out int childId);
                 nodeInfo.AddChild(_view, childId);
             }

--- a/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
+++ b/src/Android/Avalonia.Android/AvaloniaAccessHelper.cs
@@ -85,26 +85,6 @@ namespace Avalonia.Android
             }
         }
 
-        /// <summary>
-        /// Peers of native interop controls (<see cref="Avalonia.Controls.NativeControlHost"/>) must
-        /// never be walked: <c>InteropAutomationPeer</c> throws
-        /// <see cref="System.NotImplementedException"/> from almost every member, because it is meant
-        /// to be special-cased by each platform backend. The other backends already do so
-        /// (<c>AvnAutomationPeer.IsInteropPeer</c>, <c>AutomationNode.InteropAutomationNode</c>);
-        /// Android did not, so any accessibility traversal reaching a native control threw from
-        /// inside an accessibility callback and took the application down.
-        /// <para>
-        /// Skipping is the correct behaviour here, not merely the safe one: a native control is a
-        /// real Android <c>View</c>, already exposed to the accessibility framework on its own.
-        /// Presenting it a second time as an Avalonia virtual view would duplicate it.
-        /// </para>
-        /// </summary>
-        /// <remarks>
-        /// Interop peers are filtered at every point where a virtual view ID could be handed out, so
-        /// that one is never allocated for them. <c>OnPopulateNodeForVirtualView</c> therefore never
-        /// has to deal with one - which matters, because it may not answer with an unpopulated node:
-        /// <c>ExploreByTouchHelper.createNodeForChild</c> rejects that and throws.
-        /// </remarks>
         private static bool IsInteropPeer(AutomationPeer peer) => peer is InteropAutomationPeer;
 
         private HashSet<INodeInfoProvider> GetOrCreateNodeInfoProvidersFromPeer(AutomationPeer peer, out int virtualViewId)
@@ -200,7 +180,6 @@ namespace Avalonia.Android
             {
                 if (IsInteropPeer(peer))
                 {
-                    // The point lands on a native control, which Android already exposes itself.
                     return InvalidId;
                 }
 

--- a/src/Avalonia.Controls/Avalonia.Controls.csproj
+++ b/src/Avalonia.Controls/Avalonia.Controls.csproj
@@ -22,6 +22,7 @@
     <InternalsVisibleTo Include="AvaloniaUI.DiagnosticsSupport.Avalonia, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.LeakTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Headless, PublicKey=$(AvaloniaPublicKey)" />
+    <InternalsVisibleTo Include="Avalonia.Android, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Native, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Win32, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Win32.Automation, PublicKey=$(AvaloniaPublicKey)" />


### PR DESCRIPTION
## What does the pull request do?

Stops the Android accessibility backend from walking `InteropAutomationPeer`, the peer of a native
interop control (`NativeControlHost`).

That peer throws `NotImplementedException` from almost every member — `GetOrCreateChildrenCore`,
`GetNameCore`, `GetBoundingRectangleCore`, `IsEnabledCore` — because it is meant to be special-cased
by each platform backend. macOS does that through `AvnAutomationPeer.IsInteropPeer`, Windows through
`AutomationNode.InteropAutomationNode`. Android did not, and `AvaloniaAccessHelper` called those
members with no guard.

## What is the current behavior?

Any accessibility traversal of a screen hosting a `NativeControlHost` — a WebView, an embedded media
surface — throws from inside an accessibility callback. That is not recoverable: the process goes
down.

Reproduced on an Android 13 device, four times in a row, on a screen with a WebView:

```
adb shell uiautomator dump
```

```
System.NotImplementedException
  at Avalonia.Controls.Automation.Peers.InteropAutomationPeer.GetOrCreateChildrenCore
  at Avalonia.Automation.Peers.AutomationPeer.GetChildren
  at Avalonia.Android.AvaloniaAccessHelper.OnPopulateNodeForVirtualView
```

`uiautomator` is only the cheapest trigger — any accessibility client walking the tree takes the same
path, so a screen reader or an MDM agent does too.

## What is the updated/expected behavior with this PR?

The same traversal completes, and the native control is left to the accessibility framework, which
already exposes it as the real Android `View` that it is.

To test: run `samples/ControlCatalog.Android`, open the **Native Embed** page, enable an
accessibility service, then `adb shell uiautomator dump`. Before this change the app dies; after it,
the dump completes.

## How was the solution implemented (if it's not obvious)?

Interop peers are filtered at the four places where a virtual view ID can be handed out: the point
hit test, the visible-views enumeration, the focused peer, and the children walk. A virtual view ID
is therefore never allocated for one, and `OnPopulateNodeForVirtualView` never receives one.

Filtering at allocation rather than at population is deliberate. `OnPopulateNodeForVirtualView` may
not simply return early either: `ExploreByTouchHelper.createNodeForChild` rejects a node carrying
neither text nor content description and throws in turn — that is #22122. Guarding inside the
populate callback would have traded one crash for another.

Skipping is also the semantically correct answer, not just the safe one: presenting a native control
a second time as an Avalonia virtual view would duplicate a node the platform already publishes.

`InteropAutomationPeer` is `internal`, hence the `InternalsVisibleTo` entry — `Avalonia.Native` and
`Avalonia.Win32.Automation` already have one for the same reason.

## Checklist

- [ ] Added unit tests (if possible)? — not possible: the path needs a device with an accessibility
  service running and a native control on screen.
- [x] Added XML documentation to any related classes? — no public API is added; the private helper is
  left undocumented as requested in review.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
  — not applicable.

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Touches the same file as #22122 but not the same lines; either merge order is fine.
