### PR TITLE
Run GenerateAvaloniaResources before _InjectAvaloniaAdditionalFiles

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -39,7 +39,11 @@
                       Condition="'$(ApplicationIcon)' != ''" />
   </ItemGroup>
 
-  <Target Name="_InjectAvaloniaAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
+  <!-- GenerateAvaloniaResources adds AvaloniaXaml to AvaloniaResource, so it has to run first
+       or the items read below are incomplete. -->
+  <Target Name="_InjectAvaloniaAdditionalFiles"
+          BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun"
+          DependsOnTargets="GenerateAvaloniaResources">
     <!-- Include AvaloniaXaml and AvaloniaResource (XAML only) as a Roslyn-visible additional files. -->
     <!-- This is necessary to use these files in source generators and other Roslyn-based extension. -->
     <!-- AdditionalFiles ensures that each file has Compilation available for them. -->


### PR DESCRIPTION
## What does the pull request do?

Makes `_InjectAvaloniaAdditionalFiles` depend on `GenerateAvaloniaResources`, so `AvaloniaResourcePaths` is always complete.

## What is the current behavior?

`GenerateAvaloniaResources` adds `AvaloniaXaml` items to `AvaloniaResource`. `_InjectAvaloniaAdditionalFiles` reads `AvaloniaResource` to build `AvaloniaResourcePaths`. Nothing orders the two, so the result depends on which target MSBuild happens to schedule first.

Using `samples/AppWithoutLifetime` on main:

```
> dotnet build samples/AppWithoutLifetime -t:Build -getproperty:AvaloniaResourcePaths
build\Assets\icon.ico,samples\AppWithoutLifetime\App.axaml,samples\AppWithoutLifetime\MainWindow.axaml,samples\AppWithoutLifetime\Sub.axaml

> dotnet build samples/AppWithoutLifetime -t:Compile -getproperty:AvaloniaResourcePaths
build\Assets\icon.ico
```

The three `.axaml` files are missing in the second case, so source generators using the property see an incomplete list.

Only affects projects whose XAML comes through `AvaloniaXaml`, which is the default for `.axaml`. Projects that put files straight into `AvaloniaResource` were never affected, which is why most samples in this repo don't show it.

## What is the updated/expected behavior with this PR?

Both commands return the full list.

## How was the solution implemented (if it's not obvious)?

Added `DependsOnTargets="GenerateAvaloniaResources"`, as suggested in the issue. `GenerateAvaloniaResources` depends on `AddAvaloniaResources;ResolveReferences;_GenerateAvaloniaResourcesDependencyCache`, so there's no cycle.

## On the side effects @timunie asked about

`GenerateAvaloniaResources` now runs whenever `_InjectAvaloniaAdditionalFiles` does, including design-time builds. As far as I can tell that's harmless:

- Both a `.axaml` and a `.xaml` sample build clean.
- `dotnet build -t:GenerateMSBuildEditorConfigFile -p:DesignTimeBuild=true` succeeds.
- The target is incremental, so repeat builds log `Skipping target "GenerateAvaloniaResources" because all output files are up-to-date`. It isn't redoing work in the IDE.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

No test, since this is target ordering and I couldn't find a harness for it. The two commands above are the check.

## Breaking changes

None.

## Fixed issues

Fixes #21945
