### PR TITLE
Add TableViewColumn.IsVisible property

### DIFF
--- a/samples/ControlCatalog/Pages/TableViewPage.axaml
+++ b/samples/ControlCatalog/Pages/TableViewPage.axaml
@@ -38,6 +38,11 @@
                 IsChecked="True"
                 Margin="8" />
 
+      <CheckBox Name="ShowRegionColumn"
+                Content="Show region column"
+                IsChecked="True"
+                Margin="8" />
+
     </StackPanel>
 
     <TableView ItemsSource="{Binding Countries}"
@@ -48,6 +53,7 @@
                          Width="{Binding #UseStarSizes.IsChecked, Converter={StaticResource TableViewColumnWidthConverter}, ConverterParameter=3}" />
         <TableViewColumn Header="Region"
                          Binding="{Binding Region}"
+                         IsVisible="{Binding #ShowRegionColumn.IsChecked}"
                          Width="{Binding #UseStarSizes.IsChecked, Converter={StaticResource TableViewColumnWidthConverter}, ConverterParameter=2}" />
         <TableViewColumn Header="Population"
                          Binding="{Binding Population, StringFormat=N0}"

--- a/src/Avalonia.Controls/Presenters/TableViewLayoutHelper.cs
+++ b/src/Avalonia.Controls/Presenters/TableViewLayoutHelper.cs
@@ -27,7 +27,14 @@ internal static class TableViewLayoutHelper
         for (var i = 0; i < columns.Count; i++)
         {
             if (!columns[i].IsVisible)
+            {
+                if (columns[i].ActualWidth != 0)
+                {
+                    columns[i].ActualWidth = 0;
+                    modified = true;
+                }
                 continue;
+            }
 
             var width = columns[i].Width;
             if (width.IsAbsolute)
@@ -103,23 +110,12 @@ internal static class TableViewLayoutHelper
     }
 
     public static bool NeedsActualWidths(AvaloniaList<TableViewColumn> columns)
-    {
-        foreach (var column in columns)
-        {
-            if (column.IsVisible)
-                return double.IsNaN(column.ActualWidth);
-        }
-
-        return false;
-    }
+        => columns.Count > 0 && double.IsNaN(columns[0].ActualWidth);
 
     public static void ResetActualWidths(AvaloniaList<TableViewColumn> columns)
     {
         foreach (var column in columns)
-        {
-            if (column.IsVisible)
-                column.ActualWidth = double.NaN;
-        }
+            column.ActualWidth = double.NaN;
     }
 
     public static Size MeasureRow(AvaloniaList<TableViewColumn> columns, Controls cells, Size availableSize)

--- a/src/Avalonia.Controls/Presenters/TableViewLayoutHelper.cs
+++ b/src/Avalonia.Controls/Presenters/TableViewLayoutHelper.cs
@@ -109,6 +109,11 @@ internal static class TableViewLayoutHelper
         return modified;
     }
 
+    /// <remarks>
+    /// Contract between <see cref="UpdateActualWidths"/>, <see cref="NeedsActualWidths"/> and <see cref="ResetActualWidths"/>: <br/>
+    /// If <see cref="TableViewColumn.ActualWidth"/> is NaN, a recalculation of the ActualWidths is needed.
+    /// All column widths are reset and recalculated together, so checking the first one is sufficient.
+    /// </remarks>
     public static bool NeedsActualWidths(AvaloniaList<TableViewColumn> columns)
         => columns.Count > 0 && double.IsNaN(columns[0].ActualWidth);
 

