### PR TITLE
[Text] Glyph Outline Part 6/15 - fvar / avar parsing and the variation axis API

### DIFF
--- a/src/Avalonia.Base/Media/FontVariationAxis.cs
+++ b/src/Avalonia.Base/Media/FontVariationAxis.cs
@@ -1,0 +1,42 @@
+using Avalonia.Media.Fonts;
+
+namespace Avalonia.Media
+{
+    /// <summary>
+    /// Describes a single variation axis declared by a variable font's <c>fvar</c> table.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Variation axes are the design dimensions a variable font exposes — typical examples
+    /// include <c>wght</c> (weight, 1..1000), <c>wdth</c> (width, percentage), <c>opsz</c>
+    /// (optical size, points), <c>ital</c> (italic, 0..1), and <c>slnt</c> (slant, degrees).
+    /// </para>
+    /// <para>
+    /// Values are in <b>user-space</b>: the same values the font designer chose to expose to
+    /// end users (e.g. weight <c>700</c> for "Bold"). The platform-neutral
+    /// <see cref="FontVariationSettings"/> also speaks user-space values; they are
+    /// normalized into <c>[-1, 1]</c> through the font's <c>fvar</c> / <c>avar</c> tables
+    /// per font when the settings are applied.
+    /// </para>
+    /// </remarks>
+    /// <param name="Tag">The four-character OpenType axis tag (e.g. <c>wght</c>).</param>
+    /// <param name="Name">
+    /// A human-readable axis name resolved from the font's <c>name</c> table. Falls back to the
+    /// tag's string form when no name record is available.
+    /// </param>
+    /// <param name="MinimumValue">The minimum allowed user-space value for this axis.</param>
+    /// <param name="DefaultValue">The default user-space value (selected when no variation is applied).</param>
+    /// <param name="MaximumValue">The maximum allowed user-space value for this axis.</param>
+    /// <param name="IsHidden">
+    /// <c>true</c> if the font designer flagged this axis as hidden (intended for internal use
+    /// rather than direct user exposure). Hidden axes are typically still functional but should
+    /// not be surfaced in a font-picker UI.
+    /// </param>
+    public readonly record struct FontVariationAxis(
+        OpenTypeTag Tag,
+        string Name,
+        float MinimumValue,
+        float DefaultValue,
+        float MaximumValue,
+        bool IsHidden);
+}

--- a/src/Avalonia.Base/Media/FontVariationInstance.cs
+++ b/src/Avalonia.Base/Media/FontVariationInstance.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Avalonia.Media.Fonts;
+
+namespace Avalonia.Media
+{
+    /// <summary>
+    /// Describes a named variation instance declared by a variable font's <c>fvar</c> table.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Named instances are pre-defined points in variation space the font designer has
+    /// labeled — for example "Regular" at <c>wght=400</c>, or "Light Condensed" at
+    /// <c>wght=300, wdth=75</c>. They give applications a curated set of preset combinations
+    /// without having to invent their own.
+    /// </para>
+    /// <para>
+    /// Coordinates are in <b>user-space</b> (the same values the font designer chose to
+    /// expose) — the same space <see cref="FontVariationSettings"/> speaks, so an
+    /// instance's coordinates translate directly into settings values. Normalization to
+    /// the font's internal coordinate space happens when the settings are applied.
+    /// </para>
+    /// </remarks>
+    public readonly struct FontVariationInstance : IEquatable<FontVariationInstance>
+    {
+        private readonly IReadOnlyDictionary<OpenTypeTag, float>? _coordinates;
+
+        internal FontVariationInstance(
+            string name,
+            int index,
+            IReadOnlyDictionary<OpenTypeTag, float> coordinates,
+            int? postScriptNameId)
+        {
+            Name = name ?? string.Empty;
+            Index = index;
+            _coordinates = coordinates;
+            PostScriptNameId = postScriptNameId;
+        }
+
+        /// <summary>
+        /// Gets the human-readable instance name resolved from the font's <c>name</c> table
+        /// (e.g. "Regular", "SemiBold", "Light Condensed"). Empty when the font omits the
+        /// name record for this instance.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the zero-based position of this instance in the font's <c>fvar</c> instance
+        /// array. Use this with the <c>instanceIndex</c> parameter on
+        /// <c>GlyphTypeface.CreateNormalizedPosition</c> as a shorthand for "give me the
+        /// position of this preset".
+        /// </summary>
+        public int Index { get; }
+
+        /// <summary>
+        /// Gets the user-space axis coordinates that define this instance, keyed by axis tag
+        /// (e.g. <c>{ wght: 700, wdth: 100 }</c> for a Bold). Always non-null; empty when the
+        /// instance has no axis values declared (a malformed font).
+        /// </summary>
+        public IReadOnlyDictionary<OpenTypeTag, float> Coordinates
+            => _coordinates ?? (IReadOnlyDictionary<OpenTypeTag, float>)ImmutableDictionary<OpenTypeTag, float>.Empty;
+
+        /// <summary>
+        /// Gets the optional name-ID of a PostScript name record for this instance, when the
+        /// font declares one. <c>null</c> when not present.
+        /// </summary>
+        public int? PostScriptNameId { get; }
+
+        /// <summary>
+        /// Two instances are equal when they describe the same preset on the same font —
+        /// i.e. they have the same name, index, and PostScript name ID. Coordinates are
+        /// not compared because the dictionary type doesn't support value equality;
+        /// within a font, <see cref="Index"/> already uniquely identifies an instance.
+        /// </summary>
+        public bool Equals(FontVariationInstance other)
+            => Index == other.Index
+            && PostScriptNameId == other.PostScriptNameId
+            && string.Equals(Name, other.Name, StringComparison.Ordinal);
+
+        public override bool Equals(object? obj)
+            => obj is FontVariationInstance other && Equals(other);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Name, Index, PostScriptNameId);
+
+        public static bool operator ==(FontVariationInstance left, FontVariationInstance right)
+            => left.Equals(right);
+
+        public static bool operator !=(FontVariationInstance left, FontVariationInstance right)
+            => !left.Equals(right);
+    }
+}

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/AvarTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/AvarTable.cs
@@ -177,14 +177,30 @@ namespace Avalonia.Media.Fonts.Tables.Variation
                     }
 
                     var entries = ImmutableArray.CreateBuilder<SegmentMapEntry>(positionMapCount);
+                    var monotonic = true;
+                    var previousFrom = float.NegativeInfinity;
+
                     for (var j = 0; j < positionMapCount; j++)
                     {
                         var from = reader.ReadF2dot14();
                         var to = reader.ReadF2dot14();
+
+                        // Remap's interpolation scan assumes ascending fromCoordinates; a
+                        // descending entry would make it return values from the wrong segment.
+                        // Equal fromCoordinates (degenerate segments) are tolerated — Remap
+                        // already handles those explicitly.
+                        if (from < previousFrom)
+                        {
+                            monotonic = false;
+                        }
+
+                        previousFrom = from;
                         entries.Add(new SegmentMapEntry(from, to));
                     }
 
-                    mapsBuilder.Add(entries.MoveToImmutable());
+                    // A non-monotonic axis degrades to identity (empty map). Keep the entries
+                    // consumed above either way so the reader stays aligned for the next axis.
+                    mapsBuilder.Add(monotonic ? entries.MoveToImmutable() : ImmutableArray<SegmentMapEntry>.Empty);
                 }
             }
             catch

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/AvarTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/AvarTable.cs
@@ -164,25 +164,35 @@ namespace Avalonia.Media.Fonts.Tables.Variation
 
             var mapsBuilder = ImmutableArray.CreateBuilder<ImmutableArray<SegmentMapEntry>>(axisCount);
 
