### PR TITLE
fix: [22091] Fixed PopupFlyoutBase.Opening not passing CancelEventArgs

### DIFF
--- a/samples/ControlCatalog/Pages/ContextFlyoutPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ContextFlyoutPage.xaml.cs
@@ -32,12 +32,9 @@ namespace ControlCatalog.Pages
             e.Cancel = CancelCloseCheckBox?.IsChecked ?? false;
         }
 
-        private void ContextFlyoutPage_Opening(object? sender, EventArgs e)
+        private void ContextFlyoutPage_Opening(object? sender, CancelEventArgs e)
         {
-            if (e is CancelEventArgs cancelArgs)
-            {
-                cancelArgs.Cancel = CancelCloseCheckBox?.IsChecked ?? false;
-            }
+            e.Cancel = CancelCloseCheckBox?.IsChecked ?? false;
         }
 
         private void CloseFlyout(object? sender, RoutedEventArgs e)

--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -178,7 +178,7 @@ namespace Avalonia.Controls.Primitives
         }
 
         public event EventHandler<CancelEventArgs>? Closing;
-        public event EventHandler? Opening;
+        public event EventHandler<CancelEventArgs>? Opening;
 
         /// <summary>
         /// Pre-registers a control as the default placement target for this flyout.

--- a/tests/Avalonia.Controls.UnitTests/FlyoutTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/FlyoutTests.cs
@@ -77,10 +77,7 @@ namespace Avalonia.Controls.UnitTests
                 f.Opening += (s, e) =>
                 {
                     tracker++;
-                    if (e is CancelEventArgs cancelEventArgs)
-                    {
-                        cancelEventArgs.Cancel = true;
-                    }
+                    e.Cancel = true;
                 };
                 f.ShowAt(window);
 
@@ -834,8 +831,7 @@ namespace Avalonia.Controls.UnitTests
 
                 flyout.Opening += (s, e) =>
                 {
-                    if (e is CancelEventArgs cancelArgs)
-                        cancelArgs.Cancel = true;
+                    e.Cancel = true;
                 };
 
                 flyout.IsOpen = true;


### PR DESCRIPTION
## What does the pull request do?
Changed PopupFlyoutBase.Opening to pass CancelEventArgs.


## What is the current behavior?
PopupFlyoutBase.Opening does not pass CancelEventArgs. a cast of (CancelEventArgs)EventArgs needs to be done to cancel the event.


## What is the updated/expected behavior with this PR?
CancelEventArgs.Cancel can be used directly without casting.


## Breaking changes
As of https://github.com/AvaloniaUI/Avalonia/issues/22091#issuecomment-5455131886, this is a BREAKING CHANGE, scheduled for milestone 13.0.

## Fixed issues
Fixes #22091
