### PR TITLE
Fix for ListBox ghost items

### DIFF
--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -700,8 +700,21 @@ namespace Avalonia.Controls
                 // hence the width extent should be correct now, and we can try to scroll again.
                 scrollToElement.BringIntoView();
 
-                _scrollToElement = null;
-                _scrollToIndex = -1;
+                // The layout pass normally adopts the temporary element into the realized range.
+                // When it doesn't (for example, while its containing pane has no usable width),
+                // it is still an internal child. Recycle it before dropping the reference so it
+                // cannot remain as a visible, unindexed "ghost" element.
+                if (_scrollToElement is { } unadoptedScrollToElement)
+                {
+                    var unadoptedScrollToIndex = _scrollToIndex;
+                    _scrollToElement = null;
+                    _scrollToIndex = -1;
+                    RecycleElement(unadoptedScrollToElement, unadoptedScrollToIndex);
+                }
+                else
+                {
+                    _scrollToIndex = -1;
+                }
                 return scrollToElement;
             }
 

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -710,11 +710,10 @@ namespace Avalonia.Controls
                     _scrollToElement = null;
                     _scrollToIndex = -1;
                     RecycleElement(unadoptedScrollToElement, unadoptedScrollToIndex);
+                    return null;
                 }
-                else
-                {
-                    _scrollToIndex = -1;
-                }
+
+                _scrollToIndex = -1;
                 return scrollToElement;
             }
 

--- a/tests/Avalonia.Controls.UnitTests/ListBoxVirtualizationIssueTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxVirtualizationIssueTests.cs
@@ -12,6 +12,60 @@ namespace Avalonia.Controls.UnitTests;
 public class ListBoxVirtualizationIssueTests : ScopedTestBase
 {
     [Fact]
+    public void Expanding_ListBox_After_Scrolling_In_Zero_Width_Pane_Does_Not_Show_Unrealized_Containers()
+    {
+        using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+        var items = new[]
+        {
+            new SizedItem(196, 331),
+            new SizedItem(186, 258),
+            new SizedItem(196, 321),
+            new SizedItem(186, 296),
+            new SizedItem(150, 340),
+            new SizedItem(196, 319),
+        };
+        var target = new ListBox
+        {
+            Width = 0,
+            Height = 774,
+            Template = new FuncControlTemplate(CreateListBoxTemplate),
+            ItemsSource = items,
+            ItemTemplate = new FuncDataTemplate<SizedItem>((item, _) => new Border
+            {
+                Width = item?.Width ?? 0,
+                Height = item?.Height ?? 0,
+            }),
+            ItemsPanel = new FuncTemplate<Panel?>(() => new VirtualizingStackPanel()),
+            SelectionMode = SelectionMode.Single | SelectionMode.AlwaysSelected,
+        };
+
+        var root = new TestRoot(target) { ClientSize = new Size(300, 774) };
+        root.LayoutManager.ExecuteInitialLayoutPass();
+
+        // Scroll the selected item into view while the SplitView pane is effectively hidden.
+        for (var index = 1; index <= 3; ++index)
+        {
+            target.SelectedIndex = index;
+            root.LayoutManager.ExecuteLayoutPass();
+        }
+
+        // Opening the pane increases the ListBox viewport to 300.
+        target.Width = 300;
+        root.LayoutManager.ExecuteLayoutPass();
+
+        var panel = Assert.IsType<VirtualizingStackPanel>(target.Presenter!.Panel);
+        var realized = target.GetRealizedContainers().ToHashSet();
+        var visibleChildren = panel.Children.Where(x => x.IsVisible).ToList();
+
+        Assert.All(visibleChildren, child =>
+        {
+            Assert.NotEqual(-1, target.IndexFromContainer(child));
+            Assert.Contains(child, realized);
+        });
+    }
+
+    [Fact]
     public void Removing_First_Item_After_Scrolling_To_End_Should_Allow_Scrolling_To_Start()
     {
         using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
@@ -357,5 +411,17 @@ public class ListBoxVirtualizationIssueTests : ScopedTestBase
             Id = id;
         }
         public int Id { get; }
+    }
+
+    private class SizedItem
+    {
+        public SizedItem(double width, double height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        public double Width { get; }
+        public double Height { get; }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes an issue where a ListBox with 0 width can produce ghost items. See #15194 for a repro.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
A ListBox of size 0 can produce ghost items.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
No more ghost items. 

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Ensure that those items are recycled.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes #15194 