-            for (var i = 0; i < axisCount; i++)
+            try
             {
-                var positionMapCount = reader.ReadUInt16();
-
-                if (positionMapCount == 0)
+                for (var i = 0; i < axisCount; i++)
                 {
-                    mapsBuilder.Add(ImmutableArray<SegmentMapEntry>.Empty);
-                    continue;
-                }
+                    var positionMapCount = reader.ReadUInt16();
 
-                var entries = ImmutableArray.CreateBuilder<SegmentMapEntry>(positionMapCount);
-                for (var j = 0; j < positionMapCount; j++)
-                {
-                    var from = reader.ReadF2dot14();
-                    var to = reader.ReadF2dot14();
-                    entries.Add(new SegmentMapEntry(from, to));
-                }
+                    if (positionMapCount == 0)
+                    {
+                        mapsBuilder.Add(ImmutableArray<SegmentMapEntry>.Empty);
+                        continue;
+                    }
 
-                mapsBuilder.Add(entries.MoveToImmutable());
+                    var entries = ImmutableArray.CreateBuilder<SegmentMapEntry>(positionMapCount);
+                    for (var j = 0; j < positionMapCount; j++)
+                    {
+                        var from = reader.ReadF2dot14();
+                        var to = reader.ReadF2dot14();
+                        entries.Add(new SegmentMapEntry(from, to));
+                    }
+
+                    mapsBuilder.Add(entries.MoveToImmutable());
+                }
+            }
+            catch
+            {
+                // A truncated segment map makes the reader run past the table end and throw. avar is
+                // optional, so degrade to "no avar" (identity normalization) instead of letting the
+                // exception escape TryLoad and fail the whole typeface load.
+                return false;
             }
 
             avarTable = new AvarTable(mapsBuilder.MoveToImmutable());

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/AvarTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/AvarTable.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Avalonia.Media.Fonts.Tables.Variation
+{
+    /// <summary>
+    /// Parses the OpenType 'avar' (axis variations) table. Provides per-axis segment maps
+    /// that remap normalized coordinates after the linear fvar normalization.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// avar is the font designer's tool for compensating for non-perceptually-linear axes.
+    /// The classic example is the weight axis: fvar's linear mapping makes "halfway between
+    /// Regular and Black" land at wght=550, but the font designer might prefer that point to
+    /// look like wght=600 visually. avar lets them bend the normalized coordinate so that
+    /// e.g. a user request for 0.5 actually maps to 0.45 internally.
+    /// </para>
+    /// <para>
+    /// The table is optional — many variable fonts ship without one and rely on the linear
+    /// normalization. When present, every requested normalized coordinate goes through
+    /// <see cref="Remap"/> before reaching gvar / HVAR / VVAR / MVAR.
+    /// </para>
+    /// <para>
+    /// Reference: <see href="https://learn.microsoft.com/en-us/typography/opentype/spec/avar"/>.
+    /// This parser handles avar v1.0 (segment maps only). v2.0 adds axis-value-table
+    /// extensions for variation-dependent default values; that's a follow-up if a use case
+    /// surfaces.
+    /// </para>
+    /// </remarks>
+    internal sealed class AvarTable
+    {
+        internal const string TableName = "avar";
+        internal static OpenTypeTag Tag { get; } = OpenTypeTag.Parse(TableName);
+
+        private const ushort SupportedMajorVersion = 1;
+
+        // Per the spec, every segment map must include the three identity-mapped boundary
+        // entries (-1, 0, +1). We don't require this in parsing — corrupt fonts that omit
+        // them still get a reasonable result because Remap clamps + extrapolates — but it
+        // matters for understanding what "zero entries" means: it means the entire table
+        // was empty for this axis, not just the identity points.
+        private readonly ImmutableArray<ImmutableArray<SegmentMapEntry>> _segmentMaps;
+
+        private AvarTable(ImmutableArray<ImmutableArray<SegmentMapEntry>> segmentMaps)
+        {
+            _segmentMaps = segmentMaps;
+        }
+
+        /// <summary>
+        /// Gets the number of axes the table provides segment maps for. Should equal the
+        /// fvar axis count; the spec requires this and platforms differ on how strictly
+        /// they enforce it.
+        /// </summary>
+        public int AxisCount => _segmentMaps.Length;
+
+        /// <summary>
+        /// Remaps a normalized axis coordinate through this axis's segment map.
+        /// Returns <paramref name="normalizedCoordinate"/> unchanged when
+        /// <paramref name="axisIndex"/> is out of range or when the axis has no segment
+        /// map entries (degenerate avar — treat as identity).
+        /// </summary>
+        /// <param name="axisIndex">
+        /// Zero-based axis index, matching the fvar axis order.
+        /// </param>
+        /// <param name="normalizedCoordinate">
+        /// The linearly-normalized coordinate in <c>[-1, 1]</c> (the output of fvar
+        /// normalization, before avar correction).
+        /// </param>
+        /// <returns>
+        /// The avar-corrected normalized coordinate, also in <c>[-1, 1]</c>.
+        /// </returns>
+        public float Remap(int axisIndex, float normalizedCoordinate)
+        {
+            if ((uint)axisIndex >= (uint)_segmentMaps.Length)
+            {
+                return normalizedCoordinate;
+            }
+
+            var map = _segmentMaps[axisIndex];
+            if (map.Length == 0)
+            {
+                return normalizedCoordinate;
+            }
+
+            // Spec-mandated clamp: the table's domain is exactly [-1, 1]. Anything outside
+            // that range is clamped before lookup. fvar normalization already guarantees the
+            // range, but a malformed coord (or a future caller passing arbitrary values)
+            // should not extrapolate off the end of the segment list.
+            if (normalizedCoordinate <= -1f)
+            {
+                return -1f;
+            }
+
+            if (normalizedCoordinate >= 1f)
+            {
+                return 1f;
+            }
+
+            // Segment maps are sorted ascending by fromCoordinate. Find the surrounding
+            // entries and linearly interpolate. The axis count is small (typically 3..15
+            // entries) so a linear scan is faster than a binary search and avoids the
+            // overhead of computing midpoints.
+            for (var i = 1; i < map.Length; i++)
+            {
+                var hi = map[i];
+                if (normalizedCoordinate <= hi.From)
+                {
+                    var lo = map[i - 1];
+
+                    var range = hi.From - lo.From;
+                    if (range <= 0f)
+                    {
+                        // Degenerate segment — both endpoints at the same input. Pick
+                        // the high mapping; in a well-formed table this never happens.
+                        return hi.To;
+                    }
+
+                    var t = (normalizedCoordinate - lo.From) / range;
+                    return lo.To + t * (hi.To - lo.To);
+                }
+            }
+
+            // The coordinate is beyond the last segment entry. In a spec-compliant table
+            // the final entry's From should be +1 so we never reach here; return its
+            // mapped value as a safe fallback.
+            return map[map.Length - 1].To;
+        }
+
+        public static bool TryLoad(
+            GlyphTypeface glyphTypeface,
+            [NotNullWhen(true)] out AvarTable? avarTable)
+        {
+            avarTable = null;
+
+            if (!glyphTypeface.PlatformTypeface.TryGetTable(Tag, out var data))
+            {
+                return false;
+            }
+
+            var span = data.Span;
+            if (span.Length < 8)
+            {
+                return false;
+            }
+
+            var reader = new BigEndianBinaryReader(span);
+
+            var majorVersion = reader.ReadUInt16();
+            _ = reader.ReadUInt16(); // minorVersion — v1.0 and v2.0 share the segment-map prefix.
+
+            if (majorVersion != SupportedMajorVersion)
+            {
+                return false;
+            }
+
+            _ = reader.ReadUInt16(); // Reserved field, set to 0 per spec.
+            var axisCount = reader.ReadUInt16();
+
+            if (axisCount == 0)
+            {
+                return false;
+            }
+
+            var mapsBuilder = ImmutableArray.CreateBuilder<ImmutableArray<SegmentMapEntry>>(axisCount);
+
+            for (var i = 0; i < axisCount; i++)
+            {
+                var positionMapCount = reader.ReadUInt16();
+
+                if (positionMapCount == 0)
+                {
+                    mapsBuilder.Add(ImmutableArray<SegmentMapEntry>.Empty);
+                    continue;
+                }
+
+                var entries = ImmutableArray.CreateBuilder<SegmentMapEntry>(positionMapCount);
+                for (var j = 0; j < positionMapCount; j++)
+                {
+                    var from = reader.ReadF2dot14();
+                    var to = reader.ReadF2dot14();
+                    entries.Add(new SegmentMapEntry(from, to));
+                }
+
+                mapsBuilder.Add(entries.MoveToImmutable());
+            }
+
+            avarTable = new AvarTable(mapsBuilder.MoveToImmutable());
+            return true;
+        }
+
+        /// <summary>
+        /// A single (fromCoordinate, toCoordinate) entry in an axis segment map. Both
+        /// values are in the OpenType normalized range <c>[-1, 1]</c>.
+        /// </summary>
+        private readonly struct SegmentMapEntry
+        {
+            public SegmentMapEntry(float from, float to)
+            {
+                From = from;
+                To = to;
+            }
+
+            public float From { get; }
+
+            public float To { get; }
+        }
+    }
+}

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/FvarTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/FvarTable.cs
@@ -37,6 +37,13 @@ namespace Avalonia.Media.Fonts.Tables.Variation
         // seek past any extra trailing bytes when reading each axis record.
         private const ushort MinimumAxisSize = 20;
 
