### PR TITLE
Match font family names case-insensitively

### DIFF
--- a/src/Avalonia.Base/Media/FontManager.cs
+++ b/src/Avalonia.Base/Media/FontManager.cs
@@ -34,10 +34,37 @@ namespace Avalonia.Media
 
             var options = AvaloniaLocator.Current.GetService<FontManagerOptions>();
             _fontFallbacks = options?.FontFallbacks;
-            _fontFamilyMappings = options?.FontFamilyMappings;
+            _fontFamilyMappings = CreateFontFamilyMappings(options?.FontFamilyMappings);
 
             var defaultFontFamilyName = GetDefaultFontFamilyName(options);
             DefaultFontFamily = new FontFamily(defaultFontFamilyName);
+        }
+
+        /// <summary>
+        /// Copies the configured mappings into a case-insensitive dictionary. Family names are matched
+        /// case-insensitively everywhere else, so a mapping must apply whatever casing the requested
+        /// name arrives in - and the dictionary handed to <see cref="FontManagerOptions"/> carries
+        /// whichever comparer its author happened to give it.
+        /// </summary>
+        private static IReadOnlyDictionary<string, FontFamily>? CreateFontFamilyMappings(
+            IReadOnlyDictionary<string, FontFamily>? fontFamilyMappings)
+        {
+            if (fontFamilyMappings is null || fontFamilyMappings.Count == 0)
+            {
+                return null;
+            }
+
+            var mappings = new Dictionary<string, FontFamily>(fontFamilyMappings.Count, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var mapping in fontFamilyMappings)
+            {
+                // Names that collide only by casing were distinct entries before the copy. Take the
+                // last rather than throwing: a mapping table is configuration, and failing here would
+                // bring the application down at startup.
+                mappings[mapping.Key] = mapping.Value;
+            }
+
+            return mappings;
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
+++ b/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
@@ -853,13 +853,10 @@ namespace Avalonia.Media.Fonts
                             glyphTypeface = syntheticGlyphTypeface;
                         }
 
-                        // Cache the resolved typeface under the REQUESTED family name, whether it is
-                        // the nearest match or a synthetic one. TryCreateSyntheticGlyphTypeface only
-                        // registers the synthetic under the *source font's own* family names, so a
-                        // request coming through a different name (an alias, or a "Family Style"
-                        // composite normalized by Typeface.Normalize) never hits the cache and
-                        // re-enters synthesis on every single call — and synthesis copies the whole
-                        // font file through TryGetStream.
+                        // TryCreateSyntheticGlyphTypeface registers the synthetic only under the
+                        // source font's own family names, so a request arriving through a different
+                        // name would otherwise miss the cache and re-synthesise on every call,
+                        // copying the whole font file each time.
                         TryAddGlyphTypeface(familyName, key, glyphTypeface);
                     }
 

--- a/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
+++ b/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
@@ -502,7 +502,26 @@ namespace Avalonia.Media.Fonts
                 fontSimulations |= FontSimulations.Bold;
             }
 
