### PR TITLE
Fix AssemblyDescriptorResolver.GetAssembly(string name) to not throw CultureNotFoundException

### DIFF
--- a/src/Avalonia.Base/Platform/Internal/AssemblyDescriptorResolver.cs
+++ b/src/Avalonia.Base/Platform/Internal/AssemblyDescriptorResolver.cs
@@ -26,7 +26,7 @@ internal class AssemblyDescriptorResolver: IAssemblyDescriptorResolver
         if (!_assemblyNameCache.TryGetValue(name, out var rv))
         {
             var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
-            var match = loadedAssemblies.FirstOrDefault(a => name.Equals(a.GetName().Name, StringComparison.InvariantCultureIgnoreCase));
+            var match = loadedAssemblies.FirstOrDefault(a => a.ManifestModule.ScopeName.StartsWith(name, StringComparison.InvariantCultureIgnoreCase));
             if (match != null)
             {
                 _assemblyNameCache[name] = rv = new AssemblyDescriptor(match);

--- a/src/Avalonia.Base/Platform/Internal/AssemblyDescriptorResolver.cs
+++ b/src/Avalonia.Base/Platform/Internal/AssemblyDescriptorResolver.cs
@@ -26,6 +26,7 @@ internal class AssemblyDescriptorResolver: IAssemblyDescriptorResolver
         if (!_assemblyNameCache.TryGetValue(name, out var rv))
         {
             var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+            // Select assembly by ManifestModule.ScopeName instead of GetName().Name to avoid CultureInfo dependency.
             var match = loadedAssemblies.Where(a => a.ManifestModule.ScopeName.StartsWith(name, StringComparison.InvariantCultureIgnoreCase)).OrderBy(a => a.ManifestModule.ScopeName.Length).FirstOrDefault();
             if (match != null)
             {

--- a/src/Avalonia.Base/Platform/Internal/AssemblyDescriptorResolver.cs
+++ b/src/Avalonia.Base/Platform/Internal/AssemblyDescriptorResolver.cs
@@ -26,7 +26,7 @@ internal class AssemblyDescriptorResolver: IAssemblyDescriptorResolver
         if (!_assemblyNameCache.TryGetValue(name, out var rv))
         {
             var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
-            var match = loadedAssemblies.FirstOrDefault(a => a.ManifestModule.ScopeName.StartsWith(name, StringComparison.InvariantCultureIgnoreCase));
+            var match = loadedAssemblies.Where(a => a.ManifestModule.ScopeName.StartsWith(name, StringComparison.InvariantCultureIgnoreCase)).OrderBy(a => a.ManifestModule.ScopeName.Length).FirstOrDefault();
             if (match != null)
             {
                 _assemblyNameCache[name] = rv = new AssemblyDescriptor(match);


### PR DESCRIPTION
## What does the pull request do?
Fixes `Avalonia.Platform.Internal.AssemblyDescriptorResolver.GetAssembly(string name)` to not throw `CultureNotFoundException` when project with culture specific resources has properties set `InvariantGlobalization=true` and `PublishAot=true` .


## What is the current behavior?
AssemblyDescriptorResolver.GetAssembly(string name) calls Assembly.GetName() which returns AssemblyName. AssemblyName constructor calls constructor of CultureInfo [src](https://github.com/dotnet/dotnet/blob/main/src/runtime/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs#L53) 

In project with properties set `InvariantGlobalization=true` and `PublishAot=true` which comes with culture specific resources this **throws "System.Globalization.CultureNotFoundException: Only the invariant culture is supported in globalization-invariant mode."**. Culture specific resources ('zh-Hans') can be included by referencing "Avalonia.AvaloniaEdit" for example.

## What is the updated/expected behavior with this PR?
AssemblyDescriptorResolver.GetAssembly(string name) uses Assembly.ManifestModule.ScopeName for comparison.


## How was the solution implemented (if it's not obvious)?
Updated method uses StartsWith instead of Equals for comparison because Assembly.ManifestModule.ScopeName may end with extension like ".dll" on Windows for example "AvaloniaEdit.resources.dll".

## Fixed issues
Fixes #21517
