### PR TITLE
Fix for ListBox ghost items - Alternative version

### DIFF
--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -700,8 +700,21 @@ namespace Avalonia.Controls
                 // hence the width extent should be correct now, and we can try to scroll again.
                 scrollToElement.BringIntoView();
 
-                _scrollToElement = null;
-                _scrollToIndex = -1;
+                // The layout pass normally adopts the temporary element into the realized range.
+                // When it doesn't (for example, while its containing pane has no usable width),
+                // it is still an internal child. Recycle it before dropping the reference so it
+                // cannot remain as a visible, unindexed "ghost" element.
+                if (_scrollToElement is { } unadoptedScrollToElement)
+                {
+                    var unadoptedScrollToIndex = _scrollToIndex;
+                    _scrollToElement = null;
+                    _scrollToIndex = -1;
+                    RecycleElement(unadoptedScrollToElement, unadoptedScrollToIndex);
+                }
+                else
+                {
+                    _scrollToIndex = -1;
+                }
                 return scrollToElement;
             }
 

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -710,7 +710,9 @@ namespace Avalonia.Controls
                     _scrollToElement = null;
                     _scrollToIndex = -1;
                     RecycleElement(scrollToElement, scrollToIndex);
+                    return null;
                 }
+
                 return scrollToElement;
             }
 

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -700,20 +700,16 @@ namespace Avalonia.Controls
                 // hence the width extent should be correct now, and we can try to scroll again.
                 scrollToElement.BringIntoView();
 
-                // The layout pass normally adopts the temporary element into the realized range.
-                // When it doesn't (for example, while its containing pane has no usable width),
-                // it is still an internal child. Recycle it before dropping the reference so it
-                // cannot remain as a visible, unindexed "ghost" element.
-                if (_scrollToElement is { } unadoptedScrollToElement)
+                // A layout pass normally adopts the temporary element into the realized range and
+                // clears _scrollToElement. If it cannot (for example, because the containing pane
+                // has no usable width), the element remains an internal child. Recycle only the
+                // temporary element created by this call so it cannot remain visible and unindexed.
+                if (ReferenceEquals(_scrollToElement, scrollToElement))
                 {
-                    var unadoptedScrollToIndex = _scrollToIndex;
+                    var scrollToIndex = _scrollToIndex;
                     _scrollToElement = null;
                     _scrollToIndex = -1;
-                    RecycleElement(unadoptedScrollToElement, unadoptedScrollToIndex);
-                }
-                else
-                {
-                    _scrollToIndex = -1;
+                    RecycleElement(scrollToElement, scrollToIndex);
                 }
                 return scrollToElement;
             }

--- a/tests/Avalonia.Controls.UnitTests/ListBoxVirtualizationIssueTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxVirtualizationIssueTests.cs
@@ -89,6 +89,62 @@ public class ListBoxVirtualizationIssueTests : ScopedTestBase
             Assert.NotEqual(-1, target.IndexFromContainer(child));
             Assert.Contains(child, realized);
         });
+
+        var selectedContainer = Assert.IsType<ListBoxItem>(target.ContainerFromIndex(target.SelectedIndex));
+        Assert.Contains(selectedContainer, realized);
+        Assert.True(selectedContainer.Bounds.Bottom > target.Scroll!.Offset.Y);
+        Assert.True(selectedContainer.Bounds.Top < target.Scroll.Offset.Y + target.Scroll.Viewport.Height);
+    }
+
+    [Fact]
+    public void Opening_SplitView_Pane_After_Scrolling_Keeps_TabOnce_Container_Indexed()
+    {
+        using var app = UnitTestApplication.Start(TestServices.StyledWindow
+            .With(globalClock: new MockGlobalClock()));
+
+        var target = CreateSizedListBox();
+        var (window, splitView) = CreateSplitViewWindow(target);
+
+        ScrollWhilePaneIsClosed(target, window);
+
+        var tabOnceContainer = Assert.IsType<ListBoxItem>(target.ContainerFromIndex(0));
+        KeyboardNavigation.SetTabOnceActiveElement(target, tabOnceContainer);
+
+        OpenPane(splitView, target, window);
+
+        var activeContainer = Assert.IsType<ListBoxItem>(KeyboardNavigation.GetTabOnceActiveElement(target));
+        var activeIndex = target.IndexFromContainer(activeContainer);
+
+        Assert.InRange(activeIndex, 0, 5);
+        Assert.Same(activeContainer, target.ContainerFromIndex(activeIndex));
+    }
+
+    [Fact]
+    public void Opening_SplitView_Pane_After_Scrolling_Own_Container_Items_Does_Not_Show_Unrealized_Containers()
+    {
+        using var app = UnitTestApplication.Start(TestServices.StyledWindow
+            .With(globalClock: new MockGlobalClock()));
+
+        var target = new ListBox
+        {
+            ItemsSource = new[]
+            {
+                new ListBoxItem { Content = new Border { Width = 196, Height = 331 } },
+                new ListBoxItem { Content = new Border { Width = 186, Height = 258 } },
+                new ListBoxItem { Content = new Border { Width = 196, Height = 321 } },
+                new ListBoxItem { Content = new Border { Width = 186, Height = 296 } },
+                new ListBoxItem { Content = new Border { Width = 150, Height = 340 } },
+                new ListBoxItem { Content = new Border { Width = 196, Height = 319 } },
+            },
+            ItemsPanel = new FuncTemplate<Panel?>(() => new VirtualizingStackPanel()),
+            SelectionMode = SelectionMode.Single | SelectionMode.AlwaysSelected,
+        };
+        var (window, splitView) = CreateSplitViewWindow(target);
+
+        ScrollWhilePaneIsClosed(target, window);
+        OpenPane(splitView, target, window);
+
+        AssertVisibleChildrenAreRealized(target);
     }
 
     [Fact]
