### PR TITLE
Fix macOS accent color not respecting the current theme

### DIFF
--- a/native/Avalonia.Native/src/OSX/PlatformSettings.mm
+++ b/native/Avalonia.Native/src/OSX/PlatformSettings.mm
@@ -45,9 +45,20 @@ public:
     {
         @autoreleasepool
         {
-            if (@available(macOS 10.14, *))
+            if (@available(macOS 11.0, *))
             {
-                auto color = [NSColor controlAccentColor];
+                __block NSColor* color;
+                [[NSApp effectiveAppearance] performAsCurrentDrawingAppearance:^{
+                    color = [[NSColor controlAccentColor] colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
+                }];
+                return to_argb(color);
+            }
+            else if (@available(macOS 10.14, *))
+            {
+                auto previousAppearance = NSAppearance.currentAppearance;
+                NSAppearance.currentAppearance = [NSApp effectiveAppearance];
+                auto color = [[NSColor controlAccentColor] colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
+                NSAppearance.currentAppearance = previousAppearance;
                 return to_argb(color);
             }
             else


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the accent color reported for macOS being incorrect after a system appearance (theme) change.

It turns out the accent color is slightly different between the light and dark theme, so this can easily be missed.
For example, the color of the Purple accent is `#A550A7` on the dark theme, but `#953D96` on the light one.

## What is the current behavior?
The accent color is always reported with the system appearance that was used when the application started.
Note that accent color changes are reported and read, but the actual value isn't correct.

## What is the updated/expected behavior with this PR?
The reported accent color matches the current appearance.

## How was the solution implemented (if it's not obvious)?
`NSColor.controlAccentColor` uses the `currentDrawingAppearance`, which is a thread-local value that might not correspond to the actual system appearance. `NSApp.effectiveAppearance` is now forced as the current drawing appearance before retrieving the value.
