### PR TITLE
feat(macos): add traffic light position customization

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -109,6 +109,18 @@
     return YES;
 }
 
+- (void)viewDidChangeEffectiveAppearance
+{
+    [super viewDidChangeEffectiveAppearance];
+
+    // AppKit can reset standard button frames when the effective appearance changes.
+    auto window = _parent.tryGetWithCast<WindowImpl>();
+    if (window != nullptr)
+    {
+        window->UpdateTrafficLightLayout();
+    }
+}
+
 - (BOOL)wantsUpdateLayer
 {
     return YES;

--- a/native/Avalonia.Native/src/OSX/WindowImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.h
@@ -65,6 +65,8 @@ BEGIN_INTERFACE_MAP()
     virtual HRESULT GetExtendTitleBarHeight (double*ret) override;
 
     virtual HRESULT SetExtendTitleBarHeight (double value) override;
+
+    virtual HRESULT SetTrafficLightPosition (AvnPoint position, bool useCustomLayout) override;
     
     virtual HRESULT GetWindowZOrder (long* zOrder) override;
 
@@ -88,11 +90,40 @@ BEGIN_INTERFACE_MAP()
 
     bool IsTransitioningWindowState() { return _transitioningWindowState; }
 
+    void UpdateTrafficLightLayout();
+
 protected:
     virtual NSWindowStyleMask CalculateStyleMask() override;
     virtual void UpdateAppearance() override;
 
 private:
+    enum class TrafficLightLayout
+    {
+        System,
+        Custom
+    };
+
+    struct TrafficLightViews
+    {
+        NSView* Container;
+        NSButton* Close;
+        NSButton* Miniaturize;
+        NSButton* Zoom;
+    };
+
+    struct TrafficLightFrames
+    {
+        NSRect Container;
+        NSRect Close;
+        NSRect Miniaturize;
+        NSRect Zoom;
+    };
+
+    void UpdateWindowedTrafficLightLayout();
+    void RestoreTrafficLightLayout();
+    bool TryGetTrafficLightViews(TrafficLightViews* views);
+    void UpdateTrafficLightTrackingAreas(const TrafficLightViews& views);
+
     void ZOrderChildWindows();
     void OnInitialiseNSWindow();
     NSString *_lastTitle;
@@ -109,6 +140,10 @@ private:
     bool _transitioningWindowState;
     bool _isClientAreaExtended;
     bool _isModal;
+    bool _hasDefaultTrafficLightFrames;
+    TrafficLightLayout _trafficLightLayout;
+    AvnPoint _trafficLightPosition;
+    TrafficLightFrames _defaultTrafficLightFrames;
 };
 
 #endif //AVALONIA_NATIVE_OSX_WINDOWIMPL_H

--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -23,6 +23,9 @@ WindowImpl::WindowImpl(IAvnWindowEvents *events) : TopLevelImpl(events), WindowB
     _lastWindowState = Normal;
     _actualWindowState = Normal;
     _lastTitle = @"";
+    _hasDefaultTrafficLightFrames = false;
+    _trafficLightLayout = TrafficLightLayout::System;
+    _trafficLightPosition = { 0, 0 };
     Parent = nullptr;
     WindowEvents = events;
 
@@ -60,7 +63,14 @@ HRESULT WindowImpl::Show(bool activate, bool isDialog) {
             _lastWindowState = _actualWindowState;
         }
 
-        return SetWindowState(_lastWindowState);
+        auto result = SetWindowState(_lastWindowState);
+
+        // Showing the window can schedule a deferred AppKit titlebar layout.
+        // Flush it before applying custom traffic-light frames.
+        [Window layoutIfNeeded];
+        UpdateTrafficLightLayout();
+
+        return result;
     }
 }
 
