### PR TITLE
Rebuild TextBlock text runs only when the content changes

### DIFF
--- a/src/Avalonia.Controls/Documents/Inline.cs
+++ b/src/Avalonia.Controls/Documents/Inline.cs
@@ -70,14 +70,17 @@ namespace Avalonia.Controls.Documents
         /// <summary>
         /// Measures the controls this inline embeds against the width available to the block.
         /// </summary>
+        /// <returns>
+        /// True when a control came back a different size, so the caller can drop line metrics
+        /// that were measured against the old one.
+        /// </returns>
         /// <remarks>
         /// Text runs depend on the content alone, so they survive a constraint change. An embedded
-        /// control is the exception: its size answers to the available width, and the run reports
-        /// that size live, so re-measuring the control is what resizes the line.
+        /// control is the exception: its size answers to the available width. The run reports that
+        /// size live, but a formatted line snapshots its metrics, so a layout built before the
+        /// control resized keeps reporting the old width and height.
         /// </remarks>
-        internal virtual void MeasureEmbeddedControls(Size blockSize)
-        {
-        }
+        internal virtual bool MeasureEmbeddedControls(Size blockSize) => false;
 
         internal abstract void AppendText(StringBuilder stringBuilder);
 

--- a/src/Avalonia.Controls/Documents/Inline.cs
+++ b/src/Avalonia.Controls/Documents/Inline.cs
@@ -65,7 +65,19 @@ namespace Avalonia.Controls.Documents
             control.SetValue(TextDecorationsProperty, value);
         }
         
-        internal abstract void BuildTextRun(IList<TextRun> textRuns, Size blockSize);
+        internal abstract void BuildTextRun(IList<TextRun> textRuns);
+
+        /// <summary>
+        /// Measures the controls this inline embeds against the width available to the block.
+        /// </summary>
+        /// <remarks>
+        /// Text runs depend on the content alone, so they survive a constraint change. An embedded
+        /// control is the exception: its size answers to the available width, and the run reports
+        /// that size live, so re-measuring the control is what resizes the line.
+        /// </remarks>
+        internal virtual void MeasureEmbeddedControls(Size blockSize)
+        {
+        }
 
         internal abstract void AppendText(StringBuilder stringBuilder);
 

--- a/src/Avalonia.Controls/Documents/InlineUIContainer.cs
+++ b/src/Avalonia.Controls/Documents/InlineUIContainer.cs
@@ -53,15 +53,18 @@ namespace Avalonia.Controls.Documents
             set => SetValue(ChildProperty, value);
         }
 
-        internal override void BuildTextRun(IList<TextRun> textRuns, Size blockSize)
+        internal override void BuildTextRun(IList<TextRun> textRuns)
+        {
+            textRuns.Add(new EmbeddedControlRun(Child, CreateTextRunProperties()));
+        }
+
+        internal override void MeasureEmbeddedControls(Size blockSize)
         {
             if (_measuredWidth != blockSize.Width || !Child.IsMeasureValid)
             {
                 Child.Measure(new Size(blockSize.Width, double.PositiveInfinity));
                 _measuredWidth = blockSize.Width;
             }
-
-            textRuns.Add(new EmbeddedControlRun(Child, CreateTextRunProperties()));
         }
 
         internal override void AppendText(StringBuilder stringBuilder)

--- a/src/Avalonia.Controls/Documents/InlineUIContainer.cs
+++ b/src/Avalonia.Controls/Documents/InlineUIContainer.cs
@@ -58,13 +58,19 @@ namespace Avalonia.Controls.Documents
             textRuns.Add(new EmbeddedControlRun(Child, CreateTextRunProperties()));
         }
 
