### PR TITLE
[Text input] Let composite automation peers redirect focus to an inner element

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
@@ -567,6 +567,39 @@ namespace Avalonia.Automation.Peers
         public T? GetProvider<T>() => (T?)GetProviderCore(typeof(T));
 
         /// <summary>
+        /// Gets the peer that automation clients should treat as focused when this peer's owner holds
+        /// keyboard focus.
+        /// </summary>
+        /// <remarks>
+        /// A composite control whose interaction patterns live on an inner element - an editor whose
+        /// text pattern is exposed by its text view, for example - redirects focus reporting there, so
+        /// clients see keyboard focus land on the element that carries the patterns. This is what lets
+        /// a screen reader engage its document behaviors (such as reading a focused document) instead
+        /// of stopping at a container. Redirection resolves transitively with a small bound so a
+        /// misconfigured cycle cannot hang the client.
+        /// </remarks>
+        public AutomationPeer GetFocusTarget()
+        {
+            var peer = this;
+
+            for (var i = 0; i < 8; i++)
+            {
+                var next = peer.GetFocusTargetCore();
+                if (next is null || next == peer)
+                    return peer;
+                peer = next;
+            }
+
+            return peer;
+        }
+
+        /// <summary>
+        /// Overridden by composite controls to redirect focus reporting to an inner peer; returning
+        /// null keeps focus reporting on this peer.
+        /// </summary>
+        protected virtual AutomationPeer? GetFocusTargetCore() => null;
+
+        /// <summary>
         /// Occurs when the children of the automation peer have changed.
         /// </summary>
         public event EventHandler? ChildrenChanged;

--- a/src/Avalonia.Controls/Automation/Peers/EmbeddableControlRootAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/EmbeddableControlRootAutomationPeer.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Controls.Automation.Peers
 
         public event EventHandler? FocusChanged;
 
-        public AutomationPeer? GetFocus() => _focus is object ? GetOrCreate(_focus) : null;
+        public AutomationPeer? GetFocus() => _focus is object ? GetOrCreate(_focus).GetFocusTarget() : null;
 
         public AutomationPeer? GetPeerFromPoint(Point p)
         {

--- a/src/Avalonia.Controls/Automation/Peers/WindowBaseAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/WindowBaseAutomationPeer.cs
@@ -28,7 +28,7 @@ namespace Avalonia.Automation.Peers
             return AutomationControlType.Window;
         }
 
-        public AutomationPeer? GetFocus() => _focus is object ? GetOrCreate(_focus) : null;
+        public AutomationPeer? GetFocus() => _focus is object ? GetOrCreate(_focus).GetFocusTarget() : null;
 
         public AutomationPeer? GetPeerFromPoint(Point p)
         {

--- a/tests/Avalonia.Controls.UnitTests/Automation/AutomationFocusTargetTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Automation/AutomationFocusTargetTests.cs
@@ -1,0 +1,51 @@
+using Avalonia.Automation.Peers;
+using Avalonia.Controls;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests.Automation
+{
+    public class AutomationFocusTargetTests : ScopedTestBase
+    {
+        private class RedirectingPeer : ControlAutomationPeer
+        {
+            public RedirectingPeer(Control owner, AutomationPeer? target)
+                : base(owner)
+            {
+                Target = target;
+            }
+
+            public AutomationPeer? Target { get; set; }
+
+            protected override AutomationPeer? GetFocusTargetCore() => Target;
+        }
+
+        [Fact]
+        public void GetFocusTarget_Defaults_To_Self()
+        {
+            var peer = new RedirectingPeer(new Border(), null);
+
+            Assert.Same(peer, peer.GetFocusTarget());
+        }
+
+        [Fact]
+        public void GetFocusTarget_Follows_Redirection_Transitively()
+        {
+            var inner = new RedirectingPeer(new Border(), null);
+            var middle = new RedirectingPeer(new Border(), inner);
+            var outer = new RedirectingPeer(new Border(), middle);
+
+            Assert.Same(inner, outer.GetFocusTarget());
+        }
+
+        [Fact]
+        public void GetFocusTarget_Terminates_On_A_Cycle()
+        {
+            var a = new RedirectingPeer(new Border(), null);
+            var b = new RedirectingPeer(new Border(), a);
+            a.Target = b;
+
+            Assert.NotNull(a.GetFocusTarget());
+        }
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Part of the structured text input work tracked in #22168.

Lets a composite automation peer report automation focus on an inner element instead of on itself.

Screen readers engage their document behaviors only when UIA keyboard focus lands on the element that carries the text pattern - Narrator, for instance, auto-reads a document only then. A composite control keeps real keyboard focus on itself while an inner element exposes the pattern (an editor whose document is its text view), so focus was reported on the container and clients stopped after announcing it.

`AutomationPeer` gains `GetFocusTarget`/`GetFocusTargetCore`. A peer overrides the core method to redirect focus reporting to an inner peer; the redirect is resolved transitively, with a bound that stops a cycle. Both root providers route `GetFocus` through it, which is what feeds the UIA focus-changed event and fragment-root focus resolution.

## What is the updated/expected behavior with this PR?

Unchanged for every peer that does not override `GetFocusTargetCore`: the default returns the peer itself, so `GetFocus` still reports the focused peer. A peer that does override it has its inner peer reported as the focused element, and a screen reader then sees focus on the element carrying the pattern.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None. `GetFocusTargetCore` is virtual with a default that preserves current behavior.

## Obsoletions / Deprecations

None.

## Fixed issues

Part of #22168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
