### PR TITLE
Report deselected items and batch SelectAll in TreeView

### DIFF
--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -52,6 +52,10 @@ namespace Avalonia.Controls
         private object? _selectedItem;
         private IList? _selectedItems;
         private bool _syncingSelectedItems;
+        private readonly List<object> _previousSelectedItems = new();
+        private bool _batchingSelectionChanges;
+        private List<object>? _pendingAdded;
+        private List<object>? _pendingRemoved;
 
         /// <summary>
         /// Initializes static members of the <see cref="TreeView"/> class.
@@ -221,7 +225,19 @@ namespace Avalonia.Controls
             }
 
             AddItems(this);
-            SynchronizeItems(SelectedItems, allItems);
+
+            _batchingSelectionChanges = true;
+
+            try
+            {
+                SynchronizeItems(SelectedItems, allItems);
+            }
+            finally
+            {
+                _batchingSelectionChanges = false;
+            }
+
+            RaisePendingSelectionChanged();
         }
 
         /// <summary>
@@ -330,10 +346,22 @@ namespace Avalonia.Controls
         {
             var oldValue = _selectedItem;
             _syncingSelectedItems = true;
-            SelectedItems.Clear();
-            _selectedItem = item;
-            SelectedItems.Add(item);
-            _syncingSelectedItems = false;
+            _batchingSelectionChanges = true;
+
+            try
+            {
+                // Clearing and repopulating the collection is one selection change, not two.
+                SelectedItems.Clear();
+                _selectedItem = item;
+                SelectedItems.Add(item);
+            }
+            finally
+            {
+                _syncingSelectedItems = false;
+                _batchingSelectionChanges = false;
+            }
+
+            RaisePendingSelectionChanged();
 
             RaisePropertyChanged(SelectedItemProperty, oldValue, _selectedItem);    
         }
@@ -405,6 +433,18 @@ namespace Avalonia.Controls
                         MarkContainerSelected(container, false);
                     }
 
+                    // A reset carries no OldItems, so work out what was deselected by comparing
+                    // against the previous selection.
+                    if (_previousSelectedItems.Count > 0)
+                    {
+                        var deselected = _previousSelectedItems.Where(x => !SelectedItems.Contains(x)).ToArray();
+
+                        if (deselected.Length > 0)
+                        {
+                            removed = deselected;
+                        }
+                    }
+
                     if (SelectedItems.Count > 0)
                     {
                         SelectedItemsAdded(SelectedItems);
@@ -445,11 +485,74 @@ namespace Avalonia.Controls
 
             if (added?.Count > 0 || removed?.Count > 0)
             {
-                var changed = new SelectionChangedEventArgs(
+                if (_batchingSelectionChanges)
+                {
+                    Accumulate(ref _pendingRemoved, removed);
+                    Accumulate(ref _pendingAdded, added);
+                }
+                else
+                {
+                    var changed = new SelectionChangedEventArgs(
+                        SelectingItemsControl.SelectionChangedEvent,
+                        removed ?? Empty,
+                        added ?? Empty);
+                    RaiseEvent(changed);
+                }
+            }
+
+            _previousSelectedItems.Clear();
+
+            foreach (object? item in SelectedItems)
+            {
+                if (item is not null)
+                {
+                    _previousSelectedItems.Add(item);
+                }
+            }
+        }
+
+        private static void Accumulate(ref List<object>? target, IList? items)
+        {
+            if (items is null || items.Count == 0)
+            {
+                return;
+            }
+
+            target ??= new List<object>();
+
+            foreach (object? item in items)
+            {
+                if (item is not null)
+                {
+                    target.Add(item);
+                }
+            }
+        }
+
+        private void RaisePendingSelectionChanged()
+        {
+            var added = _pendingAdded;
+            var removed = _pendingRemoved;
+
+            _pendingAdded = null;
+            _pendingRemoved = null;
+
+            // An item that was deselected and reselected hasn't changed.
+            if (added is not null && removed is not null)
+            {
+                foreach (var item in removed.Intersect(added).ToArray())
+                {
+                    added.Remove(item);
+                    removed.Remove(item);
+                }
+            }
+
+            if (added?.Count > 0 || removed?.Count > 0)
+            {
+                RaiseEvent(new SelectionChangedEventArgs(
                     SelectingItemsControl.SelectionChangedEvent,
-                    removed ?? Empty,
-                    added ?? Empty);
-                RaiseEvent(changed);
+                    (IList?)removed ?? Empty,
+                    (IList?)added ?? Empty));
             }
         }
 

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -52,10 +52,12 @@ namespace Avalonia.Controls
         private object? _selectedItem;
         private IList? _selectedItems;
         private bool _syncingSelectedItems;
-        private readonly List<object> _previousSelectedItems = new();
-        private bool _batchingSelectionChanges;
-        private List<object>? _pendingAdded;
-        private List<object>? _pendingRemoved;
+        private bool _suppressSelectionChanged;
+
+        /// <summary>
+        /// The selection as of the last <see cref="SelectingItemsControl.SelectionChangedEvent"/>.
+        /// </summary>
+        private readonly List<object> _reportedSelection = new();
 
         /// <summary>
         /// Initializes static members of the <see cref="TreeView"/> class.
@@ -226,7 +228,7 @@ namespace Avalonia.Controls
 
             AddItems(this);
 
-            _batchingSelectionChanges = true;
+            _suppressSelectionChanged = true;
 
             try
             {
@@ -234,10 +236,10 @@ namespace Avalonia.Controls
             }
             finally
             {
-                _batchingSelectionChanges = false;
+                _suppressSelectionChanged = false;
             }
 
-            RaisePendingSelectionChanged();
+            RaiseSelectionChanged();
         }
 
         /// <summary>
@@ -346,11 +348,10 @@ namespace Avalonia.Controls
         {
             var oldValue = _selectedItem;
             _syncingSelectedItems = true;
-            _batchingSelectionChanges = true;
+            _suppressSelectionChanged = true;
 
             try
             {
-                // Clearing and repopulating the collection is one selection change, not two.
                 SelectedItems.Clear();
                 _selectedItem = item;
                 SelectedItems.Add(item);
@@ -358,10 +359,10 @@ namespace Avalonia.Controls
             finally
             {
                 _syncingSelectedItems = false;
-                _batchingSelectionChanges = false;
+                _suppressSelectionChanged = false;
             }
 
-            RaisePendingSelectionChanged();
+            RaiseSelectionChanged();
 
             RaisePropertyChanged(SelectedItemProperty, oldValue, _selectedItem);    
         }
@@ -433,23 +434,13 @@ namespace Avalonia.Controls
                         MarkContainerSelected(container, false);
                     }
 
-                    // A reset carries no OldItems, so work out what was deselected by comparing
-                    // against the previous selection.
-                    if (_previousSelectedItems.Count > 0)
-                    {
-                        var deselected = _previousSelectedItems.Where(x => !SelectedItems.Contains(x)).ToArray();
-
-                        if (deselected.Length > 0)
-                        {
-                            removed = deselected;
-                        }
-                    }
+                    // A reset carries no OldItems or NewItems, so diff against the last
+                    // reported selection instead.
+                    (removed, added) = GetSelectionDelta();
 
                     if (SelectedItems.Count > 0)
                     {
                         SelectedItemsAdded(SelectedItems);
-
-                        added = SelectedItems;
                     }
                     else if (!_syncingSelectedItems)
                     {
@@ -483,76 +474,45 @@ namespace Avalonia.Controls
                     break;
             }
 
-            if (added?.Count > 0 || removed?.Count > 0)
+            // While suppressed, leave _reportedSelection alone so that the delta accumulates
+            // until the caller raises the event itself.
+            if (!_suppressSelectionChanged)
             {
-                if (_batchingSelectionChanges)
-                {
-                    Accumulate(ref _pendingRemoved, removed);
-                    Accumulate(ref _pendingAdded, added);
-                }
-                else
-                {
-                    var changed = new SelectionChangedEventArgs(
-                        SelectingItemsControl.SelectionChangedEvent,
-                        removed ?? Empty,
-                        added ?? Empty);
-                    RaiseEvent(changed);
-                }
-            }
-
-            _previousSelectedItems.Clear();
-
-            foreach (object? item in SelectedItems)
-            {
-                if (item is not null)
-                {
-                    _previousSelectedItems.Add(item);
-                }
+                RaiseSelectionChanged(removed, added);
             }
         }
 
-        private static void Accumulate(ref List<object>? target, IList? items)
+        /// <summary>
+        /// Compares the current selection against the last reported selection.
+        /// </summary>
+        private (IList Removed, IList Added) GetSelectionDelta()
         {
-            if (items is null || items.Count == 0)
-            {
-                return;
-            }
-
-            target ??= new List<object>();
-
-            foreach (object? item in items)
-            {
-                if (item is not null)
-                {
-                    target.Add(item);
-                }
-            }
+            return (
+                _reportedSelection.Where(x => !SelectedItems.Contains(x)).ToArray(),
+                SelectedItems.OfType<object>().Where(x => !_reportedSelection.Contains(x)).ToArray());
         }
 