--- a/src/Avalonia.Controls/Presenters/TableViewLayoutHelper.cs
+++ b/src/Avalonia.Controls/Presenters/TableViewLayoutHelper.cs
@@ -26,6 +26,9 @@ internal static class TableViewLayoutHelper
 
         for (var i = 0; i < columns.Count; i++)
         {
+            if (!columns[i].IsVisible)
+                continue;
+
             var width = columns[i].Width;
             if (width.IsAbsolute)
             {
@@ -68,6 +71,9 @@ internal static class TableViewLayoutHelper
 
         for (var i = 0; i < columns.Count; i++)
         {
+            if (!columns[i].IsVisible)
+                continue;
+
             var width = columns[i].Width;
             if (!width.IsAbsolute)
             {
@@ -97,12 +103,23 @@ internal static class TableViewLayoutHelper
     }
 
     public static bool NeedsActualWidths(AvaloniaList<TableViewColumn> columns)
-        => columns.Count > 0 && double.IsNaN(columns[0].ActualWidth);
+    {
+        foreach (var column in columns)
+        {
+            if (column.IsVisible)
+                return double.IsNaN(column.ActualWidth);
+        }
+
+        return false;
+    }
 
     public static void ResetActualWidths(AvaloniaList<TableViewColumn> columns)
     {
         foreach (var column in columns)
-            column.ActualWidth = double.NaN;
+        {
+            if (column.IsVisible)
+                column.ActualWidth = double.NaN;
+        }
     }
 
     public static Size MeasureRow(AvaloniaList<TableViewColumn> columns, Controls cells, Size availableSize)
@@ -115,6 +132,9 @@ internal static class TableViewLayoutHelper
 
         for (var i = 0; i < cells.Count; i++)
         {
+            if (!columns[i].IsVisible)
+                continue;
+
             var child = cells[i];
             var columnWidth = columns[i].ActualWidth;
             child.Measure(new Size(columnWidth, availableSize.Height));
@@ -133,6 +153,9 @@ internal static class TableViewLayoutHelper
         var x = offset;
         for (var i = 0; i < cells.Count; i++)
         {
+            if (!columns[i].IsVisible)
+                continue;
+
             var width = columns[i].ActualWidth;
             cells[i].Arrange(new Rect(x, 0, width, finalSize.Height));
             x += width;

--- a/src/Avalonia.Controls/TableView.cs
+++ b/src/Avalonia.Controls/TableView.cs
@@ -139,8 +139,10 @@ public class TableView : ListBox
                 $"The column {column.DebugDisplay} is already attached to a {nameof(TableView)}.");
         }
 
-        column.TableView = this;
+        // Resolve styles and bindings before enabling refresh notifications. The headers
+        // and cells are rebuilt after attachment to apply the column's current values.
         ((ISetLogicalParent)column).SetParent(this);
+        column.TableView = this;
     }
 
     private void DetachColumn(TableViewColumn column)

--- a/src/Avalonia.Controls/TableViewCell.cs
+++ b/src/Avalonia.Controls/TableViewCell.cs
@@ -35,6 +35,7 @@ public class TableViewCell : ContentControl
 
     private void ClearProperties()
     {
+        ClearValue(IsVisibleProperty);
         ClearValue(ThemeProperty);
         ClearValue(HorizontalContentAlignmentProperty);
         ClearValue(ContentTemplateProperty);
@@ -48,6 +49,7 @@ public class TableViewCell : ContentControl
         // Second, we have additional logic depending on whether a cell template is specified.
         // Instead, values are updated manually via Refresh().
 
+        SetValue(IsVisibleProperty, column.IsVisible);
         SetValue(ThemeProperty, column.CellTheme);
         SetValue(HorizontalContentAlignmentProperty, column.HorizontalContentAlignment);
 

--- a/src/Avalonia.Controls/TableViewColumn.cs
+++ b/src/Avalonia.Controls/TableViewColumn.cs
@@ -210,7 +210,6 @@ public class TableViewColumn : StyledElement, IHeadered
     /// <summary>
     /// Gets the actual width of the column, in device independent pixels.
     /// If the column hasn't yet been measured, returns <see cref="double.NaN"/>.
-    /// Hidden columns retain their current value.
     /// </summary>
     public double ActualWidth
     {

--- a/src/Avalonia.Controls/TableViewColumn.cs
+++ b/src/Avalonia.Controls/TableViewColumn.cs
@@ -15,6 +15,12 @@ namespace Avalonia.Controls;
 public class TableViewColumn : StyledElement, IHeadered
 {
     /// <summary>
+    /// Defines the <see cref="IsVisible"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsVisibleProperty =
+        Visual.IsVisibleProperty.AddOwner<TableViewColumn>();
+
+    /// <summary>
     /// Defines the <see cref="HeaderTheme"/> property.
     /// </summary>
     public static readonly StyledProperty<ControlTheme?> HeaderThemeProperty =
@@ -86,6 +92,16 @@ public class TableViewColumn : StyledElement, IHeadered
     /// </summary>
     public static readonly DirectProperty<TableViewColumn, bool> CanUserEffectivelyResizeProperty =
         AvaloniaProperty.RegisterDirect<TableViewColumn, bool>(nameof(CanUserEffectivelyResize), o => o.CanUserEffectivelyResize);
+
+    /// <summary>
+    /// Gets or sets whether the column is visible. The default is true.
+    /// </summary>
+    /// <remarks>Hidden columns do not occupy layout space and retain their configured <see cref="Width"/>.</remarks>
+    public bool IsVisible
+    {
+        get => GetValue(IsVisibleProperty);
+        set => SetValue(IsVisibleProperty, value);
+    }
 
     /// <summary>
     /// Gets or sets the theme to apply to the header.
@@ -195,6 +211,7 @@ public class TableViewColumn : StyledElement, IHeadered
     /// <summary>
     /// Gets the actual width of the column, in device independent pixels.
     /// If the column hasn't yet been measured, returns <see cref="double.NaN"/>.
+    /// Hidden columns retain their current value.
     /// </summary>
     public double ActualWidth
     {
@@ -217,22 +234,25 @@ public class TableViewColumn : StyledElement, IHeadered
         => property == CellThemeProperty ||
            property == CellTemplateProperty ||
            property == BindingProperty ||
-           property == HorizontalContentAlignmentProperty;
+           property == HorizontalContentAlignmentProperty ||
+           property == IsVisibleProperty;
 
     private static bool IsHeaderProperty(AvaloniaProperty property)
         => property == HeaderThemeProperty ||
            property == HeaderTemplateProperty ||
            property == HeaderProperty ||
-           property == HorizontalContentAlignmentProperty;
+           property == HorizontalContentAlignmentProperty ||
+           property == IsVisibleProperty;
 
     /// <inheritdoc />
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
 
-        if (change.Property == WidthProperty)
+        if (change.Property == WidthProperty || change.Property == IsVisibleProperty)
             TableView?.OnColumnsSizeChanged();
-        else if (change.Property == CanUserResizeProperty)
+
+        if (change.Property == CanUserResizeProperty)
             UpdateCanUserEffectivelyResize();
         else
         {

--- a/src/Avalonia.Controls/TableViewColumn.cs
+++ b/src/Avalonia.Controls/TableViewColumn.cs
@@ -96,7 +96,6 @@ public class TableViewColumn : StyledElement, IHeadered
     /// <summary>
     /// Gets or sets whether the column is visible. The default is true.
     /// </summary>
-    /// <remarks>Hidden columns do not occupy layout space and retain their configured <see cref="Width"/>.</remarks>
     public bool IsVisible
     {
         get => GetValue(IsVisibleProperty);

--- a/src/Avalonia.Controls/TableViewColumnHeader.cs
+++ b/src/Avalonia.Controls/TableViewColumnHeader.cs
@@ -78,6 +78,7 @@ public class TableViewColumnHeader : ContentControl
 
     private void ClearProperties()
     {
+        ClearValue(IsVisibleProperty);
         ClearValue(ThemeProperty);
         ClearValue(HorizontalContentAlignmentProperty);
         ClearValue(ContentTemplateProperty);
@@ -86,6 +87,7 @@ public class TableViewColumnHeader : ContentControl
 
     private void SetProperties(TableViewColumn column)
     {
+        SetValue(IsVisibleProperty, column.IsVisible);
         SetOrClearValue(ThemeProperty, column.HeaderTheme);
         SetValue(HorizontalContentAlignmentProperty, column.HorizontalContentAlignment);
         SetOrClearValue(ContentTemplateProperty, column.HeaderTemplate);

--- a/tests/Avalonia.Controls.UnitTests/Presenters/TableViewLayoutHelperTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/TableViewLayoutHelperTests.cs
@@ -104,7 +104,7 @@ public sealed class TableViewLayoutHelperTests : ScopedTestBase
     [InlineData(GridUnitType.Pixel)]
     [InlineData(GridUnitType.Star)]
     [InlineData(GridUnitType.Auto)]
-    public void UpdateActualWidths_Excludes_Hidden_Columns_And_Preserves_Their_Widths(GridUnitType unit)
+    public void UpdateActualWidths_Zeros_Hidden_Columns_And_Preserves_Configured_Widths(GridUnitType unit)
     {
         var hidden = new TableViewColumn { Width = new GridLength(2, unit) };
         var columns = new AvaloniaList<TableViewColumn>
@@ -119,7 +119,7 @@ public sealed class TableViewLayoutHelperTests : ScopedTestBase
         TableViewLayoutHelper.UpdateActualWidths(columns, 200, false, 1);
 
         Assert.Equal(new GridLength(2, unit), hidden.Width);
-        Assert.Equal(actualWidth, hidden.ActualWidth);
+        Assert.Equal(0, hidden.ActualWidth);
         Assert.Equal(200, columns[1].ActualWidth);
 
         hidden.IsVisible = true;
@@ -252,11 +252,10 @@ public sealed class TableViewLayoutHelperTests : ScopedTestBase
 
         TableViewLayoutHelper.UpdateActualWidths(columns, 100, useLayoutRounding: true, layoutScale: 2);
 
-        // Hidden columns are skipped, so their uncalculated widths remain NaN.
         Assert.Equal(43, columns[0].ActualWidth);
-        Assert.Equal(double.NaN, columns[1].ActualWidth);
+        Assert.Equal(0, columns[1].ActualWidth);
         Assert.Equal(14, columns[2].ActualWidth);
-        Assert.Equal(double.NaN, columns[3].ActualWidth);
+        Assert.Equal(0, columns[3].ActualWidth);
         Assert.Equal(43, columns[4].ActualWidth);
         Assert.Equal(100, columns[0].ActualWidth + columns[2].ActualWidth + columns[4].ActualWidth);
     }
@@ -278,6 +277,22 @@ public sealed class TableViewLayoutHelperTests : ScopedTestBase
         Assert.Equal(50, columns[0].ActualWidth);
         Assert.Equal(50, columns[1].ActualWidth);
         Assert.Equal(100, columns[2].ActualWidth);
+    }
+
+    [Fact]
+    public void UpdateActualWidths_Sets_All_Hidden_Widths_To_Zero()
+    {
+        var columns = new AvaloniaList<TableViewColumn>
+        {
+            new() { IsVisible = false },
+            new() { IsVisible = false },
+        };
+
+        Assert.True(TableViewLayoutHelper.UpdateActualWidths(columns, 200, false, 1));
+
+        Assert.All(columns, column => Assert.Equal(0, column.ActualWidth));
+        Assert.False(TableViewLayoutHelper.NeedsActualWidths(columns));
+        Assert.False(TableViewLayoutHelper.UpdateActualWidths(columns, 200, false, 1));
     }
 
     [Fact]
@@ -311,7 +326,7 @@ public sealed class TableViewLayoutHelperTests : ScopedTestBase
     }
 
     [Fact]
-    public void NeedsActualWidths_Ignores_Hidden_Columns_After_Reset()
+    public void NeedsActualWidths_Detects_Reset_When_First_Column_Is_Hidden()
     {
         var columns = new AvaloniaList<TableViewColumn> { new(), new() };
         TableViewLayoutHelper.UpdateActualWidths(columns, 200, false, 1);
@@ -319,15 +334,13 @@ public sealed class TableViewLayoutHelperTests : ScopedTestBase
 
         TableViewLayoutHelper.ResetActualWidths(columns);
 
-        Assert.Equal(100, columns[0].ActualWidth);
+        Assert.True(double.IsNaN(columns[0].ActualWidth));
         Assert.True(TableViewLayoutHelper.NeedsActualWidths(columns));
 
         TableViewLayoutHelper.UpdateActualWidths(columns, 200, false, 1);
 
+        Assert.Equal(0, columns[0].ActualWidth);
         Assert.Equal(200, columns[1].ActualWidth);
-        Assert.False(TableViewLayoutHelper.NeedsActualWidths(columns));
-
-        columns[1].IsVisible = false;
         Assert.False(TableViewLayoutHelper.NeedsActualWidths(columns));
     }
 

--- a/tests/Avalonia.Controls.UnitTests/Presenters/TableViewLayoutHelperTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/TableViewLayoutHelperTests.cs
@@ -100,6 +100,34 @@ public sealed class TableViewLayoutHelperTests : ScopedTestBase
         Assert.Equal(100, columns[1].ActualWidth);
     }
 
+    [Theory]
+    [InlineData(GridUnitType.Pixel)]
+    [InlineData(GridUnitType.Star)]
+    [InlineData(GridUnitType.Auto)]
+    public void UpdateActualWidths_Excludes_Hidden_Columns_And_Preserves_Their_Widths(GridUnitType unit)
+    {
+        var hidden = new TableViewColumn { Width = new GridLength(2, unit) };
+        var columns = new AvaloniaList<TableViewColumn>
+        {
+            hidden,
+            new() { Width = new GridLength(1, GridUnitType.Star) },
+        };
+        TableViewLayoutHelper.UpdateActualWidths(columns, 200, false, 1);
+        var actualWidth = hidden.ActualWidth;
+
+        hidden.IsVisible = false;
+        TableViewLayoutHelper.UpdateActualWidths(columns, 200, false, 1);
+
+        Assert.Equal(new GridLength(2, unit), hidden.Width);
+        Assert.Equal(actualWidth, hidden.ActualWidth);
+        Assert.Equal(200, columns[1].ActualWidth);
+
+        hidden.IsVisible = true;
+        TableViewLayoutHelper.UpdateActualWidths(columns, 200, false, 1);
+
+        Assert.Equal(actualWidth, hidden.ActualWidth);
+    }
+
     [Fact]
     public void UpdateActualWidths_Falls_Back_To_1000_For_Infinite_Width()
     {
@@ -211,6 +239,29 @@ public sealed class TableViewLayoutHelperTests : ScopedTestBase
     }
 
     [Fact]
+    public void UpdateActualWidths_Ignores_Hidden_Columns()
+    {
+        var columns = new AvaloniaList<TableViewColumn>
+        {
+            new() { Width = new GridLength(3, GridUnitType.Star) },
+            new() { Width = new GridLength(100), IsVisible = false },
+            new() { Width = new GridLength(1, GridUnitType.Star) },
+            new() { Width = new GridLength(5, GridUnitType.Star), IsVisible = false },
+            new() { Width = new GridLength(3, GridUnitType.Star) },
+        };
+
+        TableViewLayoutHelper.UpdateActualWidths(columns, 100, useLayoutRounding: true, layoutScale: 2);
+
+        // Hidden columns are skipped, so their uncalculated widths remain NaN.
+        Assert.Equal(43, columns[0].ActualWidth);
+        Assert.Equal(double.NaN, columns[1].ActualWidth);
+        Assert.Equal(14, columns[2].ActualWidth);
+        Assert.Equal(double.NaN, columns[3].ActualWidth);
+        Assert.Equal(43, columns[4].ActualWidth);
+        Assert.Equal(100, columns[0].ActualWidth + columns[2].ActualWidth + columns[4].ActualWidth);
+    }
+
+    [Fact]
     public void UpdateActualWidths_Rounds_Fixed_Column_Width_And_Star_Absorbs_Remainder()
     {
         var columns = new AvaloniaList<TableViewColumn>
@@ -256,6 +307,27 @@ public sealed class TableViewLayoutHelperTests : ScopedTestBase
 
         TableViewLayoutHelper.UpdateActualWidths(columns, 200, false, 1.0);
 
+        Assert.False(TableViewLayoutHelper.NeedsActualWidths(columns));
+    }
+
+    [Fact]
+    public void NeedsActualWidths_Ignores_Hidden_Columns_After_Reset()
+    {
+        var columns = new AvaloniaList<TableViewColumn> { new(), new() };
+        TableViewLayoutHelper.UpdateActualWidths(columns, 200, false, 1);
+        columns[0].IsVisible = false;
+
+        TableViewLayoutHelper.ResetActualWidths(columns);
+
+        Assert.Equal(100, columns[0].ActualWidth);
+        Assert.True(TableViewLayoutHelper.NeedsActualWidths(columns));
+
+        TableViewLayoutHelper.UpdateActualWidths(columns, 200, false, 1);
+
+        Assert.Equal(200, columns[1].ActualWidth);
+        Assert.False(TableViewLayoutHelper.NeedsActualWidths(columns));
+
+        columns[1].IsVisible = false;
         Assert.False(TableViewLayoutHelper.NeedsActualWidths(columns));
     }
 

--- a/tests/Avalonia.Controls.UnitTests/TableViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TableViewTests.cs
@@ -158,6 +158,31 @@ public sealed class TableViewTests : ScopedTestBase
         Assert.Equal(cellsPresenter.Children, logicalChildren);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void Adding_Hidden_Column_Updates_Cells_And_Headers(int columnIndex)
+    {
+        using var app = Start();
+        var target = CreateTarget(new[] { "Foo" });
+        target.Styles.Add(new Style(x => x.OfType<TableViewColumn>().Class("hidden"))
+        {
+            Setters = { new Setter(TableViewColumn.IsVisibleProperty, false) },
+        });
+        target.Columns.Add(new TableViewColumn());
+        Prepare(target);
+        var column = new TableViewColumn { Classes = { "hidden" } };
+
+        target.Columns.Insert(columnIndex, column);
+        Layout(target);
+
+        var row = (TableViewRow)target.GetRealizedContainers().Single();
+        Assert.False(GetCellsPresenter(row).Children[columnIndex].IsVisible);
+        Assert.False(GetColumnHeadersPresenter(target).Children[columnIndex].IsVisible);
+        Assert.True(GetCellsPresenter(row).Children[1 - columnIndex].IsVisible);
+        Assert.True(GetColumnHeadersPresenter(target).Children[1 - columnIndex].IsVisible);
+    }
+
     [Fact]
     public void Removing_Column_Removes_Cell_From_Realized_Rows_And_Headers()
     {
@@ -255,6 +280,79 @@ public sealed class TableViewTests : ScopedTestBase
     }
 
     [Fact]
+    public void Hiding_Column_Closes_Gap_Without_Recreating_Controls()
+    {
+        using var app = Start();
+        var column = new TableViewColumn { Width = new GridLength(80) };
+        var target = CreateTarget(new[] { "Foo" });
+        target.Columns.Add(column);
+        target.Columns.Add(new TableViewColumn());
+        Prepare(target, width: 200);
+        var row = (TableViewRow)target.GetRealizedContainers().Single();
+        var cells = GetCellsPresenter(row);
+        var headers = GetColumnHeadersPresenter(target);
+        var originalCells = cells.Children.ToArray();
+        var originalHeaders = headers.Children.ToArray();
+
+        column.IsVisible = false;
+        Layout(target);
+
+        Assert.False(cells.Children[0].IsVisible);
+        Assert.False(headers.Children[0].IsVisible);
+        Assert.Equal(0, cells.Children[1].Bounds.X);
+        Assert.Equal(0, headers.Children[1].Bounds.X);
+        Assert.Equal(200, target.Columns[1].ActualWidth);
+        Assert.Equal(80, column.ActualWidth);
+        Assert.Equal(new GridLength(80), column.Width);
+
+        column.IsVisible = true;
+        Layout(target);
+
+        Assert.True(cells.Children[0].IsVisible);
+        Assert.True(headers.Children[0].IsVisible);
+        Assert.Equal(80, cells.Children[1].Bounds.X);
+        Assert.Equal(80, headers.Children[1].Bounds.X);
+        Assert.Equal(originalCells, cells.Children);
+        Assert.Equal(originalHeaders, headers.Children);
+    }
+
+    [Fact]
+    public void Hidden_Columns_Do_Not_Contribute_To_Row_Size()
+    {
+        using var app = Start();
+        var target = CreateTarget(new[] { "Foo" });
+        var column = new TableViewColumn { IsVisible = false };
+        target.Columns.Add(column);
+        target.Columns.Add(new TableViewColumn());
+        Prepare(target);
+        var row = (TableViewRow)target.GetRealizedContainers().Single();
+        var cells = GetCellsPresenter(row);
+        cells.Children[0].Height = 80;
+        cells.Children[1].Height = 20;
+        Layout(target);
+
+        Assert.False(cells.Children[0].IsVisible);
+        Assert.False(GetColumnHeadersPresenter(target).Children[0].IsVisible);
+        Assert.Equal(20, cells.DesiredSize.Height);
+
+        column.IsVisible = true;
+        Layout(target);
+
+        Assert.Equal(80, cells.DesiredSize.Height);
+
+        column.IsVisible = false;
+        target.Columns[1].IsVisible = false;
+        Layout(target);
+
+        Assert.Equal(default, cells.DesiredSize);
+
+        column.IsVisible = true;
+        Layout(target);
+
+        Assert.Equal(80, cells.DesiredSize.Height);
+    }
+
+    [Fact]
     public void Replacing_Columns_Collection_Updates_Realized_Rows_And_Headers()
     {
         using var app = Start();
@@ -332,6 +430,37 @@ public sealed class TableViewTests : ScopedTestBase
 
         Assert.Equal("Alice", firstCell.Content);
         Assert.Equal("Bob", secondCell.Content);
+    }
+
+    [Fact]
+    public void Hidden_Column_Preserves_Width_And_Visibility_Bindings()
+    {
+        using var app = Start();
+        var model = new Border { IsVisible = false, Tag = new GridLength(80) };
+        var target = CreateTarget(new[] { "Foo" });
+        target.DataContext = model;
+        var column = new TableViewColumn();
+        column.Bind(TableViewColumn.WidthProperty, new ReflectionBinding(nameof(Border.Tag)));
+        column.Bind(TableViewColumn.IsVisibleProperty, new ReflectionBinding(nameof(Border.IsVisible)));
+        target.Columns.Add(column);
+        target.Columns.Add(new TableViewColumn());
+        Prepare(target, width: 200);
+        Assert.False(column.IsVisible);
+        Assert.Equal(200, target.Columns[1].ActualWidth);
+
+        model.Tag = new GridLength(120);
+        model.IsVisible = true;
+        Layout(target);
+
+        Assert.True(column.IsVisible);
+        Assert.Equal(120, column.ActualWidth);
+        Assert.Equal(80, target.Columns[1].ActualWidth);
+
+        model.IsVisible = false;
+        Layout(target);
+
+        Assert.False(column.IsVisible);
+        Assert.Equal(200, target.Columns[1].ActualWidth);
     }
 
     [Fact]
@@ -495,13 +624,15 @@ public sealed class TableViewTests : ScopedTestBase
         Assert.Same(item, cell.Content);
     }
 
-    [Fact]
-    public void Re_Templating_Row_Detaches_Old_Cells_And_Rebuilds_New_Cells()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Re_Templating_Row_Detaches_Old_Cells_And_Rebuilds_New_Cells(bool isVisible)
     {
         using var app = Start();
 
         var target = CreateTarget(new[] { "Foo" });
-        target.Columns.Add(new TableViewColumn());
+        target.Columns.Add(new TableViewColumn { IsVisible = isVisible });
         target.Columns.Add(new TableViewColumn());
 
         Prepare(target);
@@ -516,6 +647,8 @@ public sealed class TableViewTests : ScopedTestBase
 
         var newCells = GetCellsPresenter(row).Children.ToArray();
         Assert.Equal(2, newCells.Length);
+        Assert.Equal(isVisible, newCells[0].IsVisible);
+        Assert.True(newCells[1].IsVisible);
 
         Assert.All(oldCells, cell => Assert.Null(cell.Parent));
         Assert.Equal(newCells, row.GetLogicalChildren());

--- a/tests/Avalonia.Controls.UnitTests/TableViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TableViewTests.cs
@@ -302,7 +302,7 @@ public sealed class TableViewTests : ScopedTestBase
         Assert.Equal(0, cells.Children[1].Bounds.X);
         Assert.Equal(0, headers.Children[1].Bounds.X);
         Assert.Equal(200, target.Columns[1].ActualWidth);
-        Assert.Equal(80, column.ActualWidth);
+        Assert.Equal(0, column.ActualWidth);
         Assert.Equal(new GridLength(80), column.Width);
 
         column.IsVisible = true;


### PR DESCRIPTION
## What does the pull request do?

Since I would really like to see the TableViewColumn have an `IsVisible` property, I thought I'd go ahead and prepare a small PR for it.

## What is the current behavior?

There is no IsVisible property on a TableViewColumn, so when columns are defined in axaml, you must set the width either in code-behind or using a custom converter.

## What is the updated/expected behavior with this PR?

TableViewColumn now has an IsVisible property, matching the existing DataGrid/TreeDataGrid solutions for dotnet and user expectations.

## How was the solution implemented (if it's not obvious)?

- The width is only calculated for columns that are visible
- The width of a hidden column is not updated
- When attaching a column, its logical parent is now set before its TableView reference. This lets styles and inherited bindings resolve before they can trigger refreshes on cells and headers that haven't been rebuilt yet.

Some considerations I had regarding performance: I was not sure if it makes sense to call `RefreshHeader`/`RefreshCell` on an ' IsVisible change. Those methods seem to pull the latest value for all the column's properties and update bindings, which isn't really necessary when only updating IsVisible. But I kept it simple and didn't introduce a separate refresh path in this PR.

Note: Some tests were implemented by AI and include edge cases found by the reviewer.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

- None I am aware of

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues

Closes #21818.
