### PR TITLE
Fix UIA selection never reaching the client on Windows

### DIFF
--- a/src/Windows/Avalonia.Win32.Automation/Avalonia.Win32.Automation.csproj
+++ b/src/Windows/Avalonia.Win32.Automation/Avalonia.Win32.Automation.csproj
@@ -15,5 +15,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Avalonia.Win32, PublicKey=$(AvaloniaPublicKey)"/>
+    <InternalsVisibleTo Include="Avalonia.IntegrationTests.Win32, PublicKey=$(AvaloniaPublicKey)"/>
   </ItemGroup>
 </Project>

--- a/src/Windows/Avalonia.Win32.Automation/Marshalling/SafeArrayMarshaller.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Marshalling/SafeArrayMarshaller.cs
@@ -10,7 +10,7 @@ internal static class SafeArrayMarshaller<T> where T : notnull
 {
     public static SafeArrayRef ConvertToUnmanaged(T[]? managed) =>
         managed is null ? new SafeArrayRef()
-        : SafeArrayRef.TryCreate(managed, out var result, out _) ? result.Value
+        : SafeArrayRef.TryCreate<T>(managed, out var result, out _) ? result.Value
         : throw new NotImplementedException($"SafeArray marshalling for '{managed?.GetType().Name}' is not implemented.");
 
     public static T[]? ConvertToManaged(SafeArrayRef unmanaged) => SafeArrayRef.ToArray<T>(unmanaged);

--- a/src/Windows/Avalonia.Win32.Automation/Marshalling/SafeArrayRef.cs
+++ b/src/Windows/Avalonia.Win32.Automation/Marshalling/SafeArrayRef.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 // ReSharper disable InconsistentNaming
 
 namespace Avalonia.Win32.Automation.Marshalling;
@@ -160,6 +161,25 @@ internal unsafe partial struct SafeArrayRef
         });
     }
 
+    /// <summary>
+    /// Creates a SAFEARRAY from a typed array.
+    /// </summary>
+    /// <remarks>
+    /// COM interfaces have to come through here rather than through the non-generic overload: the
+    /// element type is what tells us to wrap each item, and it isn't recoverable from the values.
+    /// </remarks>
+    public static bool TryCreate<T>(T[]? managed, [NotNullWhen(true)] out SafeArrayRef? safearray, out VarEnum varEnum)
+    {
+        if (managed is not null && typeof(T).IsInterface)
+        {
+            safearray = CreateFromComObjects(managed);
+            varEnum = VarEnum.VT_UNKNOWN;
+            return true;
+        }
+
+        return TryCreate((IEnumerable?)managed, out safearray, out varEnum);
+    }
+
     public static bool TryCreate(IEnumerable? managed, [NotNullWhen(true)] out SafeArrayRef? safearray, out VarEnum varEnum)
     {
         safearray = default;
@@ -179,38 +199,6 @@ internal unsafe partial struct SafeArrayRef
                 _ => collection.ToArray()
             };
             return CreateFromSpan<T>(collectionSpan, varEnum);
-        }
-
-        static SafeArrayRef CreateFromSpan<T>(ReadOnlySpan<T> span, VarEnum varEnum)
-        {
-            var bound = new SAFEARRAYBOUND { cElements = (uint)span.Length, lLbound = 0 };
-            var safearray = SafeArrayCreate(varEnum, 1, bound);
-            if (span.Length == 0)
-            {
-                return new SafeArrayRef
-                {
-                    _ptr = safearray
-                };
-            }
-
-            var lockResult = SafeArrayLock(safearray);
-            if (lockResult != 0) throw new Win32Exception(lockResult);
-
-            try
-            {
-                // We assume it has the same length.
-                var output = new Span<T>(safearray->pvData, (int)safearray->rgsabound[0].cElements);
-                span.CopyTo(output);
-            }
-            finally
-            {
-                SafeArrayUnlock(safearray);
-            }
-
-            return new SafeArrayRef
-            {
-                _ptr = safearray
-            };
         }
 
         static SafeArrayRef CreateFromStrings(IReadOnlyList<string> strings, VarEnum varEnum)
@@ -251,28 +239,6 @@ internal unsafe partial struct SafeArrayRef
             }
         }
 