-        internal override void MeasureEmbeddedControls(Size blockSize)
+        internal override bool MeasureEmbeddedControls(Size blockSize)
         {
-            if (_measuredWidth != blockSize.Width || !Child.IsMeasureValid)
+            if (_measuredWidth == blockSize.Width && Child.IsMeasureValid)
             {
-                Child.Measure(new Size(blockSize.Width, double.PositiveInfinity));
-                _measuredWidth = blockSize.Width;
+                return false;
             }
+
+            var previousSize = Child.DesiredSize;
+
+            Child.Measure(new Size(blockSize.Width, double.PositiveInfinity));
+            _measuredWidth = blockSize.Width;
+
+            return Child.DesiredSize != previousSize;
         }
 
         internal override void AppendText(StringBuilder stringBuilder)

--- a/src/Avalonia.Controls/Documents/LineBreak.cs
+++ b/src/Avalonia.Controls/Documents/LineBreak.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Controls.Documents
         {
         }
 
-        internal override void BuildTextRun(IList<TextRun> textRuns, Size blockSize)
+        internal override void BuildTextRun(IList<TextRun> textRuns)
         {
             var text = Environment.NewLine;
 

--- a/src/Avalonia.Controls/Documents/Run.cs
+++ b/src/Avalonia.Controls/Documents/Run.cs
@@ -50,7 +50,7 @@ namespace Avalonia.Controls.Documents
             set => SetValue(TextProperty, value);
         }
 
-        internal override void BuildTextRun(IList<TextRun> textRuns, Size blockSize)
+        internal override void BuildTextRun(IList<TextRun> textRuns)
         {
             var text = Text ?? "";
 

--- a/src/Avalonia.Controls/Documents/Span.cs
+++ b/src/Avalonia.Controls/Documents/Span.cs
@@ -38,11 +38,19 @@ namespace Avalonia.Controls.Documents
             set => SetValue(InlinesProperty, value);
         }
 
-        internal override void BuildTextRun(IList<TextRun> textRuns, Size blockSize)
+        internal override void BuildTextRun(IList<TextRun> textRuns)
         {
             foreach (var inline in Inlines)
             {
-                inline.BuildTextRun(textRuns, blockSize);
+                inline.BuildTextRun(textRuns);
+            }
+        }
+
+        internal override void MeasureEmbeddedControls(Size blockSize)
+        {
+            foreach (var inline in Inlines)
+            {
+                inline.MeasureEmbeddedControls(blockSize);
             }
         }
 

--- a/src/Avalonia.Controls/Documents/Span.cs
+++ b/src/Avalonia.Controls/Documents/Span.cs
@@ -46,12 +46,16 @@ namespace Avalonia.Controls.Documents
             }
         }
 
-        internal override void MeasureEmbeddedControls(Size blockSize)
+        internal override bool MeasureEmbeddedControls(Size blockSize)
         {
+            var resized = false;
+
             foreach (var inline in Inlines)
             {
-                inline.MeasureEmbeddedControls(blockSize);
+                resized |= inline.MeasureEmbeddedControls(blockSize);
             }
+
+            return resized;
         }
 
         internal override void AppendText(StringBuilder stringBuilder)

--- a/src/Avalonia.Controls/SelectableTextBlock.cs
+++ b/src/Avalonia.Controls/SelectableTextBlock.cs
@@ -268,9 +268,11 @@ namespace Avalonia.Controls
 
             ITextSource textSource;
 