@@ -148,6 +158,9 @@ AvnWindowState WindowImpl::WindowState() {
 }
 
 void WindowImpl::WindowStateChanged() {
+    // AppKit can recreate or reposition standard buttons during window state changes and resizing.
+    UpdateTrafficLightLayout();
+
     if (_shown && !_inSetWindowState && !_transitioningWindowState) {
         AvnWindowState state;
         GetWindowState(&state);
@@ -430,6 +443,17 @@ HRESULT WindowImpl::SetExtendTitleBarHeight(double value) {
     }
 }
 
+HRESULT WindowImpl::SetTrafficLightPosition(AvnPoint position, bool useCustomLayout) {
+    START_COM_CALL;
+
+    @autoreleasepool {
+        _trafficLightPosition = position;
+        _trafficLightLayout = useCustomLayout ? TrafficLightLayout::Custom : TrafficLightLayout::System;
+        UpdateTrafficLightLayout();
+        return S_OK;
+    }
+}
+
 void WindowImpl::EnterFullScreenMode() {
     _fullScreenActive = true;
 
@@ -611,6 +635,127 @@ void WindowImpl::UpdateAppearance() {
     [miniaturizeButton setEnabled:_isEnabled && _canMinimize];
     [zoomButton setHidden:!hasTrafficLights];
     [zoomButton setEnabled:CanZoom() || (([Window styleMask] & NSWindowStyleMaskFullScreen) != 0 && _isEnabled)];
+
+    // Style and button visibility changes can make AppKit lay out the titlebar again.
+    UpdateTrafficLightLayout();
+}
+
+void WindowImpl::UpdateTrafficLightLayout() {
+    if (Window == nil || !_shown) {
+        return;
+    }
+
+    // AppKit owns the layout for system, non-full decorations, and native fullscreen.
+    if (_trafficLightLayout == TrafficLightLayout::System ||
+        _decorations != SystemDecorationsFull ||
+        ([Window styleMask] & NSWindowStyleMaskFullScreen) != 0) {
+        RestoreTrafficLightLayout();
+        return;
+    }
+
+    UpdateWindowedTrafficLightLayout();
+}
+
+void WindowImpl::UpdateWindowedTrafficLightLayout() {
+    TrafficLightViews views;
+    if (!TryGetTrafficLightViews(&views)) {
+        return;
+    }
+
+    if (!_hasDefaultTrafficLightFrames) {
+        // Save geometry, not button objects. AppKit can recreate the standard buttons.
+        _defaultTrafficLightFrames = {
+            views.Container.frame,
+            views.Close.frame,
+            views.Miniaturize.frame,
+            views.Zoom.frame
+        };
+        _hasDefaultTrafficLightFrames = true;
+    }
+
+    NSRect groupFrame = NSUnionRect(views.Close.frame,
+        NSUnionRect(views.Miniaturize.frame, views.Zoom.frame));
+    NSRect containerFrame = views.Container.frame;
+    // Equal bottom padding keeps the titlebar tracking geometry around the moved buttons.
+    containerFrame.size.height = NSHeight(groupFrame) + 2 * _trafficLightPosition.Y;
+    containerFrame.origin.y = NSHeight(Window.frame) - NSHeight(containerFrame);
+    [views.Container setFrame:containerFrame];
+
+    // Move the group as a whole to preserve AppKit's button sizes, spacing, and RTL order.
+    groupFrame = NSUnionRect(views.Close.frame,
+        NSUnionRect(views.Miniaturize.frame, views.Zoom.frame));
+    bool isRightToLeft = Window.windowTitlebarLayoutDirection == NSUserInterfaceLayoutDirectionRightToLeft;
+    double desiredLeading = isRightToLeft
+        ? NSWidth(Window.frame) - _trafficLightPosition.X
+        : _trafficLightPosition.X;
+    double horizontalOffset = desiredLeading - (isRightToLeft ? NSMaxX(groupFrame) : NSMinX(groupFrame));
+    double verticalOffset = NSHeight(containerFrame) - _trafficLightPosition.Y - NSMaxY(groupFrame);
+
+    [views.Close setFrameOrigin:NSMakePoint(
+        NSMinX(views.Close.frame) + horizontalOffset,
+        NSMinY(views.Close.frame) + verticalOffset)];
+    [views.Miniaturize setFrameOrigin:NSMakePoint(
+        NSMinX(views.Miniaturize.frame) + horizontalOffset,
+        NSMinY(views.Miniaturize.frame) + verticalOffset)];
+    [views.Zoom setFrameOrigin:NSMakePoint(
+        NSMinX(views.Zoom.frame) + horizontalOffset,
+        NSMinY(views.Zoom.frame) + verticalOffset)];
+
+    UpdateTrafficLightTrackingAreas(views);
+}
+
+void WindowImpl::RestoreTrafficLightLayout() {
+    if (!_hasDefaultTrafficLightFrames) {
+        return;
+    }
+
+    TrafficLightViews views;
+    if (!TryGetTrafficLightViews(&views)) {
+        return;
+    }
+
+    [views.Container setFrame:_defaultTrafficLightFrames.Container];
+    [views.Close setFrame:_defaultTrafficLightFrames.Close];
+    [views.Miniaturize setFrame:_defaultTrafficLightFrames.Miniaturize];
+    [views.Zoom setFrame:_defaultTrafficLightFrames.Zoom];
+    UpdateTrafficLightTrackingAreas(views);
+    _hasDefaultTrafficLightFrames = false;
+}
+
+bool WindowImpl::TryGetTrafficLightViews(TrafficLightViews* views) {
+    if (Window == nil || views == nullptr) {
+        return false;
+    }
+
+    // Standard buttons can be removed and recreated, so always fetch the live views.
+    NSButton* closeButton = [Window standardWindowButton:NSWindowCloseButton];
+    NSButton* miniaturizeButton = [Window standardWindowButton:NSWindowMiniaturizeButton];
+    NSButton* zoomButton = [Window standardWindowButton:NSWindowZoomButton];
+    NSView* buttonContainer = closeButton.superview;
+
+    if (closeButton == nil ||
+        miniaturizeButton == nil ||
+        zoomButton == nil ||
+        buttonContainer == nil ||
+        miniaturizeButton.superview != buttonContainer ||
+        zoomButton.superview != buttonContainer ||
+        buttonContainer.superview == nil) {
+        return false;
+    }
+
+    views->Container = buttonContainer.superview;
+    views->Close = closeButton;
+    views->Miniaturize = miniaturizeButton;
+    views->Zoom = zoomButton;
+    return true;
+}
+
+void WindowImpl::UpdateTrafficLightTrackingAreas(const TrafficLightViews& views) {
+    // Moving frames alone can leave AppKit's hover and hit-test geometry stale.
+    [views.Container updateTrackingAreas];
+    [views.Close updateTrackingAreas];
+    [views.Miniaturize updateTrackingAreas];
+    [views.Zoom updateTrackingAreas];
 }
 
 extern IAvnWindow* CreateAvnWindow(IAvnWindowEvents*events)

--- a/samples/IntegrationTestApp/Pages/WindowDecorationsPage.axaml
+++ b/samples/IntegrationTestApp/Pages/WindowDecorationsPage.axaml
@@ -14,6 +14,9 @@
     <Button Name="ShowNewWindowDecorations"
             Content="Show new Window with decorations"
             Click="ShowNewWindowDecorations_Click"/>
+    <Button Name="ShowTrafficLightPositionWindow"
+            Content="Show traffic light position window"
+            Click="ShowTrafficLightPositionWindow_Click"/>
     <TextBox Name="WindowDecorationProperties" AcceptsReturn="True" />
   </StackPanel>
 </UserControl>

--- a/samples/IntegrationTestApp/Pages/WindowDecorationsPage.axaml.cs
+++ b/samples/IntegrationTestApp/Pages/WindowDecorationsPage.axaml.cs
@@ -61,4 +61,7 @@ public partial class WindowDecorationsPage : UserControl
         SetWindowDecorations(window);
         window.Show();
     }
+
+    private void ShowTrafficLightPositionWindow_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) =>
+        new TrafficLightPositionWindow().Show();
 }

--- a/samples/IntegrationTestApp/TrafficLightPositionWindow.axaml
+++ b/samples/IntegrationTestApp/TrafficLightPositionWindow.axaml
@@ -1,0 +1,26 @@
+<Window
+  ExtendClientAreaToDecorationsHint="True"
+  Height="300"
+  MacOSProperties.TrafficLightPosition="50,50"
+  Name="TrafficLightPositionTestWindow"
+  Title="Traffic Light Position"
+  Width="400"
+  WindowDecorations="Full"
+  x:Class="IntegrationTestApp.TrafficLightPositionWindow"
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <StackPanel Margin="40,100,40,40" Spacing="8">
+    <Button Click="SetCustomTrafficLightPosition_Click" Name="SetCustomTrafficLightPosition">
+      Set custom traffic light position
+    </Button>
+    <Button Click="ResetTrafficLightPosition_Click" Name="ResetTrafficLightPosition">
+      Reset traffic light position
+    </Button>
+    <Button Click="ToggleTrafficLightAppearance_Click" Name="ToggleTrafficLightAppearance">
+      Toggle appearance
+    </Button>
+    <Button Click="ResizeTrafficLightWindow_Click" Name="ResizeTrafficLightWindow">
+      Resize window
+    </Button>
+  </StackPanel>
+</Window>