+        // The spec allows axisCount up to 65535, but real variable fonts have at most ~15 axes.
+        // An unclamped count flows into per-axis `stackalloc float[axisCount]` buffers in the gvar
+        // reader, so an adversarial font declaring tens of thousands of axes is a StackOverflow DoS
+        // vector. Reject implausibly large counts — well above any real font, far
+        // below the danger zone — and treat such a font as static rather than processing it.
+        private const ushort MaxAxisCount = 64;
+
         private FvarTable(
             ImmutableArray<FontVariationAxis> axes,
             ImmutableArray<FontVariationInstance> instances,
@@ -111,7 +118,7 @@ namespace Avalonia.Media.Fonts.Tables.Variation
             var instanceCount = reader.ReadUInt16();
             var instanceSize = reader.ReadUInt16();
 
-            if (axisCount == 0 || axisSize < MinimumAxisSize)
+            if (axisCount == 0 || axisCount > MaxAxisCount || axisSize < MinimumAxisSize)
             {
                 return false;
             }

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/FvarTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/FvarTable.cs
@@ -1,0 +1,211 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Avalonia.Media.Fonts.Tables.Name;
+
+namespace Avalonia.Media.Fonts.Tables.Variation
+{
+    /// <summary>
+    /// Parses the OpenType 'fvar' (font variations) table. Provides the variation axis
+    /// definitions and named instances declared by a variable font.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// fvar declares which design axes a variable font exposes (weight, width, optical size,
+    /// slant, italic, custom axes) and any pre-named instances ("Regular", "Bold", etc.) the
+    /// designer has curated. It does NOT carry the per-glyph deltas — those live in 'gvar'
+    /// (outlines), HVAR / VVAR (advances and side bearings), and MVAR (font-wide metrics).
+    /// </para>
+    /// <para>
+    /// Reference: <see href="https://learn.microsoft.com/en-us/typography/opentype/spec/fvar"/>.
+    /// </para>
+    /// </remarks>
+    internal sealed class FvarTable
+    {
+        internal const string TableName = "fvar";
+        internal static OpenTypeTag Tag { get; } = OpenTypeTag.Parse(TableName);
+
+        // Flag bits inside VariationAxisRecord.flags. Only bit 0 is currently defined.
+        private const ushort HiddenAxisFlag = 0x0001;
+
+        // The fvar table version we understand. The spec has only ever defined v1.0.
+        private const ushort SupportedMajorVersion = 1;
+
+        // Per the spec, axisSize is always 20 in v1.0. Implementations are required to be
+        // forward-compatible with a larger axisSize, so we treat 20 as a lower bound and
+        // seek past any extra trailing bytes when reading each axis record.
+        private const ushort MinimumAxisSize = 20;
+
+        private FvarTable(
+            ImmutableArray<FontVariationAxis> axes,
+            ImmutableArray<FontVariationInstance> instances,
+            ImmutableArray<OpenTypeTag> axisTags)
+        {
+            Axes = axes;
+            Instances = instances;
+            AxisTags = axisTags;
+        }
+
+        /// <summary>
+        /// Gets the variation axes declared by the font, in the order they appear in the
+        /// table. Indexable; the order matches the per-instance coordinate order.
+        /// </summary>
+        public ImmutableArray<FontVariationAxis> Axes { get; }
+
+        /// <summary>
+        /// Gets the named variation instances declared by the font, in declaration order.
+        /// </summary>
+        public ImmutableArray<FontVariationInstance> Instances { get; }
+
+        /// <summary>
+        /// Gets the axis tags in declaration order. Kept as a separate array so consumers
+        /// reading raw coordinate sequences (e.g. avar segment maps) can index into the
+        /// right axis without paying the cost of unpacking the public
+        /// <see cref="FontVariationAxis"/> record.
+        /// </summary>
+        public ImmutableArray<OpenTypeTag> AxisTags { get; }
+
+        /// <summary>
+        /// Loads the fvar table from <paramref name="glyphTypeface"/>, resolving axis and
+        /// instance names via <paramref name="nameTable"/> when available.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> when the font carries an fvar table that we recognize and could
+        /// parse; <c>false</c> for static fonts, for an unrecognized version, or for a
+        /// malformed table.
+        /// </returns>
+        public static bool TryLoad(
+            GlyphTypeface glyphTypeface,
+            NameTable? nameTable,
+            [NotNullWhen(true)] out FvarTable? fvarTable)
+        {
+            fvarTable = null;
+
+            if (!glyphTypeface.PlatformTypeface.TryGetTable(Tag, out var data))
+            {
+                return false;
+            }
+
+            var span = data.Span;
+            if (span.Length < 16)
+            {
+                return false;
+            }
+
+            var reader = new BigEndianBinaryReader(span);
+
+            // Header (16 bytes).
+            var majorVersion = reader.ReadUInt16();
+            _ = reader.ReadUInt16(); // minorVersion — ignored; v1.x is forward-compatible.
+
+            if (majorVersion != SupportedMajorVersion)
+            {
+                return false;
+            }
+
+            var axesArrayOffset = reader.ReadOffset16();
+            _ = reader.ReadUInt16(); // Reserved field, set to 2 per spec.
+            var axisCount = reader.ReadUInt16();
+            var axisSize = reader.ReadUInt16();
+            var instanceCount = reader.ReadUInt16();
+            var instanceSize = reader.ReadUInt16();
+
+            if (axisCount == 0 || axisSize < MinimumAxisSize)
+            {
+                return false;
+            }
+
+            // Reject the table when the declared instance layout cannot even hold the
+            // mandatory (subfamilyNameID, flags, coordinates) prefix — a strong signal
+            // that the table is malformed and not worth parsing further.
+            var minimumInstanceSize = 4 + axisCount * 4;
+            if (instanceCount != 0 && instanceSize < minimumInstanceSize)
+            {
+                return false;
+            }
+
+            var axesEnd = axesArrayOffset + axisCount * axisSize;
+            var instancesEnd = axesEnd + instanceCount * instanceSize;
+            if (instancesEnd > span.Length)
+            {
+                return false;
+            }
+
+            // English (US) — matches GlyphTypeface's existing FamilyName / TypographicFamilyName
+            // resolution. Localization across all platform name records is a follow-up.
+            var culture = (ushort)CultureInfo.InvariantCulture.LCID;
+
+            var axisTagsBuilder = ImmutableArray.CreateBuilder<OpenTypeTag>(axisCount);
+            var axesBuilder = ImmutableArray.CreateBuilder<FontVariationAxis>(axisCount);
+
+            for (var i = 0; i < axisCount; i++)
+            {
+                reader.Seek(axesArrayOffset + i * axisSize);
+
+                var tag = new OpenTypeTag(reader.ReadUInt32());
+                var minValue = reader.ReadFixed();
+                var defaultValue = reader.ReadFixed();
+                var maxValue = reader.ReadFixed();
+                var flags = reader.ReadUInt16();
+                var axisNameId = reader.ReadUInt16();
+
+                var name = nameTable?.GetNameById(culture, axisNameId);
+                if (string.IsNullOrEmpty(name))
+                {
+                    name = tag.ToString();
+                }
+
+                axisTagsBuilder.Add(tag);
+                axesBuilder.Add(new FontVariationAxis(
+                    Tag: tag,
+                    Name: name,
+                    MinimumValue: minValue,
+                    DefaultValue: defaultValue,
+                    MaximumValue: maxValue,
+                    IsHidden: (flags & HiddenAxisFlag) != 0));
+            }
+
+            // InstanceRecord.postScriptNameID is optional. The spec encodes "present" via
+            // instanceSize being big enough to hold the extra uint16 after the coordinates.
+            var hasPostScriptName = instanceSize >= minimumInstanceSize + 2;
+
+            var instancesBuilder = ImmutableArray.CreateBuilder<FontVariationInstance>(instanceCount);
+
+            for (var i = 0; i < instanceCount; i++)
+            {
+                reader.Seek(axesEnd + i * instanceSize);
+
+                var subfamilyNameId = reader.ReadUInt16();
+                _ = reader.ReadUInt16(); // flags — reserved, must be 0.
+
+                var coordinates = new Dictionary<OpenTypeTag, float>(axisCount);
+                for (var a = 0; a < axisCount; a++)
+                {
+                    coordinates[axisTagsBuilder[a]] = reader.ReadFixed();
+                }
+
+                int? postScriptNameId = null;
+                if (hasPostScriptName)
+                {
+                    postScriptNameId = reader.ReadUInt16();
+                }
+
+                var instanceName = nameTable?.GetNameById(culture, subfamilyNameId) ?? string.Empty;
+
+                instancesBuilder.Add(new FontVariationInstance(
+                    instanceName,
+                    i,
+                    coordinates,
+                    postScriptNameId));
+            }
+
+            fvarTable = new FvarTable(
+                axesBuilder.MoveToImmutable(),
+                instancesBuilder.MoveToImmutable(),
+                axisTagsBuilder.MoveToImmutable());
+
+            return true;
+        }
+    }
+}

--- a/src/Avalonia.Base/Media/GlyphTypeface.cs
+++ b/src/Avalonia.Base/Media/GlyphTypeface.cs
@@ -8,6 +8,7 @@ using Avalonia.Media.Fonts.Tables.Cmap;
 using Avalonia.Media.Fonts.Tables.Glyf;
 using Avalonia.Media.Fonts.Tables.Metrics;
 using Avalonia.Media.Fonts.Tables.Name;
+using Avalonia.Media.Fonts.Tables.Variation;
 using Avalonia.Media.TextFormatting.Unicode;
 using Avalonia.Platform;
 
@@ -39,6 +40,12 @@ namespace Avalonia.Media
         private readonly VerticalMetricsTable? _vmTable;
 
         private readonly GlyfTable? _glyfTable;
+
+        // Variation tables (null on static fonts). The fvar table is loaded after the
+        // name table so axis / instance names can be resolved during parsing; avar is
+        // optional and may be absent even on a variable font.
+        private readonly FvarTable? _fvarTable;
+        private readonly AvarTable? _avarTable;
 
         private readonly bool _hasOs2Table;
         private readonly bool _hasHorizontalMetrics;
@@ -250,6 +257,17 @@ namespace Avalonia.Media
             {
                 FamilyNames = new Dictionary<CultureInfo, string> { { CultureInfo.InvariantCulture, FamilyName } };
                 FaceNames = new Dictionary<CultureInfo, string> { { CultureInfo.InvariantCulture, Weight.ToString() } };
+            }
+
+            // Variable-font tables. fvar declares the axes and any named instances; avar
+            // (optional) carries per-axis segment maps that correct the linear fvar
+            // normalization. Both are absent on static fonts — they're read once here so
+            // the per-call cost on VariationAxes / CreateNormalizedPosition is just a field
+            // access.
+            FvarTable.TryLoad(this, _nameTable, out _fvarTable);
+            if (_fvarTable is not null)
+            {
+                AvarTable.TryLoad(this, out _avarTable);
             }
 
             static CultureInfo GetCulture(int lcid)
@@ -635,6 +653,36 @@ namespace Avalonia.Media
         }
 
         /// <summary>