-            if (_textRuns != null)
+            if (HasComplexContent)
             {
-                textSource = new InlinesTextSource(_textRuns, textStyleOverrides);
+                EnsureTextRuns();
+
+                textSource = new InlinesTextSource(_textRuns!, textStyleOverrides);
             }
             else
             {

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Avalonia.Automation.Peers;
 using Avalonia.Collections;
@@ -186,7 +187,18 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets the <see cref="TextLayout"/> used to render the text.
         /// </summary>
-        public TextLayout TextLayout => _textLayout ??= CreateTextLayout(Text);
+        public TextLayout TextLayout => _textLayout ??= CreateTextLayoutCore();
+
+        private TextLayout CreateTextLayoutCore()
+        {
+            // A layout can be created outside of a measure pass - a render pass that runs before a
+            // queued measure, or a read of this property - so it cannot rely on the measure pass
+            // having brought the complex content up to date.
+            EnsureTextRuns();
+            MeasureEmbeddedControls(GetMaxSizeFromConstraint());
+
+            return CreateTextLayout(Text);
+        }
 
         /// <summary>
         /// Gets or sets the padding to place around the <see cref="Text"/>.
@@ -362,6 +374,7 @@ namespace Avalonia.Controls
 
         protected override bool BypassFlowDirectionPolicies => true;
 
+        [MemberNotNullWhen(true, nameof(Inlines))]
         internal bool HasComplexContent => Inlines != null && Inlines.Count > 0;
 
         /// <summary>
@@ -674,9 +687,11 @@ namespace Avalonia.Controls
 
             ITextSource textSource;
 
-            if (_textRuns != null)
+            if (HasComplexContent)
             {
-                textSource = new InlinesTextSource(_textRuns);
+                EnsureTextRuns();
+
+                textSource = new InlinesTextSource(_textRuns!);
             }
             else
             {
@@ -701,6 +716,7 @@ namespace Avalonia.Controls
         protected void InvalidateTextLayout()
         {
             _textRunCache?.Invalidate();
+            _textRuns = null;
             InvalidateVisual();
             InvalidateMeasure();
         }
@@ -719,9 +735,52 @@ namespace Avalonia.Controls
         {
             _textLayout?.Dispose();
             _textLayout = null;
-            _textRuns = null;
 
             base.OnMeasureInvalidated();
+        }
+
+        /// <summary>
+        /// Builds the text runs for <see cref="Inlines"/> unless they are already in sync with the
+        /// content. The runs are derived from the content alone, so only a content change discards
+        /// them; the constraint does not.
+        /// </summary>
+        /// <remarks>
+        /// Missing runs are not the same as no inlines: shaping without them falls back to
+        /// <see cref="Text"/>, which is null whenever the content lives in <see cref="Inlines"/>,
+        /// and that empty result is what the <see cref="TextRunCache"/> stores for the rest of the
+        /// control's life.
+        /// </remarks>
+        private protected void EnsureTextRuns()
+        {
+            if (_textRuns != null || !HasComplexContent)
+            {
+                return;
+            }
+
+            var textRuns = new List<TextRun>();
+
+            foreach (var inline in Inlines)
+            {
+                inline.BuildTextRun(textRuns);
+            }
+
+            _textRuns = textRuns;
+        }
+
+        /// <summary>
+        /// Measures the controls the inlines embed against the width available to the block.
+        /// </summary>
+        private void MeasureEmbeddedControls(Size constraint)
+        {
+            if (!HasComplexContent)
+            {
+                return;
+            }
+
+            foreach (var inline in Inlines)
+            {
+                inline.MeasureEmbeddedControls(constraint);
+            }
         }
 
         protected override Size MeasureOverride(Size availableSize)
@@ -747,19 +806,8 @@ namespace Avalonia.Controls
                 InvalidateArrange();
             }
            
-            var inlines = Inlines;
-
-            if (HasComplexContent)
-            {
-                var textRuns = new List<TextRun>();
-
-                foreach (var inline in inlines!)
-                {
-                    inline.BuildTextRun(textRuns, deflatedSize);
-                }
-
-                _textRuns = textRuns;
-            }
+            EnsureTextRuns();
+            MeasureEmbeddedControls(deflatedSize);
 
             //This implicitly recreated the TextLayout with a new constraint if we previously reset it.
             var textLayout = TextLayout;

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -717,6 +717,7 @@ namespace Avalonia.Controls
         {
             _textRunCache?.Invalidate();
             _textRuns = null;
+            DisposeTextLayout();
             InvalidateVisual();
             InvalidateMeasure();
         }
@@ -727,14 +728,25 @@ namespace Avalonia.Controls
         /// </summary>
         private void InvalidateTextLayoutKeepCache()
         {
+            DisposeTextLayout();
             InvalidateVisual();
             InvalidateMeasure();
         }
 
-        protected override void OnMeasureInvalidated()
+        /// <remarks>
+        /// InvalidateMeasure only raises OnMeasureInvalidated while the measure is still
+        /// valid, so a second invalidation before the next measure pass would leave the
+        /// layout built from the content the first one replaced.
+        /// </remarks>
+        private void DisposeTextLayout()
         {
             _textLayout?.Dispose();
             _textLayout = null;
+        }
+
+        protected override void OnMeasureInvalidated()
+        {
+            DisposeTextLayout();
 
             base.OnMeasureInvalidated();
         }

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -918,6 +918,7 @@ namespace Avalonia.Controls
                 case nameof(TextAlignment):
                 case nameof(Padding):
                 case nameof(LineHeight):
+                case nameof(LineSpacing):
                 case nameof(MaxLines):
                     {
                         InvalidateTextLayoutKeepCache();

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -780,19 +780,24 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Measures the controls the inlines embed against the width available to the block.
+        /// Measures the controls the inlines embed against the width available to the block, and
+        /// reports whether any of them came back a different size.
         /// </summary>
-        private void MeasureEmbeddedControls(Size constraint)
+        private bool MeasureEmbeddedControls(Size constraint)
         {
             if (!HasComplexContent)
             {
-                return;
+                return false;
             }
+
+            var resized = false;
 
             foreach (var inline in Inlines)
             {
-                inline.MeasureEmbeddedControls(constraint);
+                resized |= inline.MeasureEmbeddedControls(constraint);
             }
+
+            return resized;
         }
 
         protected override Size MeasureOverride(Size availableSize)
@@ -810,8 +815,7 @@ namespace Avalonia.Controls
             if (_constraint != deflatedSize)
             {
                 //Reset TextLayout when the constraint is not matching.
-                _textLayout?.Dispose();
-                _textLayout = null;
+                DisposeTextLayout();
                 _constraint = deflatedSize;
 
                 //Force arrange so text will be properly aligned.
@@ -819,7 +823,13 @@ namespace Avalonia.Controls
             }
            
             EnsureTextRuns();
-            MeasureEmbeddedControls(deflatedSize);
+
+            if (MeasureEmbeddedControls(deflatedSize))
+            {
+                // A line snapshots its metrics when it is formatted, so an existing layout still
+                // reports the width and height the child had before it was measured again.
+                DisposeTextLayout();
+            }
 
             //This implicitly recreated the TextLayout with a new constraint if we previously reset it.
             var textLayout = TextLayout;
@@ -842,8 +852,7 @@ namespace Avalonia.Controls
             var availableSize = finalSize.Deflate(padding);
 
             // Dispose the TextLayout but preserve the TextRunCache so shaped runs are reused.
-            _textLayout?.Dispose();
-            _textLayout = null;
+            DisposeTextLayout();
             _constraint = availableSize;
 
             //This implicitly recreated the TextLayout with a new constraint.

--- a/tests/Avalonia.Controls.UnitTests/InlineTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/InlineTests.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Controls.UnitTests
             bold.Inlines.Add(span);
 
             var textRuns = new List<TextRun>();
-            bold.BuildTextRun(textRuns, default);
+            bold.BuildTextRun(textRuns);
 
             var runProperties = textRuns[0].Properties;
             Assert.NotNull(runProperties);
@@ -36,7 +36,7 @@ namespace Avalonia.Controls.UnitTests
             italic.Inlines.Add(span);
 
             var textRuns = new List<TextRun>();
-            italic.BuildTextRun(textRuns, default);
+            italic.BuildTextRun(textRuns);
 
             var runProperties = textRuns[0].Properties;
             Assert.NotNull(runProperties);
@@ -54,7 +54,7 @@ namespace Avalonia.Controls.UnitTests
             span.Inlines.Add(innerSpan);
 
             var textRuns = new List<TextRun>();
-            span.BuildTextRun(textRuns, default);
+            span.BuildTextRun(textRuns);
 
             var runProperties = textRuns[0].Properties;
             Assert.NotNull(runProperties);
@@ -74,7 +74,7 @@ namespace Avalonia.Controls.UnitTests
             span.Inlines.Add(innerSpan);
 
             var textRuns = new List<TextRun>();
-            span.BuildTextRun(textRuns, default);
+            span.BuildTextRun(textRuns);
 
             var runProperties = textRuns[0].Properties;
             Assert.NotNull(runProperties);

--- a/tests/Avalonia.Controls.UnitTests/SelectableTextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SelectableTextBlockTests.cs
@@ -358,6 +358,25 @@ namespace Avalonia.Controls.UnitTests
             return target;
         }
 
+        [Fact]
+        public void Should_Shape_Inlines_When_TextLayout_Is_Created_Between_Content_Change_And_Measure()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var target = new SelectableTextBlock { Inlines = new InlineCollection() };
+
+            target.Measure(new Size(1000, 1000));
+            target.Arrange(new Rect(0, 0, 1000, 1000));
+
+            target.Inlines = new InlineCollection { new Run("Hello World") };
+
+            _ = target.TextLayout;
+
+            target.Measure(new Size(1000, 1000));
+
+            Assert.True(target.DesiredSize.Width > 0, $"DesiredSize was {target.DesiredSize}");
+        }
+
         private class TestTopLevel(ITopLevelImpl impl) : TopLevel(impl);
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -614,6 +614,127 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Rect(default, expectedSize), target.Bounds);
         }
 
