### PR TITLE
Automatically dispatch CollectionChanged notification to the UI thread

### DIFF
--- a/src/Avalonia.Base/Collections/NotifyCollectionChangedExtensions.cs
+++ b/src/Avalonia.Base/Collections/NotifyCollectionChangedExtensions.cs
@@ -76,13 +76,13 @@ namespace Avalonia.Collections
             protected override void Initialize()
             {
                 if (_sourceReference.TryGetTarget(out var instance))
-                    WeakEvents.CollectionChanged.Subscribe(instance, this);
+                    WeakEvents.ThreadSafeCollectionChanged.Subscribe(instance, this);
             }
 
             protected override void Deinitialize()
             {
                 if (_sourceReference.TryGetTarget(out var instance))
-                    WeakEvents.CollectionChanged.Unsubscribe(instance, this);
+                    WeakEvents.ThreadSafeCollectionChanged.Unsubscribe(instance, this);
             }
         }
     }

--- a/src/Avalonia.Base/Data/Core/ExpressionNodes/CollectionNodeBase.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNodes/CollectionNodeBase.cs
@@ -34,7 +34,7 @@ internal abstract class CollectionNodeBase : ExpressionNode,
     protected override void Unsubscribe(object source)
     {
         if (source is INotifyCollectionChanged incc)
-            WeakEvents.CollectionChanged.Unsubscribe(incc, this);
+            WeakEvents.ThreadSafeCollectionChanged.Unsubscribe(incc, this);
         if (source is INotifyPropertyChanged inpc)
             WeakEvents.ThreadSafePropertyChanged.Unsubscribe(inpc, this);
     }
@@ -71,7 +71,7 @@ internal abstract class CollectionNodeBase : ExpressionNode,
     private void Subscribe(object? source)
     {
         if (source is INotifyCollectionChanged incc)
-            WeakEvents.CollectionChanged.Subscribe(incc, this);
+            WeakEvents.ThreadSafeCollectionChanged.Subscribe(incc, this);
         if (source is INotifyPropertyChanged inpc)
             WeakEvents.ThreadSafePropertyChanged.Subscribe(inpc, this);
     }

--- a/src/Avalonia.Base/Data/Core/Parsers/BindingExpressionVisitor.cs
+++ b/src/Avalonia.Base/Data/Core/Parsers/BindingExpressionVisitor.cs
@@ -456,14 +456,14 @@ internal class BindingExpressionVisitor<TIn>(LambdaExpression expression) : Expr
         {
             base.SubscribeCore();
             if (_reference.TryGetTarget(out var o) && o is INotifyCollectionChanged incc)
-                WeakEvents.CollectionChanged.Subscribe(incc, this);
+                WeakEvents.ThreadSafeCollectionChanged.Subscribe(incc, this);
         }
 
         protected override void UnsubscribeCore()
         {
             base.UnsubscribeCore();
             if (_reference.TryGetTarget(out var o) && o is INotifyCollectionChanged incc)
-                WeakEvents.CollectionChanged.Unsubscribe(incc, this);
+                WeakEvents.ThreadSafeCollectionChanged.Unsubscribe(incc, this);
         }
 
         public void OnEvent(object? sender, WeakEvent ev, NotifyCollectionChangedEventArgs args)

--- a/src/Avalonia.Base/Utilities/WeakEvents.cs
+++ b/src/Avalonia.Base/Utilities/WeakEvents.cs
@@ -9,15 +9,30 @@ namespace Avalonia.Utilities;
 public class WeakEvents
 {
     /// <summary>
-    /// Represents CollectionChanged event from <see cref="INotifyCollectionChanged"/>
+    /// Represents CollectionChanged event from <see cref="INotifyCollectionChanged"/> with auto-dispatching to the UI thread
     /// </summary>
     public static readonly WeakEvent<INotifyCollectionChanged, NotifyCollectionChangedEventArgs>
-        CollectionChanged = WeakEvent.Register<INotifyCollectionChanged, NotifyCollectionChangedEventArgs>(
+        ThreadSafeCollectionChanged = WeakEvent.Register<INotifyCollectionChanged, NotifyCollectionChangedEventArgs>(
             (c, s) =>
             {
-                NotifyCollectionChangedEventHandler handler = (_, e) => s(c, e);
+                bool unsubscribed = false;
+                NotifyCollectionChangedEventHandler handler = (_, e) =>
+                {
+                    if (Dispatcher.UIThread.CheckAccess())
+                        s(c, e);
+                    else
+                        Dispatcher.UIThread.Post(() =>
+                        {
+                            if (!unsubscribed)
+                                s(c, e);
+                        });
+                };
                 c.CollectionChanged += handler;
-                return () => c.CollectionChanged -= handler;
+                return () =>
+                {
+                    unsubscribed = true;
+                    c.CollectionChanged -= handler;
+                };
             });
     
     /// <summary>

--- a/src/Avalonia.Base/Utilities/WeakHashList.cs
+++ b/src/Avalonia.Base/Utilities/WeakHashList.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Avalonia.Collections.Pooled;
 
@@ -190,7 +191,7 @@ internal class WeakHashList<T> where T : class
         }
     }
 