+        /// Gets the variation axes declared by the font's <c>fvar</c> table, in declaration
+        /// order. Empty for static fonts.
+        /// </summary>
+        /// <remarks>
+        /// Axes describe the design dimensions the font exposes — common ones are
+        /// <c>wght</c> (weight), <c>wdth</c> (width), <c>opsz</c> (optical size),
+        /// <c>ital</c> (italic), and <c>slnt</c> (slant). Each <see cref="FontVariationAxis"/>
+        /// carries its minimum / default / maximum user-space values and a human-readable
+        /// name. Desired user-space values are expressed as a
+        /// <see cref="FontVariationSettings"/>; the renderer normalizes them per font when
+        /// the settings are applied.
+        /// </remarks>
+        public IReadOnlyList<FontVariationAxis> VariationAxes
+            => _fvarTable?.Axes ?? (IReadOnlyList<FontVariationAxis>)Array.Empty<FontVariationAxis>();
+
+        /// <summary>
+        /// Gets the named variation instances declared by the font's <c>fvar</c> table, in
+        /// declaration order. Empty for static fonts.
+        /// </summary>
+        /// <remarks>
+        /// Named instances are pre-defined points in variation space the font designer has
+        /// labeled (e.g. "SemiBold" at <c>wght=600</c>). Pass an instance's
+        /// <see cref="FontVariationInstance.Index"/> to
+        /// <see cref="CreateNormalizedPosition"/> as a shorthand for "give me a settings
+        /// value for this preset".
+        /// </remarks>
+        public IReadOnlyList<FontVariationInstance> NamedInstances
+            => _fvarTable?.Instances ?? (IReadOnlyList<FontVariationInstance>)Array.Empty<FontVariationInstance>();
+
+        /// <summary>
         /// Gets the platform-specific typeface associated with this font.
         /// </summary>
         public IPlatformTypeface PlatformTypeface { get; }
