### PR TITLE
fix: Support StylableElement for styles inside ContainerQueries

### DIFF
--- a/src/Avalonia.Base/Styling/Activators/AndQueryActivator.cs
+++ b/src/Avalonia.Base/Styling/Activators/AndQueryActivator.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Styling.Activators
     {
         private List<IStyleActivator>? _sources;
 
-        public AndQueryActivator(Visual visual) : base(visual)
+        public AndQueryActivator(StyledElement target) : base(target)
         {
         }
 

--- a/src/Avalonia.Base/Styling/Activators/AndQueryActivatorBuilder.cs
+++ b/src/Avalonia.Base/Styling/Activators/AndQueryActivatorBuilder.cs
@@ -11,13 +11,13 @@ namespace Avalonia.Styling.Activators
     /// </remarks>
     internal struct AndQueryActivatorBuilder
     {
-        private readonly Visual _visual;
+        private readonly StyledElement _target;
         private IStyleActivator? _single;
         private AndQueryActivator? _multiple;
 
-        public AndQueryActivatorBuilder(Visual visual) : this()
+        public AndQueryActivatorBuilder(StyledElement target) : this()
         {
-            _visual = visual;
+            _target = target;
         }
 
         public int Count => _multiple?.Count ?? (_single is object ? 1 : 0);
@@ -37,7 +37,7 @@ namespace Avalonia.Styling.Activators
             {
                 if (_multiple is null)
                 {
-                    _multiple = new AndQueryActivator(_visual);
+                    _multiple = new AndQueryActivator(_target);
                     _multiple.Add(_single!);
                     _single = null;
                 }

--- a/src/Avalonia.Base/Styling/Activators/ContainerQueryActivatorBase.cs
+++ b/src/Avalonia.Base/Styling/Activators/ContainerQueryActivatorBase.cs
@@ -1,20 +1,21 @@
 ﻿using System;
 using System.Linq;
 using Avalonia.Layout;
+using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Styling.Activators
 {
     internal abstract class ContainerQueryActivatorBase : StyleActivatorBase, IStyleActivatorSink
     {
-        private readonly Visual _visual;
+        private readonly StyledElement _target;
         private readonly string? _containerName;
+        private Visual? _visual;
         private Layoutable? _currentScreenSizeProvider;
 
-        public ContainerQueryActivatorBase(
-            Visual visual, string? containerName = null)
+        public ContainerQueryActivatorBase(StyledElement target, string? containerName = null)
         {
-            _visual = visual;
+            _target = target;
             _containerName = containerName;
         }
 
@@ -28,24 +29,67 @@ namespace Avalonia.Styling.Activators
             InitializeScreenSizeProvider();
         }
 
+        private void Target_DetachedFromLogicalTree(object? sender, LogicalTreeAttachmentEventArgs e)
+        {
+            SetVisual(null);
+            ReevaluateIsActive();
+        }
+
+        private void Target_AttachedToLogicalTree(object? sender, LogicalTreeAttachmentEventArgs e)
+        {
+            SetVisual(GetVisual(_target));
+            InitializeScreenSizeProvider();
+        }
+
         protected Layoutable? CurrentContainer => _currentScreenSizeProvider;
 
         void IStyleActivatorSink.OnNext(bool value) => ReevaluateIsActive();
 
         protected override void Initialize()
         {
-            InitializeScreenSizeProvider();
+            if (_target is not Visual)
+            {
+                _target.AttachedToLogicalTree += Target_AttachedToLogicalTree;
+                _target.DetachedFromLogicalTree += Target_DetachedFromLogicalTree;
+            }
 
-            _visual.AttachedToVisualTree += Visual_AttachedToVisualTree;
-            _visual.DetachedFromVisualTree += Visual_DetachedFromVisualTree;
+            SetVisual(GetVisual(_target));
+            InitializeScreenSizeProvider();
         }
 
         protected override void Deinitialize()
         {
-            _visual.AttachedToVisualTree -= Visual_AttachedToVisualTree;
-            _visual.DetachedFromVisualTree -= Visual_DetachedFromVisualTree;
+            if (_target is not Visual)
+            {
+                _target.AttachedToLogicalTree -= Target_AttachedToLogicalTree;
+                _target.DetachedFromLogicalTree -= Target_DetachedFromLogicalTree;
+            }
+
+            SetVisual(null);
+        }
+
+        private void SetVisual(Visual? visual)
+        {
+            if (_visual == visual)
+            {
+                return;
+            }
 
             DeInitializeScreenSizeProvider();
+
+            if (_visual is { } oldVisual)
+            {
+                oldVisual.AttachedToVisualTree -= Visual_AttachedToVisualTree;
+                oldVisual.DetachedFromVisualTree -= Visual_DetachedFromVisualTree;
+            }
+
+            _visual = visual;
+
+            if (_visual is { } newVisual)
+            {
+                newVisual.AttachedToVisualTree += Visual_AttachedToVisualTree;
+                newVisual.DetachedFromVisualTree += Visual_DetachedFromVisualTree;
+            }
         }
 
         private void DeInitializeScreenSizeProvider()
@@ -60,7 +104,7 @@ namespace Avalonia.Styling.Activators
 
         private void InitializeScreenSizeProvider()
         {
-            if (_currentScreenSizeProvider == null && GetContainer(_visual, _containerName) is { } container && Container.GetQueryProvider(container) is { } provider)
+            if (_currentScreenSizeProvider == null && GetContainer(_target, _containerName) is { } container && Container.GetQueryProvider(container) is { } provider)
             {
                 _currentScreenSizeProvider = container;
 
@@ -71,12 +115,24 @@ namespace Avalonia.Styling.Activators
             ReevaluateIsActive();
         }
 
-        internal static Layoutable? GetContainer(Visual visual, string? containerName)
+        internal static Layoutable? GetContainer(StyledElement target, string? containerName)
         {
-            return visual.GetVisualAncestors().Where(x => x is Layoutable layoutable &&
-                ((containerName == null && Container.GetSizing(layoutable) != ContainerSizing.Normal)
-                || (containerName != null && Container.GetName(layoutable) == containerName))).FirstOrDefault() as Layoutable;
+            var visual = GetVisual(target);
+            if (visual is null)
+            {
+                return null;
+            }
+
+            // The first visual logical ancestor can itself be the container for a non-visual target.
+            var ancestors = target is Visual ? visual.GetVisualAncestors() : visual.GetSelfAndVisualAncestors();
+
+            return ancestors.OfType<Layoutable>().FirstOrDefault(layoutable =>
+                (containerName == null && Container.GetSizing(layoutable) != ContainerSizing.Normal)
+                || (containerName != null && Container.GetName(layoutable) == containerName));
         }
+
+        private static Visual? GetVisual(StyledElement target)
+            => target as Visual ?? target.GetLogicalAncestors().OfType<Visual>().FirstOrDefault();
 
         private void HeightChanged(object? sender, EventArgs e)
         {

--- a/src/Avalonia.Base/Styling/Activators/OrQueryActivator.cs
+++ b/src/Avalonia.Base/Styling/Activators/OrQueryActivator.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Styling.Activators
     {
         private List<IStyleActivator>? _sources;
 
-        public OrQueryActivator(Visual visual) : base(visual)
+        public OrQueryActivator(StyledElement target) : base(target)
         {
         }
 

--- a/src/Avalonia.Base/Styling/Activators/OrQueryActivatorBuilder.cs
+++ b/src/Avalonia.Base/Styling/Activators/OrQueryActivatorBuilder.cs
@@ -11,13 +11,13 @@ namespace Avalonia.Styling.Activators
     /// </remarks>
     internal struct OrQueryActivatorBuilder
     {
+        private readonly StyledElement _target;
         private IStyleActivator? _single;
         private OrQueryActivator? _multiple;
-        private Visual _visual;
 
-        public OrQueryActivatorBuilder(Visual visual) : this()
+        public OrQueryActivatorBuilder(StyledElement target) : this()
         {
-            _visual = visual;
+            _target = target;
         }
 
         public int Count => _multiple?.Count ?? (_single is object ? 1 : 0);
@@ -37,7 +37,7 @@ namespace Avalonia.Styling.Activators
             {
                 if (_multiple is null)
                 {
-                    _multiple = new OrQueryActivator(_visual);
+                    _multiple = new OrQueryActivator(_target);
                     _multiple.Add(_single!);
                     _single = null;
                 }

--- a/src/Avalonia.Base/Styling/Activators/ScreenActivator.cs
+++ b/src/Avalonia.Base/Styling/Activators/ScreenActivator.cs
@@ -6,7 +6,7 @@ namespace Avalonia.Styling.Activators
     {
         private readonly (StyleQueryComparisonOperator @operator, double value) _argument;
 
-        public WidthActivator(Visual visual, (StyleQueryComparisonOperator @operator, double value) argument, string? containerName = null) : base(visual, containerName)
+        public WidthActivator(StyledElement target, (StyleQueryComparisonOperator @operator, double value) argument, string? containerName = null) : base(target, containerName)
         {
             _argument = argument;
         }
@@ -23,7 +23,7 @@ namespace Avalonia.Styling.Activators
     {
         private readonly (StyleQueryComparisonOperator @operator, double value) _argument;
 
-        public HeightActivator(Visual visual, (StyleQueryComparisonOperator @operator, double value) argument, string? containerName = null) : base(visual, containerName)
+        public HeightActivator(StyledElement target, (StyleQueryComparisonOperator @operator, double value) argument, string? containerName = null) : base(target, containerName)
         {
             _argument = argument;
         }

--- a/src/Avalonia.Base/Styling/AndQuery.cs
+++ b/src/Avalonia.Base/Styling/AndQuery.cs
@@ -50,12 +50,7 @@ namespace Avalonia.Styling
 
         internal override SelectorMatch Evaluate(StyledElement control, IStyle? parent, bool subscribe, string? containerName = null)
         {
-            if (control is not Visual visual)
-            {
-                return SelectorMatch.NeverThisType;
-            }
-
-            var activators = new AndQueryActivatorBuilder(visual);
+            var activators = new AndQueryActivatorBuilder(control);
             var alwaysThisInstance = false;
 
             var count = _queries.Count;

--- a/src/Avalonia.Base/Styling/OrQuery.cs
+++ b/src/Avalonia.Base/Styling/OrQuery.cs
@@ -50,12 +50,7 @@ namespace Avalonia.Styling
 
         internal override SelectorMatch Evaluate(StyledElement control, IStyle? parent, bool subscribe, string? containerName = null)
         {
-            if (control is not Visual visual)
-            {
-                return SelectorMatch.NeverThisType;
-            }
-
-            var activators = new OrQueryActivatorBuilder(visual);
+            var activators = new OrQueryActivatorBuilder(control);
             var neverThisInstance = false;
 
             var count = _queries.Count;

--- a/src/Avalonia.Base/Styling/ScreenQueries.cs
+++ b/src/Avalonia.Base/Styling/ScreenQueries.cs
@@ -13,17 +13,12 @@ namespace Avalonia.Styling
 
         internal override SelectorMatch Evaluate(StyledElement control, IStyle? parent, bool subscribe, string? containerName = null)
         {
-            if (control is not Visual visual)
-            {
-                return SelectorMatch.NeverThisType;
-            }
-
             if (subscribe)
             {
-                return new SelectorMatch(new WidthActivator(visual, Argument, containerName));
+                return new SelectorMatch(new WidthActivator(control, Argument, containerName));
             }
 
-            if (ContainerQueryActivatorBase.GetContainer(visual, containerName) is { } container
+            if (ContainerQueryActivatorBase.GetContainer(control, containerName) is { } container
                 && container is Layoutable layoutable
                 && Container.GetQueryProvider(layoutable) is { } queryProvider
                 && Container.GetSizing(layoutable) == Styling.ContainerSizing.WidthAndHeight)
@@ -94,17 +89,12 @@ namespace Avalonia.Styling
 
         internal override SelectorMatch Evaluate(StyledElement control, IStyle? parent, bool subscribe, string? containerName = null)
         {
-            if (control is not Visual visual)
-            {
-                return SelectorMatch.NeverThisType;
-            }
-
             if (subscribe)
             {
-                return new SelectorMatch(new HeightActivator(visual, Argument, containerName));
+                return new SelectorMatch(new HeightActivator(control, Argument, containerName));
             }
 
-            if (ContainerQueryActivatorBase.GetContainer(visual, containerName) is { } container
+            if (ContainerQueryActivatorBase.GetContainer(control, containerName) is { } container
                 && container is Layoutable layoutable
                 && Container.GetQueryProvider(layoutable) is { } queryProvider
                 && Container.GetSizing(layoutable) == Styling.ContainerSizing.WidthAndHeight)

--- a/tests/Avalonia.Base.UnitTests/Styling/ContainerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/ContainerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Avalonia.Base.UnitTests.Layout;
 using Avalonia.Controls;
+using Avalonia.Controls.Documents;
 using Avalonia.Styling;
 using Avalonia.UnitTests;
 using Xunit;
@@ -218,6 +219,197 @@ namespace Avalonia.Base.UnitTests.Styling
 
             root.LayoutManager.ExecuteLayoutPass();
             Assert.Equal(300, child.Height);
+        }
+
+        [Fact]
+        public void Container_Does_Not_Query_Itself()
+        {
+            using var app = UnitTestApplication.Start();
+            var root = new LayoutTestRoot
+            {
+                ClientSize = new Size(400, 400)
+            };
+            var containerQuery = new ContainerQuery(x => new WidthQuery(x, StyleQueryComparisonOperator.LessThanOrEquals, 500));
+            containerQuery.Children.Add(new Style(x => x.Is<Border>())
+            {
+                Setters = { new Setter(Visual.OpacityProperty, 0.5) }
+            });
+            root.Styles.Add(containerQuery);
+            var container = new Border();
+            Container.SetSizing(container, ContainerSizing.Width);
+            root.Child = container;
+
+            root.LayoutManager.ExecuteInitialLayoutPass();
+
+            Assert.Equal(1, container.Opacity);
+        }
+
+        [Fact]
+        public void Container_Query_Tracks_Non_Visual_Target_After_Logical_Reparenting()
+        {
+            using var app = UnitTestApplication.Start(TestServices.TextServices);
+            var root = new LayoutTestRoot
+            {
+                ClientSize = new Size(1000, 400)
+            };
+            var containerQuery = new ContainerQuery(x => new WidthQuery(x, StyleQueryComparisonOperator.LessThanOrEquals, 500));
+            containerQuery.Children.Add(new Style(x => x.Is<Run>())
+            {
+                Setters = { new Setter(StyledElement.DataContextProperty, "matched") }
+            });
+            var theme = new ControlTheme(typeof(Run));
+            theme.Children.Add(containerQuery);
+            var target = new Run
+            {
+                Theme = theme
+            };
+            target.ApplyStyling();
+            var smallContainer = new TextBlock
+            {
+                Width = 400
+            };
+            var largeContainer = new TextBlock
+            {
+                Width = 600
+            };
+            Container.SetSizing(smallContainer, ContainerSizing.Width);
+            Container.SetSizing(largeContainer, ContainerSizing.Width);
+            root.Child = new StackPanel
+            {
+                Children =
+                {
+                    smallContainer,
+                    largeContainer
+                }
+            };
+
+            root.LayoutManager.ExecuteInitialLayoutPass();
+
+            smallContainer.Inlines!.Add(target);
+            Assert.Equal("matched", target.DataContext);
+
+            smallContainer.Inlines.Remove(target);
+            largeContainer.Inlines!.Add(target);
+            Assert.Null(target.DataContext);
+
+            largeContainer.Width = 400;
+            root.LayoutManager.ExecuteLayoutPass();
+            Assert.Equal("matched", target.DataContext);
+        }
+
+        [Theory]
+        [InlineData(ContainerQueryType.Width)]
+        [InlineData(ContainerQueryType.Height)]
+        [InlineData(ContainerQueryType.And)]
+        [InlineData(ContainerQueryType.Or)]
+        public void Container_Query_Matches_Non_Visual_StyledElement(ContainerQueryType queryType)
+        {
+            using var app = UnitTestApplication.Start();
+            var root = new LayoutTestRoot
+            {
+                ClientSize = queryType == ContainerQueryType.Or ? new Size(400, 600) : new Size(400, 400)
+            };
+            var widthQuery = new WidthQuery(null, StyleQueryComparisonOperator.LessThanOrEquals, 500);
+            var heightQuery = new HeightQuery(null, StyleQueryComparisonOperator.LessThanOrEquals, 500);
+            var containerQuery = new ContainerQuery
+            {
+                Query = queryType switch
+                {
+                    ContainerQueryType.Width => widthQuery,
+                    ContainerQueryType.Height => heightQuery,
+                    ContainerQueryType.And => StyleQueries.And(widthQuery, heightQuery),
+                    ContainerQueryType.Or => StyleQueries.Or(widthQuery, heightQuery),
+                    _ => throw new ArgumentOutOfRangeException(nameof(queryType))
+                }
+            };
+            containerQuery.Children.Add(new Style(x => x.Is<NonVisualStyledElement>())
+            {
+                Setters = { new Setter(NonVisualStyledElement.ValueProperty, 42) }
+            });
+            root.Styles.Add(containerQuery);
+            var container = new Border();
+            Container.SetSizing(container, queryType switch
+            {
+                ContainerQueryType.Width => ContainerSizing.Width,
+                ContainerQueryType.Height => ContainerSizing.Height,
+                _ => ContainerSizing.WidthAndHeight
+            });
+            root.Child = container;
+            var target = new NonVisualStyledElement();
+            ((ISetLogicalParent)target).SetParent(container);
+
+            root.LayoutManager.ExecuteInitialLayoutPass();
+            Assert.Equal(42, target.Value);
+
+            root.ClientSize = queryType switch
+            {
+                ContainerQueryType.Width or ContainerQueryType.And => new Size(600, 400),
+                ContainerQueryType.Height => new Size(400, 600),
+                ContainerQueryType.Or => new Size(600, 600),
+                _ => throw new ArgumentOutOfRangeException(nameof(queryType))
+            };
+            root.InvalidateMeasure();
+            root.LayoutManager.ExecuteLayoutPass();
+            Assert.Equal(0, target.Value);
+        }
+
+        [Fact]
+        public void Container_Query_Uses_Named_Visual_Ancestor_For_Non_Visual_Target()
+        {
+            using var app = UnitTestApplication.Start();
+            var root = new LayoutTestRoot
+            {
+                ClientSize = new Size(1000, 400)
+            };
+            var containerQuery = new ContainerQuery(x => new WidthQuery(x, StyleQueryComparisonOperator.LessThanOrEquals, 500), "target");
+            containerQuery.Children.Add(new Style(x => x.Is<NonVisualStyledElement>())
+            {
+                Setters = { new Setter(NonVisualStyledElement.ValueProperty, 42) }
+            });
+            root.Styles.Add(containerQuery);
+            var innerContainer = new Border
+            {
+                Width = 400
+            };
+            Container.SetName(innerContainer, "other");
+            Container.SetSizing(innerContainer, ContainerSizing.Width);
+            var namedContainer = new Border
+            {
+                Width = 600,
+                Child = innerContainer
+            };
+            Container.SetName(namedContainer, "target");
+            Container.SetSizing(namedContainer, ContainerSizing.Width);
+            root.Child = namedContainer;
+            var target = new NonVisualStyledElement();
+            ((ISetLogicalParent)target).SetParent(innerContainer);
+
+            root.LayoutManager.ExecuteInitialLayoutPass();
+            Assert.Equal(0, target.Value);
+
+            namedContainer.Width = 400;
+            root.LayoutManager.ExecuteLayoutPass();
+            Assert.Equal(42, target.Value);
+        }
+
+        private sealed class NonVisualStyledElement : StyledElement
+        {
+            public static readonly StyledProperty<int> ValueProperty =
+                AvaloniaProperty.Register<NonVisualStyledElement, int>(nameof(Value));
+
+            public int Value
+            {
+                get => GetValue(ValueProperty);
+                set => SetValue(ValueProperty, value);
+            }
+        }
+
+        public enum ContainerQueryType
+        {
+            Width,
+            Height,
+            And,
+            Or
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

StyleSelectors work on stylable elements. But for container queries, the query selection silently limits this to visuals only (see #22166 for details). 

This PR removes that restriction. For a non-visual `StyledElement`, container queries find the first `Visual` in its logical ancestors and use that visual as the starting point when searching for a matching container.

The existing behavior for visual targets remains unchanged.

## What is the current behavior?

Only classes extending `Visual` work; when extending only ' StyledElement', styles are silently ignored.

## What is the updated/expected behavior with this PR?

Works

## How was the solution implemented (if it's not obvious)?

Container-query activators now accept a `StyledElement` instead of requiring a `Visual`.

For a visual target, container lookup still starts with its visual parent.

For a non-visual target, the activator:

- finds the first `Visual` in the target's logical ancestors;
- takes that visual when matching a container
- tracks logical attachment and detachment

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes #22166