### PR TITLE
Fix DateTimePickerPanel ItemHeight updates

### DIFF
--- a/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
@@ -386,6 +386,22 @@ namespace Avalonia.Controls.Primitives
             base.OnKeyDown(e);
         }
 
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == ItemHeightProperty)
+            {
+                foreach (var child in Children)
+                {
+                    child.Height = ItemHeight;
+                }
+
+                UpdateHelperInfo();
+                _hasInit = false;
+            }
+        }
+
         /// <summary>
         /// Refreshes the content of the visible items
         /// </summary>

--- a/tests/Avalonia.Controls.UnitTests/DatePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DatePickerTests.cs
@@ -255,6 +255,42 @@ namespace Avalonia.Controls.UnitTests
         public void Selector_ScrollDown_Should_Work(string selectorName)
             => TestSelectorScrolling(selectorName, panel => panel.ScrollDown());
 
+        [Theory]
+        [InlineData(false, 120d, 40d)]
+        [InlineData(true, 12000d, 6040d)]
+        public void Selector_ItemHeight_Change_Should_Update_Layout_State(
+            bool shouldLoop,
+            double expectedExtentHeight,
+            double expectedOffsetY)
+        {
+            using var app = UnitTestApplication.Start(Services);
+
+            var panel = new DateTimePickerPanel
+            {
+                MinimumValue = 1,
+                MaximumValue = 3,
+                ShouldLoop = shouldLoop,
+                ItemHeight = 20,
+            };
+
+            panel.Measure(new Size(100, 100));
+            panel.Arrange(new Rect(0, 0, 100, 100));
+            panel.SelectedValue = 2;
+
+            panel.ItemHeight = 40;
+
+            Assert.Equal(expectedExtentHeight, panel.Extent.Height);
+            Assert.Equal(expectedOffsetY, panel.Offset.Y);
+            Assert.All(panel.Children, child => Assert.Equal(40, child.Height));
+
+            panel.Measure(new Size(100, 100));
+            panel.Arrange(new Rect(0, 0, 100, 100));
+
+            var selectedItem = Assert.Single(panel.Children.OfType<ListBoxItem>().Where(item => item.IsSelected));
+            Assert.Equal(2, selectedItem.Tag);
+            Assert.Equal(50, selectedItem.Bounds.Center.Y);
+        }
+
         private static void TestSelectorScrolling(string selectorName, Action<DateTimePickerPanel> scroll)
         {
             using var app = UnitTestApplication.Start(Services);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes `DateTimePickerPanel` when `ItemHeight` changes dynamically, such as when it is bound to a Fluent theme resource:

```xml
ItemHeight="{DynamicResource DatePickerFlyoutPresenterItemHeight}"
```

## What is the current behavior?
<img width="790" height="612" alt="bugdemo6" src="https://github.com/user-attachments/assets/075429ac-63a1-48b3-bf1c-241293094f16" />

## What is the updated/expected behavior with this PR?
<img width="790" height="612" alt="bugdemo5" src="https://github.com/user-attachments/assets/cfce6fe1-a93c-4e55-9515-4476bba3995f" />

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation


## Fixed issues
Fixes #22157