@@ -995,6 +1043,150 @@ namespace Avalonia.Media
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Derives this font's <see cref="NormalizedVariationPosition"/> from user-space
+        /// settings (e.g. <c>wght = 700</c>), normalizing through the font's <c>fvar</c>
+        /// and <c>avar</c> tables. Internal: normalized coordinates are font-relative, so
+        /// the public API speaks user space (<see cref="FontVariationSettings"/>) and this
+        /// conversion happens per font at application time.
+        /// </summary>
+        /// <param name="settings">
+        /// Axis values in the same space the font designer exposed
+        /// (<see cref="FontVariationAxis.MinimumValue"/> .. <see cref="FontVariationAxis.MaximumValue"/>).
+        /// Axes the font does not declare are silently ignored; axes present in the font
+        /// but absent from the settings use their default value (overridable by
+        /// <paramref name="instanceIndex"/>). Pass <c>null</c> when relying entirely on a
+        /// named instance.
+        /// </param>
+        /// <param name="instanceIndex">
+        /// Optional zero-based index into <see cref="NamedInstances"/>. When provided, the
+        /// instance's coordinates are used as the baseline; values in
+        /// <paramref name="settings"/> override them per axis. Useful as a shorthand for
+        /// "start from this preset and tweak one axis".
+        /// </param>
+        /// <returns>
+        /// The font's normalized position. Returns
+        /// <c>default(NormalizedVariationPosition)</c> when the font has no <c>fvar</c>
+        /// table (static fonts) or when every axis resolves to its default value.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="instanceIndex"/> is non-null and outside the bounds of
+        /// <see cref="NamedInstances"/>.
+        /// </exception>
+        internal NormalizedVariationPosition CreateNormalizedPosition(
+            FontVariationSettings? settings,
+            int? instanceIndex = null)
+        {
+            if (_fvarTable is null)
+            {
+                // Static font — no axes to normalize.
+                return default;
+            }
+
+            var axes = _fvarTable.Axes;
+
+            // Start from the named instance's coords when one was requested, then overlay
+            // any explicit user values. Both inputs are user-space.
+            Dictionary<OpenTypeTag, float>? effective = null;
+
+            if (instanceIndex is int idx)
+            {
+                if ((uint)idx >= (uint)_fvarTable.Instances.Length)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(instanceIndex),
+                        idx,
+                        $"Instance index must be in the range [0, {_fvarTable.Instances.Length}).");
+                }
+
+                var instance = _fvarTable.Instances[idx];
+                effective = new Dictionary<OpenTypeTag, float>(instance.Coordinates);
+            }
+
+            if (settings is not null && !settings.IsEmpty)
+            {
+                effective ??= new Dictionary<OpenTypeTag, float>(settings.Variations.Length);
+                foreach (var variation in settings.Variations)
+                {
+                    effective[variation.Tag] = (float)variation.Value;
+                }
+            }
+
+            // Per-axis normalization. Skip axes that resolve to the default so the result
+            // equals default(NormalizedVariationPosition) when the caller asked for the
+            // default-instance point — important for cache identity at the
+            // GlyphTypeface layer (WithVariation(default) returns the source).
+            Dictionary<OpenTypeTag, float>? normalized = null;
+
+            for (var i = 0; i < axes.Length; i++)
+            {
+                var axis = axes[i];
+
+                var userValue = axis.DefaultValue;
+                if (effective is not null && effective.TryGetValue(axis.Tag, out var supplied))
+                {
+                    userValue = supplied;
+                }
+
+                // Clamp to the axis range. fvar treats values outside [min, max] as a
+                // best-effort clamp rather than an error — matches CSS and DirectWrite.
+                if (userValue < axis.MinimumValue)
+                {
+                    userValue = axis.MinimumValue;
+                }
+                else if (userValue > axis.MaximumValue)
+                {
+                    userValue = axis.MaximumValue;
+                }
+
+                // Linear fvar normalization into [-1, 1] anchored at the default value.
+                // The two halves of the axis (below and above default) are normalized
+                // independently — this is what makes the design "default" land at 0
+                // regardless of where min and max sit.
+                float normalizedValue;
+                if (userValue == axis.DefaultValue)
+                {
+                    normalizedValue = 0f;
+                }
+                else if (userValue < axis.DefaultValue)
+                {
+                    var range = axis.DefaultValue - axis.MinimumValue;
+                    normalizedValue = range > 0f
+                        ? (userValue - axis.DefaultValue) / range
+                        : 0f;
+                }
+                else
+                {
+                    var range = axis.MaximumValue - axis.DefaultValue;
+                    normalizedValue = range > 0f
+                        ? (userValue - axis.DefaultValue) / range
+                        : 0f;
+                }
+
+                // avar segment-map correction. Identity on axes the table doesn't cover
+                // (or when the table is absent), so safe to call unconditionally inside
+                // the loop once we've checked _avarTable is non-null.
+                if (_avarTable is not null)
+                {
+                    normalizedValue = _avarTable.Remap(i, normalizedValue);
+                }
+
+                if (normalizedValue != 0f)
+                {
+                    normalized ??= new Dictionary<OpenTypeTag, float>(axes.Length);
+                    normalized[axis.Tag] = normalizedValue;
+                }
+            }
+
+            if (normalized is null)
+            {
+                // Every axis came out at default — return the canonical "no variation" value.
+                return default;
+            }
+
+            return NormalizedVariationPosition.FromCoordinates(normalized);
         }
 
         public void Dispose()

