### PR TITLE
Fix RenderTargetBitmap clipping shapes with drop shadows

### DIFF
--- a/src/Avalonia.Base/Media/DrawingContext.cs
+++ b/src/Avalonia.Base/Media/DrawingContext.cs
@@ -458,8 +458,15 @@ namespace Avalonia.Media
         /// </param>
         /// <returns>A disposable used to undo the effect.</returns>
         public PushedState PushEffect(IEffect effect, Rect bounds)
+            => PushEffect(effect, (Rect?)bounds);
+
+        // Visual effects cannot use layout bounds: strokes and descendants may render outside them.
+        internal PushedState PushEffect(IEffect effect, Rect? bounds)
         {
-            PushEffectCore(effect, bounds);
+            if (bounds is { } rect)
+                PushEffectCore(effect, rect);
+            else
+                PushEffectCore(effect);
             _states ??= StateStackPool.Get();
             _states.Push(new RestoreState(this, RestoreState.PushedStateType.Effect));
             return new PushedState(this);
@@ -475,6 +482,9 @@ namespace Avalonia.Media
         /// <param name="effect">The effect.</param>
         /// <param name="bounds">The bounds of the effect.</param>
         protected abstract void PushEffectCore(IEffect effect, Rect bounds);
+
+        private protected virtual void PushEffectCore(IEffect effect)
+            => throw new NotSupportedException("This drawing context requires explicit effect bounds.");
 
         protected abstract void PopClipCore();
         protected abstract void PopGeometryClipCore();

--- a/src/Avalonia.Base/Media/DrawingGroup.cs
+++ b/src/Avalonia.Base/Media/DrawingGroup.cs
@@ -418,6 +418,12 @@ namespace Avalonia.Media
                 drawingGroup.EffectBounds = bounds;
             }
 
+            private protected override void PushEffectCore(IEffect effect)
+            {
+                var drawingGroup = PushNewDrawingGroup();
+                drawingGroup.Effect = effect;
+            }
+
             protected override void PopClipCore() => Pop();
 
             protected override void PopGeometryClipCore() => Pop();

--- a/src/Avalonia.Base/Media/PlatformDrawingContext.cs
+++ b/src/Avalonia.Base/Media/PlatformDrawingContext.cs
@@ -97,6 +97,12 @@ internal sealed class PlatformDrawingContext : DrawingContext
         }
     }
 
+    private protected override void PushEffectCore(IEffect effect)
+    {
+        if (_impl is IDrawingContextImplWithEffects effectImpl)
+            effectImpl.PushEffect(null, effect);
+    }
+
     protected override void PopClipCore() => _impl.PopClip();
 
     protected override void PopGeometryClipCore() => _impl.PopGeometryClip();

--- a/src/Avalonia.Base/Rendering/Composition/Drawing/IRenderDataVisitor.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/IRenderDataVisitor.cs
@@ -25,6 +25,6 @@ internal interface IRenderDataVisitor<TScope> where TScope : unmanaged
     TScope OnPushTransform(Matrix matrix);
     TScope OnPushRenderOptions(RenderOptions options);
     TScope OnPushTextOptions(TextOptions options);
-    TScope OnPushEffect(IEffect? effect, Rect bounds);
+    TScope OnPushEffect(IEffect? effect, Rect? bounds);
     void OnPop(in TScope scope);
 }

--- a/src/Avalonia.Base/Rendering/Composition/Drawing/RenderDataDrawingContext.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/RenderDataDrawingContext.cs
@@ -244,6 +244,13 @@ internal class RenderDataDrawingContext : DrawingContext
         PushedScope(before);
     }
 
+    private protected override void PushEffectCore(IEffect effect)
+    {
+        var before = Stream.OpcodeLength;
+        Stream.PushEffect(effect.ToImmutable(), null);
+        PushedScope(before);
+    }
+
     protected override void PopClipCore() => PopCore();
 
     protected override void PopGeometryClipCore() => PopCore();

--- a/src/Avalonia.Base/Rendering/Composition/Drawing/RenderDataPayloads.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/RenderDataPayloads.cs
@@ -128,5 +128,5 @@ internal struct PushEffectPayload : IRenderDataPayload<PushEffectPayload>
     public static RenderDataOpcode Opcode => RenderDataOpcode.PushEffect;
 
     public int Effect;
-    public Rect Bounds;
+    public Rect? Bounds;
 }

--- a/src/Avalonia.Base/Rendering/Composition/Drawing/RenderDataStream.Bounds.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/RenderDataStream.Bounds.cs
@@ -70,7 +70,7 @@ internal partial class RenderDataStream
         public BoundsScope OnPushRenderOptions(RenderOptions options) => EnterChildScope();
         public BoundsScope OnPushTextOptions(TextOptions options) => EnterChildScope();
 