+        [Fact]
+        public void Should_Shape_Inlines_When_TextLayout_Is_Created_Before_Measure()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var target = new TextBlock { Inlines = new InlineCollection { new Run("Hello World") } };
+
+            // A render pass that runs before the queued measure reads the layout while the
+            // runs have not been built yet.
+            _ = target.TextLayout;
+
+            target.Measure(new Size(1000, 1000));
+
+            Assert.True(target.DesiredSize.Width > 0, $"DesiredSize was {target.DesiredSize}");
+        }
+
+        [Fact]
+        public void Should_Shape_Inlines_When_TextLayout_Is_Created_Between_Content_Change_And_Measure()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var target = new TextBlock { Inlines = new InlineCollection() };
+
+            target.Measure(new Size(1000, 1000));
+            target.Arrange(new Rect(0, 0, 1000, 1000));
+
+            target.Inlines = new InlineCollection { new Run("Hello World") };
+
+            _ = target.TextLayout;
+
+            target.Measure(new Size(1000, 1000));
+
+            Assert.True(target.DesiredSize.Width > 0, $"DesiredSize was {target.DesiredSize}");
+        }
+
+        [Fact]
+        public void Should_Not_Cache_Shaped_Runs_Built_Outside_Of_Measure_From_Text()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var target = new TextBlock { Inlines = new InlineCollection() };
+
+            target.Measure(new Size(1000, 1000));
+            target.Arrange(new Rect(0, 0, 1000, 1000));
+
+            target.Inlines = new InlineCollection { new Run("Hello World") };
+
+            _ = target.TextLayout;
+
+            // Measuring at a different constraint drops the layout, so a wrong result here can
+            // only come from shaped runs that were cached outside of the measure pass.
+            target.Measure(new Size(900, 1000));
+
+            Assert.True(target.DesiredSize.Width > 0, $"DesiredSize was {target.DesiredSize}");
+        }
+
+        [Fact]
+        public void Should_Shape_Inlines_Added_To_The_Collection_Before_Measure()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var target = new TextBlock { Inlines = new InlineCollection() };
+
+            target.Measure(new Size(1000, 1000));
+            target.Arrange(new Rect(0, 0, 1000, 1000));
+
+            target.Inlines!.Add(new Run("Hello World"));
+
+            _ = target.TextLayout;
+
+            target.Measure(new Size(1000, 1000));
+
+            Assert.True(target.DesiredSize.Width > 0, $"DesiredSize was {target.DesiredSize}");
+        }
+
+        [Fact]
+        public void Should_Remeasure_Embedded_Controls_When_The_Constraint_Changes()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var child = new TextBlock { Text = "Hello World Hello World", TextWrapping = TextWrapping.Wrap };
+            var target = new TextBlock { Inlines = new InlineCollection { new InlineUIContainer(child) } };
+
+            target.Measure(new Size(1000, 1000));
+            target.Arrange(new Rect(0, 0, 1000, 1000));
+
+            var wide = target.DesiredSize;
+
+            target.Measure(new Size(60, 1000));
+            target.Arrange(new Rect(0, 0, 60, 1000));
+
+            var narrow = target.DesiredSize;
+
+            Assert.True(narrow.Width < wide.Width, $"wide {wide}, narrow {narrow}");
+            Assert.True(narrow.Height > wide.Height, $"wide {wide}, narrow {narrow}");
+        }
+
+        [Fact]
+        public void Should_Remeasure_Embedded_Controls_When_The_Child_Invalidates_Its_Measure()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var child = new Border { Width = 20, Height = 20 };
+            var target = new TextBlock { Inlines = new InlineCollection { new InlineUIContainer(child) } };
+
+            target.Measure(new Size(1000, 1000));
+            target.Arrange(new Rect(0, 0, 1000, 1000));
+
+            var before = target.DesiredSize;
+
+            child.Width = 80;
+
+            // Stands in for the layout manager propagating the child's invalidation to its parent.
+            target.InvalidateMeasure();
+
+            target.Measure(new Size(1000, 1000));
+            target.Arrange(new Rect(0, 0, 1000, 1000));
+
+            Assert.True(target.DesiredSize.Width > before.Width, $"before {before}, after {target.DesiredSize}");
+        }
+
         private class TestTextBlock : TextBlock
         {
             public Size Constraint => _constraint;

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -735,6 +735,24 @@ namespace Avalonia.Controls.UnitTests
             Assert.True(target.DesiredSize.Width > before.Width, $"before {before}, after {target.DesiredSize}");
         }
 