-            if (fontSimulations != FontSimulations.None && glyphTypeface.PlatformTypeface.TryGetStream(out var stream))
+            if (fontSimulations == FontSimulations.None)
+            {
+                return false;
+            }
+
+            // A synthetic for this key may already be cached under the source family, reached
+            // through another of its names or by another thread. Building a second one copies the
+            // whole font file through TryGetStream, then loses the slot below to the instance
+            // already there, so nothing caches it, nothing disposes it, and its native typeface is
+            // never released.
+            if (glyphTypefaces.TryGetValue(key, out var cachedGlyphTypeface) &&
+                cachedGlyphTypeface is not null &&
+                cachedGlyphTypeface.FontSimulations == fontSimulations)
+            {
+                syntheticGlyphTypeface = cachedGlyphTypeface;
+
+                return true;
+            }
+
+            if (glyphTypeface.PlatformTypeface.TryGetStream(out var stream))
             {
                 using (stream)
                 {

--- a/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
+++ b/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
@@ -18,7 +18,8 @@ namespace Avalonia.Media.Fonts
             Comparer<FontFamily>.Create((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
 
         // Make this internal for testing purposes
-        internal readonly ConcurrentDictionary<string, ConcurrentDictionary<FontCollectionKey, GlyphTypeface?>> _glyphTypefaceCache = new();
+        internal readonly ConcurrentDictionary<string, ConcurrentDictionary<FontCollectionKey, GlyphTypeface?>> _glyphTypefaceCache =
+            new(StringComparer.OrdinalIgnoreCase);
 
         // Cache of resolved script/culture fallback family names. A non-null value is the preferred
         // fallback family for that script bucket: a Tier B hint that is still re-checked for coverage

--- a/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
@@ -69,7 +69,7 @@ namespace Avalonia.Media.Fonts
             TryAddGlyphTypeface(platformTypeface.FamilyName, key, glyphTypeface);
             
             // Then the requested family name
-            if (familyName != platformTypeface.FamilyName)
+            if (!string.Equals(familyName, platformTypeface.FamilyName, StringComparison.OrdinalIgnoreCase))
                 TryAddGlyphTypeface(familyName, key, glyphTypeface);
 
             //Add to cache

--- a/tests/Avalonia.Skia.UnitTests/Media/FontCollectionTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontCollectionTests.cs
@@ -195,7 +195,7 @@ namespace Avalonia.Skia.UnitTests.Media
 
         /// <summary>
         /// Font manager whose <c>MyAlias</c> family resolves through the platform but is absent from
-        /// the installed family list — the shape of a platform alias (for instance Android's
+        /// the installed family list, the shape of a platform alias (for instance Android's
         /// <c>&lt;alias name="arial" to="sans-serif"/&gt;</c> in <c>/system/etc/fonts.xml</c>).
         /// Such a family cannot be found again by the family-name search, so nothing repairs a
         /// missing cache entry.
@@ -219,7 +219,9 @@ namespace Avalonia.Skia.UnitTests.Media
                 _alias = alias;
             }
 
-            /// <summary>Number of typefaces created from a stream, i.e. of synthetic emboldenings.</summary>
+            /// <summary>Number of typefaces created from a stream: both the alias resolution and every
+            /// synthetic emboldening go through this overload, so the counter also proves that a cached
+            /// result short-circuits the platform call.</summary>
             public int StreamTypefaceCreations { get; private set; }
 
             public string GetDefaultFontFamilyName() => _inner.GetDefaultFontFamilyName();
@@ -231,7 +233,7 @@ namespace Avalonia.Skia.UnitTests.Media
                 FontStretch stretch, [NotNullWhen(true)] out IPlatformTypeface? platformTypeface)
             {
                 // The alias always resolves to the regular face of the backing font, never to the
-                // requested weight — exactly what a platform alias does.
+                // requested weight, exactly what a platform alias does.
                 if (string.Equals(familyName, _alias, StringComparison.OrdinalIgnoreCase))
                 {
                     using var stream = OpenBackingFont();

--- a/tests/Avalonia.Skia.UnitTests/Media/FontCollectionTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontCollectionTests.cs
@@ -248,6 +248,37 @@ namespace Avalonia.Skia.UnitTests.Media
             }
         }
 
+        [Fact]
+        public void Should_Reuse_An_Already_Cached_Synthetic_Glyph_Typeface()
+        {
+            var fontManager = new AliasFontManagerImpl(alias: "MyAlias");
+
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: fontManager)))
+            {
+                var fontCollection = new TestSystemFontCollection(fontManager);
+
+                Assert.True(fontCollection.TryGetGlyphTypeface(
+                    "MyAlias", FontStyle.Normal, FontWeight.Normal, FontStretch.Normal, out var regular));
+
+                Assert.True(fontCollection.TryCreateSyntheticGlyphTypeface(
+                    regular, FontStyle.Normal, FontWeight.Black, FontStretch.Normal, out var first));
+
+                Assert.Equal(FontSimulations.Bold, first.FontSimulations);
+
+                var creationsAfterFirstCall = fontManager.StreamTypefaceCreations;
+
+                Assert.True(fontCollection.TryCreateSyntheticGlyphTypeface(
+                    regular, FontStyle.Normal, FontWeight.Black, FontStretch.Normal, out var second));
+
+                // A second synthesis builds a GlyphTypeface that then loses the cache slot to the
+                // first one, so it is returned to the caller but never cached and never disposed -
+                // and GlyphTypeface has no finalizer, so its native typeface is retained until the
+                // process exits.
+                Assert.Same(first, second);
+                Assert.Equal(creationsAfterFirstCall, fontManager.StreamTypefaceCreations);
+            }
+        }
+
         /// <summary>
         /// Font manager whose <c>MyAlias</c> family resolves through the platform but is absent from
         /// the installed family list, the shape of a platform alias (for instance Android's

