### PR TITLE
[Text input] Add ITextNavigation, a shared text navigation contract

### DIFF
--- a/src/Avalonia.Base/Input/TextInput/ITextNavigation.cs
+++ b/src/Avalonia.Base/Input/TextInput/ITextNavigation.cs
@@ -1,0 +1,75 @@
+using System;
+using Avalonia.Metadata;
+
+namespace Avalonia.Input.TextInput
+{
+    /// <summary>
+    /// Layout-free logical navigation over a text document: the shared core beneath IME and
+    /// accessibility consumers. Any backing store
+    /// (string, gap buffer, piece table, rope + element tree) can implement it.
+    /// </summary>
+    /// <remarks>
+    /// All members are UI-thread only. Every <see cref="ITextPointer"/> passed in must have been produced
+    /// by this same instance; passing a foreign pointer throws <see cref="ArgumentException"/>. There is
+    /// deliberately no factory from a raw integer: to turn a platform offset <c>n</c> into a position call
+    /// <c>GetPosition(DocumentStart, n)</c>, and to report a position as an integer read
+    /// <see cref="ITextPointer.Offset"/>.
+    /// </remarks>
+    [Unstable]
+    public interface ITextNavigation
+    {
+        /// <summary>The position at the start of the document. Carries forward gravity.</summary>
+        ITextPointer DocumentStart { get; }
+
+        /// <summary>The position at the end of the document. Carries backward gravity.</summary>
+        ITextPointer DocumentEnd { get; }
+
+        /// <summary>The range covering the whole document.</summary>
+        ITextRange DocumentRange { get; }
+
+        /// <summary>A monotonically increasing token bumped once per contiguous text change.</summary>
+        long DocumentVersion { get; }
+
+        /// <summary>
+        /// The position <paramref name="distance"/> UTF-16 code units from <paramref name="origin"/>
+        /// (negative moves toward the document start), clamped to the document and snapped, in the
+        /// direction of travel, to a valid position. The result carries the direction of travel as its
+        /// gravity; a zero-distance move preserves the origin's gravity.
+        /// </summary>
+        ITextPointer GetPosition(ITextPointer origin, int distance);
+
+        /// <summary>
+        /// The position <paramref name="count"/> <paramref name="unit"/> boundaries from
+        /// <paramref name="origin"/> (negative moves toward the document start), clamped to the document.
+        /// </summary>
+        /// <remarks>
+        /// A caller needing the number of boundaries actually crossed (UIA <c>Move</c>) single-steps with
+        /// <c>count = +/-1</c>, counting until a step does not advance (the document edge). That count is
+        /// not recoverable from offsets - a code-unit distance is not a boundary count. The result carries
+        /// the direction of travel as its gravity; a zero-count move preserves the origin's gravity.
+        /// </remarks>
+        ITextPointer GetPosition(ITextPointer origin, TextUnit unit, int count);
+
+        /// <summary>
+        /// The range of the <paramref name="unit"/> containing <paramref name="position"/>. At a unit
+        /// boundary the tie is broken by <c>position.Gravity</c> (Forward selects the following unit,
+        /// Backward the preceding).
+        /// </summary>
+        ITextRange GetRangeEnclosing(ITextPointer position, TextUnit unit);
+
+        /// <summary>A normalized range from two positions; the order of the arguments does not matter.</summary>
+        ITextRange GetRange(ITextPointer a, ITextPointer b);
+
+        /// <summary>The signed UTF-16 code-unit distance from <paramref name="from"/> to <paramref name="to"/>.</summary>
+        int GetOffset(ITextPointer from, ITextPointer to);
+
+        /// <summary>
+        /// The text in <paramref name="range"/>. The result length always equals
+        /// <c>range.End.Offset - range.Start.Offset</c>; embedded objects contribute their offset footprint.
+        /// </summary>
+        string GetText(ITextRange range);
+
+        /// <summary>Raised after a contiguous text change is applied. Never raised mid-mutation.</summary>
+        event EventHandler<TextChange>? TextChanged;
+    }
+}

--- a/src/Avalonia.Base/Input/TextInput/ITextPointer.cs
+++ b/src/Avalonia.Base/Input/TextInput/ITextPointer.cs
@@ -1,0 +1,26 @@
+using System;
+using Avalonia.Media.TextFormatting;
+using Avalonia.Metadata;
+
+namespace Avalonia.Input.TextInput
+{
+    /// <summary>
+    /// Represents a document position in UTF-16 code units.
+    /// </summary>
+    /// <remarks>
+    /// Implementations are UI-thread-only.
+    /// </remarks>
+    [Unstable]
+    public interface ITextPointer : IComparable<ITextPointer>, IEquatable<ITextPointer>
+    {
+        /// <summary>
+        /// Gets the zero-based UTF-16 offset from the start of the document.
+        /// </summary>
+        int Offset { get; }
+
+        /// <summary>
+        /// Gets the pointer's logical gravity for insertion behavior.
+        /// </summary>
+        LogicalDirection Gravity { get; }
+    }
+}

--- a/src/Avalonia.Base/Input/TextInput/ITextRange.cs
+++ b/src/Avalonia.Base/Input/TextInput/ITextRange.cs
@@ -1,0 +1,29 @@
+using Avalonia.Metadata;
+
+namespace Avalonia.Input.TextInput
+{
+    /// <summary>
+    /// Represents a range between two text pointers.
+    /// </summary>
+    /// <remarks>
+    /// Implementations are UI-thread-only.
+    /// </remarks>
+    [Unstable]
+    public interface ITextRange
+    {
+        /// <summary>
+        /// Gets the start pointer.
+        /// </summary>
+        ITextPointer Start { get; }
+
+        /// <summary>
+        /// Gets the end pointer.
+        /// </summary>
+        ITextPointer End { get; }
+
+        /// <summary>
+        /// Gets whether the range is empty.
+        /// </summary>
+        bool IsEmpty { get; }
+    }
+}

--- a/src/Avalonia.Base/Input/TextInput/TextAttribute.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextAttribute.cs
@@ -1,0 +1,41 @@
+using Avalonia.Metadata;
+
+namespace Avalonia.Input.TextInput
+{
+    /// <summary>
+    /// A formatting attribute an <see cref="ITextNavigation"/> can report over a run of text.
+    /// </summary>
+    /// <remarks>
+    /// The vocabulary is the subset shared by the platform accessibility protocols (UIA TextPattern,
+    /// AT-SPI). A plain-text control reports a single uniform run spanning the whole document; richer
+    /// editors report the run over which each attribute is constant. Values are boxed per the type
+    /// noted on each member.
+    /// </remarks>
+    [Unstable]
+    public enum TextAttribute
+    {
+        /// <summary>Font family name. Value: <see cref="string"/>.</summary>
+        FontFamily,
+
+        /// <summary>Font size in device-independent pixels. Value: <see cref="double"/>.</summary>
+        FontSize,
+
+        /// <summary>Font weight (100-900). Value: <see cref="Avalonia.Media.FontWeight"/>.</summary>
+        FontWeight,
+
+        /// <summary>Font style (normal/italic/oblique). Value: <see cref="Avalonia.Media.FontStyle"/>.</summary>
+        FontStyle,
+
+        /// <summary>Foreground colour. Value: <see cref="Avalonia.Media.Color"/>.</summary>
+        Foreground,
+
+        /// <summary>Background colour. Value: <see cref="Avalonia.Media.Color"/>.</summary>
+        Background,
+
+        /// <summary>Whether the text is read-only. Value: <see cref="bool"/>.</summary>
+        IsReadOnly,
+
+        /// <summary>The paragraph/character style, e.g. a heading level. Value: <see cref="TextStyleId"/>.</summary>
+        StyleId
+    }
+}

