### PR TITLE
Fix hidden Win32 TrayIcon appearing after icon updates

### DIFF
--- a/src/Windows/Avalonia.Win32/TrayIconImpl.cs
+++ b/src/Windows/Avalonia.Win32/TrayIconImpl.cs
@@ -94,7 +94,7 @@ namespace Avalonia.Win32
         {
             _iconImpl = (IconImpl?)icon;
             _iconStale = true;
-            UpdateIcon();
+            UpdateIcon(!_iconAdded);
         }
 
         /// <inheritdoc />
@@ -376,6 +376,10 @@ namespace Avalonia.Win32
             if (!_disposedValue)
             {
                 UpdateIcon(true);
+                
+                s_trayIcons.Remove(_uniqueId);
+                _icon?.Dispose();
+                _icon = null;
 
                 _disposedValue = true;
             }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Preserves the current Win32 tray icon registration state when its icon is updated.

A hidden `TrayIcon` now remains hidden until `SetIsVisible(true)` is called.

## What is the current behavior?

`TrayIconImpl.SetIcon` calls `UpdateIcon()` without considering whether the tray icon is currently registered.

When `_iconAdded` is `false`, `UpdateIcon()` executes `Shell_NotifyIcon(NIM.ADD, ...)`, causing a hidden or initializing `TrayIcon` to unexpectedly appear in the Windows system tray.

For example, updating the icon after hiding it can make it visible again:

```csharp
trayIcon.IsVisible = false;
trayIcon.Icon = anotherIcon;
```

## What is the updated/expected behavior with this PR?

Updating the icon preserves the current registration state:

- A hidden tray icon remains hidden.
- The tray icon is added only when `SetIsVisible(true)` is called.

To test the change:

1. Create and attach a `TrayIcon`.
2. Set `IsVisible` to `false`.
3. Change its `Icon`.
4. Verify that it does not appear in the Windows system tray.
5. Set `IsVisible` to `true` and verify that it appears.

## How was the solution implemented (if it's not obvious)?
```csharp
UpdateIcon(!_iconAdded);
```

When the tray icon is already registered, it is updated normally. When it is not registered, updating its icon does not add it to the system tray.