@@ -396,6 +452,92 @@ public class ListBoxVirtualizationIssueTests : ScopedTestBase
             var visibleChildren = panel.Children.Where(c => c.IsVisible).ToList();
             Assert.Equal(target.GetRealizedContainers().Count(), visibleChildren.Count);
         }
+    }
+
+    private static ListBox CreateSizedListBox()
+    {
+        var items = new[]
+        {
+            new SizedItem(196, 331),
+            new SizedItem(186, 258),
+            new SizedItem(196, 321),
+            new SizedItem(186, 296),
+            new SizedItem(150, 340),
+            new SizedItem(196, 319),
+        };
+
+        return new ListBox
+        {
+            ItemsSource = items,
+            ItemTemplate = new FuncDataTemplate<SizedItem>((item, _) => new Border
+            {
+                Width = item?.Width ?? 0,
+                Height = item?.Height ?? 0,
+            }),
+            ItemsPanel = new FuncTemplate<Panel?>(() => new VirtualizingStackPanel()),
+            SelectionMode = SelectionMode.Single | SelectionMode.AlwaysSelected,
+        };
+    }
+
+    private static (Window Window, SplitView SplitView) CreateSplitViewWindow(ListBox listBox)
+    {
+        var splitView = new SplitView
+        {
+            DisplayMode = SplitViewDisplayMode.CompactInline,
+            CompactPaneLength = 0,
+            OpenPaneLength = 300,
+            Pane = listBox,
+            Content = new TextBlock(),
+        };
+        var window = new Window
+        {
+            Width = 800,
+            Height = 804,
+            Content = new Grid
+            {
+                RowDefinitions = new RowDefinitions("30,*"),
+                Children = { new TextBlock(), splitView },
+            },
+        };
+        Grid.SetRow(splitView, 1);
+        window.Show();
+        return (window, splitView);
+    }
+
+    private static void ScrollWhilePaneIsClosed(ListBox listBox, Window window)
+    {
+        Assert.Equal(0, listBox.Bounds.Width);
+
+        for (var index = 1; index <= 3; ++index)
+        {
+            listBox.SelectedIndex = index;
+            window.LayoutManager.ExecuteLayoutPass();
+        }
+    }
+
+    private static void OpenPane(SplitView splitView, ListBox listBox, Window window)
+    {
+        var paneRoot = splitView.GetVisualDescendants()
+            .OfType<Panel>()
+            .Single(x => x.Name == "PART_PaneRoot");
+        paneRoot.Transitions = null;
+
+        splitView.IsPaneOpen = true;
+        window.LayoutManager.ExecuteLayoutPass();
+
+        Assert.Equal(300, listBox.Bounds.Width);
+    }
+
+    private static void AssertVisibleChildrenAreRealized(ListBox listBox)
+    {
+        var panel = Assert.IsType<VirtualizingStackPanel>(listBox.Presenter!.Panel);
+        var realized = listBox.GetRealizedContainers().ToHashSet();
+
+        Assert.All(panel.Children.Where(x => x.IsVisible), child =>
+        {
+            Assert.NotEqual(-1, listBox.IndexFromContainer(child));
+            Assert.Contains(child, realized);
+        });
     }
 
     private Control CreateListBoxTemplate(TemplatedControl parent, INameScope scope)

