### PR TITLE
Send a synthetic UnmapNotify when hiding an X11 window

### DIFF
--- a/src/Avalonia.X11/X11WindowModes/DefaultWindowMode.cs
+++ b/src/Avalonia.X11/X11WindowModes/DefaultWindowMode.cs
@@ -49,7 +49,31 @@ partial class X11Window
         public override void Hide()
         {
             XUnmapWindow(X11.Display, Handle);
+
+            if (!Window._overrideRedirect)
+                SendSyntheticUnmapNotify();
+
             base.Hide();
+        }
+
+        // ICCCM 4.1.4: withdrawing also requires a synthetic UnmapNotify, since XUnmapWindow
+        // generates no event when the window manager has already unmapped the window.
+        private void SendSyntheticUnmapNotify()
+        {
+            var ev = new XEvent
+            {
+                UnmapEvent =
+                {
+                    type = XEventName.UnmapNotify,
+                    send_event = 1,
+                    display = X11.Display,
+                    xevent = X11.RootWindow,
+                    window = Handle,
+                    from_configure = 0
+                }
+            };
+            XSendEvent(X11.Display, X11.RootWindow, false,
+                (IntPtr)(EventMask.SubstructureRedirectMask | EventMask.SubstructureNotifyMask), ref ev);
         }
 
         public override Point PointToClient(PixelPoint point) => new Point(


### PR DESCRIPTION
## What does the pull request do?

`DefaultWindowMode.Hide()` calls `XUnmapWindow` only. ICCCM 4.1.4 requires a client withdrawing a top-level window to also send a synthetic `UnmapNotify` to the root window, which this PR now does.

## What is the current behavior?

When the window manager has already unmapped the window because it is minimized, `XUnmapWindow` on an already-unmapped window generates no event, so the window manager never learns that the client withdrew the window and keeps it listed as managed and iconic.

For an application that hides to a tray icon, calling `Hide()` on a minimized window therefore leaves a stale taskbar entry. Activating that entry maps the window again, but `Window.Hide()` has already called `StopRendering()` and `MapNotify` does not restart it, so the frame comes back empty. Closing it again does nothing either, since `Window.Hide()` returns early on `!_shown`. Only `Show()` from the tray icon restores the content.

## What is the updated/expected behavior with this PR?

`Hide()` withdraws the window in that case: `WM_STATE` is removed and the window leaves `_NET_CLIENT_LIST`, so no stale entry remains.

Tested on KDE Plasma 6.6.6 under XWayland, with a minimal window whose `Closing` handler calls `Hide()`, and with an unmodified v2rayN 7.24.7 build with only `Avalonia.X11.dll` replaced. Hiding a mapped window still withdraws it correctly: the real and the synthetic `UnmapNotify` both arrive, which is the sequence ICCCM describes. mutter and native X11 sessions were not tested.

## How was the solution implemented (if it's not obvious)?

The event is built and sent the same way `SendNetWMMessage` does. Override-redirect windows are skipped, since the window manager does not manage them.

No unit test: the behavior depends on the window manager's response, which the X11 test setup does not cover.

## Fixed issues

Related to #18148. That report also covers rendering not restarting when the system maps a hidden window, which is not addressed here.

---

The patch, the testing described above and this description were produced with AI assistance ([Claude Code](https://claude.com/claude-code)) on my machine. I have reviewed the change and reproduced both the original problem and the fix myself.
