### PR TITLE
Unify shutdown handling and subscribe UI dispatcher event

### DIFF
--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -186,12 +186,14 @@ namespace Avalonia.Native
             Compositor = new Compositor(_platformGraphics, true);
             AvaloniaLocator.CurrentMutable.Bind<Compositor>().ToConstant(Compositor);
 
-            AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+            Dispatcher.UIThread.ShutdownFinished += OnShutdown;
+            AppDomain.CurrentDomain.ProcessExit += OnShutdown;
         }
 
-        private void OnProcessExit(object? sender, EventArgs e)
+        private void OnShutdown(object? sender, EventArgs e)
         {
-            AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
+            Dispatcher.UIThread.ShutdownFinished -= OnShutdown;
+            AppDomain.CurrentDomain.ProcessExit -= OnShutdown;
             _factory.Dispose();
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Releases Avalonia Native resources when the UI dispatcher finishes shutting down, addressing the late release of managed callbacks reported in #22062 


## What is the current behavior?
Native factory cleanup relies exclusively on `AppDomain.ProcessExit`. Managed callbacks can remain referenced by native static storage until runtime teardown, causing the reported macOS shutdown crash on .NET 11.


## What is the updated/expected behavior with this PR?
The native factory is disposed before the desktop application’s main loop returns. ProcessExit remains a fallback when dispatcher shutdown does not occur.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation


## Fixed issues
Fixes #22062