--- a/tests/Avalonia.Skia.UnitTests/Media/FontCollectionTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontCollectionTests.cs
@@ -193,6 +193,61 @@ namespace Avalonia.Skia.UnitTests.Media
             }
         }
 
+        [Fact]
+        public void Should_Ignore_Family_Name_Casing_When_Resolving_A_Synthetic_Match()
+        {
+            var fontManager = new AliasFontManagerImpl(alias: "MyAlias");
+
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: fontManager)))
+            {
+                var fontCollection = new TestSystemFontCollection(fontManager);
+
+                Assert.True(fontCollection.TryGetGlyphTypeface(
+                    "MyAlias", FontStyle.Normal, FontWeight.Normal, FontStretch.Normal, out _));
+
+                // Casing must not decide whether a request gets a synthesised bold. A cache keyed
+                // ordinally sends this lookup past the synthesis branch and down the family-name
+                // search, which returns the nearest match raw - so the very same family renders
+                // faux-bold under one casing and regular weight under another.
+                Assert.True(fontCollection.TryGetGlyphTypeface(
+                    "MYALIAS", FontStyle.Normal, FontWeight.Black, FontStretch.Normal, out var upperCase));
+
+                Assert.Equal(FontSimulations.Bold, upperCase.FontSimulations);
+
+                var creationsAfterFirstCall = fontManager.StreamTypefaceCreations;
+
+                Assert.True(fontCollection.TryGetGlyphTypeface(
+                    "MyAlias", FontStyle.Normal, FontWeight.Black, FontStretch.Normal, out var mixedCase));
+
+                // One shared cache entry, so the other casing neither re-synthesises nor gets a
+                // second instance of the same face.
+                Assert.Same(upperCase, mixedCase);
+                Assert.Equal(creationsAfterFirstCall, fontManager.StreamTypefaceCreations);
+            }
+        }
+
+        [Fact]
+        public void Should_Not_Cache_A_Family_Twice_When_The_Platform_Returns_Another_Casing()
+        {
+            // The platform reports the family as "Noto Mono"; the caller asks in lower case, as any
+            // XAML author may.
+            var fontManager = new AliasFontManagerImpl(alias: "Noto Mono");
+
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: fontManager)))
+            {
+                var fontCollection = new TestSystemFontCollection(fontManager);
+
+                Assert.True(fontCollection.TryGetGlyphTypeface(
+                    "noto mono", FontStyle.Normal, FontWeight.Normal, FontStretch.Normal, out _));
+
+                // A cache keyed ordinally stores the requested casing beside the platform's own, but
+                // AddFontFamily de-duplicates case-insensitively and publishes only the first of the
+                // two, leaving the second bucket unreachable from every family-name search.
+                Assert.Single(fontCollection.GlyphTypefaceCache);
+                Assert.Equal(fontCollection.GlyphTypefaceCache.Count, fontCollection.Count);
+            }
+        }
+
         /// <summary>
         /// Font manager whose <c>MyAlias</c> family resolves through the platform but is absent from
         /// the installed family list, the shape of a platform alias (for instance Android's

--- a/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
@@ -397,6 +397,40 @@ namespace Avalonia.Skia.UnitTests.Media
         }
 
         [Fact]