--- a/src/Avalonia.Base/Input/TextInput/TextChange.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextChange.cs
@@ -1,0 +1,18 @@
+using Avalonia.Metadata;
+
+namespace Avalonia.Input.TextInput
+{
+    /// <summary>
+    /// A single contiguous text replacement, raised by <see cref="ITextNavigation.TextChanged"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Position"/> is the start of the change as a navigator-produced pointer, valid in the
+    /// current (post-change) document. <see cref="NewLength"/> UTF-16 code units were inserted there; the
+    /// inserted text is the range [<see cref="Position"/>, Position + <see cref="NewLength"/>) and is read
+    /// on demand via <see cref="ITextNavigation.GetText"/>, so the event never eagerly materializes it.
+    /// <see cref="OldLength"/> code units were removed and are gone from the document. Maps to TSF
+    /// <c>OnTextChange(Position.Offset, Position.Offset + OldLength, Position.Offset + NewLength)</c>.
+    /// </remarks>
+    [Unstable]
+    public readonly record struct TextChange(ITextPointer Position, int OldLength, int NewLength);
+}

--- a/src/Avalonia.Base/Input/TextInput/TextNavigationExtensions.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextNavigationExtensions.cs
@@ -1,0 +1,36 @@
+using Avalonia.Media.TextFormatting;
+
+namespace Avalonia.Input.TextInput
+{
+    /// <summary>
+    /// Offset-addressing conveniences over <see cref="ITextNavigation"/> for platform adapters that
+    /// speak integer offsets. All resolution goes through the navigator's produced anchors, so the
+    /// provenance rule (no pointer fabricated from a bare integer) is preserved.
+    /// </summary>
+    internal static class TextNavigationExtensions
+    {
+        /// <summary>Resolves a document offset to a position with forward gravity.</summary>
+        public static ITextPointer PointerAt(this ITextNavigation navigation, int offset)
+            => navigation.GetPosition(navigation.DocumentStart, offset);
+
+        /// <summary>
+        /// Resolves a document offset to a position carrying the requested gravity. Forward gravity
+        /// resolves from <see cref="ITextNavigation.DocumentStart"/>, backward from
+        /// <see cref="ITextNavigation.DocumentEnd"/>, so the travel direction - which the navigator
+        /// reports back as the result's gravity and uses to snap mid-unit offsets - matches the request.
+        /// </summary>
+        public static ITextPointer PointerAt(this ITextNavigation navigation, int offset, LogicalDirection gravity)
+            => gravity == LogicalDirection.Forward
+                ? navigation.GetPosition(navigation.DocumentStart, offset)
+                : navigation.GetPosition(navigation.DocumentEnd, offset - navigation.DocumentEnd.Offset);
+
+        /// <summary>
+        /// A normalized range over the offset span [<paramref name="start"/>, start + length), with
+        /// inward-facing endpoint gravity (forward at the start, backward at the end).
+        /// </summary>
+        public static ITextRange RangeAt(this ITextNavigation navigation, int start, int length)
+            => navigation.GetRange(
+                navigation.PointerAt(start, LogicalDirection.Forward),
+                navigation.PointerAt(start + length, LogicalDirection.Backward));
+    }
+}

--- a/src/Avalonia.Base/Input/TextInput/TextStyleId.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextStyleId.cs
@@ -1,0 +1,33 @@
+using Avalonia.Metadata;
+
+namespace Avalonia.Input.TextInput
+{
+    /// <summary>
+    /// A well-known paragraph or character style an <see cref="ITextNavigation"/> can report via
+    /// <see cref="TextAttribute.StyleId"/> - most importantly the heading levels, which screen readers use
+    /// for "navigate by heading". Mirrors the UIA StyleId vocabulary; the platform accessibility layer maps
+    /// it to its protocol form (UIA <c>StyleId_*</c>).
+    /// </summary>
+    [Unstable]
+    public enum TextStyleId
+    {
+        /// <summary>A custom or unspecified style.</summary>
+        Custom = 0,
+        Heading1,
+        Heading2,
+        Heading3,
+        Heading4,
+        Heading5,
+        Heading6,
+        Heading7,
+        Heading8,
+        Heading9,
+        Title,
+        Subtitle,
+        Normal,
+        Emphasis,
+        Quote,
+        BulletedList,
+        NumberedList,
+    }
+}