+        [Fact]
+        public void Changing_LineSpacing_Should_Invalidate_Measure()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var target = new TextBlock { Text = "Hello World\nHello World" };
+
+            target.Measure(new Size(1000, 1000));
+
+            var before = target.DesiredSize;
+
+            target.LineSpacing = 20;
+
+            target.Measure(new Size(1000, 1000));
+
+            Assert.True(target.DesiredSize.Height > before.Height, $"before {before}, after {target.DesiredSize}");
+        }
+
         private class TestTextBlock : TextBlock
         {
             public Size Constraint => _constraint;

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -753,6 +753,32 @@ namespace Avalonia.Controls.UnitTests
             Assert.True(target.DesiredSize.Height > before.Height, $"before {before}, after {target.DesiredSize}");
         }
 
+        [Fact]
+        public void Should_Shape_The_Latest_Inlines_When_Content_Changes_Twice_Before_Measure()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var target = new TextBlock { Inlines = new InlineCollection { new Run("Hello World") } };
+
+            target.Measure(new Size(1000, 1000));
+            target.Arrange(new Rect(0, 0, 1000, 1000));
+
+            target.Inlines = new InlineCollection { new Run("A") };
+
+            // A render pass builds the layout from the first change, before the queued measure.
+            _ = target.TextLayout;
+
+            target.Inlines = new InlineCollection { new Run("Hello World Hello World") };
+
+            target.Measure(new Size(1000, 1000));
+
+            var expected = new TextBlock { Inlines = new InlineCollection { new Run("Hello World Hello World") } };
+
+            expected.Measure(new Size(1000, 1000));
+
+            Assert.Equal(expected.DesiredSize, target.DesiredSize);
+        }
+
         private class TestTextBlock : TextBlock
         {
             public Size Constraint => _constraint;

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -779,6 +779,34 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(expected.DesiredSize, target.DesiredSize);
         }
 
