### PR TITLE
Osx supports click trayicon

### DIFF
--- a/native/Avalonia.Native/src/OSX/trayicon.h
+++ b/native/Avalonia.Native/src/OSX/trayicon.h
@@ -11,28 +11,44 @@
 
 #include "common.h"
 
+class AvnTrayIcon;
+
+@interface AvnStatusItem : NSObject
+@property (nonatomic, strong, readonly) NSStatusItem* statusItem;
+
+- (instancetype) initWithOwner: (AvnTrayIcon*) owner;
+- (void) clicked: (id) sender;
+- (void) dispose;
+@end
+
 class AvnTrayIcon : public ComSingleObject<IAvnTrayIcon, &IID_IAvnTrayIcon>
 {
 private:
-    NSStatusItem* _native;
+    NSMenu* _menu;
     bool _isTemplateIcon;
+    AvnStatusItem* _native;
+    ComPtr<IAvnActionCallback> _clickedCallback;
 
 public:
     FORWARD_IUNKNOWN()
-    
+
     AvnTrayIcon();
-    
+
     ~AvnTrayIcon ();
-    
+
     virtual HRESULT SetIcon (void* data, size_t length) override;
-    
+
     virtual HRESULT SetMenu (IAvnMenu* menu) override;
-    
+
     virtual HRESULT SetIsVisible (bool isVisible) override;
 
     virtual HRESULT SetToolTipText (char* text) override;
 
     virtual HRESULT SetIsTemplateIcon (bool isTemplateIcon) override;
+
+    virtual HRESULT SetClickedCallback (IAvnActionCallback* callback) override;
+
+    void OnClicked(NSEvent* event);
 };
 
 #endif /* trayicon_h */

--- a/native/Avalonia.Native/src/OSX/trayicon.mm
+++ b/native/Avalonia.Native/src/OSX/trayicon.mm
@@ -2,6 +2,54 @@
 #include "trayicon.h"
 #include "menu.h"
 
+@implementation AvnStatusItem
+{
+    ComObjectWeakPtr<AvnTrayIcon> _owner;
+    NSStatusItem* _native;
+}
+
+- (NSStatusItem*) statusItem
+{
+    return _native;
+}
+
+- (instancetype) initWithOwner: (AvnTrayIcon*) owner
+{
+    self = [super init];
+    if (self != nullptr)
+    {
+        _owner = owner;
+        _native = [[NSStatusBar systemStatusBar] statusItemWithLength: NSSquareStatusItemLength];
+
+        auto button = [_native button];
+        [button setTarget: self];
+        [button setAction: @selector(clicked:)];
+        [button sendActionOn: NSEventMaskLeftMouseUp | NSEventMaskRightMouseUp];
+    }
+    return self;
+}
+
+- (void) clicked: (id) sender
+{
+    auto owner = _owner.tryGet();
+    if (owner != nullptr)
+    {
+        owner->OnClicked([NSApp currentEvent]);
+    }
+}
+
+- (void) dispose
+{
+    _owner = nullptr;
+
+    if (_native != nullptr)
+    {
+        [[_native statusBar] removeStatusItem: _native];
+        _native = nullptr;
+    }
+}
+@end
+
 extern IAvnTrayIcon* CreateTrayIcon()
 {
     @autoreleasepool
@@ -12,17 +60,18 @@ extern IAvnTrayIcon* CreateTrayIcon()
 
 AvnTrayIcon::AvnTrayIcon()
 {
-    _native = [[NSStatusBar systemStatusBar] statusItemWithLength: NSSquareStatusItemLength];
-    
+    _isTemplateIcon = false;
+    _menu = nullptr;
+    _native = [[AvnStatusItem alloc] initWithOwner: this];
 }
 
 AvnTrayIcon::~AvnTrayIcon()
 {
-    if(_native != nullptr)
-    {
-        [[_native statusBar] removeStatusItem:_native];
-        _native = nullptr;
-    }
+    [_native dispose];
+    
+    _menu = nullptr;
+    _native = nullptr;
+    _clickedCallback = nullptr;
 }
 
 HRESULT AvnTrayIcon::SetIcon (void* data, size_t length)
@@ -46,11 +95,11 @@ HRESULT AvnTrayIcon::SetIcon (void* data, size_t length)
             
             [image setSize: size];
             [image setTemplate: _isTemplateIcon];
-            [_native setImage:image];
+            [[[_native statusItem] button] setImage: image];
         }
         else
         {
-            [_native setImage:nullptr];
+            [[[_native statusItem] button] setImage: nullptr];
         }
         return S_OK;
     }
@@ -63,11 +112,7 @@ HRESULT AvnTrayIcon::SetMenu (IAvnMenu* menu)
     @autoreleasepool
     {
         auto appMenu = dynamic_cast<AvnAppMenu*>(menu);
-        
-        if(appMenu != nullptr)
-        {
-            [_native setMenu:appMenu->GetNative()];	
-        }
+        _menu = appMenu != nullptr ? appMenu->GetNative() : nullptr;
     }
     
     return  S_OK;
@@ -79,7 +124,7 @@ HRESULT AvnTrayIcon::SetIsVisible(bool isVisible)
     
     @autoreleasepool
     {
-        [_native setVisible:isVisible];
+        [[_native statusItem] setVisible: isVisible];
     }
     
     return  S_OK;
@@ -93,7 +138,7 @@ HRESULT AvnTrayIcon::SetToolTipText(char* text)
     {
         if (text != nullptr)
         {
-            [[_native button] setToolTip:[NSString stringWithUTF8String:(const char*)text]];
+            [[[_native statusItem] button] setToolTip: [NSString stringWithUTF8String:(const char*)text]];
         }
     }
     
@@ -110,7 +155,7 @@ HRESULT AvnTrayIcon::SetIsTemplateIcon(bool isTemplateIcon)
         {
             _isTemplateIcon = isTemplateIcon;
 
-            NSImage *image = [_native image];
+            NSImage* image = [[[_native statusItem] button] image];
             if (image)
             {
                 [image setTemplate: _isTemplateIcon];
@@ -119,4 +164,34 @@ HRESULT AvnTrayIcon::SetIsTemplateIcon(bool isTemplateIcon)
     }
     
     return  S_OK;
+}
+
+HRESULT AvnTrayIcon::SetClickedCallback(IAvnActionCallback* callback)
+{
+    START_COM_CALL;
+
+    @autoreleasepool
+    {
+        _clickedCallback = callback;
+    }
+
+    return S_OK;
+}
+
+void AvnTrayIcon::OnClicked(NSEvent* event)
+{
+    if ([event type] == NSEventTypeRightMouseUp)
+    {
+        if (_menu != nullptr)
+        {
+            [NSMenu
+             popUpContextMenu: _menu
+             withEvent: event
+             forView: [[_native statusItem] button]];
+        }
+    }
+    else if ([event type] == NSEventTypeLeftMouseUp)
+    {
+        _clickedCallback->Run();
+    }
 }

--- a/samples/IntegrationTestApp/App.axaml.cs
+++ b/samples/IntegrationTestApp/App.axaml.cs
@@ -18,7 +18,8 @@ namespace IntegrationTestApp
         {
             TrayIconCommand = MiniCommand.Create<string>(name =>
             {
-                _mainWindow!.Get<CheckBox>(name).IsChecked = true;
+                var checkbox = _mainWindow!.GetLogicalDescendants().OfType<CheckBox>().FirstOrDefault(x => x.Name == name);
+                checkbox?.IsChecked = true;
             });
             DockMenuCommand = MiniCommand.Create<string>(name =>
             {

--- a/src/Avalonia.Controls/TrayIcon.cs
+++ b/src/Avalonia.Controls/TrayIcon.cs
@@ -70,8 +70,7 @@ namespace Avalonia.Controls
 
         /// <summary>
         /// Raised when the TrayIcon is clicked.
-        /// Note, this is only supported on Win32 and some Linux DEs, 
-        /// on OSX this event is not raised.
+        /// Note, this is only supported on Win32, macOS and some Linux DEs.
         /// </summary>
         public event EventHandler? Clicked;
         

--- a/src/Avalonia.Native/TrayIconImpl.cs
+++ b/src/Avalonia.Native/TrayIconImpl.cs
@@ -9,10 +9,13 @@ namespace Avalonia.Native
     internal class TrayIconImpl : ITrayIconWithIsTemplateImpl
     {
         private readonly IAvnTrayIcon _native;
+        private readonly MenuActionCallback _clickedCallback;
 
         public TrayIconImpl(IAvaloniaNativeFactory factory)
         {
             _native = factory.CreateTrayIcon();
+            _clickedCallback = new MenuActionCallback(() => OnClicked?.Invoke());
+            _native.SetClickedCallback(_clickedCallback);
 
             MenuExporter = new AvaloniaNativeMenuExporter(_native, factory);
         }
@@ -22,6 +25,7 @@ namespace Avalonia.Native
         public void Dispose()
         {
             _native.Dispose();
+            _clickedCallback.Dispose();
         }
 
         public unsafe void SetIcon(IWindowIconImpl? icon)

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -1154,6 +1154,7 @@ interface IAvnTrayIcon : IUnknown
     HRESULT SetIsVisible(bool isVisible);
     HRESULT SetToolTipText(char* text);
     HRESULT SetIsTemplateIcon(bool text);
+    HRESULT SetClickedCallback(IAvnActionCallback* callback);
 }
 
 [uuid(a7724dc1-cf6b-4fa8-9d23-228bf2593edc)]

--- a/tests/Avalonia.IntegrationTests.Appium/TrayIconTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/TrayIconTests.cs
@@ -25,8 +25,7 @@ public class TrayIconTests : TestBase
         }
     }
 
-    // Left click is only supported on Windows.
-    [PlatformFact(TestPlatforms.Windows, Skip = "Flaky test")]
+    [PlatformFact(TestPlatforms.Windows | TestPlatforms.MacOS, Skip = "Flaky test")]
     public void Should_Handle_Left_Click()
     {
         var avaloniaTrayIconButton = GetTrayIconButton(_rootSession ?? Session, TrayIconName);
@@ -134,8 +133,11 @@ public class TrayIconTests : TestBase
         }
         else
         {
-            trayIcon.Click();
-            return trayIcon.FindElementByXPath("//XCUIElementTypeStatusItem/XCUIElementTypeMenu");
+            new Actions(trayIcon.WrappedDriver).ContextClick(trayIcon).Perform();
+            
+            Thread.Sleep(100);
+            
+            return trayIcon.FindElementByXPath("//XCUIElementTypeMenu");
         }
     }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Adds support for the `TrayIcon.Clicked` event and tray icon commands on macOS.

- Left-click raises `TrayIcon.Clicked` and executes the configured command.
- Right-click opens the tray icon's native context menu.

## What is the current behavior?

On macOS, clicking a tray icon only opens its native menu. The `TrayIcon.Clicked` event is not raised.

This means applications cannot assign an independent action to a primary click on a macOS tray icon.

## What is the updated/expected behavior with this PR?

macOS tray icons now behave as follows:

- A left-click raises `TrayIcon.Clicked` and executes `TrayIcon.Command`.
- A right-click opens the configured `NativeMenu`.

## How was the solution implemented (if it's not obvious)?

A `SetClickedCallback` method was added to `IAvnTrayIcon` to forward native macOS click events to the managed `TrayIconImpl`.

An Objective-C `AvnStatusItem` helper owns the system-created `NSStatusItem`, and forwards the event .

`AvnTrayIcon` handles the event based on its mouse-button type:

- `NSEventTypeLeftMouseUp` invokes the managed click callback.
- `NSEventTypeRightMouseUp` displays the native menu using [`NSMenu.popUpContextMenu:withEvent:forView:`](https://developer.apple.com/documentation/appkit/nsmenu/popupcontextmenu(_:with:for:)).

> Assigning a menu directly through `NSStatusItem.menu` causes AppKit to handle clicks by opening the menu instead of invoking the status item button's action. Therefore, the menu is displayed explicitly using `NSMenu.popUpContextMenu:withEvent:forView:`.

## Breaking changes

There are no API-breaking changes.

There is an intentional behavioral change on macOS: the tray icon menu is now opened with a right-click, while a left-click raises `TrayIcon.Clicked`.