--- a/tests/Avalonia.Controls.UnitTests/ListBoxVirtualizationIssueTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxVirtualizationIssueTests.cs
@@ -12,6 +12,60 @@ namespace Avalonia.Controls.UnitTests;
 public class ListBoxVirtualizationIssueTests : ScopedTestBase
 {
     [Fact]
+    public void Expanding_ListBox_After_Scrolling_In_Zero_Width_Pane_Does_Not_Show_Unrealized_Containers()
+    {
+        using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+        var items = new[]
+        {
+            new SizedItem(196, 331),
+            new SizedItem(186, 258),
+            new SizedItem(196, 321),
+            new SizedItem(186, 296),
+            new SizedItem(150, 340),
+            new SizedItem(196, 319),
+        };
+        var target = new ListBox
+        {
+            Width = 0,
+            Height = 774,
+            Template = new FuncControlTemplate(CreateListBoxTemplate),
+            ItemsSource = items,
+            ItemTemplate = new FuncDataTemplate<SizedItem>((item, _) => new Border
+            {
+                Width = item?.Width ?? 0,
+                Height = item?.Height ?? 0,
+            }),
+            ItemsPanel = new FuncTemplate<Panel?>(() => new VirtualizingStackPanel()),
+            SelectionMode = SelectionMode.Single | SelectionMode.AlwaysSelected,
+        };
+
+        var root = new TestRoot(target) { ClientSize = new Size(300, 774) };
+        root.LayoutManager.ExecuteInitialLayoutPass();
+
+        // Scroll the selected item into view while the SplitView pane is effectively hidden.
+        for (var index = 1; index <= 3; ++index)
+        {
+            target.SelectedIndex = index;
+            root.LayoutManager.ExecuteLayoutPass();
+        }
+
+        // Opening the pane increases the ListBox viewport to 300.
+        target.Width = 300;
+        root.LayoutManager.ExecuteLayoutPass();
+
+        var panel = Assert.IsType<VirtualizingStackPanel>(target.Presenter!.Panel);
+        var realized = target.GetRealizedContainers().ToHashSet();
+        var visibleChildren = panel.Children.Where(x => x.IsVisible).ToList();
+
+        Assert.All(visibleChildren, child =>
+        {
+            Assert.NotEqual(-1, target.IndexFromContainer(child));
+            Assert.Contains(child, realized);
+        });
+    }
+
+    [Fact]
     public void Removing_First_Item_After_Scrolling_To_End_Should_Allow_Scrolling_To_Start()
     {
         using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
@@ -357,5 +411,17 @@ public class ListBoxVirtualizationIssueTests : ScopedTestBase
             Id = id;
         }
         public int Id { get; }
+    }
+
+    private class SizedItem
+    {
+        public SizedItem(double width, double height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        public double Width { get; }
+        public double Height { get; }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/ListBoxVirtualizationIssueTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxVirtualizationIssueTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.UnitTests;
+using Avalonia.VisualTree;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests;
@@ -12,9 +13,10 @@ namespace Avalonia.Controls.UnitTests;
 public class ListBoxVirtualizationIssueTests : ScopedTestBase
 {
     [Fact]
-    public void Expanding_ListBox_After_Scrolling_In_Zero_Width_Pane_Does_Not_Show_Unrealized_Containers()
+    public void Opening_SplitView_Pane_After_Scrolling_ListBox_Does_Not_Show_Unrealized_Containers()
     {
-        using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+        using var app = UnitTestApplication.Start(TestServices.StyledWindow
+            .With(globalClock: new MockGlobalClock()));
 
         var items = new[]
         {
@@ -27,9 +29,6 @@ public class ListBoxVirtualizationIssueTests : ScopedTestBase
         };
         var target = new ListBox
         {
-            Width = 0,
-            Height = 774,
-            Template = new FuncControlTemplate(CreateListBoxTemplate),
             ItemsSource = items,
             ItemTemplate = new FuncDataTemplate<SizedItem>((item, _) => new Border
             {
@@ -40,19 +39,46 @@ public class ListBoxVirtualizationIssueTests : ScopedTestBase
             SelectionMode = SelectionMode.Single | SelectionMode.AlwaysSelected,
         };
 
-        var root = new TestRoot(target) { ClientSize = new Size(300, 774) };
-        root.LayoutManager.ExecuteInitialLayoutPass();
+        var splitView = new SplitView
+        {
+            DisplayMode = SplitViewDisplayMode.CompactInline,
+            CompactPaneLength = 0,
+            OpenPaneLength = 300,
+            Pane = target,
+            Content = new TextBlock(),
+        };
+        var window = new Window
+        {
+            Width = 800,
+            Height = 804,
+            Content = new Grid
+            {
+                RowDefinitions = new RowDefinitions("30,*"),
+                Children = { new TextBlock(), splitView },
+            },
+        };
+        Grid.SetRow(splitView, 1);
+        window.Show();
+
+        Assert.Equal(0, target.Bounds.Width);
 
         // Scroll the selected item into view while the SplitView pane is effectively hidden.
         for (var index = 1; index <= 3; ++index)
         {
             target.SelectedIndex = index;
-            root.LayoutManager.ExecuteLayoutPass();
+            window.LayoutManager.ExecuteLayoutPass();
         }
 
-        // Opening the pane increases the ListBox viewport to 300.
-        target.Width = 300;
-        root.LayoutManager.ExecuteLayoutPass();
+        // Disable the theme animation so the assertion observes the opened-pane layout directly.
+        var paneRoot = splitView.GetVisualDescendants()
+            .OfType<Panel>()
+            .Single(x => x.Name == "PART_PaneRoot");
+        paneRoot.Transitions = null;
+
+        splitView.IsPaneOpen = true;
+        window.LayoutManager.ExecuteLayoutPass();
+
+        Assert.Equal(300, target.Bounds.Width);
 
         var panel = Assert.IsType<VirtualizingStackPanel>(target.Presenter!.Panel);
         var realized = target.GetRealizedContainers().ToHashSet();


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes an issue where a ListBox with 0 width can produce ghost items. See #15194 for a repro.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
A ListBox of size 0 can produce ghost items.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
No more ghost items. 

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Ensure that those items are recycled.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes #15194 
Closes #22161 