### PR TITLE
Short-circuit a null-conditional operator after a cast

### DIFF
--- a/src/Avalonia.Base/Data/Core/ExpressionNodes/FuncTransformNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNodes/FuncTransformNode.cs
@@ -23,9 +23,8 @@ internal sealed class FuncTransformNode : ExpressionNode
 
     protected override void OnSourceChanged(object? source, Exception? dataValidationError)
     {
-        if (!ValidateNonNullSource(source))
-            return;
-
+        // Only used for type casts, which produce null from null as in C#. Any error belongs to
+        // the member access which follows, where a null-conditional operator can short-circuit it.
         SetValue(_transform(source));
     }
 }

--- a/src/Avalonia.Base/Data/Core/ExpressionNodes/Reflection/ReflectionTypeCastNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNodes/Reflection/ReflectionTypeCastNode.cs
@@ -21,8 +21,13 @@ internal sealed class ReflectionTypeCastNode : ExpressionNode
 
     protected override void OnSourceChanged(object? source, Exception? dataValidationError)
     {
-        if (!ValidateNonNullSource(source))
+        // Casting null produces null, as in C#. Any error belongs to the member access which
+        // follows, where a null-conditional operator gets the chance to short-circuit it.
+        if (source is null)
+        {
+            SetValue(null);
             return;
+        }
 
         if (_targetType.IsInstanceOfType(source))
             SetValue(source);

--- a/tests/Avalonia.Base.UnitTests/Data/Core/NullConditionalBindingTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/NullConditionalBindingTests.cs
@@ -13,6 +13,13 @@ using Xunit;
 namespace Avalonia.Base.UnitTests.Data.Core;
 
 /// <summary>
+/// A top-level type used to test casting in a binding path.
+/// </summary>
+public class DerivedSecond : NullConditionalBindingTests.Second
+{
+}
+
+/// <summary>
 /// Tests for null-conditional operator in binding paths.
 /// </summary>
 /// <remarks>
@@ -377,6 +384,32 @@ public class NullConditionalBindingTests
         result.DataContext = data;
         result.Show();
         return result;
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Should_Not_Report_Error_With_Null_Conditional_Operator_After_Cast(bool compileBindings)
+    {
+        using var app = Start();
+        using var log = TestLogger.Create();
+        var xaml = $$$"""
+            <Window xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                    xmlns:local='clr-namespace:Avalonia.Base.UnitTests.Data.Core;assembly=Avalonia.Base.UnitTests'
+                    x:DataType='local:NullConditionalBindingTests+First'
+                    x:CompileBindings='{{{compileBindings}}}'>
+                <local:ErrorCollectingTextBox Text='{Binding ((local:DerivedSecond)Second)?.Third.Final}'/>
+            </Window>
+            """;
+        var data = new First { Second = null };
+        var window = CreateTarget(xaml, data);
+        var textBox = Assert.IsType<ErrorCollectingTextBox>(window.Content);
+
+        Assert.Null(textBox.Text);
+        Assert.Null(textBox.Error);
+        Assert.Equal(BindingValueType.Value, textBox.ErrorState);
+        Assert.Empty(log.Messages);
     }
 
     private static IDisposable Start()


### PR DESCRIPTION
## What does the pull request do?

Follow-up to #22082. A null-conditional operator after a cast now short-circuits instead of logging an error.

## What is the current behavior?

```xaml
<Button Content="{Binding $self.((MenuFlyout)Flyout)?.IsOpen}">
```

logs:

> An error occurred binding 'Content' to 'Flyout.IsOpen' at 'Flyout': 'Value is null.'

Without the cast it's fine.

## What is the updated/expected behavior with this PR?

No error, same as without the cast.

## How was the solution implemented (if it's not obvious)?

#22082 added the short-circuit to the property accessor nodes, but the cast nodes still called `ValidateNonNullSource`, so the cast reported the error before the `?.` could suppress it. There are two of them: `ReflectionTypeCastNode` for reflection bindings and `FuncTransformNode` for compiled ones, the latter only ever being used for casts.

Rather than thread an `acceptsNull` flag through the grammar, casting null now just produces null, like it does in C#. Any error then belongs to the member access that follows, which is where `?.` gets a say. I checked that a path without `?.` still reports the error.

It has to be `SetValue(null)` and not `ClearValue()`. `ClearValue` gives `UnsetValue`, which the next node still errors on, so nothing short-circuits.

## Two things for you to weigh

- You solved this in #22082 with an explicit flag per node. This does it by making the cast null-transparent instead, which is smaller but a different shape. Tell me if you'd rather it matched.
- In `ReflectionTypeCastNode` a null source now takes `SetValue(null)` while a type mismatch still takes `ClearValue()`. That difference was already there, but this change puts the two next to each other.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

One test in `NullConditionalBindingTests`, covering compiled and reflection bindings. Both fail on main with the error above.

## Breaking changes

For a null cast with no `?.`, the error is now reported at the member access rather than at the cast. Same message, same failure.

## Fixed issues

Fixes #22136
