### PR TITLE
Fix fatal NRE when the Win32 input pane is disposed during window close

### DIFF
--- a/src/Windows/Avalonia.Win32/Input/WindowsInputPane.cs
+++ b/src/Windows/Avalonia.Win32/Input/WindowsInputPane.cs
@@ -52,10 +52,8 @@ internal unsafe class WindowsInputPane : InputPaneBase, IDisposable
 
     private void OnStateChanged(bool showing, UnmanagedMethods.RECT? prcInputPaneScreenLocation)
     {
-        // Unadvise can deliver one last notification while it unwinds, and the shell can call back
-        // after teardown. Either would dereference a disposed _windowImpl, and this frame is invoked
-        // from native code, so the resulting NullReferenceException cannot unwind: it terminates the
-        // process with 0xC0000005 rather than raising a managed exception.
+        // Unadvise can deliver last notification while it unwinds, and the shell can call back after teardown.
+        // Either would dereference a disposed _windowImpl, crashing the process.
         if (_disposed)
             return;
 

--- a/src/Windows/Avalonia.Win32/Input/WindowsInputPane.cs
+++ b/src/Windows/Avalonia.Win32/Input/WindowsInputPane.cs
@@ -52,6 +52,13 @@ internal unsafe class WindowsInputPane : InputPaneBase, IDisposable
 
     private void OnStateChanged(bool showing, UnmanagedMethods.RECT? prcInputPaneScreenLocation)
     {
+        // Unadvise can deliver one last notification while it unwinds, and the shell can call back
+        // after teardown. Either would dereference a disposed _windowImpl, and this frame is invoked
+        // from native code, so the resulting NullReferenceException cannot unwind: it terminates the
+        // process with 0xC0000005 rather than raising a managed exception.
+        if (_disposed)
+            return;
+
         var oldState = (OccludedRect, State);
         OccludedRect = prcInputPaneScreenLocation.HasValue
             ? ScreenRectToClient(prcInputPaneScreenLocation.Value)
@@ -76,7 +83,6 @@ internal unsafe class WindowsInputPane : InputPaneBase, IDisposable
         if (_disposed)
             return; 
         _disposed = true;
-        _windowImpl = null!;
         if (_inputPane is not null)
         {
             if (_cookie != 0)
@@ -87,6 +93,11 @@ internal unsafe class WindowsInputPane : InputPaneBase, IDisposable
             _inputPane.Dispose();
             _inputPane = null;
         }
+
+        // Released only once Unadvise has returned, so the field stays valid for the whole of the
+        // teardown it is read during.
+        _windowImpl = null!;
+
         // Suppress finalization.
         GC.SuppressFinalize(this);
     }


### PR DESCRIPTION
## What does the pull request do?

Fixes a fatal process termination (`0xC0000005`) on ordinary window close, caused by a disposal-ordering bug in `WindowsInputPane`.

Reported in #22117, with a standalone repro in that issue body. We have now seen this four times in production telemetry across our customer base, most recently on Avalonia 11.3.14 / .NET 10.0.11 / Windows 10.0.26200.

## What is the current behavior?

`WindowsInputPane.Dispose()` nulls `_windowImpl` **before** calling `IFrameworkInputPane.Unadvise`:

```csharp
_disposed = true;
_windowImpl = null!;          // <-- released first
if (_inputPane is not null)
{
    if (_cookie != 0)
    {
        _inputPane.Unadvise(_cookie);   // <-- can still deliver a notification
    }
    ...
```

`Unadvise` can deliver a final `Showing`/`Hiding` notification as it unwinds, and the shell can also call back after teardown. Either reaches:

`Handler.Showing` → `WindowsInputPane.OnStateChanged` → `ScreenRectToClient` → `_windowImpl.PointToClient(...)`

which dereferences the null `_windowImpl`.

**Why this is fatal rather than a catchable exception:** that frame is entered from native code through a COM callback, so the `NullReferenceException` cannot unwind into managed code. The process is terminated with an access violation instead. It surfaces as a Windows Error Reporting `Application Error` 1000 (`0xc0000005` in `coreclr.dll`) paired with a `.NET Runtime` 1026 record one second later, from the same process.

**It is not a double-dispose.** `Dispose()` opens with `if (_disposed) return;`, and `WindowImpl.Dispose()` sets `_inputPane = null` after disposing it. A stack containing `WindowsInputPane.Dispose` → `Unadvise` is therefore proof of the **first and only** dispose of that pane — which is exactly what the reported mechanism predicts, and rules out the most likely alternative explanation.

The stack from our most recent occurrence, trimmed to the relevant frames:

```
at Avalonia.Win32.Win32Com.Impl.__MicroComIFrameworkInputPaneProxy.Unadvise(UInt32)
at Avalonia.Win32.Input.WindowsInputPane.Dispose()
at Avalonia.Win32.WindowImpl.Dispose()
at Avalonia.Controls.Window.CloseInternal()
at Avalonia.Controls.Window.CloseCore(Avalonia.Controls.WindowCloseReason, Boolean, Boolean)
at <our app>.MainWindow+<OnClosing>d__16.MoveNext()
...
at Avalonia.Threading.Dispatcher.ExecuteJobsCore(Boolean)
at Avalonia.Win32.Win32Platform.WndProc(IntPtr, UInt32, IntPtr, IntPtr)
at Avalonia.Win32.Interop.UnmanagedMethods.DispatchMessage(MSG ByRef)
at Avalonia.Win32.Win32DispatcherImpl.RunLoop(System.Threading.CancellationToken)
at Avalonia.Threading.Dispatcher.MainLoop(System.Threading.CancellationToken)
at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.StartCore(String[])
```

This is a plain `Window.Close()` from the application's own `Closing` handler, on an ordinary dispatcher job — no shutdown machinery and no re-entrant close.

## What is the updated/expected behavior with this PR?

The window closes normally. The late notification is ignored instead of terminating the process.

To verify, the repro in #22117 still reproduces on current `main`: calling `OnStateChanged(showing: true, rect)` while the window is open is handled correctly, while the same call after `Window.Close()` throws `NullReferenceException` in `ScreenRectToClient` before this change, and is a no-op after it.

## How was the solution implemented (if it's not obvious)?

Two minimal changes in `WindowsInputPane`:

1. **Release `_windowImpl` only after `Unadvise` has returned**, so the field stays valid for the whole of the teardown during which it can be read.
2. **Return early from `OnStateChanged` when `_disposed` is set**, so a notification arriving during or after `Dispose` is ignored rather than acted on.

Either change alone closes the reported race. Together they also cover a callback arriving after `Dispose` has fully completed, which ordering alone would not.

No behavioural change on any non-disposal path: `_disposed` is only ever set inside `Dispose`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

**On unit tests** — I could not find a feasible way to add one, and I would rather say so than quietly skip the box:

- There is no `Avalonia.Win32.UnitTests` project; the only Win32 test project is `Avalonia.IntegrationTests.Win32`, which drives real windows and runs on Windows only.
- `WindowsInputPane` is `internal`, and `Avalonia.Win32` has no `InternalsVisibleTo` for any test assembly.
- Its constructor requires a real `WindowImpl` with a valid `HWND` and creates a live COM `IFrameworkInputPane` via `UnmanagedMethods.CreateInstance`. There is no seam to substitute a fake.

Covering this properly would mean adding a test project and an interface seam — a much larger diff, touching code unrelated to the fix, which CONTRIBUTING.md advises against. **Happy to do that in a follow-up if you would like the seam introduced**, or to shape it however the team prefers.

Verified locally: `Avalonia.Win32` builds clean on all target frameworks (0 warnings, 0 errors).

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #22117
