### PR TITLE
Fix SplineEasing constructor overwriting Y1 instead of setting Y2

### DIFF
--- a/src/Avalonia.Base/Animation/Easings/SplineEasing.cs
+++ b/src/Avalonia.Base/Animation/Easings/SplineEasing.cs
@@ -65,7 +65,7 @@ namespace Avalonia.Animation.Easings
             this.X1 = x1;
             this.Y1 = y1;
             this.X2 = x2;
-            this.Y1 = y2;
+            this.Y2 = y2;
         }
 
         public SplineEasing(KeySpline keySpline)

--- a/tests/Avalonia.Base.UnitTests/Animation/KeySplineTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Animation/KeySplineTests.cs
@@ -74,6 +74,22 @@ namespace Avalonia.Base.UnitTests.Animation
             Assert.NotEqual(0.5, easing.Ease(0.5));
         }
 
+        [Fact]
+        public void SplineEasing_Constructor_Assigns_All_Control_Points()
+        {
+            // y1 != y2 and y2 != 1 (KeySpline default) so both a Y1 overwrite
+            // and a missing Y2 assignment would fail this test.
+            var easing = new SplineEasing(0.2, 0.8, 0.4, 0.3);
+
+            Assert.Equal(0.2, easing.X1);
+            Assert.Equal(0.8, easing.Y1);
+            Assert.Equal(0.4, easing.X2);
+            Assert.Equal(0.3, easing.Y2);
+
+            var expected = new SplineEasing(new KeySpline(0.2, 0.8, 0.4, 0.3));
+            Assert.Equal(expected.Ease(0.5), easing.Ease(0.5));
+        }
+
         /*
           To get the test values for the KeySpline test, you can:
           1) Grab the WPF sample for KeySpline animations from https://github.com/microsoft/WPF-Samples/tree/master/Animation/KeySplineAnimations


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
The four-parameter SplineEasing constructor copied y2 into Y1, leaving Y2 at the KeySpline default (1). XAML property setters and the KeySpline overload were unaffected.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
new SplineEasing(x1, y1, x2, y2) writes y2 into Y1. Y2 stays at the KeySpline default of 1.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
All four control points are assigned. Covered by SplineEasing_Constructor_Assigns_All_Control_Points.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