--- a/src/Avalonia.Base/Input/TextInput/TextUnit.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextUnit.cs
@@ -1,0 +1,38 @@
+using Avalonia.Metadata;
+
+namespace Avalonia.Input.TextInput
+{
+    /// <summary>
+    /// A text boundary granularity for navigation and enclosing-range queries.
+    /// </summary>
+    /// <remarks>
+    /// Units do not all strictly nest; each has a precise definition in the <see cref="ITextNavigation"/> contract.
+    /// </remarks>
+    [Unstable]
+    public enum TextUnit
+    {
+        /// <summary>A user-perceived character (Unicode grapheme cluster), not a UTF-16 code unit.</summary>
+        Character,
+
+        /// <summary>A maximal run over which all text formatting/attributes are constant.</summary>
+        Format,
+
+        /// <summary>A word per Unicode UAX-29, locale-aware.</summary>
+        Word,
+
+        /// <summary>A sentence per Unicode UAX-29.</summary>
+        Sentence,
+
+        /// <summary>A visual (laid-out, wrapped) line.</summary>
+        Line,
+
+        /// <summary>A logical paragraph (block) delimited by hard breaks.</summary>
+        Paragraph,
+
+        /// <summary>A viewport-sized page.</summary>
+        Page,
+
+        /// <summary>The whole document.</summary>
+        Document
+    }
+}

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/TextSegmentation.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/TextSegmentation.cs
@@ -1,0 +1,394 @@
+using System;
+using Avalonia.Input.TextInput;
+
+namespace Avalonia.Media.TextFormatting.Unicode
+{
+    /// <summary>
+    /// Pure UTF-16 text segmentation behind <see cref="ITextNavigation"/>: grapheme-cluster (UAX-29)
+    /// character stepping, UAX-29 word boundaries, heuristic sentence and logical-line bounds,
+    /// move-by-unit, and contiguous-change diffing. Everything operates on a
+    /// <see cref="ReadOnlySpan{T}"/> and code-unit offsets so every navigation over a text store
+    /// shares one implementation; a <see cref="string"/> caller converts implicitly.
+    /// </summary>
+    internal static class TextSegmentation
+    {
+        public static int NextGrapheme(int offset, ReadOnlySpan<char> text)
+        {
+            if (offset >= text.Length)
+            {
+                return text.Length;
+            }
+
+            var enumerator = new GraphemeEnumerator(text.Slice(offset));
+            return enumerator.MoveNext(out var grapheme) ? offset + grapheme.Length : text.Length;
+        }
+
+        public static int PreviousGrapheme(int offset, ReadOnlySpan<char> text)
+        {
+            if (offset <= 0)
+            {
+                return 0;
+            }
+
+            var enumerator = new GraphemeEnumerator(text.Slice(0, offset));
+            var start = 0;
+            while (enumerator.MoveNext(out var grapheme))
+            {
+                start = grapheme.Offset;
+            }
+
+            return start;
+        }
+
+        public static int SnapToValid(int offset, ReadOnlySpan<char> text, bool forward)
+        {
+            if (offset > 0 && offset < text.Length &&
+                char.IsLowSurrogate(text[offset]) && char.IsHighSurrogate(text[offset - 1]))
+            {
+                return forward ? offset + 1 : offset - 1;
+            }
+
+            return offset;
+        }
+
+        /// <summary>
+        /// The bounds of the <paramref name="unit"/> containing <paramref name="offset"/>, with the
+        /// boundary tie broken by <paramref name="gravity"/>: a backward-gravity position exactly at a
+        /// unit start resolves to the preceding unit. Handles Character, Word, Sentence, Line and
+        /// Paragraph (Line and Paragraph both map to the logical line here).
+        /// </summary>
+        public static (int Start, int End) UnitBounds(int offset, TextUnit unit, LogicalDirection gravity, ReadOnlySpan<char> text)
+        {
+            var bounds = UnitBoundsCore(offset, unit, text);
+
+            if (gravity == LogicalDirection.Backward && offset > 0 && bounds.Start == offset)
+            {
+                bounds = unit == TextUnit.Character
+                    ? (PreviousGrapheme(offset, text), offset)
+                    : UnitBoundsCore(offset - 1, unit, text);
+            }
+
+            return bounds;
+        }
+
+        private static (int Start, int End) UnitBoundsCore(int offset, TextUnit unit, ReadOnlySpan<char> text)
+            => unit switch
+            {
+                TextUnit.Character => CharacterBounds(offset, text),
+                TextUnit.Word => WordBounds(offset, text),
+                TextUnit.Sentence => SentenceBounds(offset, text),
+                _ => LineBounds(offset, text),
+            };
+
+        public static (int Start, int End) CharacterBounds(int offset, ReadOnlySpan<char> text)
+        {
+            if (text.Length == 0)
+            {
+                return (0, 0);
+            }
+
+            // At the document end the only enclosing character is the last grapheme; clamping to
+            // length - 1 could land inside a surrogate pair or cluster.
+            if (offset >= text.Length)
+            {
+                return (PreviousGrapheme(text.Length, text), text.Length);
+            }
+
+            var start = Math.Max(0, offset);
+            return (start, NextGrapheme(start, text));
+        }
+
+        // UAX-29 word segmentation; enumerates from the document start, so O(offset).
+        // A word unit is the word together with its trailing spaces and tabs, the extent
+        // both UIA ("word plus trailing whitespace") and AT-SPI define for the word unit, so
+        // expanding inside a gap resolves to the preceding word and stepping stops once
+        // per word. Line and paragraph separators never attach, and whitespace with no
+        // word before it on its line (leading or isolated runs) stays a unit of its own.
+        public static (int Start, int End) WordBounds(int offset, ReadOnlySpan<char> text)
+        {
+            if (text.Length == 0)
+            {
+                return (0, 0);
+            }
+
+            var clamped = Math.Clamp(offset, 0, text.Length);
+            var units = new WordUnitEnumerator(text);
+            while (units.MoveNext(out var start, out var end))
+            {
+                if (clamped < end)
+                {
+                    return (start, end);
+                }
+            }
+
+            return (text.Length, text.Length);
+        }
+
+        public static int WordBoundary(int offset, bool forward, ReadOnlySpan<char> text)
+        {
+            if (forward)
+            {
+                if (offset >= text.Length)
+                {
+                    return text.Length;
+                }
+
+                var units = new WordUnitEnumerator(text);
+                while (units.MoveNext(out _, out var end))
+                {
+                    if (end > offset)
+                    {
+                        return end;
+                    }
+                }
+
+                return text.Length;
+            }
+
+            if (offset <= 0)
+            {
+                return 0;
+            }
+
+            var previous = 0;
+            var backward = new WordUnitEnumerator(text);
+            while (backward.MoveNext(out _, out var end))
+            {
+                if (end >= offset)
+                {
+                    break;
+                }
+
+                previous = end;
+            }
+
+            return previous;
+        }
+
+        // Enumerates word units over the UAX-29 segments: a word segment absorbs the
+        // space/tab segments that follow it, separators and word-less whitespace runs
+        // come through as their own units, and the units tile the text.
+        private ref struct WordUnitEnumerator
+        {
+            private WordBreakEnumerator _segments;
+            private readonly ReadOnlySpan<char> _text;
+            private bool _hasPending;
+            private int _pendingStart;
+            private int _pendingEnd;
+            private bool _pendingIsWord;
+
+            public WordUnitEnumerator(ReadOnlySpan<char> text)
+            {
+                _segments = new WordBreakEnumerator(text);
+                _text = text;
+            }
+
+            public bool MoveNext(out int start, out int end)
+            {
+                while (_segments.MoveNext(out var segment))
+                {
+                    var segmentStart = segment.Offset;
+                    var segmentEnd = segment.Offset + segment.Length;
+                    var isSpaceRun = IsSpaceTabRun(_text.Slice(segmentStart, segmentEnd - segmentStart));
+
+                    if (_hasPending && _pendingIsWord && isSpaceRun)
+                    {
+                        _pendingEnd = segmentEnd;
+                        continue;
+                    }
+
+                    var isWord = !isSpaceRun && !IsLineSeparator(_text[segmentStart]);
+
+                    if (_hasPending)
+                    {
+                        start = _pendingStart;
+                        end = _pendingEnd;
+                        _pendingStart = segmentStart;
+                        _pendingEnd = segmentEnd;
+                        _pendingIsWord = isWord;
+                        return true;
+                    }
+
+                    _hasPending = true;
+                    _pendingStart = segmentStart;
+                    _pendingEnd = segmentEnd;
+                    _pendingIsWord = isWord;
+                }
+
+                if (_hasPending)
+                {
+                    _hasPending = false;
+                    start = _pendingStart;
+                    end = _pendingEnd;
+                    return true;
+                }
+
+                start = _text.Length;
+                end = _text.Length;
+                return false;
+            }
+        }
+
+        private static bool IsSpaceTabRun(ReadOnlySpan<char> segment)
+        {
+            if (segment.IsEmpty)
+            {
+                return false;
+            }
+
+            foreach (var c in segment)
+            {
+                if (c != ' ' && c != '\t')
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsLineSeparator(char c)
+            => c == '\r' || c == '\n' || c == (char)0x000B || c == (char)0x000C
+                || c == (char)0x0085 || c == (char)0x2028 || c == (char)0x2029;
+
+        // Logical line: bounded by UAX-14 mandatory breaks via LineBreakEnumerator (so CRLF is one
+        // break), with the terminator trimmed from the content but trailing spaces kept. This is not
+        // the visual wrapped line, which needs layout. O(offset), matching the UAX-29 word path.
+        public static (int Start, int End) LineBounds(int offset, ReadOnlySpan<char> text)
+        {
+            var length = text.Length;
+            if (length == 0)
+            {
+                return (0, 0);
+            }
+
+            offset = Math.Clamp(offset, 0, length - 1);
+
+            var start = 0;
+            var enumerator = new LineBreakEnumerator(text);
+
+            while (enumerator.MoveNext(out var lineBreak))
+            {
+                if (!lineBreak.Required)
+                {
+                    continue;
+                }
+
+                // PositionWrap is the start of the next line, past the break sequence.
+                if (lineBreak.PositionWrap <= offset)
+                {
+                    start = lineBreak.PositionWrap;
+                    continue;
+                }
+
+                // First hard break after the offset: end the content before the terminator
+                // characters, but keep any trailing spaces that precede them.
+                var end = lineBreak.PositionWrap;
+                while (end > start && IsMandatoryBreak(text[end - 1]))
+                {
+                    end--;
+                }
+
+                return (start, end);
+            }
+
+            return (start, length);
+        }
+
+        // Heuristic sentence bounds; there is no UAX-29 sentence segmenter in the tree.
+        public static (int Start, int End) SentenceBounds(int offset, ReadOnlySpan<char> text)
+        {
+            var length = text.Length;
+            if (length == 0)
+            {
+                return (0, 0);
+            }
+
+            var position = Math.Clamp(offset, 0, length - 1);
+
+            var start = position;
+            while (start > 0 && !IsSentenceBoundary(text[start - 1]))
+            {
+                start--;
+            }
+
+            var end = position;
+            while (end < length && !IsSentenceBoundary(text[end]))
+            {
+                end++;
+            }
+
+            if (end < length)
+            {
+                end++;
+            }
+
+            return (start, end);
+        }
+
+        public static int MoveByUnit(int offset, TextUnit unit, bool forward, ReadOnlySpan<char> text)
+        {
+            switch (unit)
+            {
+                case TextUnit.Document:
+                case TextUnit.Page:
+                case TextUnit.Format:
+                    return forward ? text.Length : 0;
+
+                case TextUnit.Character:
+                    return forward ? NextGrapheme(offset, text) : PreviousGrapheme(offset, text);
+
+                case TextUnit.Word:
+                    return WordBoundary(offset, forward, text);
+
+                default:
+                    var (start, end) = unit == TextUnit.Sentence
+                        ? SentenceBounds(offset, text)
+                        : LineBounds(offset, text);
+
+                    if (forward)
+                    {
+                        return end > offset ? end : NextGrapheme(offset, text);
+                    }
+
+                    return start < offset ? start : PreviousGrapheme(offset, text);
+            }
+        }
+
+        // The single contiguous change between two strings (common prefix/suffix).
+        public static (int Offset, int OldLength, int NewLength) ComputeChange(ReadOnlySpan<char> oldText, ReadOnlySpan<char> newText)
+        {
+            var min = Math.Min(oldText.Length, newText.Length);
+
+            var prefix = 0;
+            while (prefix < min && oldText[prefix] == newText[prefix])
+            {
+                prefix++;
+            }
+
+            var suffix = 0;
+            while (suffix < min - prefix &&
+                   oldText[oldText.Length - 1 - suffix] == newText[newText.Length - 1 - suffix])
+            {
+                suffix++;
+            }
+
+            return (prefix, oldText.Length - prefix - suffix, newText.Length - prefix - suffix);
+        }
+
+        private static bool IsSentenceBoundary(char c) => c is '.' or '!' or '?' or '\n' or '\r';
+
+        // A UAX-14 mandatory (hard) line break character: LF, CR, NEL, and the BK class - which covers
+        // VT, FF, U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR. Used only to trim the terminator
+        // from a line's content; LineBreakEnumerator decides where lines break. All are BMP, so one
+        // UTF-16 unit suffices.
+        private static bool IsMandatoryBreak(char c) => new Codepoint(c).LineBreakClass switch
+        {
+            LineBreakClass.MandatoryBreak => true,
+            LineBreakClass.LineFeed => true,
+            LineBreakClass.CarriageReturn => true,
+            LineBreakClass.NextLine => true,
+            _ => false,
+        };
+    }
+}

--- a/src/Avalonia.Controls/Automation/Provider/IAccessibleText.cs
+++ b/src/Avalonia.Controls/Automation/Provider/IAccessibleText.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using Avalonia.Input.TextInput;
+using Avalonia.Metadata;
+
+namespace Avalonia.Automation.Provider
+{
+    /// <summary>
+    /// Extends <see cref="ITextNavigation"/> with the editing and geometry operations the accessibility
+    /// text providers (UIA TextPattern, AT-SPI) need beyond read-only navigation. A navigation that
+    /// implements it lets an accessibility text range act on the owning control.
+    /// </summary>
+    [Unstable]
+    public interface IAccessibleText : ITextNavigation
+    {
+        /// <summary>Sets the control's selection to <paramref name="range"/>.</summary>
+        void SetSelection(ITextRange range);
+
+        /// <summary>The current selection (a collapsed range at the caret when nothing is selected).</summary>
+        ITextRange GetSelection();
+
+        /// <summary>
+        /// The top-level-coordinate rectangles covering <paramref name="range"/> (one per line); the
+        /// platform accessibility layer converts them to screen coordinates.
+        /// </summary>
+        Rect[] GetBoundingRectangles(ITextRange range);
+
+        /// <summary>
+        /// The position nearest <paramref name="point"/> (in top-level coordinates), or null when the
+        /// control has no layout. The inverse of <see cref="GetBoundingRectangles"/>; the platform
+        /// accessibility layer converts screen coordinates to top-level before calling.
+        /// </summary>
+        ITextPointer? GetPositionFromPoint(Point point);
+
+        /// <summary>The text currently visible in the control's viewport, or null when it has no layout.</summary>
+        ITextRange? GetVisibleRange();
+
+        /// <summary>Scrolls the control so <paramref name="range"/> is visible, if it supports scrolling.</summary>
+        void ScrollIntoView(ITextRange range);
+
+        /// <summary>
+        /// The formatting attributes in effect at <paramref name="position"/>, together with the run
+        /// over which they are uniform (the whole document for a control with uniform formatting). An
+        /// absent key means the control does not expose that attribute; present values are boxed per
+        /// the <see cref="TextAttribute"/> vocabulary.
+        /// </summary>
+        (IReadOnlyDictionary<TextAttribute, object?> Attributes, ITextRange Run) GetTextAttributes(ITextPointer position);
+
+        /// <summary>
+        /// The text of <paramref name="range"/> with a line feed at each block boundary, matching how the
+        /// control serializes plain text (e.g. for the clipboard). Unlike <see cref="ITextNavigation.GetText"/>,
+        /// whose length equals the range's offset span, this is presentation text for accessibility clients.
+        /// Defaults to the flat text, which is correct for a control whose content is a single block.
+        /// </summary>
+        string GetBlockSeparatedText(ITextRange range) => GetText(range);
+    }
+}

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -22,6 +22,7 @@ using Avalonia.Platform;
 using Avalonia.Reactive;
 using Avalonia.Threading;
 using Avalonia.Utilities;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
 {
@@ -935,6 +936,106 @@ namespace Avalonia.Controls
         public int GetLineCount()
         {
             return this._presenter?.TextLayout.TextLines.Count ?? -1;
+        }
+
+        // Top-level-space rectangles for a character range, used by the automation text provider
+        // (the platform layer converts them to screen coordinates).
+        internal Rect[] GetTextRangeBounds(int start, int length)
+        {
+            if (_presenter is null || length <= 0 || this.GetVisualRoot() is not Visual root)
+            {
+                return Array.Empty<Rect>();
+            }
+
+            var transform = _presenter.TransformToVisual(root);
+            if (transform is null)
+            {
+                return Array.Empty<Rect>();
+            }
+
+            var result = new List<Rect>();
+            foreach (var rect in _presenter.TextLayout.HitTestTextRange(start, length))
+            {
+                result.Add(rect.TransformToAABB(transform.Value));
+            }
+
+            return result.ToArray();
+        }
+
+        // Nearest character offset for a point in top-level coordinates (the inverse of
+        // GetTextRangeBounds), used by the automation text provider for hit-testing. Returns -1 when
+        // there is no layout.
+        internal int GetOffsetFromTopLevelPoint(Point topLevelPoint)
+        {
+            if (_presenter is null || this.GetVisualRoot() is not Visual root)
+            {
+                return -1;
+            }
+
+            var transform = root.TransformToVisual(_presenter);
+            if (transform is null)
+            {
+                return -1;
+            }
+
+            var local = topLevelPoint.Transform(transform.Value);
+            var hit = _presenter.TextLayout.HitTestPoint(local);
+
+            return hit.CharacterHit.FirstCharacterIndex + hit.CharacterHit.TrailingLength;
+        }
+
+        // The character offset range currently visible in the presenter's viewport, hit-tested at the
+        // viewport corners. Returns (-1, -1) when there is no layout.
+        internal (int Start, int End) GetVisibleTextRange()
+        {
+            if (_presenter is null || this.GetVisualRoot() is not Visual root)
+            {
+                return (-1, -1);
+            }
+
+            var transform = _presenter.TransformToVisual(root);
+            if (transform is null)
+            {
+                return (-1, -1);
+            }
+
+            var bounds = new Rect(_presenter.Bounds.Size);
+            var start = GetOffsetFromTopLevelPoint(bounds.TopLeft.Transform(transform.Value));
+            var end = GetOffsetFromTopLevelPoint(bounds.BottomRight.Transform(transform.Value));
+
+            if (start < 0 || end < 0)
+            {
+                return (-1, -1);
+            }
+
+            return start <= end ? (start, end) : (end, start);
+        }
+
+        // Scrolls the presenter so the given character range is visible (best-effort, via the
+        // ScrollViewer's BringIntoView). Used by the automation text providers' scroll operations.
+        internal void ScrollTextRangeIntoView(int start, int length)
+        {
+            if (_presenter is null)
+            {
+                return;
+            }
+
+            if (length <= 0)
+            {
+                _presenter.BringIntoView(_presenter.TextLayout.HitTestTextPosition(start));
+                return;
+            }
+
+            Rect? union = null;
+            foreach (var rect in _presenter.TextLayout.HitTestTextRange(start, length))
+            {
+                union = union is null ? rect : union.Value.Union(rect);
+            }
+
+            if (union is { } bounds)
+            {
+                _presenter.BringIntoView(bounds);
+            }
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TextBoxTextNavigation.cs
+++ b/src/Avalonia.Controls/TextBoxTextNavigation.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Automation.Provider;
+using Avalonia.Input.TextInput;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+using Avalonia.Media.TextFormatting.Unicode;
+
+namespace Avalonia.Controls
+{
+    /// <summary>
+    /// An <see cref="ITextNavigation"/> over a <see cref="TextBox"/>'s text, for the automation peer
+    /// and the accessibility text providers. Unit boundaries come from <c>TextSegmentation</c>, so a
+    /// second navigation over the same control reports the same units.
+    /// </summary>
+    internal sealed class TextBoxTextNavigation : IAccessibleText
+    {
+        private readonly TextBox _textBox;
+        private long _version;
+        private EventHandler<TextChange>? _textChanged;
+
+        public TextBoxTextNavigation(TextBox textBox)
+        {
+            _textBox = textBox ?? throw new ArgumentNullException(nameof(textBox));
+            _textBox.PropertyChanged += OnTextBoxPropertyChanged;
+        }
+
+        public ITextPointer DocumentStart => CreatePointer(0);
+
+        public ITextPointer DocumentEnd => CreatePointer(Text.Length, LogicalDirection.Backward);
+
+        public ITextRange DocumentRange => new NavRange(CreatePointer(0), CreatePointer(Text.Length));
+
+        public long DocumentVersion => _version;
+
+        public event EventHandler<TextChange>? TextChanged
+        {
+            add => _textChanged += value;
+            remove => _textChanged -= value;
+        }
+
+        private string Text => _textBox.Text ?? string.Empty;
+
+        public ITextPointer GetPosition(ITextPointer origin, int distance)
+        {
+            var text = Text;
+            var target = Math.Clamp(OffsetOf(origin) + distance, 0, text.Length);
+
+            return CreatePointer(
+                TextSegmentation.SnapToValid(target, text, distance >= 0),
+                distance > 0 ? LogicalDirection.Forward
+                : distance < 0 ? LogicalDirection.Backward
+                : origin.Gravity);
+        }
+
+        public ITextPointer GetPosition(ITextPointer origin, TextUnit unit, int count)
+        {
+            var offset = OffsetOf(origin);
+
+            if (count == 0)
+            {
+                return CreatePointer(offset, origin.Gravity);
+            }
+
+            var text = Text;
+            var forward = count > 0;
+            var current = offset;
+
+            for (var i = 0; i < Math.Abs(count); i++)
+            {
+                var next = TextSegmentation.MoveByUnit(current, unit, forward, text);
+                if (next == current)
+                {
+                    break;
+                }
+
+                current = next;
+            }
+
+            return CreatePointer(current, forward ? LogicalDirection.Forward : LogicalDirection.Backward);
+        }
+
+        public ITextRange GetRangeEnclosing(ITextPointer position, TextUnit unit)
+        {
+            var text = Text;
+            var offset = OffsetOf(position);
+
+            switch (unit)
+            {
+                case TextUnit.Document:
+                case TextUnit.Page:
+                case TextUnit.Format:
+                    return new NavRange(CreatePointer(0), CreatePointer(text.Length));
+
+                default:
+                    var (start, end) = TextSegmentation.UnitBounds(offset, unit, position.Gravity, text);
+                    return new NavRange(CreatePointer(start), CreatePointer(end));
+            }
+        }
+
+        public ITextRange GetRange(ITextPointer a, ITextPointer b)
+        {
+            var oa = OffsetOf(a);
+            var ob = OffsetOf(b);
+
+            return oa <= ob
+                ? new NavRange(CreatePointer(oa), CreatePointer(ob))
+                : new NavRange(CreatePointer(ob), CreatePointer(oa));
+        }
+
+        public int GetOffset(ITextPointer from, ITextPointer to) => OffsetOf(to) - OffsetOf(from);
+
+        public string GetText(ITextRange range)
+        {
+            var text = Text;
+            var start = OffsetOf(range.Start);
+            var end = OffsetOf(range.End);
+            if (start > end)
+            {
+                (start, end) = (end, start);
+            }
+
+            return text.Substring(start, end - start);
+        }
+
+        public void SetSelection(ITextRange range)
+        {
+            _textBox.SelectionStart = OffsetOf(range.Start);
+            _textBox.SelectionEnd = OffsetOf(range.End);
+        }
+
+        public ITextRange GetSelection()
+        {
+            var start = Math.Min(_textBox.SelectionStart, _textBox.SelectionEnd);
+            var end = Math.Max(_textBox.SelectionStart, _textBox.SelectionEnd);
+            return GetRange(CreatePointer(start), CreatePointer(end));
+        }
+
+        public Rect[] GetBoundingRectangles(ITextRange range)
+        {
+            var start = OffsetOf(range.Start);
+            var end = OffsetOf(range.End);
+            if (start > end)
+            {
+                (start, end) = (end, start);
+            }
+
+            return _textBox.GetTextRangeBounds(start, end - start);
+        }
+
+        public ITextPointer? GetPositionFromPoint(Point point)
+        {
+            var offset = _textBox.GetOffsetFromTopLevelPoint(point);
+            return offset < 0 ? null : CreatePointer(offset);
+        }
+
+        public ITextRange? GetVisibleRange()
+        {
+            var (start, end) = _textBox.GetVisibleTextRange();
+            return start < 0 ? null : new NavRange(CreatePointer(start), CreatePointer(end));
+        }
+
+        public void ScrollIntoView(ITextRange range)
+        {
+            var start = OffsetOf(range.Start);
+            var end = OffsetOf(range.End);
+            if (start > end)
+            {
+                (start, end) = (end, start);
+            }
+
+            _textBox.ScrollTextRangeIntoView(start, end - start);
+        }
+
+        public (IReadOnlyDictionary<TextAttribute, object?> Attributes, ITextRange Run) GetTextAttributes(ITextPointer position)
+        {
+            // Validate the pointer is ours; a TextBox is uniform, so the offset itself is unused.
+            _ = OffsetOf(position);
+
+            var attributes = new Dictionary<TextAttribute, object?>
+            {
+                [TextAttribute.FontFamily] = _textBox.FontFamily?.Name,
+                [TextAttribute.FontSize] = _textBox.FontSize,
+                [TextAttribute.FontWeight] = _textBox.FontWeight,
+                [TextAttribute.FontStyle] = _textBox.FontStyle,
+                [TextAttribute.IsReadOnly] = _textBox.IsReadOnly,
+            };
+
+            if ((_textBox.Foreground as ISolidColorBrush)?.Color is { } foreground)
+            {
+                attributes[TextAttribute.Foreground] = foreground;
+            }
+
+            if ((_textBox.Background as ISolidColorBrush)?.Color is { } background)
+            {
+                attributes[TextAttribute.Background] = background;
+            }
+
+            return (attributes, DocumentRange);
+        }
+
+        private void OnTextBoxPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.Property != TextBox.TextProperty)
+            {
+                return;
+            }
+
+            var (offset, oldLength, newLength) =
+                TextSegmentation.ComputeChange(e.OldValue as string ?? string.Empty, e.NewValue as string ?? string.Empty);
+
+            if (oldLength == 0 && newLength == 0)
+            {
+                return;
+            }
+
+            _version++;
+            _textChanged?.Invoke(this, new TextChange(CreatePointer(offset), oldLength, newLength));
+        }
+
+        private ITextPointer CreatePointer(int offset, LogicalDirection gravity = LogicalDirection.Forward) =>
+            new NavPointer(this, Math.Clamp(offset, 0, Text.Length), gravity);
+
+        private int OffsetOf(ITextPointer pointer)
+        {
+            if (pointer is not NavPointer own || own.Owner != this)
+            {
+                throw new ArgumentException("The text pointer was not produced by this navigator.", nameof(pointer));
+            }
+
+            return Math.Clamp(own.Offset, 0, Text.Length);
+        }
+
+        private sealed class NavPointer : ITextPointer
+        {
+            public NavPointer(TextBoxTextNavigation owner, int offset, LogicalDirection direction)
+            {
+                Owner = owner;
+                Offset = offset;
+                Gravity = direction;
+            }
+
+            public TextBoxTextNavigation Owner { get; }
+
+            public int Offset { get; }
+
+            public LogicalDirection Gravity { get; }
+
+            public int CompareTo(ITextPointer? other) => other is null ? 1 : Offset.CompareTo(other.Offset);
+
+            public bool Equals(ITextPointer? other) => other is not null && Offset == other.Offset;
+
+            public override bool Equals(object? obj) => obj is ITextPointer other && Equals(other);
+
+            public override int GetHashCode() => Offset;
+        }
+
+        private sealed class NavRange : ITextRange
+        {
+            public NavRange(ITextPointer start, ITextPointer end)
+            {
+                Start = start;
+                End = end;
+            }
+
+            public ITextPointer Start { get; }
+
+            public ITextPointer End { get; }
+
+            public bool IsEmpty => Start.Offset == End.Offset;
+        }
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTextNavigationTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTextNavigationTests.cs
@@ -1,0 +1,257 @@
+#nullable enable
+
+using System;
+using Avalonia.Automation.Provider;
+using Avalonia.Input.TextInput;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests
+{
+    public class TextBoxTextNavigationTests : ScopedTestBase
+    {
+        [Fact]
+        public void Resolves_Offsets_And_Reads_Text()
+        {
+            using var _ = UnitTestApplication.Start(TestServices.MockThreadingInterface);
+
+            var nav = CreateNavigation("Hello world");
+
+            Assert.Equal(0, nav.DocumentStart.Offset);
+            Assert.Equal(11, nav.DocumentEnd.Offset);
+
+            // A platform offset becomes a position only by walking from an anchor the navigation
+            // produced; there is no factory from a bare integer.
+            var range = nav.GetRange(nav.GetPosition(nav.DocumentStart, 6), nav.DocumentEnd);
+            var text = nav.GetText(range);
+
+            Assert.Equal("world", text);
+            Assert.Equal(range.End.Offset - range.Start.Offset, text.Length); // gapless invariant
+        }
+
+        [Fact]
+        public void GetPosition_Clamps_And_GetRange_Normalizes()
+        {
+            using var _ = UnitTestApplication.Start(TestServices.MockThreadingInterface);
+
+            var nav = CreateNavigation("abc");
+
+            Assert.Equal(3, nav.GetPosition(nav.DocumentStart, 100).Offset);
+            Assert.Equal(0, nav.GetPosition(nav.DocumentEnd, -100).Offset);
+
+            var a = nav.GetPosition(nav.DocumentStart, 2);
+            var b = nav.GetPosition(nav.DocumentStart, 1);
+            var range = nav.GetRange(a, b); // arguments out of order are normalized
+
+            Assert.Equal(1, range.Start.Offset);
+            Assert.Equal(2, range.End.Offset);
+            Assert.Equal(-1, nav.GetOffset(a, b));
+        }
+
+        [Fact]
+        public void Enclosing_And_Move_By_Word()
+        {
+            using var _ = UnitTestApplication.Start(TestServices.MockThreadingInterface);
+
+            var nav = CreateNavigation("foo bar");
+
+            var inWord = nav.GetPosition(nav.DocumentStart, 1); // inside "foo"
+            var word = nav.GetRangeEnclosing(inWord, TextUnit.Word);
+            Assert.Equal(0, word.Start.Offset);
+            Assert.Equal(4, word.End.Offset); // the word owns its trailing space
+
+            // A single word forward from the start lands on the next word's start.
+            Assert.Equal(4, nav.GetPosition(nav.DocumentStart, TextUnit.Word, 1).Offset);
+
+            var whole = nav.GetRangeEnclosing(inWord, TextUnit.Document);
+            Assert.Equal(0, whole.Start.Offset);
+            Assert.Equal(7, whole.End.Offset);
+        }
+
+        [Fact]
+        public void Word_Owns_Trailing_Whitespace()
+        {
+            using var _ = UnitTestApplication.Start(TestServices.MockThreadingInterface);
+
+            var nav = CreateNavigation("one  two\tthree");
+
+            // A word unit runs to the start of the following word (UIA "word plus
+            // trailing whitespace", AT-SPI GRANULARITY_WORD): spaces and tabs after a
+            // word belong to it, and expanding inside the gap resolves to that word.
+            var first = nav.GetRangeEnclosing(nav.GetPosition(nav.DocumentStart, 1), TextUnit.Word);
+            Assert.Equal(0, first.Start.Offset);
+            Assert.Equal(5, first.End.Offset);
+
+            var inGap = nav.GetRangeEnclosing(nav.GetPosition(nav.DocumentStart, 4), TextUnit.Word);
+            Assert.Equal(0, inGap.Start.Offset);
+            Assert.Equal(5, inGap.End.Offset);
+
+            var second = nav.GetRangeEnclosing(nav.GetPosition(nav.DocumentStart, 6), TextUnit.Word);
+            Assert.Equal(5, second.Start.Offset);
+            Assert.Equal(9, second.End.Offset); // "two" plus its tab
+
+            // One stop per word when stepping by the unit.
+            Assert.Equal(5, nav.GetPosition(nav.DocumentStart, TextUnit.Word, 1).Offset);
+            Assert.Equal(9, nav.GetPosition(nav.DocumentStart, TextUnit.Word, 2).Offset);
+            Assert.Equal(14, nav.GetPosition(nav.DocumentStart, TextUnit.Word, 3).Offset);
+        }
+
+        [Fact]
+        public void Word_Never_Attaches_Line_Breaks_Or_Leading_Whitespace()
+        {
+            using var _ = UnitTestApplication.Start(TestServices.MockThreadingInterface);
+
+            var nav = CreateNavigation("one \n  two");
+
+            // The space before the break attaches to "one"; the break itself does not.
+            var word = nav.GetRangeEnclosing(nav.GetPosition(nav.DocumentStart, 3), TextUnit.Word);
+            Assert.Equal(0, word.Start.Offset);
+            Assert.Equal(4, word.End.Offset);
+
+            var separator = nav.GetRangeEnclosing(nav.GetPosition(nav.DocumentStart, 4), TextUnit.Word);
+            Assert.Equal(4, separator.Start.Offset);
+            Assert.Equal(5, separator.End.Offset);
+
+            // Whitespace with no word before it on its line stays a gap unit of its own.
+            var leading = nav.GetRangeEnclosing(nav.GetPosition(nav.DocumentStart, 5), TextUnit.Word);
+            Assert.Equal(5, leading.Start.Offset);
+            Assert.Equal(7, leading.End.Offset);
+        }
+
+        [Fact]
+        public void Character_Unit_Is_Grapheme_Aware()
+        {
+            using var _ = UnitTestApplication.Start(TestServices.MockThreadingInterface);
+
+            var nav = CreateNavigation("áb");
+
+            // "a" followed by combining acute is a single grapheme spanning two code units.
+            var grapheme = nav.GetRangeEnclosing(nav.DocumentStart, TextUnit.Character);
+            Assert.Equal(0, grapheme.Start.Offset);
+            Assert.Equal(2, grapheme.End.Offset);
+
+            var afterTwo = nav.GetPosition(nav.DocumentStart, TextUnit.Character, 2);
+            Assert.Equal(3, afterTwo.Offset);
+            Assert.Equal(2, nav.GetPosition(afterTwo, TextUnit.Character, -1).Offset);
+        }
+
+        [Fact]
+        public void Word_Unit_Uses_Uax29()
+        {
+            using var _ = UnitTestApplication.Start(TestServices.MockThreadingInterface);
+
+            var nav = CreateNavigation("don't stop");
+
+            // Unicode word segmentation keeps the contraction together; a segmenter that
+            // treated the apostrophe as a separator would split it. The word owns its
+            // trailing space.
+            var word = nav.GetRangeEnclosing(nav.GetPosition(nav.DocumentStart, 2), TextUnit.Word);
+            Assert.Equal(0, word.Start.Offset);
+            Assert.Equal(6, word.End.Offset);
+
+            // Word units: 0 | "don't " 6 | "stop" 10.
+            Assert.Equal(6, nav.GetPosition(nav.DocumentStart, TextUnit.Word, 1).Offset);
+            Assert.Equal(0, nav.GetPosition(nav.GetPosition(nav.DocumentStart, 5), TextUnit.Word, -1).Offset);
+        }
+
+        [Fact]
+        public void GetRangeEnclosing_Honors_Gravity_At_Boundary()
+        {
+            using var _ = UnitTestApplication.Start(TestServices.MockThreadingInterface);
+
+            var nav = CreateNavigation("foo bar");
+
+            // Offset 4 is the boundary between the "foo " unit [0,4) (the word owns its
+            // trailing space) and the "bar" unit [4,7).
+            var forward = nav.PointerAt(4, LogicalDirection.Forward);
+            var backward = nav.PointerAt(4, LogicalDirection.Backward);
+
+            var following = nav.GetRangeEnclosing(forward, TextUnit.Word);
+            Assert.Equal(4, following.Start.Offset);
+            Assert.Equal(7, following.End.Offset);
+
+            var preceding = nav.GetRangeEnclosing(backward, TextUnit.Word);
+            Assert.Equal(0, preceding.Start.Offset);
+            Assert.Equal(4, preceding.End.Offset);
+        }
+
+        [Fact]
+        public void TextChanged_Reports_Delta_And_Bumps_Version()
+        {
+            using var _ = UnitTestApplication.Start(TestServices.MockThreadingInterface);
+
+            var textBox = new TextBox { Text = "Hello" };
+            var nav = new TextBoxTextNavigation(textBox);
+
+            TextChange? captured = null;
+            nav.TextChanged += (_, c) => captured = c;
+            var startVersion = nav.DocumentVersion;
+
+            textBox.Text = "Hello!";
+
+            Assert.NotNull(captured);
+            Assert.Equal(5, captured!.Value.Position.Offset);
+            Assert.Equal(0, captured.Value.OldLength);
+            Assert.Equal(1, captured.Value.NewLength);
+            Assert.True(nav.DocumentVersion > startVersion);
+
+            // The inserted text is read on demand from the change position.
+            var inserted = nav.GetRange(
+                captured.Value.Position,
+                nav.GetPosition(captured.Value.Position, captured.Value.NewLength));
+            Assert.Equal("!", nav.GetText(inserted));
+        }
+
+        [Fact]
+        public void GetSelection_Round_Trips_The_Control_Selection()
+        {
+            using var _ = UnitTestApplication.Start(TestServices.MockThreadingInterface);
+
+            var textBox = new TextBox { Text = "Hello world" };
+            var nav = new TextBoxTextNavigation(textBox);
+
+            nav.SetSelection(nav.GetRange(
+                nav.GetPosition(nav.DocumentStart, 6),
+                nav.GetPosition(nav.DocumentStart, 11)));
+
+            Assert.Equal(6, textBox.SelectionStart);
+            Assert.Equal(11, textBox.SelectionEnd);
+
+            var selection = nav.GetSelection();
+            Assert.Equal(6, selection.Start.Offset);
+            Assert.Equal(11, selection.End.Offset);
+            Assert.Equal("world", nav.GetText(selection));
+        }
+
+        [Fact]
+        public void Rejects_Foreign_Pointer()
+        {
+            using var _ = UnitTestApplication.Start(TestServices.MockThreadingInterface);
+
+            var navA = CreateNavigation("aaa");
+            var navB = CreateNavigation("bbb");
+
+            Assert.Throws<ArgumentException>(() => navA.GetOffset(navA.DocumentStart, navB.DocumentStart));
+        }
+
+        [Fact]
+        public void Rejects_Foreign_Pointer_In_Mutation()
+        {
+            using var _ = UnitTestApplication.Start(TestServices.MockThreadingInterface);
+
+            var a = new TextBox { Text = "aaa" };
+            var navA = new TextBoxTextNavigation(a);
+            var navB = CreateNavigation("bbb");
+
+            // The mutation path enforces the same provenance rule as the navigation reads.
+            Assert.Throws<ArgumentException>(() => navA.SetSelection(navB.DocumentRange));
+            Assert.Equal(0, a.SelectionStart);
+            Assert.Equal(0, a.SelectionEnd);
+        }
+
+        private static IAccessibleText CreateNavigation(string text)
+            => new TextBoxTextNavigation(new TextBox { Text = text });
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/TextSegmentationTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextSegmentationTests.cs
@@ -1,0 +1,51 @@
+using Avalonia.Media.TextFormatting.Unicode;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests
+{
+    public class TextSegmentationTests : ScopedTestBase
+    {
+        [Theory]
+        [InlineData(0x000A)] // LF
+        [InlineData(0x000D)] // CR
+        [InlineData(0x0085)] // NEL  (Next Line)
+        [InlineData(0x000B)] // VT   (Vertical Tab)
+        [InlineData(0x000C)] // FF   (Form Feed)
+        [InlineData(0x2028)] // LINE SEPARATOR
+        [InlineData(0x2029)] // PARAGRAPH SEPARATOR
+        public void LineBounds_Splits_On_Each_Uax14_Mandatory_Break(int separatorCode)
+        {
+            var text = "ab" + (char)separatorCode + "cd";
+
+            // The break character bounds the line on either side and is excluded from the content.
+            Assert.Equal((0, 2), TextSegmentation.LineBounds(0, text));
+            Assert.Equal((3, 5), TextSegmentation.LineBounds(3, text));
+        }
+
+        [Fact]
+        public void LineBounds_Does_Not_Break_On_A_Soft_Wrap_Opportunity()
+        {
+            // A space is a UAX-14 break *opportunity*, not a mandatory break: the logical line spans it.
+            var text = "ab cd";
+
+            Assert.Equal((0, 5), TextSegmentation.LineBounds(0, text));
+            Assert.Equal((0, 5), TextSegmentation.LineBounds(4, text));
+        }
+
+        [Fact]
+        public void LineBounds_Treats_Crlf_As_A_Single_Break()
+        {
+            var text = "ab" + (char)0x000D + (char)0x000A + "cd";
+
+            // Content carets resolve to their own line, terminator excluded.
+            Assert.Equal((0, 2), TextSegmentation.LineBounds(0, text));
+            Assert.Equal((4, 6), TextSegmentation.LineBounds(4, text));
+
+            // A caret on either half of the CR/LF pair belongs to the first line - CRLF is one break
+            // (UAX-14 LB5), not two with an empty line between them.
+            Assert.Equal((0, 2), TextSegmentation.LineBounds(2, text)); // on CR
+            Assert.Equal((0, 2), TextSegmentation.LineBounds(3, text)); // on LF
+        }
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Part of the structured text input work tracked in #22168.

Adds `ITextNavigation`, the layout-free core that IME and accessibility both need to walk a text document, and implements it over `TextBox`.

Today each consumer does that walk itself, with control-specific integer maths over a flattened string: the IME client, the automation peer and every platform bridge carry their own notion of where a word ends. This is the shared contract they can be written against instead.

- `ITextNavigation` addresses a document by opaque `ITextPointer` positions with gravity, normalized `ITextRange` values, and boundary units (`TextUnit`), and raises a `TextChange` delta when the text changes. Positions and lengths are UTF-16 code units; a pointer stays valid across edits, which a bare offset cannot, and a pointer produced by a different navigation is rejected rather than silently reinterpreted in the wrong index space.
- `TextSegmentation` (internal, in `Avalonia.Base`) supplies the unit boundaries: grapheme clusters for `Character`, UAX-29 for `Word`, mandatory line breaks for `Line`, and a heuristic for `Sentence` until real sentence segmentation lands. A word owns its trailing spaces and tabs, which is what UIA's "word plus trailing whitespace" and AT-SPI's `GRANULARITY_WORD` expect.
- `IAccessibleText` extends the navigation with what a screen reader needs beyond reading: selection, geometry and hit testing, the visible range, scrolling, and formatting attributes over the run they are uniform across, reported through the `TextAttribute` and `TextStyleId` vocabularies.
- `TextBoxTextNavigation` implements it for `TextBox`, backed by four new internal `TextBox` helpers that answer geometry queries from the presenter's `TextLayout`.

Everything new in the public surface is `[Unstable]`.

This is the first slice of #22168, which #20890 carried as one unreviewable change. The accessibility providers (UIA, AT-SPI) and the IME contract land on top of it as separate PRs; nothing consumes `TextBoxTextNavigation` yet, so this PR changes no behavior on its own.

## What is the updated/expected behavior with this PR?

No user-visible change. What a reviewer can check is the contract's own semantics: offsets clamp to the document, ranges normalize regardless of argument order, `Character` steps by grapheme cluster rather than code unit, `Word` follows UAX-29 and keeps contractions together, gravity decides which unit a boundary position belongs to, `TextChanged` reports the changed span and bumps the document version, and a foreign pointer throws on both the read and the mutation path.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None. The new types are additive and `[Unstable]`; `TextSegmentation` and `TextBoxTextNavigation` are internal.

## Obsoletions / Deprecations

None.

## Fixed issues

Part of #22168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