-        public BoundsScope OnPushEffect(IEffect? effect, Rect bounds)
+        public BoundsScope OnPushEffect(IEffect? effect, Rect? bounds)
             => EnterChildScope(effectPadding: effect.GetEffectOutputPadding());
 
         public void OnPop(in BoundsScope scope)

--- a/src/Avalonia.Base/Rendering/Composition/Drawing/RenderDataStream.HitTest.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/RenderDataStream.HitTest.cs
@@ -238,7 +238,7 @@ internal partial class RenderDataStream
         public HitTestScope OnPushTextOptions(TextOptions options)
             => new HitTestScope { SavedLive = Live };
 
-        public HitTestScope OnPushEffect(IEffect? effect, Rect bounds)
+        public HitTestScope OnPushEffect(IEffect? effect, Rect? bounds)
             => new HitTestScope { SavedLive = Live };
 
         public void OnPop(in HitTestScope scope)

--- a/src/Avalonia.Base/Rendering/Composition/Drawing/RenderDataStream.Replay.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/RenderDataStream.Replay.cs
@@ -105,7 +105,7 @@ internal partial class RenderDataStream
             return new ReplayScope { Kind = RenderDataOpcode.PushTextOptions, Active = true };
         }
 
-        public ReplayScope OnPushEffect(IEffect? effect, Rect bounds)
+        public ReplayScope OnPushEffect(IEffect? effect, Rect? bounds)
         {
             var active = false;
             if (effect != null && _context is IDrawingContextImplWithEffects effectImpl)

--- a/src/Avalonia.Base/Rendering/Composition/Drawing/RenderDataStream.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/RenderDataStream.cs
@@ -178,7 +178,7 @@ internal partial class RenderDataStream : IDisposable
         EnterScope();
     }
 