--- a/tests/Avalonia.Base.UnitTests/Media/Fonts/MalformedFvarAvarTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/Fonts/MalformedFvarAvarTests.cs
@@ -1,0 +1,76 @@
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Media.Fonts
+{
+    /// <summary>
+    /// Characterization tests for the fvar / avar robustness of the GlyphTypeface parsers, using the
+    /// <see cref="SyntheticFont"/> / <see cref="BigEndianBuffer"/> harness. A hostile axis count or a
+    /// truncated optional avar must degrade to a static / identity normalization rather than denying
+    /// the font or feeding an unbounded stack allocation.
+    /// </summary>
+    public class MalformedFvarAvarTests
+    {
+        [Fact]
+        public void Truncated_Avar_Segment_Map_Does_Not_Deny_The_Font()
+        {
+            // The avar header is 6 bytes (major/minor version + axisCount). Keeping 8 leaves the
+            // first segment map's positionMapCount readable but cuts its value-pair array (and the
+            // next map), so the read loop would over-run AvarTable's reader.
+            var font = SyntheticFont.FromAsset(SyntheticFont.Assets.InterVariable).Truncate("avar", 8);
+
+            var typeface = font.TryCreateGlyphTypeface();
+
+            // AvarTable.TryLoad now bounds its reads (try/catch), so a malformed optional avar degrades
+            // to identity normalization instead of denying the whole font.
+            Assert.NotNull(typeface);
+        }
+
+        [Fact]
+        public void FvarTable_Rejects_An_Unclamped_AxisCount()
+        {
+            // No real font exceeds ~64 variation axes. An unclamped axisCount flows into three
+            // `stackalloc float[axisCount]` buffers in GlyphVariationReader — an uncatchable
+            // StackOverflow (DoS) on a hostile variable font declaring thousands of axes.
+            const ushort axisCount = 2048;
+            var font = SyntheticFont.FromAsset(SyntheticFont.Assets.InterRegular)
+                .Replace("fvar", BuildFvar(axisCount));
+
+            var typeface = font.TryCreateGlyphTypeface();
+
+            // fvar now rejects an implausibly large axisCount (> MaxAxisCount), so the font loads as
+            // static (no variation axes) rather than feeding the gvar stackalloc.
+            Assert.NotNull(typeface);
+            Assert.Empty(typeface!.VariationAxes);
+        }
+
+        /// <summary>Builds a valid fvar table declaring <paramref name="axisCount"/> axes (no instances).</summary>
+        private static byte[] BuildFvar(ushort axisCount)
+        {
+            var fvar = new BigEndianBuffer();
+
+            // fvar header (16 bytes).
+            fvar.UInt16(1);          // majorVersion
+            fvar.UInt16(0);          // minorVersion
+            fvar.UInt16(16);         // axesArrayOffset (axes follow the header)
+            fvar.UInt16(2);          // reserved
+            fvar.UInt16(axisCount);
+            fvar.UInt16(20);         // axisSize
+            fvar.UInt16(0);          // instanceCount
+            fvar.UInt16(0);          // instanceSize
+
+            // AxisRecord[axisCount]: Tag(4) + min/default/max Fixed(4 each) + flags(2) + axisNameID(2).
+            for (var i = 0; i < axisCount; i++)
+            {
+                fvar.Tag("axis");
+                fvar.Fixed(0.0);     // min
+                fvar.Fixed(0.0);     // default
+                fvar.Fixed(1.0);     // max
+                fvar.UInt16(0);      // flags
+                fvar.UInt16(0);      // axisNameID
+            }
+
+            return fvar.ToArray();
+        }
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/Media/Fonts/Tables/AvarTableTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/Fonts/Tables/AvarTableTests.cs
@@ -1,0 +1,105 @@
+using System;
+using Avalonia.Media;
+using Avalonia.Media.Fonts.Tables.Variation;
+using Avalonia.Platform;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Media.Fonts.Tables
+{
+    public class AvarTableTests
+    {
+        private const string InterRegularAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.Inter-Regular.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private const string InterVariableAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.InterVariable.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private static GlyphTypeface LoadTypeface(string assetUri)
+        {
+            var assetLoader = new StandardAssetLoader();
+            using var stream = assetLoader.Open(new Uri(assetUri));
+            return new GlyphTypeface(new CustomPlatformTypeface(stream));
+        }
+
+        [Fact]
+        public void TryLoad_Returns_False_For_Static_Font()
+        {
+            var typeface = LoadTypeface(InterRegularAsset);
+
+            Assert.False(AvarTable.TryLoad(typeface, out var avar));
+            Assert.Null(avar);
+        }
+
+        [Fact]
+        public void TryLoad_Returns_True_For_Inter_Variable()
+        {
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            Assert.True(AvarTable.TryLoad(typeface, out var avar));
+            Assert.NotNull(avar);
+            Assert.Equal(2, avar!.AxisCount);
+        }
+
+        [Fact]
+        public void Remap_Is_Identity_For_Linear_Axis()
+        {
+            // Inter Variable's opsz axis has an identity-only segment map:
+            //   (-1 → -1), (0 → 0), (+1 → +1). Any input passes through unchanged.
+            var typeface = LoadTypeface(InterVariableAsset);
+            Assert.True(AvarTable.TryLoad(typeface, out var avar));
+
+            Assert.Equal(-1f, avar!.Remap(axisIndex: 0, -1f));
+            Assert.Equal(0f, avar.Remap(axisIndex: 0, 0f));
+            Assert.Equal(0.5f, avar.Remap(axisIndex: 0, 0.5f));
+            Assert.Equal(1f, avar.Remap(axisIndex: 0, 1f));
+        }
+
+        [Fact]
+        public void Remap_Applies_Bend_For_NonLinear_Axis()
+        {
+            // Inter Variable's wght axis bends through these segment-map entries:
+            //   (-1 → -1), (0 → 0), (0.2 → 0.18), (0.4 → 0.36),
+            //   (0.6 → 0.54), (0.8 → 0.76), (1.0 → 1.0)
+            // Each exact entry must round-trip; intermediate values are linear between
+            // the surrounding entries.
+            var typeface = LoadTypeface(InterVariableAsset);
+            Assert.True(AvarTable.TryLoad(typeface, out var avar));
+
+            const float tolerance = 1e-4f;
+
+            Assert.Equal(0.18f, avar!.Remap(axisIndex: 1, 0.2f), tolerance);
+            Assert.Equal(0.36f, avar.Remap(axisIndex: 1, 0.4f), tolerance);
+            Assert.Equal(0.54f, avar.Remap(axisIndex: 1, 0.6f), tolerance);
+            Assert.Equal(0.76f, avar.Remap(axisIndex: 1, 0.8f), tolerance);
+
+            // Midpoint between (0.4 → 0.36) and (0.6 → 0.54) should be (0.5 → 0.45) under
+            // linear interpolation.
+            Assert.Equal(0.45f, avar.Remap(axisIndex: 1, 0.5f), tolerance);
+        }
+
+        [Fact]
+        public void Remap_Clamps_Out_Of_Range_Input()
+        {
+            // The avar domain is exactly [-1, 1]; values outside that range are clamped
+            // before lookup. This prevents extrapolation off the ends of the segment list.
+            var typeface = LoadTypeface(InterVariableAsset);
+            Assert.True(AvarTable.TryLoad(typeface, out var avar));
+
+            Assert.Equal(-1f, avar!.Remap(axisIndex: 1, -2f));
+            Assert.Equal(1f, avar.Remap(axisIndex: 1, 5f));
+        }
+
+        [Fact]
+        public void Remap_Is_Identity_For_Out_Of_Range_Axis_Index()
+        {
+            // Defensive: an axis index beyond the table's axisCount returns the input
+            // unchanged. This matters if a font's avar declares fewer axes than fvar,
+            // which the spec forbids but malformed fonts sometimes do.
+            var typeface = LoadTypeface(InterVariableAsset);
+            Assert.True(AvarTable.TryLoad(typeface, out var avar));
+
+            Assert.Equal(0.5f, avar!.Remap(axisIndex: 99, 0.5f));
+            Assert.Equal(0.5f, avar.Remap(axisIndex: -1, 0.5f));
+        }
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/Media/Fonts/Tables/FvarTableTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/Fonts/Tables/FvarTableTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.IO;
+using Avalonia.Media;
+using Avalonia.Media.Fonts;
+using Avalonia.Media.Fonts.Tables.Name;
+using Avalonia.Media.Fonts.Tables.Variation;
+using Avalonia.Platform;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Media.Fonts.Tables
+{
+    public class FvarTableTests
+    {
+        private const string InterRegularAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.Inter-Regular.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private const string InterVariableAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.InterVariable.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private static GlyphTypeface LoadTypeface(string assetUri)
+        {
+            var assetLoader = new StandardAssetLoader();
+            using var stream = assetLoader.Open(new Uri(assetUri));
+            return new GlyphTypeface(new CustomPlatformTypeface(stream));
+        }
+
+        [Fact]
+        public void TryLoad_Returns_False_For_Static_Font()
+        {
+            var typeface = LoadTypeface(InterRegularAsset);
+            var nameTable = NameTable.Load(typeface);
+
+            Assert.False(FvarTable.TryLoad(typeface, nameTable, out var fvar));
+            Assert.Null(fvar);
+        }
+
+        [Fact]
+        public void TryLoad_Returns_True_For_Inter_Variable()
+        {
+            var typeface = LoadTypeface(InterVariableAsset);
+            var nameTable = NameTable.Load(typeface);
+
+            Assert.True(FvarTable.TryLoad(typeface, nameTable, out var fvar));
+            Assert.NotNull(fvar);
+        }
+
+        [Fact]
+        public void Axes_Reports_Inter_Variable_Axes()
+        {
+            // Inter Variable carries two axes: opsz (14..32, default 14) and wght (100..900,
+            // default 400). Verified directly against the font's binary fvar table.
+            var typeface = LoadTypeface(InterVariableAsset);
+            var nameTable = NameTable.Load(typeface);
+            Assert.True(FvarTable.TryLoad(typeface, nameTable, out var fvar));
+
+            Assert.Equal(2, fvar!.Axes.Length);
+
+            var opsz = fvar.Axes[0];
+            Assert.Equal(OpenTypeTag.Parse("opsz"), opsz.Tag);
+            Assert.Equal(14f, opsz.MinimumValue);
+            Assert.Equal(14f, opsz.DefaultValue);
+            Assert.Equal(32f, opsz.MaximumValue);
+            Assert.False(opsz.IsHidden);
+
+            var wght = fvar.Axes[1];
+            Assert.Equal(OpenTypeTag.Parse("wght"), wght.Tag);
+            Assert.Equal(100f, wght.MinimumValue);
+            Assert.Equal(400f, wght.DefaultValue);
+            Assert.Equal(900f, wght.MaximumValue);
+            Assert.False(wght.IsHidden);
+        }
+
+        [Fact]
+        public void Axis_Names_Resolve_When_Name_Table_Present()
+        {
+            // The fvar axisNameID points into the name table. Resolution should produce a
+            // non-tag name when the table is available — Inter Variable's name records use
+            // "Optical Size" and "Weight". We only assert the names are non-empty and
+            // distinct from the raw tag, to avoid brittleness if Inter renames them.
+            var typeface = LoadTypeface(InterVariableAsset);
+            var nameTable = NameTable.Load(typeface);
+            Assert.True(FvarTable.TryLoad(typeface, nameTable, out var fvar));
+
+            foreach (var axis in fvar!.Axes)
+            {
+                Assert.False(string.IsNullOrWhiteSpace(axis.Name));
+                Assert.NotEqual(axis.Tag.ToString(), axis.Name);
+            }
+        }
+
+        [Fact]
+        public void Axis_Names_Fall_Back_To_Tag_When_Name_Table_Missing()
+        {
+            var typeface = LoadTypeface(InterVariableAsset);
+            Assert.True(FvarTable.TryLoad(typeface, nameTable: null, out var fvar));
+
+            foreach (var axis in fvar!.Axes)
+            {
+                Assert.Equal(axis.Tag.ToString(), axis.Name);
+            }
+        }
+
+        [Fact]
+        public void Instances_Reports_All_Nine_Inter_Variable_Presets()
+        {
+            // Inter Variable declares 9 named instances (Thin through Black, all at the
+            // default opsz=14). The first three are wght=100/200/300 — verified directly
+            // against the binary fvar.
+            var typeface = LoadTypeface(InterVariableAsset);
+            var nameTable = NameTable.Load(typeface);
+            Assert.True(FvarTable.TryLoad(typeface, nameTable, out var fvar));
+
+            Assert.Equal(9, fvar!.Instances.Length);
+
+            // The default-instance preset is at index 3 — wght=400 in Inter Variable.
+            var defaultInstance = fvar.Instances[3];
+            Assert.Equal(3, defaultInstance.Index);
+            Assert.Equal(400f, defaultInstance.Coordinates[OpenTypeTag.Parse("wght")]);
+            Assert.Equal(14f, defaultInstance.Coordinates[OpenTypeTag.Parse("opsz")]);
+        }
+
+        [Fact]
+        public void Instance_Coordinates_Match_fvar_Data()
+        {
+            // First instance is Thin at wght=100; last is Black at wght=900. Both at
+            // opsz=14 since Inter Variable's named instances are all at the default opsz.
+            var typeface = LoadTypeface(InterVariableAsset);
+            var nameTable = NameTable.Load(typeface);
+            Assert.True(FvarTable.TryLoad(typeface, nameTable, out var fvar));
+
+            var thin = fvar!.Instances[0];
+            Assert.Equal(100f, thin.Coordinates[OpenTypeTag.Parse("wght")]);
+
+            var black = fvar.Instances[fvar.Instances.Length - 1];
+            Assert.Equal(900f, black.Coordinates[OpenTypeTag.Parse("wght")]);
+        }
+
+        [Fact]
+        public void Instances_Have_Sequential_Indices()
+        {
+            // Index uniquely identifies an instance within a font — used as the lookup key
+            // for CreateNormalizedPosition(instanceIndex: ...).
+            var typeface = LoadTypeface(InterVariableAsset);
+            var nameTable = NameTable.Load(typeface);
+            Assert.True(FvarTable.TryLoad(typeface, nameTable, out var fvar));
+
+            for (var i = 0; i < fvar!.Instances.Length; i++)
+            {
+                Assert.Equal(i, fvar.Instances[i].Index);
+            }
+        }
+
+        [Fact]
+        public void AxisTags_Are_Available_For_Indexed_Lookup()
+        {
+            // AxisTags exists so downstream consumers (avar, gvar, HVAR) can index by axis
+            // position without unpacking the full FontVariationAxis record. The order must
+            // match the public Axes list.
+            var typeface = LoadTypeface(InterVariableAsset);
+            var nameTable = NameTable.Load(typeface);
+            Assert.True(FvarTable.TryLoad(typeface, nameTable, out var fvar));
+
+            Assert.Equal(fvar!.Axes.Length, fvar.AxisTags.Length);
+            for (var i = 0; i < fvar.Axes.Length; i++)
+            {
+                Assert.Equal(fvar.Axes[i].Tag, fvar.AxisTags[i]);
+            }
+        }
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/Media/GlyphTypefaceVariationTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/GlyphTypefaceVariationTests.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Linq;
+using Avalonia.Base.UnitTests.Media.Fonts.Tables;
+using Avalonia.Media;
+using Avalonia.Media.Fonts;
+using Avalonia.Platform;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Media
+{
+    public class GlyphTypefaceVariationTests
+    {
+        private const string InterRegularAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.Inter-Regular.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private const string InterVariableAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.InterVariable.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private static readonly OpenTypeTag s_wghtTag = OpenTypeTag.Parse("wght");
+        private static readonly OpenTypeTag s_opszTag = OpenTypeTag.Parse("opsz");
+
+        private static GlyphTypeface LoadTypeface(string assetUri)
+        {
+            var assetLoader = new StandardAssetLoader();
+            using var stream = assetLoader.Open(new Uri(assetUri));
+            return new GlyphTypeface(new CustomPlatformTypeface(stream));
+        }
+
+        private static FontVariationSettings Settings(params (OpenTypeTag Tag, double Value)[] variations) =>
+            new(variations.Select(v => new FontVariation(v.Tag, v.Value)));
+
+        [Fact]
+        public void VariationAxes_Is_Empty_For_Static_Font()
+        {
+            var typeface = LoadTypeface(InterRegularAsset);
+
+            Assert.Empty(typeface.VariationAxes);
+            Assert.Empty(typeface.NamedInstances);
+        }
+
+        [Fact]
+        public void VariationAxes_Reports_Inter_Variable_Axes()
+        {
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            Assert.Equal(2, typeface.VariationAxes.Count);
+            Assert.Equal(s_opszTag, typeface.VariationAxes[0].Tag);
+            Assert.Equal(s_wghtTag, typeface.VariationAxes[1].Tag);
+        }
+
+        [Fact]
+        public void NamedInstances_Reports_All_Nine_Presets()
+        {
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            Assert.Equal(9, typeface.NamedInstances.Count);
+        }
+
+        [Fact]
+        public void CreateNormalizedPosition_Returns_Default_For_Static_Font()
+        {
+            // Static fonts have no axes to normalize — every call returns the canonical
+            // "no variation" value regardless of the requested values.
+            var typeface = LoadTypeface(InterRegularAsset);
+
+            var position = typeface.CreateNormalizedPosition(Settings((s_wghtTag, 700)));
+
+            Assert.True(position.IsDefault);
+        }
+
+        [Fact]
+        public void CreateNormalizedPosition_Returns_Default_For_Axis_At_Default()
+        {
+            // Asking for the default-instance point yields the canonical default position.
+            // Identity here matters for the FontCollection cache contract — two
+            // requests for the default instance must produce equal positions.
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            var position = typeface.CreateNormalizedPosition(Settings(
+                (s_wghtTag, 400),   // = default
+                (s_opszTag, 14)));  // = default
+
+            Assert.True(position.IsDefault);
+        }
+
+        [Fact]
+        public void CreateNormalizedPosition_Returns_Default_When_No_Input_Provided()
+        {
+            // Null / empty input + no instance index = all axes at default = default position.
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            Assert.True(typeface.CreateNormalizedPosition(null).IsDefault);
+            Assert.True(typeface.CreateNormalizedPosition(FontVariationSettings.Empty).IsDefault);
+        }
+
+        [Fact]
+        public void CreateNormalizedPosition_Normalizes_Above_Default_Through_Avar()
+        {
+            // wght=700 → linear normalization: (700-400) / (900-400) = 0.6
+            //         → avar wght segment map: 0.6 → 0.54 (per the bend declared in
+            //           Inter Variable's avar table, verified in AvarTableTests).
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            var position = typeface.CreateNormalizedPosition(Settings((s_wghtTag, 700)));
+
+            Assert.True(position.TryGetCoordinate(s_wghtTag, out var wght));
+            Assert.Equal(0.54f, wght, precision: 4);
+        }
+
+        [Fact]
+        public void CreateNormalizedPosition_Normalizes_Below_Default()
+        {
+            // wght=200 → (200-400) / (400-100) = -2/3 ≈ -0.6667
+            //         → avar wght map below 0 is linear identity through (-1, 0):
+            //           (-1 → -1), (0 → 0); midpoint -2/3 stays -2/3.
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            var position = typeface.CreateNormalizedPosition(Settings((s_wghtTag, 200)));
+
+            Assert.True(position.TryGetCoordinate(s_wghtTag, out var wght));
+            Assert.Equal(-0.6667f, wght, precision: 3);
+        }
+
+        [Fact]
+        public void CreateNormalizedPosition_Clamps_Above_Maximum()
+        {
+            // wght=10000 is silently clamped to the axis maximum (900) → +1 normalized
+            //  → avar (1 → 1) = +1 corrected. Matches CSS and DirectWrite behavior.
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            var position = typeface.CreateNormalizedPosition(Settings((s_wghtTag, 10000)));
+
+            Assert.True(position.TryGetCoordinate(s_wghtTag, out var wght));
+            Assert.Equal(1f, wght, precision: 4);
+        }
+
+        [Fact]
+        public void CreateNormalizedPosition_Clamps_Below_Minimum()
+        {
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            var position = typeface.CreateNormalizedPosition(Settings((s_wghtTag, -500)));
+
+            Assert.True(position.TryGetCoordinate(s_wghtTag, out var wght));
+            Assert.Equal(-1f, wght, precision: 4);
+        }
+
+        [Fact]
+        public void CreateNormalizedPosition_Ignores_Unknown_Axes()
+        {
+            // Axes not declared by the font are silently dropped — matches the
+            // typeface-agnostic semantics documented on FontVariationSettings.
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            var bogus = OpenTypeTag.Parse("xxxx");
+            var position = typeface.CreateNormalizedPosition(Settings(
+                (bogus, 0.5),
+                (s_wghtTag, 400))); // at default
+
+            Assert.True(position.IsDefault);
+            Assert.False(position.TryGetCoordinate(bogus, out _));
+        }
+
+        [Fact]
+        public void CreateNormalizedPosition_Uses_Named_Instance_Coordinates()
+        {
+            // Instance index 8 in Inter Variable is the last preset (Black, wght=900).
+            // Picking it through the shorthand parameter should produce the same position
+            // as requesting wght=900 explicitly.
+            var typeface = LoadTypeface(InterVariableAsset);
+            var lastIndex = typeface.NamedInstances.Count - 1;
+
+            var byIndex = typeface.CreateNormalizedPosition(null, instanceIndex: lastIndex);
+            var byValues = typeface.CreateNormalizedPosition(Settings((s_wghtTag, 900)));
+
+            Assert.Equal(byValues, byIndex);
+        }
+
+        [Fact]
+        public void CreateNormalizedPosition_Overrides_Named_Instance_With_Explicit_Values()
+        {
+            // Instance index + explicit values: the explicit value wins per axis. Useful
+            // for "start from Bold, but bump optical size".
+            var typeface = LoadTypeface(InterVariableAsset);
+            var lastIndex = typeface.NamedInstances.Count - 1;  // Black (wght=900)
+
+            var position = typeface.CreateNormalizedPosition(Settings((s_wghtTag, 400)),
+                instanceIndex: lastIndex);
+
+            // wght was forced back to the default → no contribution to the position,
+            // and opsz stayed at the instance's default → also no contribution.
+            Assert.True(position.IsDefault);
+        }
+
+        [Fact]
+        public void CreateNormalizedPosition_Throws_For_Invalid_Instance_Index()
+        {
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                typeface.CreateNormalizedPosition(null, instanceIndex: 99));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                typeface.CreateNormalizedPosition(null, instanceIndex: -1));
+        }
+
+        [Fact]
+        public void CreateNormalizedPosition_Ignores_InstanceIndex_For_Static_Font()
+        {
+            // Static fonts short-circuit to default before validating the instance index,
+            // matching the "static fonts are inert to variation" pattern — important
+            // when a global wght=600 is applied to a UI mixing static + variable fonts.
+            var typeface = LoadTypeface(InterRegularAsset);
+
+            Assert.True(typeface.CreateNormalizedPosition(null, instanceIndex: 99).IsDefault);
+        }
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

**Part 6 of 15** of the glyph-outline / variable-font workstream, and the entry point to the variable-font run (Parts 6 to 12). Stacked on **Part 5** (`pr2d/shaped-buffer-glyph-indices`); please merge that one first.

## What does the pull request do?

Parses `fvar` and `avar` and exposes the variable-font inspection surface: which axes a font declares, their ranges, the named instances the designer ships, and the conversion from user-space axis values into the normalized space every variation table is indexed by.

```csharp
public IReadOnlyList<FontVariationAxis> VariationAxes { get; }
public IReadOnlyList<FontVariationInstance> NamedInstances { get; }
```

- `FontVariationAxis` is a public readonly record struct carrying the axis tag, its minimum, default and maximum in user space, its display name and whether the designer marked it hidden.
- `FontVariationInstance` is a public readonly struct carrying a named instance's name, its index, its user-space coordinate map and the optional name-ID of a PostScript name record.
- `GlyphTypeface.CreateNormalizedPosition(FontVariationSettings?, int? instanceIndex)` is internal: it clamps user-space values to the fvar ranges, runs each through the `avar` segment map when the font has one, and normalizes into the `[-1, 0, +1]` space that gvar, HVAR, VVAR and MVAR all index by.

`FontVariationSettings`, the public user-space type, and `NormalizedVariationPosition`, the internal font-relative one, both come from Part 1. This PR is the layer that translates between them for a particular font.

No deformation happens here. Parts 8 to 11 plug the individual tables in.

## What is the updated/expected behavior with this PR?

- Static fonts report empty `VariationAxes` and `NamedInstances`, and normalize to the default position. Nothing is allocated on that path.
- Variable fonts report their axes in fvar order and their named instances with the designer's coordinates, so a font picker can enumerate both without ever asking for a varied typeface.
- Axis and instance names are resolved through the `name` table when the font provides them, and fall back to the tag's string form when it does not.
- Values outside an axis range clamp to that range rather than being rejected, which matches how CSS treats out-of-range `font-variation-settings`.
- A font whose `fvar` is truncated, declares a bogus axis count, or points its instance array outside the table degrades to "not a variable font" instead of failing to load. The same applies to `avar`: a malformed or non-monotonic segment map is treated as the identity mapping, so the axis still works, just without the designer's remapping.

## How was the solution implemented (if it's not obvious)?

- Axis and instance names are bound eagerly at parse time rather than lazily. The strings are few, small and live as long as the typeface, so binding once avoids repeated cross-table lookups.
- All user-space to normalized conversion goes through one entry point, so no later PR has to know whether `avar` was present.
- `avar` segment maps are required by the specification to be monotonic. Fonts in the wild violate this, and a non-monotonic map produces a remap that is not invertible, so those maps are ignored per axis rather than trusted.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None. The API is additive and static fonts behave exactly as before.

## Obsoletions / Deprecations

None.

## Fixed issues

None.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