-    private static readonly Stack<PooledList<T>> s_listPool = new();
+    private static readonly ConcurrentStack<PooledList<T>> s_listPool = new();
 
     public static void ReturnToSharedPool(PooledList<T> list)
     {
@@ -208,8 +209,8 @@ internal class WeakHashList<T> where T : class
             {
                 if (_arr[c]?.TryGetTarget(out var target) == true)
                     (pooled ??= factory?.Invoke()
-                                ?? (s_listPool.Count > 0
-                                    ? s_listPool.Pop()
+                                ?? (s_listPool.TryPop(out var fromPool)
+                                    ? fromPool
                                     : new PooledList<T>())).Add(target!);
                 else
                 {
@@ -227,8 +228,8 @@ internal class WeakHashList<T> where T : class
             {
                 if (kvp.Key.Weak?.TryGetTarget(out var target) == true)
                     (pooled ??= factory?.Invoke()
-                                ?? (s_listPool.Count > 0
-                                    ? s_listPool.Pop()
+                                ?? (s_listPool.TryPop(out var listFromPool)
+                                    ? listFromPool
                                     : new PooledList<T>()))
                         .Add(target!);
                 else

--- a/src/Avalonia.Controls/Utils/CollectionChangedEventManager.cs
+++ b/src/Avalonia.Controls/Utils/CollectionChangedEventManager.cs
@@ -89,14 +89,14 @@ namespace Avalonia.Controls.Utils
             {
                 _collection = collection;
                 Listeners = new List<WeakReference<ICollectionChangedListener>>();
-                WeakEvents.CollectionChanged.Subscribe(_collection, this);
+                WeakEvents.ThreadSafeCollectionChanged.Subscribe(_collection, this);
             }
 
             public List<WeakReference<ICollectionChangedListener>> Listeners { get; }
 
             public void Dispose()
             {
-                WeakEvents.CollectionChanged.Unsubscribe(_collection, this);
+                WeakEvents.ThreadSafeCollectionChanged.Unsubscribe(_collection, this);
             }
 
             void IWeakEventSubscriber<NotifyCollectionChangedEventArgs>.

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/PropertyInfoAccessorFactory.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/PropertyInfoAccessorFactory.cs
@@ -175,14 +175,14 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
         {
             base.SubscribeCore();
             if (_reference.TryGetTarget(out var o) && o is INotifyCollectionChanged incc)
-                WeakEvents.CollectionChanged.Subscribe(incc, this);
+                WeakEvents.ThreadSafeCollectionChanged.Subscribe(incc, this);
         }
 
         protected override void UnsubscribeCore()
         {
             base.UnsubscribeCore();
             if (_reference.TryGetTarget(out var o) && o is INotifyCollectionChanged incc)
-                WeakEvents.CollectionChanged.Unsubscribe(incc, this);
+                WeakEvents.ThreadSafeCollectionChanged.Unsubscribe(incc, this);
         }
         
         public void OnEvent(object? sender, WeakEvent ev, NotifyCollectionChangedEventArgs args)


### PR DESCRIPTION
## What does the pull request do?

This PR makes two changes to address crashes found in local testing:

1. Make `WeakEvents.CollectionChanged` thread-safe by posting to the UI thread
    - Previously noted in https://github.com/AvaloniaUI/Avalonia/issues/8810#issuecomment-3032532931
    - Follows the same pattern as the fix done for `PropertyChanged` in #10362
    - Related: #20729
2. Use a `ConcurrentStack` rather than `Stack` for `WeakHashList`'s static `PooledList` pool
    - Without this change, if multiple threads were raising `CollectionChanged` events for different collections, they could both pop the same `PooledList` from the pool, causing the same `PooledList` to be used by two threads at once

## What is the current behavior?

Given the following test program:

```AXAML
<Window xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        x:Class="ThreadTest.MainWindow"
        xmlns:local="using:ThreadCheck"
        x:DataType="local:MainWindow">
  <UniformGrid Columns="3" Rows="2">
    <ListBox ItemsSource="{Binding LogLines1}" />
    <ListBox ItemsSource="{Binding LogLines2}" />
    <ListBox ItemsSource="{Binding LogLines3}" />
    <ListBox ItemsSource="{Binding LogLines4}" />
    <ListBox ItemsSource="{Binding LogLines5}" />
    <ListBox ItemsSource="{Binding LogLines6}" />
  </UniformGrid>
</Window>
```

```C#
using Avalonia.Controls;
using System;
using System.Collections.ObjectModel;
using System.Threading;
using System.Threading.Tasks;

namespace ThreadTest;
public partial class MainWindow : Window
{
    public ObservableCollection<string> LogLines1 { get; } = [];
    public ObservableCollection<string> LogLines2 { get; } = [];
    public ObservableCollection<string> LogLines3 { get; } = [];
    public ObservableCollection<string> LogLines4 { get; } = [];
    public ObservableCollection<string> LogLines5 { get; } = [];
    public ObservableCollection<string> LogLines6 { get; } = [];

    public MainWindow()
    {
        InitializeComponent();
        DataContext = this;

        Random rand = new();
        ObservableCollection<string>[] collections = [LogLines1, LogLines2, LogLines3, LogLines4, LogLines5, LogLines6];
        foreach (var collection in collections)
        {
            Task.Run(() => {
                while (true) {
                    collection.Add(rand.GetHexString(32));
                    Thread.Sleep(rand.Next(10));
                }
            });
        }
    }
}
```

We get the following exceptions:

```text
 	[System.NullReferenceException thrown]
>	Avalonia.Base.dll!Avalonia.Utilities.WeakEvent<System.Collections.Specialized.INotifyCollectionChanged, System.Collections.Specialized.NotifyCollectionChangedEventArgs>.Subscription.OnEvent(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs eventArgs) Line 134	C#
 	Avalonia.Base.dll!Avalonia.Utilities.WeakEvents..cctor.AnonymousMethod__5(object _, System.Collections.Specialized.NotifyCollectionChangedEventArgs e) Line 14	C#
 	System.ObjectModel.dll!System.Collections.ObjectModel.ObservableCollection<string>.OnCollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventArgs e)	Unknown
 	System.ObjectModel.dll!System.Collections.ObjectModel.ObservableCollection<string>.OnCollectionChanged(System.Collections.Specialized.NotifyCollectionChangedAction action, object item, int index)	Unknown
 	System.ObjectModel.dll!System.Collections.ObjectModel.ObservableCollection<string>.InsertItem(int index, string item)	Unknown
 	System.Private.CoreLib.dll!System.Collections.ObjectModel.Collection<string>.Add(string item)	Unknown
 	ThreadTest.dll!ThreadTest.MainWindow..ctor.AnonymousMethod__0() Line 28	C#
```

```text
 	[System.NullReferenceException thrown]
>	Avalonia.Base.dll!Avalonia.Utilities.WeakHashList<Avalonia.Utilities.IWeakEventSubscriber<System.Collections.Specialized.NotifyCollectionChangedEventArgs>>.GetAlive(System.Func<Avalonia.Collections.Pooled.PooledList<Avalonia.Utilities.IWeakEventSubscriber<System.Collections.Specialized.NotifyCollectionChangedEventArgs>>> factory) Line 277	C#
 	Avalonia.Base.dll!Avalonia.Utilities.WeakEvent<System.Collections.Specialized.INotifyCollectionChanged, System.Collections.Specialized.NotifyCollectionChangedEventArgs>.Subscription.OnEvent(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs eventArgs) Line 124	C#
 	Avalonia.Base.dll!Avalonia.Utilities.WeakEvents..cctor.AnonymousMethod__5(object _, System.Collections.Specialized.NotifyCollectionChangedEventArgs e) Line 14	C#
 	System.ObjectModel.dll!System.Collections.ObjectModel.ObservableCollection<string>.OnCollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventArgs e)	Unknown
 	System.ObjectModel.dll!System.Collections.ObjectModel.ObservableCollection<string>.OnCollectionChanged(System.Collections.Specialized.NotifyCollectionChangedAction action, object item, int index)	Unknown
 	System.ObjectModel.dll!System.Collections.ObjectModel.ObservableCollection<string>.InsertItem(int index, string item)	Unknown
 	System.Private.CoreLib.dll!System.Collections.ObjectModel.Collection<string>.Add(string item)	Unknown
 	ThreadTest.dll!ThreadTest.MainWindow..ctor.AnonymousMethod__0() Line 28	C#
```

## What is the updated/expected behavior with this PR?

With the changes from this PR, I am no longer able to reproduce the exceptions above.

## Automated Testing

Because these exceptions require a thread race to reproduce, I'm not sure how to reliably test them in CI.  
I have omitted tests for now -- please let me know if they're required.