+        [Fact]
+        public void Should_Remeasure_Embedded_Controls_When_The_Child_Changes_While_Measure_Is_Invalid()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var child = new Border { Width = 20, Height = 20 };
+            var target = new TextBlock { Inlines = new InlineCollection { new InlineUIContainer(child) } };
+
+            target.Measure(new Size(1000, 1000));
+            target.Arrange(new Rect(0, 0, 1000, 1000));
+
+            target.InvalidateMeasure();
+
+            // A render pass builds the layout while the child still has its old size.
+            _ = target.TextLayout;
+
+            // The block is already measure invalid, so this raises no further invalidation on it.
+            child.Width = 80;
+
+            target.Measure(new Size(1000, 1000));
+
+            var expected = new TextBlock { Inlines = new InlineCollection { new InlineUIContainer(new Border { Width = 80, Height = 20 }) } };
+
+            expected.Measure(new Size(1000, 1000));
+
+            Assert.Equal(expected.DesiredSize, target.DesiredSize);
+        }
+
         private class TestTextBlock : TextBlock
         {
             public Size Constraint => _constraint;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Rebuilds a `TextBlock`'s text runs only when the content they are built from changes, instead of on every measure pass. Embedded controls are re-measured in place, against the current constraint, rather than riding along on that rebuild: `Inline.BuildTextRun` loses its `blockSize` parameter, which only `InlineUIContainer` ever used, and the measuring moves to a new `Inline.MeasureEmbeddedControls(Size)`. `EmbeddedControlRun` already reports its child's `DesiredSize` live, so the existing runs stay valid across a constraint change.

Also folds in a one-line fix for `TextBlock.LineSpacing`, which invalidated nothing when it changed.

## What is the current behavior?

`_textRuns` is built from `Inlines`, but `OnMeasureInvalidated` discards it on any measure invalidation, while `Inlines` still holds the content. Between that point and the next measure pass the control disagrees with itself about what it contains, and `CreateTextLayout` reads a null `_textRuns` as "no inlines":

```csharp
if (_textRuns != null)
    textSource = new InlinesTextSource(_textRuns);
else
    textSource = new SimpleTextSource(text ?? "", defaultProperties);
```

So the textSource itself is built on the wrong condition. The empty result is then shaped and stored in the `TextRunCache` under the text source index, so every later layout reuses it and the control never recovers on its own.

`_textLayout` has the same problem from the other side. `InvalidateMeasure` only raises `OnMeasureInvalidated` while the measure is still valid, and that callback is the only thing clearing the layout, so anything happening after the first invalidation leaves it in place: a second content change, or an embedded control resizing. `MeasureOverride` keeps that layout whenever the constraint has not moved, and a line snapshots its metrics when it is formatted, so the block measures and renders the superseded content.

## What is the updated/expected behavior with this PR?

A `TextBlock` shapes and renders its `Inlines` no matter when the layout is created, and a `TextRunCache` entry can no longer be built from content the control does not have.

The layout is dropped by the content change itself rather than by the measure-invalidation callback, and by a measure pass that finds an embedded control has resized, so neither can leave a superseded layout in place.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None. `Inline.BuildTextRun` changes signature and `Inline.MeasureEmbeddedControls` is new, but both are `internal`, and `Inline` cannot be derived from outside the assembly because `BuildTextRun` is an internal abstract member.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21902

Supersedes #21904

🤖 Generated with [Claude Code](https://claude.com/claude-code)


