### PR TITLE
Don't enter a KeyboardNavigationMode.None group via its active element

### DIFF
--- a/src/Avalonia.Base/Input/Navigation/TabNavigation.cs
+++ b/src/Avalonia.Base/Input/Navigation/TabNavigation.cs
@@ -23,10 +23,16 @@ namespace Avalonia.Input.Navigation
                 if (IsTabStop(container))
                     return container;
 
-                // Using ActiveElement if set
-                var activeElement = GetActiveElement(container);
-                if (activeElement != null)
-                    return GetNextTab(null, activeElement, true);
+                // Using ActiveElement if set. A None group never hands out an element
+                // inside itself, not even a remembered one: ItemsControl records the
+                // last focused child as the active element, so without this an
+                // ItemsControl with TabNavigation="None" is still entered.
+                if (tabbingType != KeyboardNavigationMode.None)
+                {
+                    var activeElement = GetActiveElement(container);
+                    if (activeElement != null)
+                        return GetNextTab(null, activeElement, true);
+                }
             }
             else
             {
@@ -95,8 +101,11 @@ namespace Avalonia.Input.Navigation
 
             if (e == null)
             {
-                // Using ActiveElement if set
-                var activeElement = GetActiveElement(container);
+                // Using ActiveElement if set, except for None groups, which never hand
+                // out an element inside themselves. See the matching note in GetNextTab.
+                var activeElement = tabbingType == KeyboardNavigationMode.None
+                    ? null
+                    : GetActiveElement(container);
                 if (activeElement != null)
                     return GetPrevTab(null, activeElement, true);
                 else

--- a/tests/Avalonia.Base.UnitTests/Input/KeyboardNavigationTests_Tab.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/KeyboardNavigationTests_Tab.cs
@@ -640,6 +640,76 @@ namespace Avalonia.Base.UnitTests.Input
         }
 
         [Fact]
+        public void Next_None_Skips_Container_With_Active_Element_Inside()
+        {
+            StackPanel container;
+            Button current;
+            Button inside;
+            Button next;
+
+            var top = new StackPanel
+            {
+                [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Cycle,
+                Children =
+                {
+                    (current = new Button { Name = "Button1" }),
+                    (container = new StackPanel
+                    {
+                        [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.None,
+                        Children =
+                        {
+                            (inside = new Button { Name = "Button2" }),
+                            new Button { Name = "Button3" },
+                        }
+                    }),
+                    (next = new Button { Name = "Button4" }),
+                }
+            };
+
+            // ItemsControl.OnGotFocus records the last focused child as the active
+            // element, so a ListBox whose item has been focused has one set.
+            KeyboardNavigation.SetTabOnceActiveElement(container, inside);
+
+            var result = KeyboardNavigationHandler.GetNext(current, NavigationDirection.Next);
+
+            Assert.Equal(next, result);
+        }
+
+        [Fact]
+        public void Previous_None_Skips_Container_With_Active_Element_Inside()
+        {
+            StackPanel container;
+            Button current;
+            Button inside;
+            Button previous;
+
+            var top = new StackPanel
+            {
+                [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Cycle,
+                Children =
+                {
+                    (previous = new Button { Name = "Button1" }),
+                    (container = new StackPanel
+                    {
+                        [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.None,
+                        Children =
+                        {
+                            new Button { Name = "Button2" },
+                            (inside = new Button { Name = "Button3" }),
+                        }
+                    }),
+                    (current = new Button { Name = "Button4" }),
+                }
+            };
+
+            KeyboardNavigation.SetTabOnceActiveElement(container, inside);
+
+            var result = KeyboardNavigationHandler.GetNext(current, NavigationDirection.Previous);
+
+            Assert.Equal(previous, result);
+        }
+
+        [Fact]
         public void Previous_Continue_Returns_Previous_Control_In_Container()
         {
             Button current;

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
@@ -633,6 +633,45 @@ namespace Avalonia.Controls.UnitTests
                 });
         }
 
+        [Fact]
+        public void TabNavigation_None_Is_Skipped_When_An_Item_Is_Selected()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                Button before;
+                Button after;
+
+                // Selecting an item records it as the tab-once active element, and the
+                // navigation code follows that without consulting the navigation mode.
+                var target = new ListBox
+                {
+                    Template = ListBoxTemplate(),
+                    ItemsSource = new[] { "Foo", "Bar" },
+                    SelectedIndex = 0,
+                    Width = 100,
+                    Height = 100,
+                    [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.None,
+                };
+
+                var root = new TestRoot(new StackPanel
+                {
+                    [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Cycle,
+                    Children =
+                    {
+                        (before = new Button()),
+                        target,
+                        (after = new Button()),
+                    }
+                });
+
+                root.LayoutManager.ExecuteInitialLayoutPass();
+
+                var result = KeyboardNavigationHandler.GetNext(before, NavigationDirection.Next);
+
+                Assert.Same(after, result);
+            }
+        }
+
         private static void Prepare(ListBox target)
         {
             target.Width = target.Height = 100;


### PR DESCRIPTION
Fixes #22048.

Split into the two commits the contributing guide asks for: the failing tests first, then the fix.

## Root cause

`GetNextTab` and `GetPrevTab` fall back to `TabOnceActiveElement` when entering a container, and neither checked the navigation mode first:

```csharp
if (e == null)
{
    if (IsTabStop(container))
        return container;

    // Using ActiveElement if set
    var activeElement = GetActiveElement(container);
    if (activeElement != null)
        return GetNextTab(null, activeElement, true);
}
```

`ItemsControl.OnGotFocus` records the last focused child as that active element:

```csharp
// If the focus is coming from a child control, set the tab once active element to
// the focused control. This ensures that tabbing back into the control will focus
// the last focused control when TabNavigationMode == Once.
if (e.Source != this && e.Source is IInputElement ie)
    KeyboardNavigation.SetTabOnceActiveElement(this, ie);
```

So once a `ListBox` item has been focused, the `ListBox` has an active element pointing inside itself, and Tab enters it even with `TabNavigation="None"`. `GetNextTabInGroup` already returns `null` for `None`, so the group walk was correct; only this fallback leaked.

This also explains the asymmetry in the report. `TreeView` is not inherently better behaved here, it just had no focused item in the repro and therefore no active element. A `TreeView` whose item has been focused should show the same bug.

## The fix

A `None` group never hands out an element inside itself, not even a remembered one. `GetNextTab` skips the active-element lookup for `None` and falls through to the existing group walk, which already returns nothing for `None`; `GetPrevTab` does the same.

I deliberately left `IsTabStop(container)` above it alone. `None` governs navigation *within* the group, and a container that is itself a tab stop should still be reachable, which matches WPF. Changing that would be a wider behavioural change than this issue calls for.

## Tests

Two new tests in `KeyboardNavigationTests_Tab`, one per direction. Both **fail on the first commit and pass on the second**:

```
failed ...KeyboardNavigationTests_Tab.Next_None_Skips_Container_With_Active_Element_Inside
failed ...KeyboardNavigationTests_Tab.Previous_None_Skips_Container_With_Active_Element_Inside
  total: 3440   failed: 2   succeeded: 3426
```

after the fix:

```
  total: 3440   failed: 0   succeeded: 3428   skipped: 12
```

Worth noting why this was not already covered: the existing `Next_None_Skips_Container` does call `SetTabOnceActiveElement`, but points it at a button in a *sibling* panel, which is also the expected result, so the assertion passes whether or not the fallback fires.

`Avalonia.Controls.UnitTests` as well, since this is a shared navigation path: **3915 total, 0 failed, 3914 succeeded, 1 skipped.**

Windows, .NET 10, Release.

## Not verified

I have not run the attached sample app, only the unit tests, so I have not confirmed the end-to-end fix in a real window. I also have not checked whether `TreeView` reproduces the same bug once one of its items has been focused, though the analysis above says it should.

## AI usage

Per the contributing guide, which accepts AI-assisted contributions but wants a human in the loop: Claude Code (Claude Opus 5) helped locate the cause and draft this. I reviewed the diff and ran all the test runs above myself, and will handle review comments personally.
