### PR TITLE
Fix the issue in macOS when WindowTransparencyLevel is set to AcrylicBlur

### DIFF
--- a/native/Avalonia.Native/src/OSX/AutoFitContentView.mm
+++ b/native/Avalonia.Native/src/OSX/AutoFitContentView.mm
@@ -43,9 +43,16 @@
 
     _blurBehind = [NSVisualEffectView new];
     [_blurBehind setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
-    [_blurBehind setMaterial:NSVisualEffectMaterialLight];
     [_blurBehind setWantsLayer:true];
     _blurBehind.hidden = true;
+    if (@available(macOS 10.14, *))
+    {
+        [_blurBehind setMaterial:NSVisualEffectMaterialHUDWindow];
+    }
+    else
+    {
+        [_blurBehind setMaterial:NSVisualEffectMaterialSidebar];
+    }
 
     [_blurBehind setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
     [_content setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -56,11 +56,11 @@ WindowBaseImpl::WindowBaseImpl(IAvnWindowBaseEvents *events, bool usePanel) : To
     lastMaxSize = NSSize { CGFLOAT_MAX, CGFLOAT_MAX};
     lastMinSize = NSSize { 0, 0 };
     lastMenu = nullptr;
-    
+
     CreateNSWindow(usePanel);
-    
+
     StandardContainer = [[AutoFitContentView new] initWithContent:View];
-    
+
     [Window setContentView:StandardContainer];
     [Window setBackingType:NSBackingStoreBuffered];
     [Window setContentMinSize:lastMinSize];
@@ -89,7 +89,7 @@ HRESULT WindowBaseImpl::Show(bool activate, bool isDialog) {
 
     @autoreleasepool {
         [Window setContentSize:lastSize];
-        
+
         if(hasPosition)
         {
             SetPosition(lastPositionSet);
@@ -110,7 +110,7 @@ HRESULT WindowBaseImpl::Show(bool activate, bool isDialog) {
         [Window setCollectionBehavior:collectionBehavior & ~NSWindowCollectionBehaviorFullScreenPrimary];
 
         UpdateAppearance();
-        
+
         [Window invalidateShadow];
 
         if (ShouldTakeFocusOnShow() && activate) {
@@ -124,13 +124,13 @@ HRESULT WindowBaseImpl::Show(bool activate, bool isDialog) {
 
         _shown = true;
         [Window setCollectionBehavior:collectionBehavior];
-        
+
         // Ensure that we call needsDisplay = YES so that AvnView.updateLayer is called after the
         // window is shown: if the client is pumping messages during the window creation/show
         // process, it's possible that updateLayer gets called after the window is created but
         // before it's is shown.
         [View.layer setNeedsDisplay];
-        
+
         return S_OK;
     }
 }
@@ -161,7 +161,7 @@ HRESULT WindowBaseImpl::Hide() {
 
     @autoreleasepool {
         if (Window != nullptr) {
-            
+
             // If window is hidden without ending attached sheet first, it will stuck in "order out" state,
             // and block any new sheets from being attached.
             // Additionaly, we don't know if user would define any custom panels, so we only end/close file dialog sheets.
@@ -501,18 +501,18 @@ HRESULT WindowBaseImpl::SetParent(IAvnWindowBase *parent) {
     START_COM_CALL;
 
     @autoreleasepool {
-        
+
         auto oldParent = Parent.tryGet();
-        
+
         if(oldParent != nullptr)
         {
             oldParent->_children.remove(this);
         }
 
         auto cparent = dynamic_cast<WindowImpl *>(parent);
-        
+
         Parent = cparent;
-       
+
         if(cparent != nullptr && Window != nullptr){
             // If one tries to show a child window with a minimized parent window, then the parent window will be
             // restored but macOS isn't kind enough to *tell* us that, so the window will be left in a non-interactive
@@ -521,9 +521,9 @@ HRESULT WindowBaseImpl::SetParent(IAvnWindowBase *parent) {
                 cparent->SetWindowState(Normal);
 
             [Window setCollectionBehavior:NSWindowCollectionBehaviorFullScreenAuxiliary];
-                
+
             cparent->_children.push_back(this);
-                
+
             UpdateAppearance();
         }
 

--- a/native/Avalonia.Native/src/OSX/WindowImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.h
@@ -45,9 +45,9 @@ BEGIN_INTERFACE_MAP()
     void DoZoom();
 
     virtual HRESULT SetCanResize(bool value) override;
-    
+
     virtual HRESULT SetCanMinimize(bool value) override;
-    
+
     virtual HRESULT SetCanMaximize(bool value) override;
 
     virtual HRESULT SetDecorations(SystemDecorations value) override;
@@ -65,7 +65,7 @@ BEGIN_INTERFACE_MAP()
     virtual HRESULT GetExtendTitleBarHeight (double*ret) override;
 
     virtual HRESULT SetExtendTitleBarHeight (double value) override;
-    
+
     virtual HRESULT GetWindowZOrder (long* zOrder) override;
 
     void EnterFullScreenMode ();
@@ -73,15 +73,15 @@ BEGIN_INTERFACE_MAP()
     void ExitFullScreenMode ();
 
     virtual HRESULT SetWindowState (AvnWindowState state) override;
-    
+
     virtual HRESULT SetWindowState (AvnWindowState state, bool shouldResize);
 
     virtual bool IsModal() override;
-    
+
     bool IsOwned();
-    
+
     virtual void BringToFront () override;
-    
+
     bool CanBecomeKeyWindow ();
 
     bool CanZoom() override { return _isEnabled && _canMaximize; }


### PR DESCRIPTION
## What does the pull request do?
Fix the issue in macOS when WindowTransparencyLevel is set to AcrylicBlur

1. Background fully white in inactive state
2. Unusable when dark theme and white content behind window

## What is the current behavior?
See #18453

## What is the updated/expected behavior with this PR?
Dark Mode Activation
<img width="2200" height="1656" alt="image" src="https://github.com/user-attachments/assets/16a15697-4a32-4c7f-9199-68cc68b1fdda" />
Dark inactive
<img width="2200" height="1656" alt="image" src="https://github.com/user-attachments/assets/ef55f222-d792-4759-8d75-de4d44a7a8ac" />
Light activation
<img width="2200" height="1656" alt="image" src="https://github.com/user-attachments/assets/a8ff222e-cc4b-438e-bf39-eafbc436a7ba" />
Light inactive
<img width="2200" height="1656" alt="image" src="https://github.com/user-attachments/assets/3d96aea4-fedd-4e69-a916-a616dbf07d61" />

## Fixed issues
Fixes #18453