-        static SafeArrayRef CreateFromObjects(IReadOnlyList<object> objects, VarEnum varEnum)
-        {
-            Debug.Assert(varEnum == VarEnum.VT_UNKNOWN); // other types not supported yet
-            var pointers = ArrayPool<IntPtr>.Shared.Rent(objects.Count);
-            try
-            {
-                for (int i = 0; i < objects.Count; i++)
-                {
-                    if (ComWrappers.TryGetComInstance(objects[i], out var pointer))
-                    {
-                        pointers[i] = pointer;
-                    }
-                }
-
-                return CreateFromSpan<IntPtr>(pointers, varEnum);
-            }
-            finally
-            {
-                ArrayPool<IntPtr>.Shared.Return(pointers);
-            }
-        }
-
         safearray = managed switch
         {
             IReadOnlyCollection<sbyte> ints => CreateFromCollection(ints, varEnum = VarEnum.VT_I1),
@@ -295,12 +261,61 @@ internal unsafe partial struct SafeArrayRef
 
             IReadOnlyList<string> strings => CreateFromStrings(strings, varEnum = VarEnum.VT_BSTR),
 
-            IReadOnlyList<object> objects => CreateFromObjects(objects, varEnum = VarEnum.VT_UNKNOWN),
-            
             _ => null
         };
 
         return safearray is not null;
+    }
+
+    private static SafeArrayRef CreateFromSpan<T>(ReadOnlySpan<T> span, VarEnum varEnum)
+    {
+        var bound = new SAFEARRAYBOUND { cElements = (uint)span.Length, lLbound = 0 };
+        var safearray = SafeArrayCreate(varEnum, 1, bound);
+        if (span.Length == 0)
+        {
+            return new SafeArrayRef
+            {
+                _ptr = safearray
+            };
+        }
+
+        var lockResult = SafeArrayLock(safearray);
+        if (lockResult != 0) throw new Win32Exception(lockResult);
+
+        try
+        {
+            // We assume it has the same length.
+            var output = new Span<T>(safearray->pvData, (int)safearray->rgsabound[0].cElements);
+            span.CopyTo(output);
+        }
+        finally
+        {
+            SafeArrayUnlock(safearray);
+        }
+
+        return new SafeArrayRef
+        {
+            _ptr = safearray
+        };
+    }
+
+    private static SafeArrayRef CreateFromComObjects<T>(T[] objects)
+    {
+        var pointers = ArrayPool<IntPtr>.Shared.Rent(objects.Length);
+
+        try
+        {
+            for (var i = 0; i < objects.Length; i++)
+            {
+                pointers[i] = (IntPtr)ComInterfaceMarshaller<T>.ConvertToUnmanaged(objects[i]);
+            }
+
+            return CreateFromSpan<IntPtr>(pointers.AsSpan(0, objects.Length), VarEnum.VT_UNKNOWN);
+        }
+        finally
+        {
+            ArrayPool<IntPtr>.Shared.Return(pointers);
+        }
     }
 
     [LibraryImport("oleaut32.dll")]