-    public void PushEffect(IImmutableEffect? effect, Rect bounds)
+    public void PushEffect(IImmutableEffect? effect, Rect? bounds)
     {
         _writer.WritePayload(new PushEffectPayload
         {

--- a/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
@@ -63,7 +63,7 @@ internal class ImmediateRenderer
         })
         using (visual.Clip is { } clip ? context.PushGeometryClip(clip) : default(DrawingContext.PushedState?))
         using (visual.OpacityMask is { } opctMask ? context.PushOpacityMask(opctMask, rect) : default(DrawingContext.PushedState?))
-        using (visual.Effect is { } effect ? context.PushEffect(effect, rect) : default(DrawingContext.PushedState?))
+        using (visual.Effect is { } effect ? context.PushEffect(effect, null) : default(DrawingContext.PushedState?))
         {
             var totalTransform = transform * parentTransform;
             var effectRect = visual.Effect is { } e ? rect.Inflate(e.GetEffectOutputPadding()) : rect;

--- a/tests/Avalonia.Base.UnitTests/Rendering/SceneGraph/RenderDataStreamEffectTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/SceneGraph/RenderDataStreamEffectTests.cs
@@ -1,21 +1,42 @@
 using Avalonia.Media;
+using Avalonia.Platform;
 using Avalonia.Rendering.Composition.Drawing;
+using Moq;
 using Xunit;
 
 namespace Avalonia.Base.UnitTests.Rendering.SceneGraph;
 
 public class RenderDataStreamEffectTests
 {
-    [Fact]
-    public void Effect_Inflates_Child_Bounds_By_Padding()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Effect_Inflates_Child_Bounds_By_Padding(bool unbounded)
     {
         using var stream = new RenderDataStream();
-        stream.PushEffect(new ImmutableBlurEffect(5), new Rect(0, 0, 100, 100));
+        stream.PushEffect(new ImmutableBlurEffect(5), unbounded ? null : new Rect(0, 0, 100, 100));
         stream.DrawRectangle(null, null, null, new RoundedRect(new Rect(0, 0, 100, 100)), default);
         stream.Pop();
 
         var padding = ((IEffect)new ImmutableBlurEffect(5)).GetEffectOutputPadding();
         Assert.Equal(new Rect(0, 0, 100, 100).Inflate(padding), stream.CalculateBounds());
+    }
+
+    [Fact]
+    public void Unbounded_Effect_Replays_Without_A_Clip_Rectangle()
+    {
+        var effect = new ImmutableBlurEffect(5);
+        var context = new Mock<IDrawingContextImplWithEffects>();
+        using var stream = new RenderDataStream();
+        stream.PushEffect(effect, null);
+        stream.DrawRectangle(Brushes.Red, null, null, new RoundedRect(new Rect(0, 0, 100, 100)), default);
+        stream.Pop();
+
+        stream.Replay(context.Object);
+
+        context.Verify(x => x.PushEffect(null, effect), Times.Once);
+        context.Verify(x => x.PopEffect(), Times.Once);
+        Assert.True(stream.HitTest(new Point(50, 50)));
     }
 
     [Fact]

--- a/tests/Avalonia.RenderTests/Media/RenderTargetBitmapTests.cs
+++ b/tests/Avalonia.RenderTests/Media/RenderTargetBitmapTests.cs
@@ -5,7 +5,9 @@ using Avalonia.Controls.Shapes;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.UnitTests;
+using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
+using Path = System.IO.Path;
 
 namespace Avalonia.Skia.RenderTests;
 
@@ -13,6 +15,72 @@ public class RenderTargetBitmapTests : TestBase
 {
     public RenderTargetBitmapTests() : base(@"Media\RenderTargetBitmap")
     {
+    }
+
+    [Theory]
+    [InlineData(false, 3, 96, false, false)]
+    [InlineData(false, -3, 96, false, false)]
+    [InlineData(false, 3, 144, false, false)]
+    [InlineData(true, 3, 96, false, false)]
+    [InlineData(true, -3, 96, false, false)]
+    [InlineData(false, 3, 96, true, false)]
+    [InlineData(false, 3, 96, false, true)]
+    [InlineData(true, 3, 96, false, true)]
+    public async Task DropShadow_Should_Not_Clip_Content_Outside_Layout_Bounds(
+        bool effectOnParent, double offset, double dpi, bool clipToBounds, bool useVisualBrush)
+    {
+        var effect = new DropShadowEffect
+        {
+            Color = Colors.Black,
+            BlurRadius = 3,
+            OffsetX = offset,
+            OffsetY = offset
+        };
+        var line = new Line
+        {
+            StartPoint = new Point(50, 50),
+            EndPoint = new Point(250, 250),
+            Stroke = Brushes.Red,
+            StrokeThickness = 30,
+            StrokeLineCap = PenLineCap.Round,
+            Effect = effectOnParent ? null : effect
+        };
+        Control target = new Canvas
+        {
+            Width = 300 * dpi / 96,
+            Height = 300 * dpi / 96,
+            Background = Brushes.White,
+            Children =
+            {
+                new Canvas
+                {
+                    Width = clipToBounds ? 250 : double.NaN,
+                    Height = clipToBounds ? 250 : double.NaN,
+                    ClipToBounds = clipToBounds,
+                    Effect = effectOnParent ? effect : null,
+                    Children = { line }
+                }
+            }
+        };
+        if (useVisualBrush)
+        {
+            target = new Border
+            {
+                Width = target.Width,
+                Height = target.Height,
+                Background = new VisualBrush(target)
+            };
+        }
+        var testName = $"{nameof(DropShadow_Should_Not_Clip_Content_Outside_Layout_Bounds)}_{effectOnParent}_{offset}_{dpi}_{clipToBounds}_{useVisualBrush}";
+
+        await RenderToFile(target, testName, dpi);
+
+        using var immediate = SixLabors.ImageSharp.Image.Load<Rgba32>(
+            Path.Combine(OutputPath, testName + ".immediate.out.png"));
+        using var composited = SixLabors.ImageSharp.Image.Load<Rgba32>(
+            Path.Combine(OutputPath, testName + ".composited.out.png"));
+        var error = TestRenderHelper.CompareImages(immediate, composited);
+        Assert.True(error < 0.001, $"Bitmap and compositor differ: {error}");
     }
 
     [Fact]


### PR DESCRIPTION
## What does the pull request do?

Fixes shape and shadow clipping when rendering visuals with `DropShadowEffect` using `RenderTargetBitmap.Render`.

## What is the current behavior?

Effect layers use the visual’s layout bounds, which may not contain its entire drawing. Thick strokes extending outside these bounds are cropped before the shadow is applied. For example, a line with rounded caps renders with a flattened endpoint and a clipped shadow.

## What is the updated/expected behavior with this PR?

The full stroke and shadow render correctly, while explicit clipping remains respected.

To verify, render a canvas containing a thick line with rounded caps and a `DropShadowEffect` into a `RenderTargetBitmap`. Its output should match the on-screen rendering.

Regression tests cover positive and negative shadow offsets, higher DPI, parent effects, explicit clipping, and visual brushes.

## How was the solution implemented (if it's not obvious)?

The immediate renderer now lets the backend determine effect layer bounds instead of supplying the visual’s layout bounds. Optional bounds are carried through the recorded rendering pipeline to support visual brushes as well.

Existing public APIs and explicitly bounded drawing effects retain their behavior.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to [avalonia-docs](https://github.com/AvaloniaUI/avalonia-docs) with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #21497