--- a/samples/IntegrationTestApp/TrafficLightPositionWindow.axaml.cs
+++ b/samples/IntegrationTestApp/TrafficLightPositionWindow.axaml.cs
@@ -1,0 +1,29 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Styling;
+
+namespace IntegrationTestApp;
+
+public partial class TrafficLightPositionWindow : Window
+{
+    public TrafficLightPositionWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void SetCustomTrafficLightPosition_Click(object? sender, RoutedEventArgs e) =>
+        MacOSProperties.SetTrafficLightPosition(this, new Point(70, 40));
+
+    private void ResetTrafficLightPosition_Click(object? sender, RoutedEventArgs e) =>
+        MacOSProperties.SetTrafficLightPosition(this, null);
+
+    private void ToggleTrafficLightAppearance_Click(object? sender, RoutedEventArgs e) =>
+        RequestedThemeVariant = ActualThemeVariant == ThemeVariant.Dark ? ThemeVariant.Light : ThemeVariant.Dark;
+
+    private void ResizeTrafficLightWindow_Click(object? sender, RoutedEventArgs e)
+    {
+        Width += 20;
+        Height += 20;
+    }
+}

--- a/src/Avalonia.Controls/Platform/IMacOSOptionsTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Platform/IMacOSOptionsTopLevelImpl.cs
@@ -1,0 +1,17 @@
+using Avalonia.Metadata;
+using Avalonia.Platform;
+
+namespace Avalonia.Controls.Platform;
+
+/// <summary>
+/// Defines macOS-specific options for top-level platform implementations.
+/// </summary>
+[PrivateApi]
+public interface IMacOSOptionsTopLevelImpl : ITopLevelImpl
+{
+    /// <summary>
+    /// Sets the top-leading position of the native macOS window buttons.
+    /// </summary>
+    /// <param name="position">The position, or <see langword="null"/> to use the system layout.</param>
+    void SetTrafficLightPosition(Point? position);
+}

--- a/src/Avalonia.Controls/Platform/MacOSProperties.cs
+++ b/src/Avalonia.Controls/Platform/MacOSProperties.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Platform;
+﻿using Avalonia.Controls.Platform;
+using Avalonia.Platform;
 
 namespace Avalonia.Controls;
 
@@ -10,6 +11,7 @@ public class MacOSProperties
     static MacOSProperties()
     {
         IsTemplateIconProperty.Changed.AddClassHandler<TrayIcon>(TrayIconIsTemplateIconChanged);
+        TrafficLightPositionProperty.Changed.AddClassHandler<Window>(TrafficLightPositionChanged);
     }
 
     /// <summary>
@@ -17,6 +19,14 @@ public class MacOSProperties
     /// </summary>
     public static readonly AttachedProperty<bool> IsTemplateIconProperty =
         AvaloniaProperty.RegisterAttached<MacOSProperties, TrayIcon, bool>("IsTemplateIcon");
+
+    /// <summary>
+    /// Defines the <c>TrafficLightPosition</c> attached property.
+    /// </summary>
+    public static readonly AttachedProperty<Point?> TrafficLightPositionProperty =
+        AvaloniaProperty.RegisterAttached<MacOSProperties, Window, Point?>(
+            "TrafficLightPosition",
+            validate: IsValidTrafficLightPosition);
 
     /// <summary>
     /// A Boolean value that determines whether the TrayIcon image represents a template image.
@@ -28,8 +38,36 @@ public class MacOSProperties
     /// </summary>
     public static bool GetIsTemplateIcon(TrayIcon obj) => obj.GetValue(IsTemplateIconProperty);
 
+    /// <summary>
+    /// Sets the top-leading position of the native macOS window buttons.
+    /// </summary>
+    /// <param name="window">The window.</param>
+    /// <param name="value">The position in logical units, or <see langword="null"/> to use the system layout.</param>
+    public static void SetTrafficLightPosition(Window window, Point? value) =>
+        window.SetValue(TrafficLightPositionProperty, value);
+
+    /// <summary>
+    /// Gets the top-leading position of the native macOS window buttons.
+    /// </summary>
+    /// <param name="window">The window.</param>
+    /// <returns>The position in logical units, or <see langword="null"/> when using the system layout.</returns>
+    public static Point? GetTrafficLightPosition(Window window) =>
+        window.GetValue(TrafficLightPositionProperty);
+
     private static void TrayIconIsTemplateIconChanged(TrayIcon trayIcon, AvaloniaPropertyChangedEventArgs args)
     {
         (trayIcon.Impl as ITrayIconWithIsTemplateImpl)?.SetIsTemplateIcon(args.GetNewValue<bool>());
     }