--- a/tests/Avalonia.IntegrationTests.Win32/Automation/SafeArrayRefTests.cs
+++ b/tests/Avalonia.IntegrationTests.Win32/Automation/SafeArrayRefTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Avalonia.Win32.Automation.Marshalling;
+using Xunit;
+
+namespace Avalonia.IntegrationTests.Win32.Automation;
+
+public unsafe class SafeArrayRefTests
+{
+    [Fact]
+    public void ConvertToUnmanaged_Sizes_String_Array_To_Input()
+    {
+        var safeArray = SafeArrayMarshaller<string>.ConvertToUnmanaged(["foo", "bar", "baz"]);
+
+        Assert.Equal(3, GetLength(safeArray));
+
+        SafeArrayMarshaller<string>.Free(safeArray);
+    }
+
+    [Fact]
+    public void ConvertToUnmanaged_Sizes_Provider_Array_To_Input()
+    {
+        ITestProvider[] providers = [new TestProvider(1), new TestProvider(2)];
+
+        var safeArray = SafeArrayMarshaller<ITestProvider>.ConvertToUnmanaged(providers);
+
+        Assert.Equal(providers.Length, GetLength(safeArray));
+
+        SafeArrayMarshaller<ITestProvider>.Free(safeArray);
+    }
+
+    [Fact]
+    public void ConvertToUnmanaged_Fills_Provider_Array_With_Com_Wrappers()
+    {
+        ITestProvider[] providers = [new TestProvider(1), new TestProvider(2)];
+
+        var safeArray = SafeArrayMarshaller<ITestProvider>.ConvertToUnmanaged(providers);
+
+        // Check the length before reading the entries. A wrongly sized array holds slots that were
+        // never written, and dereferencing those below would take down the test host.
+        Assert.Equal(providers.Length, GetLength(safeArray));
+        Assert.All(GetEntries(safeArray), x => Assert.NotEqual(IntPtr.Zero, x));
+
+        var roundTripped = SafeArrayMarshaller<ITestProvider>.ConvertToManaged(safeArray);
+        Assert.NotNull(roundTripped);
+        Assert.Equal([1, 2], Array.ConvertAll(roundTripped, x => x.GetValue()));
+
+        SafeArrayMarshaller<ITestProvider>.Free(safeArray);
+    }
+
+    private static int GetLength(SafeArrayRef safeArray)
+    {
+        var ptr = (SafeArrayRef.SAFEARRAY*)Unsafe.As<SafeArrayRef, IntPtr>(ref safeArray);
+        return (int)ptr->rgsabound[0].cElements;
+    }
+
+    private static IntPtr[] GetEntries(SafeArrayRef safeArray)
+    {
+        var ptr = (SafeArrayRef.SAFEARRAY*)Unsafe.As<SafeArrayRef, IntPtr>(ref safeArray);
+        var result = new IntPtr[(int)ptr->rgsabound[0].cElements];
+        new Span<IntPtr>(ptr->pvData, result.Length).CopyTo(result);
+        return result;
+    }
+}
+
+[GeneratedComInterface]
+[Guid("6ADEBBF3-6C63-4C1B-9C4F-9EE7C3B8A6D1")]
+internal partial interface ITestProvider
+{
+    int GetValue();
+}
+
+[GeneratedComClass]
+internal partial class TestProvider : ITestProvider
+{
+    private readonly int _value;
+
+    public TestProvider(int value) => _value = value;
+
+    public int GetValue() => _value;
+}


### PR DESCRIPTION
## What does the pull request do?

Fixes UI Automation clients getting an empty selection from any selecting control on Windows.

## What is the current behavior?

`SelectionPattern.GetCurrentSelection()` returns a zero-length array for a `ListBox` or `ComboBox`, even when an item is selected. The Avalonia peers are correct. The array is lost when it is marshalled to the client.

Two things went wrong in `SafeArrayRef.CreateFromObjects`:

1. The SAFEARRAY was sized to the buffer rented from `ArrayPool`, not to the input. A one-element selection became a 16-element array. The rented buffer is not cleared, so stale pointers from an earlier rent could leak in and later be released by `SafeArrayDestroy`.
2. Slots were filled only when `ComWrappers.TryGetComInstance` succeeded. That call looks up the native pointer behind a managed object that wraps a COM instance. Our peers are plain managed objects, so it always failed and no slot was ever filled.

The client therefore got an array of nulls and reported no selection.

A `ComboBox` hides this in practice because Avalonia also exposes `ValuePattern` with the selection text. A `ListBox` has no such fallback.

## What is the updated/expected behavior with this PR?

`GetCurrentSelection()` returns one element per selected item.

The same code path is used by `ITableProvider.GetRowHeaders`/`GetColumnHeaders`, `ITableItemProvider`, and `ITextProvider.GetSelection`/`GetVisibleRanges`, so those are fixed too.

## How was the solution implemented (if it's not obvious)?

Wrappers now come from `ComInterfaceMarshaller<T>`. It handles both cases: it finds an existing wrapper, and creates one when there is none. The array is sized with `.AsSpan(0, objects.Length)`, which is what `CreateFromStrings` and `CreateFromBools` already did.

It has to be the same `ComInterfaceMarshaller` the rest of the interop uses. UI Automation tells elements apart by their `IUnknown` pointer, so a wrapper from a second `ComWrappers` would look like a different element.

Knowing to wrap an item at all needs the element type, and that is not recoverable from an `object`. So `SafeArrayMarshaller<T>` now passes `T` through a new generic `TryCreate<T>` overload. `CreateFromSpan` moved out of `TryCreate` so both paths can call it.

The `IReadOnlyList<object>` branch of the non-generic `TryCreate` is removed rather than left broken. Nothing reached it. The only other caller is `ComVariant.Create`, and no property value is an array of providers.

The tests are in their own commit so you can check that they fail without the fix.

Note that `ComVariant.cs` makes the same `TryGetComInstance` mistake for a single `VT_UNKNOWN` value. It is left alone here: it throws rather than failing quietly, and nothing currently reaches it.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Fixed issues

Fixes #22150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYYMWsTkmkKjptFL88xjAg
