### PR TITLE
Allow casting to a nested type in a binding path

### DIFF
--- a/src/Avalonia.Base/Data/Core/Parsers/BindingExpressionGrammar.cs
+++ b/src/Avalonia.Base/Data/Core/Parsers/BindingExpressionGrammar.cs
@@ -377,12 +377,12 @@ namespace Avalonia.Data.Core.Parsers
         {
             ReadOnlySpan<char> ns, typeName;
             ns = ReadOnlySpan<char>.Empty;
-            var typeNameOrNamespace = r.ParseIdentifier();
+            var typeNameOrNamespace = r.ParseTypeIdentifier();
 
             if (!r.End && r.TakeIf(':'))
             {
                 ns = typeNameOrNamespace;
-                typeName = r.ParseIdentifier();
+                typeName = r.ParseTypeIdentifier();
             }
             else
             {

--- a/src/Avalonia.Base/Utilities/IdentifierParser.cs
+++ b/src/Avalonia.Base/Utilities/IdentifierParser.cs
@@ -21,6 +21,25 @@ namespace Avalonia.Utilities
             }
         }
 
+        /// <summary>
+        /// Parses an identifier that may name a nested type, e.g. "Outer+Inner".
+        /// </summary>
+        public static ReadOnlySpan<char> ParseTypeIdentifier(this
+#if NET7SDK
+            scoped
+#endif
+            ref CharacterReader r)
+        {
+            if (IsValidIdentifierStart(r.Peek))
+            {
+                return r.TakeWhile(c => IsValidIdentifierChar(c) || c == '+');
+            }
+            else
+            {
+                return ReadOnlySpan<char>.Empty;
+            }
+        }
+
         private static bool IsValidIdentifierStart(char c)
         {
             return char.IsLetter(c) || c == '_';

--- a/tests/Avalonia.Base.UnitTests/Data/Core/Parsers/BindingExpressionGrammarTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/Parsers/BindingExpressionGrammarTests.cs
@@ -244,6 +244,26 @@ namespace Avalonia.Base.UnitTests.Data.Core.Parsers
             Assert.IsType<BindingExpressionGrammar.StreamNode>(result[1]);
         }
 
+        [Fact]
+        public void Should_Parse_Cast_To_Nested_Type()
+        {
+            var result = Parse("((ns:Outer+Inner)Foo).Bar");
+
+            var cast = Assert.IsType<BindingExpressionGrammar.TypeCastNode>(result[1]);
+            Assert.Equal("ns", cast.Namespace);
+            Assert.Equal("Outer+Inner", cast.TypeName);
+        }
+
+        [Fact]
+        public void Should_Parse_Cast_To_Non_Nested_Type()
+        {
+            var result = Parse("((ns:Outer)Foo).Bar");
+
+            var cast = Assert.IsType<BindingExpressionGrammar.TypeCastNode>(result[1]);
+            Assert.Equal("ns", cast.Namespace);
+            Assert.Equal("Outer", cast.TypeName);
+        }
+
         private static void AssertIsProperty(
             BindingExpressionGrammar.INode node,
             string name,

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/BindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/BindingExtensionTests.cs
@@ -12,6 +12,27 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
     public class BindingExtensionTests : XamlTestBase
     {
         [Fact]
+        public void SupportCastToNestedTypeInExpression()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        >
+    <ContentControl Content='{Binding $parent.((local:ReflectionOuter+Nested)DataContext).NestedProperty}' Name='contentControl' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var contentControl = window.GetControl<ContentControl>("contentControl");
+
+                window.DataContext = new ReflectionOuter.Nested { NestedProperty = "hello" };
+
+                Assert.Equal("hello", contentControl.Content);
+            }
+        }
+
+        [Fact]
         public void BindingExtension_Binds_To_Source()
         {
             using (StyledWindow())
@@ -165,6 +186,14 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                             }))
                 }
             };
+        }
+    }
+
+    public class ReflectionOuter
+    {
+        public class Nested
+        {
+            public string NestedProperty { get; set; } = "nested";
         }
     }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -1457,6 +1457,26 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
 
         [Fact]
+        public void SupportCastToNestedTypeInExpression()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='using:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions'>
+    <ContentControl Content='{CompiledBinding $parent.((local:OuterClass+NestedClass)DataContext).NestedProperty}' Name='contentControl' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var contentControl = window.GetControl<ContentControl>("contentControl");
+
+                window.DataContext = new OuterClass.NestedClass { NestedProperty = "hello" };
+
+                Assert.Equal("hello", contentControl.Content);
+            }
+        }
+
+        [Fact]
         public void SupportCastToTypeInExpression_DifferentTypeEvaluatesToNull()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
@@ -2823,6 +2843,14 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
     public class TestData
     {
         public string? StringProperty { get; set; }
+    }
+
+    public class OuterClass
+    {
+        public class NestedClass
+        {
+            public string NestedProperty { get; set; } = "nested value";
+        }
     }
 
     public class TestDataContextBaseClass {}


### PR DESCRIPTION
## What does the pull request do?

Lets a binding path cast to a nested type, e.g. `{Binding ((local:Outer+Nested)DataContext).SomeProperty}`.

## What is the current behavior?

It fails to compile:

```
Internal compiler error: Expected ')'. (AvaloniaXamlIlBindingPathParser)
```

`+` already works for nested types elsewhere in XAML, for instance in `x:DataType='{x:Type local:TestDataContext+NestedGeneric, ...}'`, which has a test in this repo. It just wasn't accepted in a binding path.

## What is the updated/expected behavior with this PR?

The cast resolves and the binding works, for both compiled and reflection bindings.

## How was the solution implemented (if it's not obvious)?

The binding path parser builds type names with `ParseIdentifier`, which doesn't allow `+`, so parsing stopped at the `+` and the parser then expected a `)`.

Added `ParseTypeIdentifier`, which is the same thing but also accepts `+`, and used it only where a type name is parsed. Ordinary identifiers are unchanged, so `Foo+Bar` in a normal property path is still invalid.

Nothing else needed changing. The compiled path passes the name to `TypeReferenceResolver`, and the reflection path to `Assembly.GetType`, and both already understand `Outer+Nested`.

## One thing worth flagging

The issue also mentions `.` as a separator. I haven't allowed that, because `.` after a type name is how attached properties are written, as in `(ns:Owner.Property)`, so accepting it there would break them. `+` is the CLR nested type separator anyway. Happy to revisit if you disagree.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

Four tests: two at the parser level and one each for compiled and reflection bindings. Two of them cover the non-nested case so the existing behaviour stays covered.

## Breaking changes

None. This only accepts input that previously failed to compile.

## Fixed issues

Fixes #22047
