### PR TITLE
Fix empty FlexPanel size

### DIFF
--- a/src/Avalonia.Controls/FlexPanel/FlexPanel.cs
+++ b/src/Avalonia.Controls/FlexPanel/FlexPanel.cs
@@ -198,7 +198,7 @@ namespace Avalonia.Controls
             if (_visibleChildren is not { Length: > 0 } children)
             {
                 _state.Lines.Clear();
-                return availableSize;
+                return default;
             }
 
             var isColumn = Direction is FlexDirection.Column or FlexDirection.ColumnReverse;

--- a/tests/Avalonia.Controls.UnitTests/FlexPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/FlexPanelTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia.Controls.Presenters;
 using Avalonia.Layout;
 using Avalonia.UnitTests;
 using Xunit;
@@ -410,6 +411,21 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Size(50, 15), target.Bounds.Size);
             Assert.Equal(new Rect(0, 0, 25, 15), target.Children[0].Bounds);
             Assert.Equal(new Rect(25, 0, 25, 15), target.Children[1].Bounds);
+        }
+
+        [Fact]
+        public void Empty_Panel_Does_Not_Take_Up_Available_Space()
+        {
+            var target = new FlexPanel();
+            var stack = new StackPanel { Children = { new Border { Width = 100, Height = 50 }, target } };
+
+            var presenter = new ScrollContentPresenter { CanVerticallyScroll = true, Content = stack };
+
+            presenter.UpdateChild();
+            presenter.Measure(new Size(100, 100));
+
+            Assert.Equal(default, target.DesiredSize);
+            Assert.Equal(new Size(100, 50), stack.DesiredSize);
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Fixes a regression introduced when integrating FlexPanel.

## What is the current behavior?

Throws when an empty FlexPanel in a vertical StackPanel reports infinite size.

## What is the updated/expected behavior with this PR?

Returns zero size, no crash.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