-        private void RaisePendingSelectionChanged()
+        /// <summary>
+        /// Raises <see cref="SelectingItemsControl.SelectionChangedEvent"/> for everything that has
+        /// changed since the event was last raised.
+        /// </summary>
+        private void RaiseSelectionChanged()
         {
-            var added = _pendingAdded;
-            var removed = _pendingRemoved;
+            var (removed, added) = GetSelectionDelta();
+            RaiseSelectionChanged(removed, added);
+        }
 
-            _pendingAdded = null;
-            _pendingRemoved = null;
-
-            // An item that was deselected and reselected hasn't changed.
-            if (added is not null && removed is not null)
-            {
-                foreach (var item in removed.Intersect(added).ToArray())
-                {
-                    added.Remove(item);
-                    removed.Remove(item);
-                }
-            }
+        private void RaiseSelectionChanged(IList? removed, IList? added)
+        {
+            _reportedSelection.Clear();
+            _reportedSelection.AddRange(SelectedItems.OfType<object>());
 
             if (added?.Count > 0 || removed?.Count > 0)
             {
                 RaiseEvent(new SelectionChangedEventArgs(
                     SelectingItemsControl.SelectionChangedEvent,
-                    (IList?)removed ?? Empty,
-                    (IList?)added ?? Empty));
+                    removed ?? Empty,
+                    added ?? Empty));
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
@@ -800,6 +800,46 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Changing_SelectedItem_Should_Report_Deselected_Item()
+        {
+            using var app = Start();
+            var data = CreateTestTreeData();
+            var target = CreateTarget(data: data);
+            var first = data[0].Children[0];
+            var second = data[0].Children[1];
+
+            target.SelectedItem = first;
+
+            var events = new List<(System.Collections.IList removed, System.Collections.IList added)>();
+            target.SelectionChanged += (s, e) => events.Add((e.RemovedItems, e.AddedItems));
+
+            target.SelectedItem = second;
+
+            var e = Assert.Single(events);
+            Assert.Same(second, Assert.Single(e.added));
+            Assert.Same(first, Assert.Single(e.removed));
+        }
+
+        [Fact]
+        public void SelectAll_Should_Raise_A_Single_SelectionChanged_Event()
+        {
+            using var app = Start();
+            var data = CreateTestTreeData();
+            var target = CreateTarget(data: data);
+            target.SelectionMode = SelectionMode.Multiple;
+
+            var events = new List<(System.Collections.IList removed, System.Collections.IList added)>();
+            target.SelectionChanged += (s, e) => events.Add((e.RemovedItems, e.AddedItems));
+
+            target.SelectAll();
+
+            var e = Assert.Single(events);
+            Assert.Empty(e.removed);
+            Assert.Equal(target.SelectedItems.Count, e.added.Count);
+            Assert.True(e.added.Count > 1);
+        }
+
+        [Fact]
         public void Removing_Selected_Root_Item_Should_Clear_Selection()
         {
             using var app = Start();


### PR DESCRIPTION
## What does the pull request do?

Addresses two of the three things reported in #22116: deselected items aren't reported, and `SelectAll` raises one event per item.

The third point in that issue, `ISelectionModel` support for `TreeView`, is a public API addition rather than a bug, so I've left it alone and haven't used `Fixes`.

## What is the current behavior?

Selecting one item and then another logs:

```
Added: 1, removed: 0 (selected: 1)
Added: 1, removed: 0 (selected: 1)
```

The first item is deselected but never reported. Ctrl+A on four items raises four separate events.

## What is the updated/expected behavior with this PR?

```
Added: 1, removed: 1 (selected: 1)
```

Ctrl+A raises one event containing all the items. This matches what `ListBox` already does.

## How was the solution implemented (if it's not obvious)?

`SelectSingleItem` clears `SelectedItems` and then adds to it. `AvaloniaList.Clear` raises a `Reset`, and a reset carries no `OldItems`, so there was nothing to report the deselection from. The control now keeps the previous selection so the reset case can work out what went away.

Doing only that would turn one event into two, so the clear and the add are now batched and raised as a single event. `SelectAll` uses the same batching.

I used a separate flag for the batching rather than reusing `_syncingSelectedItems`, since that one also gates some `SelectedItem` bookkeeping that shouldn't change. Both call sites use try/finally so a failure part way through can't leave the control swallowing events.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

Two tests, both of which fail on main.

## Breaking changes

Handlers that assumed `RemovedItems` was always empty, or that counted one event per item from `SelectAll`, will see different values. The selection itself is unchanged.

## Related issues

Part of #22116