+        public void Should_Map_FontFamily_Regardless_Of_Casing()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl())))
+            {
+                using (AvaloniaLocator.EnterScope())
+                {
+                    AvaloniaLocator.CurrentMutable.BindToSelf(new FontManagerOptions
+                    {
+                        DefaultFamilyName = s_fontUri,
+                        FontFamilyMappings = new Dictionary<string, FontFamily>
+                        {
+                            { "Segoe UI", new FontFamily("fonts:Inter#Inter") }
+                        }
+                    });
+
+                    FontManager.Current.AddFontCollection(new InterFontCollection());
+
+                    // The mapping table is configuration; its casing has nothing to do with the casing
+                    // a control asks in. Both the composite and the plain family path must still find
+                    // the mapping.
+                    Assert.True(FontManager.Current.TryGetGlyphTypeface(
+                        new Typeface("Abc, segoe ui"), out var fromComposite));
+
+                    Assert.Equal("Inter", fromComposite.FamilyName);
+
+                    Assert.True(FontManager.Current.TryGetGlyphTypeface(
+                        new Typeface("SEGOE UI"), out var fromPlainFamily));
+
+                    Assert.Equal("Inter", fromPlainFamily.FamilyName);
+                }
+            }
+        }
+
+        [Fact]
         public void Should_Get_FamilyTypefaces()
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl())))


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Follow-up to #21993. Family names are matched case-insensitively everywhere in the font stack except the two places that decide which typeface you actually get, so the same family resolves differently depending on how it was capitalised. Also closes the synthesis leak that #21993 made unreachable on the hot path but did not remove.

* `FontCollectionBase._glyphTypefaceCache` gets an `OrdinalIgnoreCase` comparer.
* `SystemFontCollection` compares the requested and platform family names case-insensitively before registering the second entry.
* `FontManager` copies `FontManagerOptions.FontFamilyMappings` into an `OrdinalIgnoreCase` dictionary.
* `TryCreateSyntheticGlyphTypeface` reuses a synthetic already cached for the same source family and key.

## What is the current behavior?

Every family-name comparison in `FontCollectionBase` is `OrdinalIgnoreCase` - the sorted family array, `FontFamilyNameComparer`, the binary search in `TryGetGlyphTypeface`, `AddFontFamily`'s de-duplication - but the cache itself uses the default ordinal comparer, and `Typeface.Normalize` preserves the author's casing. Three consequences:

* A request whose casing differs from the cached one misses the bucket and skips the nearest-match branch entirely. The family-name search that picks it up afterwards discards `isNearestMatch`, so it returns the nearest match raw, without synthesis and without caching. `"MyAlias"` at Black renders a synthesised bold while `"MYALIAS"` at Black renders regular weight, and the platform call repeats on every request for the mis-cased name.
* `SystemFontCollection` registers a resolved face under both the platform's family name and the requested one. When those differ only in casing that stores two buckets, while `AddFontFamily` de-duplicates case-insensitively and publishes only the first, leaving the second unreachable from every family-name search.
* A configured `FontFamilyMappings` entry silently does not apply when the requested name differs in casing from the configured key, since the dictionary carries whatever comparer its author gave it.

Separately, `TryCreateSyntheticGlyphTypeface` synthesises unconditionally. When a synthetic for the same source family and key is already cached, the second one loses `TryAddGlyphTypeface` to the instance holding the slot, so it is handed to the caller but never cached - and `GlyphTypeface` has no finalizer, only a `Dispose` reachable from the cache, so its native typeface stays alive for the rest of the process. Each one costs a full copy of the font file. #21993 removed the path that reached this on every call, but the method is public on `IFontCollection` and the race remains.

## What is the updated/expected behavior with this PR?

* A family name resolves to the same glyph typeface whatever its casing, so a mis-cased name can no longer render at the wrong weight. `FontFamily="arial"` and `FontFamily="Arial"` behave identically.
* A configured font family mapping applies whatever casing the requested name arrives in.
* Repeated synthesis for an already-synthesised key returns the cached instance instead of leaking a native typeface per call.

To see the first one, resolve a family through a platform alias at a weight the device cannot match, then ask again with different capitalisation: both now come back as the same synthesised face.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None to the public API. Three behavioural changes worth naming:

* A family name now resolves to the same typeface whatever its casing. Code that (deliberately or not) relied on two casings resolving to different faces would change behaviour.
* A font family mapping now applies whatever casing the requested name arrives in.
* `FontManager` takes a defensive copy of `FontFamilyMappings`, so it no longer observes mutations made to the caller's dictionary after construction. Mapping keys colliding only by casing were separate entries before the copy; the last wins rather than throwing, since a mapping table is configuration and failing there would take the application down at startup.

## Obsoletions / Deprecations

None.

## Fixed issues

Follows up #21993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