+
+    private static void TrafficLightPositionChanged(Window window, AvaloniaPropertyChangedEventArgs args)
+    {
+        (window.PlatformImpl as IMacOSOptionsTopLevelImpl)?.SetTrafficLightPosition(args.GetNewValue<Point?>());
+    }
+
+    private static bool IsValidTrafficLightPosition(Point? position) =>
+        position is null ||
+        (position.Value.X >= 0 &&
+            position.Value.Y >= 0 &&
+            double.IsFinite(position.Value.X) &&
+            double.IsFinite(position.Value.Y));
 }

--- a/src/Avalonia.Native/WindowImpl.cs
+++ b/src/Avalonia.Native/WindowImpl.cs
@@ -12,7 +12,7 @@ using MicroCom.Runtime;
 
 namespace Avalonia.Native
 {
-    internal class WindowImpl : WindowBaseImpl, IWindowImpl
+    internal class WindowImpl : WindowBaseImpl, IWindowImpl, IMacOSOptionsTopLevelImpl
     {
         private readonly AvaloniaNativePlatformOptions _opts;
         private readonly IAvnWindow _native;
@@ -217,6 +217,12 @@ namespace Avalonia.Native
             _native.SetExtendTitleBarHeight(titleBarHeight);
 
             InvalidateExtendedMargins();
+        }
+
+        /// <inheritdoc/>
+        public void SetTrafficLightPosition(Point? position)
+        {
+            _native.SetTrafficLightPosition(position?.ToAvnPoint() ?? default, position.HasValue.AsComBool());
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -810,6 +810,7 @@ interface IAvnWindow : IAvnWindowBase
      HRESULT SetExtendClientArea(bool enable);
      HRESULT GetExtendTitleBarHeight(double*ret);
      HRESULT SetExtendTitleBarHeight(double value);
+     HRESULT SetTrafficLightPosition(AvnPoint position, bool useCustomLayout);
      HRESULT GetWindowZOrder(long*ret);
 }
 

--- a/tests/Avalonia.Controls.UnitTests/MacOSPropertiesTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MacOSPropertiesTests.cs
@@ -1,0 +1,45 @@
+using System;
+using Avalonia.Controls.Platform;
+using Avalonia.UnitTests;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests;
+
+public class MacOSPropertiesTests : ScopedTestBase
+{
+    [Fact]
+    public void TrafficLightPosition_Defaults_To_System()
+    {
+        var window = new Window(MockWindowingPlatform.CreateWindowMock().Object);
+
+        Assert.Null(MacOSProperties.GetTrafficLightPosition(window));
+    }
+
+    [Fact]
+    public void TrafficLightPosition_Is_Forwarded_To_The_Platform()
+    {
+        var windowImpl = MockWindowingPlatform.CreateWindowMock();
+        var macOSOptions = windowImpl.As<IMacOSOptionsTopLevelImpl>();
+        var window = new Window(windowImpl.Object);
+        var position = new Point(50, 40);
+
+        MacOSProperties.SetTrafficLightPosition(window, position);
+        MacOSProperties.SetTrafficLightPosition(window, null);
+
+        macOSOptions.Verify(x => x.SetTrafficLightPosition(position), Times.Once);
+        macOSOptions.Verify(x => x.SetTrafficLightPosition(null), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(-1, 0)]
+    [InlineData(0, -1)]
+    [InlineData(double.NaN, 0)]
+    [InlineData(0, double.PositiveInfinity)]
+    public void TrafficLightPosition_Rejects_Invalid_Coordinates(double x, double y)
+    {
+        var window = new Window(MockWindowingPlatform.CreateWindowMock().Object);
+
+        Assert.Throws<ArgumentException>(() => MacOSProperties.SetTrafficLightPosition(window, new Point(x, y)));
+    }
+}

--- a/tests/Avalonia.IntegrationTests.Appium/TrafficLightPositionTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/TrafficLightPositionTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Reactive.Disposables;
+using System.Threading;
+using Xunit;
+
+namespace Avalonia.IntegrationTests.Appium;
+
+[Collection("WindowDecorations")]
+public class TrafficLightPositionTests : TestBase
+{
+    public TrafficLightPositionTests(DefaultAppFixture fixture)
+        : base(fixture, "Window Decorations")
+    {
+    }
+
+    [PlatformFact(TestPlatforms.MacOS)]
+    public void Xaml_Position_Is_Applied_On_First_Show()
+    {
+        using (OpenWindow())
+        {
+            AssertTrafficLightPosition(50, 50);
+        }
+    }
+
+    [PlatformFact(TestPlatforms.MacOS)]
+    public void Position_Can_Be_Changed_And_Reset_To_System()
+    {
+        using (OpenWindow())
+        {
+            ClickAndWait("ResetTrafficLightPosition");
+            var systemPosition = GetTrafficLightPosition();
+
+            ClickAndWait("SetCustomTrafficLightPosition");
+            AssertTrafficLightPosition(70, 40);
+
+            ClickAndWait("ResetTrafficLightPosition");
+            Assert.Equal(systemPosition, GetTrafficLightPosition());
+        }
+    }
+
+    [PlatformFact(TestPlatforms.MacOS)]
+    public void Custom_Position_Is_Restored_After_Appearance_Change()
+    {
+        using (OpenWindow())
+        {
+            ClickAndWait("ToggleTrafficLightAppearance");
+            AssertTrafficLightPosition(50, 50);
+        }
+    }
+
+    [PlatformFact(TestPlatforms.MacOS)]
+    public void Custom_Position_Is_Restored_After_Resize()
+    {
+        using (OpenWindow())
+        {
+            ClickAndWait("ResizeTrafficLightWindow");
+            AssertTrafficLightPosition(50, 50);
+        }
+    }
+
+    private IDisposable OpenWindow()
+    {
+        Session.FindElementByAccessibilityId("ShowTrafficLightPositionWindow").Click();
+        Thread.Sleep(1000);
+
+        return Disposable.Create(() =>
+        {
+            var window = Session.GetWindowById("TrafficLightPositionTestWindow");
+            window.GetSystemChromeButtons().Close!.Click();
+            Thread.Sleep(1000);
+        });
+    }
+
+    private void ClickAndWait(string automationId)
+    {
+        Session.FindElementByAccessibilityId(automationId).Click();
+        Thread.Sleep(500);
+    }
+
+    private (int X, int Y) GetTrafficLightPosition()
+    {
+        var window = Session.GetWindowById("TrafficLightPositionTestWindow");
+        var closeButton = window.GetSystemChromeButtons().Close;
+
+        Assert.NotNull(closeButton);
+        return (
+            closeButton.Location.X - window.Location.X,
+            closeButton.Location.Y - window.Location.Y);
+    }
+
+    private void AssertTrafficLightPosition(int expectedX, int expectedY)
+    {
+        var actual = GetTrafficLightPosition();
+        Assert.InRange(actual.X, expectedX - 1, expectedX + 1);
+        Assert.InRange(actual.Y, expectedY - 1, expectedY + 1);
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Adds support for customizing macOS traffic light button positions through `MacOSProperties.TrafficLightPosition`, including XAML usage.

### API

```csharp
/// <summary>
/// Defines the <c>TrafficLightPosition</c> attached property.
/// </summary>
public static readonly AttachedProperty<Point?> TrafficLightPositionProperty;

/// <summary>
/// Gets the top-leading position of the native macOS window buttons.
/// </summary>
/// <param name="window">The window.</param>
/// <returns>The position in logical units, or <see langword="null"/> when using the system layout.</returns>
public static Point? GetTrafficLightPosition(Window window);

/// <summary>
/// Sets the top-leading position of the native macOS window buttons.
/// </summary>
/// <param name="window">The window.</param>
/// <param name="value">The position in logical units, or <see langword="null"/> to use the system layout.</param>
public static void SetTrafficLightPosition(Window window, Point? value);
```

### Usage

```xml
<Window
    ExtendClientAreaToDecorationsHint="True"
    WindowDecorations="Full"
    MacOSProperties.TrafficLightPosition="14,18" />
```

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

The macOS traffic light buttons always use the system-provided position. Applications extending content into the title bar cannot align them with a custom title bar layout.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Applications can specify the top-leading traffic light position in logical units. Setting the property to `null` restores the system layout.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

The native implementation keeps explicit System and Custom layout states. It preserves AppKit’s button sizes, spacing, RTL ordering, and tracking areas, while restoring system-owned layout for fullscreen and unsupported decoration modes.

Custom positioning is reapplied after AppKit title-bar layout changes, including initial display, resizing, appearance changes, and window-state transitions.

Electron and Zed implementations were researched to account for relevant AppKit behavior and known edge cases.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

None

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

None

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #21119
