### PR TITLE
Fix CalendarDatePicker.Focus() not focusing the text box

### DIFF
--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -396,14 +396,21 @@ namespace Avalonia.Controls
         protected override void OnGotFocus(FocusChangedEventArgs e)
         {
             base.OnGotFocus(e);
-            if(IsEnabled && _textBox != null && e.NavigationMethod == NavigationMethod.Tab)
+
+            // A programmatic Focus() call reports NavigationMethod.Unspecified, so forwarding
+            // can't be gated on Tab.
+            if (IsEnabled && _textBox != null && ReferenceEquals(e.Source, this))
             {
-                _textBox.Focus();
-                var text = _textBox.Text;
-                if(!string.IsNullOrEmpty(text))
+                _textBox.Focus(e.NavigationMethod);
+
+                if (e.NavigationMethod == NavigationMethod.Tab)
                 {
-                    _textBox.SelectionStart = 0;
-                    _textBox.SelectionEnd = text.Length;
+                    var text = _textBox.Text;
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        _textBox.SelectionStart = 0;
+                        _textBox.SelectionEnd = text.Length;
+                    }
                 }
             }
         }

--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -397,8 +397,6 @@ namespace Avalonia.Controls
         {
             base.OnGotFocus(e);
 
-            // A programmatic Focus() call reports NavigationMethod.Unspecified, so forwarding
-            // can't be gated on Tab.
             if (IsEnabled && _textBox != null && ReferenceEquals(e.Source, this))
             {
                 _textBox.Focus(e.NavigationMethod);

--- a/tests/Avalonia.Controls.UnitTests/CalendarDatePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CalendarDatePickerTests.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data.Converters;
+using Avalonia.Harfbuzz;
+using Avalonia.Headless;
 using Avalonia.Input;
 using Avalonia.Platform;
 using Avalonia.UnitTests;
@@ -194,6 +196,45 @@ namespace Avalonia.Controls.UnitTests
                 Assert.True(CompareDates(datePicker.SelectedDate.Value, new DateTime(2026, 4, 22)));
             }
         }
+
+        [Fact]
+        public void Tab_Focus_Should_Move_Focus_To_TextBox()
+        {
+            using (UnitTestApplication.Start(FocusServices))
+            {
+                var datePicker = new CalendarDatePicker { Template = CreateTemplate() };
+                var root = new TestRoot(datePicker);
+                root.LayoutManager.ExecuteInitialLayoutPass();
+
+                datePicker.Focus(NavigationMethod.Tab);
+
+                Assert.Same(GetTextBox(datePicker), root.FocusManager.GetFocusedElement());
+            }
+        }
+
+        [Fact]
+        public void Programmatic_Focus_Should_Move_Focus_To_TextBox()
+        {
+            using (UnitTestApplication.Start(FocusServices))
+            {
+                var datePicker = new CalendarDatePicker { Template = CreateTemplate() };
+                var root = new TestRoot(datePicker);
+                root.LayoutManager.ExecuteInitialLayoutPass();
+
+                datePicker.Focus();
+
+                Assert.Same(GetTextBox(datePicker), root.FocusManager.GetFocusedElement());
+            }
+        }
+
+        private static TestServices FocusServices => TestServices.MockThreadingInterface.With(
+            fontManagerImpl: new HeadlessFontManagerStub(),
+            standardCursorFactory: Mock.Of<ICursorFactory>(),
+            textShaperImpl: new HarfBuzzTextShaper(),
+            renderInterface: new HeadlessPlatformRenderInterface(),
+            keyboardDevice: () => new KeyboardDevice(),
+            keyboardNavigation: () => new KeyboardNavigationHandler(),
+            inputManager: new InputManager());
 
         private static TestServices Services => TestServices.MockThreadingInterface.With(
             standardCursorFactory: Mock.Of<ICursorFactory>());


### PR DESCRIPTION
## What does the pull request do?

Makes `CalendarDatePicker.Focus()` put the caret in the text box, like tabbing into the control already does.

Note that #21438 reports two problems. The other one, where the text turns to whitespace when you Tab onto the control, no longer reproduces on main. As far as I can tell it was fixed by #21193. I only checked on Windows.

## What is the current behavior?

Calling `Focus()` on a `CalendarDatePicker` appears to do nothing. Focus stops on the picker itself, no caret shows up and typing does nothing. Tab works fine.

## What is the updated/expected behavior with this PR?

`Focus()` moves focus into `PART_TextBox`, so the user can type straight away.

## How was the solution implemented (if it's not obvious)?

`OnGotFocus` only forwarded focus when `e.NavigationMethod == NavigationMethod.Tab`. A programmatic `Focus()` call reports `NavigationMethod.Unspecified`, so it never got there.

The check is now on the focus source instead. `GotFocus` bubbles, so without that check the handler would re-run when the text box itself is focused and re-select the text on every click, which would break click to position the caret.

Selecting all the text is still limited to Tab, so click and programmatic focus behave as before. WPF's `DatePicker` selects all whenever the text box gains focus, but that felt like a wider behaviour change than this needs. Happy to match WPF if you'd prefer.

The original navigation method is passed through to `_textBox.Focus()` so focus visuals still tell keyboard and pointer apart.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

Two tests: one for Tab, which passed before and guards the existing path, and one for `Focus()`, which failed before this change.

## Breaking changes

None.

## Fixed issues

Fixes #21438
