### PR TITLE
[Text] Glyph Outline Part 9/15 - HVAR advance widths

### DIFF
--- a/src/Avalonia.Base/Media/Fonts/Tables/Metrics/HorizontalMetricsTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Metrics/HorizontalMetricsTable.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Buffers.Binary;
+using Avalonia.Media.Fonts.Tables.Variation;
 
 namespace Avalonia.Media.Fonts.Tables.Metrics
 {
@@ -108,16 +110,30 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
 
         /// <summary>
         /// Attempts to retrieve advance widths for multiple glyphs in a single operation.
+        /// When <paramref name="hvar"/> and <paramref name="activeCoords"/> are both
+        /// supplied, HVAR's per-glyph delta is applied to each advance in the same
+        /// pass — fused so <paramref name="advances"/> is written exactly once per
+        /// glyph instead of once by hmtx and again by an HVAR post-pass.
         /// </summary>
         /// <param name="glyphIndices">Read-only span of glyph indices to query.</param>
-        /// <param name="advances">Output span to write the advance widths. Must be at least as long as <paramref name="glyphIndices"/>.</param>
+        /// <param name="advances">Output span; must be at least as long as <paramref name="glyphIndices"/>.</param>
+        /// <param name="hvar">Optional HVAR table. <c>null</c> means no variation adjustment.</param>
+        /// <param name="activeCoords">
+        /// Normalized variation coordinates in fvar axis order. Ignored when
+        /// <paramref name="hvar"/> is <c>null</c>; otherwise must match the font's axis count.
+        /// </param>
         /// <returns><c>true</c> if all glyph indices are valid and advances were retrieved; otherwise, <c>false</c>.</returns>
         /// <remarks>
-        /// This method is more efficient than calling <see cref="TryGetAdvance"/> multiple times as it reuses
-        /// the same reader and span reference. If any glyph index is invalid, the method returns <c>false</c>
+        /// Reuses the <c>lastAdvanceWidth</c> cache for monospace-tail glyphs, so a
+        /// font where most glyphs share the same advance pays one hmtx read regardless
+        /// of batch size. If any glyph index is invalid, the method returns <c>false</c>
         /// and the contents of <paramref name="advances"/> are undefined.
         /// </remarks>
-        public bool TryGetAdvances(ReadOnlySpan<ushort> glyphIndices, Span<ushort> advances)
+        public bool TryGetAdvances(
+            ReadOnlySpan<ushort> glyphIndices,
+            Span<ushort> advances,
+            HvarTable? hvar = null,
+            ReadOnlySpan<float> activeCoords = default)
         {
             if (advances.Length < glyphIndices.Length)
             {
@@ -125,10 +141,10 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
             }
 
             var data = _data.Span;
-            var reader = new BigEndianBinaryReader(data);
 
             // Cache the last advance width for glyphs beyond numOfHMetrics
             ushort? lastAdvanceWidth = null;
+            var hasHvar = hvar is not null && !activeCoords.IsEmpty;
 
             for (int i = 0; i < glyphIndices.Length; i++)
             {
@@ -139,21 +155,31 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
                     return false;
                 }
 
+                ushort raw;
                 if (glyphIndex < _numOfHMetrics)
                 {
-                    reader.Seek(glyphIndex * 4);
-                    advances[i] = reader.ReadUInt16();
+                    raw = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(glyphIndex * 4, 2));
                 }
                 else
                 {
-                    // All glyphs beyond numOfHMetrics share the same advance width
                     if (!lastAdvanceWidth.HasValue)
                     {
-                        reader.Seek((_numOfHMetrics - 1) * 4);
-                        lastAdvanceWidth = reader.ReadUInt16();
+                        lastAdvanceWidth = BinaryPrimitives.ReadUInt16BigEndian(
+                            data.Slice((_numOfHMetrics - 1) * 4, 2));
                     }
+                    raw = lastAdvanceWidth.Value;
+                }
 
-                    advances[i] = lastAdvanceWidth.Value;
+                if (hasHvar && hvar!.TryGetAdvanceDelta(glyphIndex, activeCoords, out var delta) && delta != 0f)
+                {
+                    var adjusted = raw + (int)MathF.Round(delta);
+                    advances[i] = adjusted < 0
+                        ? (ushort)0
+                        : (ushort)Math.Min(adjusted, ushort.MaxValue);
+                }
+                else
+                {
+                    advances[i] = raw;
                 }
             }
 
@@ -161,17 +187,19 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
         }
 
         /// <summary>
-        /// Attempts to retrieve horizontal glyph metrics for multiple glyphs in a single operation.
+        /// Attempts to retrieve horizontal glyph metrics for multiple glyphs in a single
+        /// operation, optionally applying HVAR variation deltas in the same pass.
         /// </summary>
         /// <param name="glyphIndices">Read-only span of glyph indices to query.</param>
-        /// <param name="metrics">Output span to write the metrics. Must be at least as long as <paramref name="glyphIndices"/>.</param>
+        /// <param name="metrics">Output span; must be at least as long as <paramref name="glyphIndices"/>.</param>
+        /// <param name="hvar">Optional HVAR table for variation-adjusted advances + LSBs.</param>
+        /// <param name="activeCoords">Normalized variation coordinates in fvar axis order.</param>
         /// <returns><c>true</c> if all glyph indices are valid and metrics were retrieved; otherwise, <c>false</c>.</returns>
-        /// <remarks>
-        /// This method is more efficient than calling <see cref="TryGetMetrics(ushort, out HorizontalGlyphMetric)"/> multiple times as it reuses
-        /// the same reader and span reference. If any glyph index is invalid, the method returns <c>false</c>
-        /// and the contents of <paramref name="metrics"/> are undefined.
-        /// </remarks>
-        public bool TryGetMetrics(ReadOnlySpan<ushort> glyphIndices, Span<HorizontalGlyphMetric> metrics)
+        public bool TryGetMetrics(
+            ReadOnlySpan<ushort> glyphIndices,
+            Span<HorizontalGlyphMetric> metrics,
+            HvarTable? hvar = null,
+            ReadOnlySpan<float> activeCoords = default)
         {
             if (metrics.Length < glyphIndices.Length)
             {
@@ -179,10 +207,10 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
             }
 
             var data = _data.Span;
-            var reader = new BigEndianBinaryReader(data);
 
             // Cache the last advance width for glyphs beyond numOfHMetrics
             ushort? lastAdvanceWidth = null;
+            var hasHvar = hvar is not null && !activeCoords.IsEmpty;
 
             for (int i = 0; i < glyphIndices.Length; i++)
             {
@@ -193,32 +221,47 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
                     return false;
                 }
 
+                ushort advanceWidth;
+                short leftSideBearing;
+
                 if (glyphIndex < _numOfHMetrics)
                 {
-                    reader.Seek(glyphIndex * 4);
-
-                    ushort advanceWidth = reader.ReadUInt16();
-                    short leftSideBearing = reader.ReadInt16();
-
-                    metrics[i] = new HorizontalGlyphMetric(advanceWidth, leftSideBearing);
+                    var entryOffset = glyphIndex * 4;
+                    advanceWidth = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(entryOffset, 2));
+                    leftSideBearing = BinaryPrimitives.ReadInt16BigEndian(data.Slice(entryOffset + 2, 2));
                 }
                 else
                 {
-                    // All glyphs beyond numOfHMetrics share the same advance width
                     if (!lastAdvanceWidth.HasValue)
                     {
-                        reader.Seek((_numOfHMetrics - 1) * 4);
-                        lastAdvanceWidth = reader.ReadUInt16();
+                        lastAdvanceWidth = BinaryPrimitives.ReadUInt16BigEndian(
+                            data.Slice((_numOfHMetrics - 1) * 4, 2));
+                    }
+                    advanceWidth = lastAdvanceWidth.Value;
+
+                    var lsbIndex = glyphIndex - _numOfHMetrics;
+                    var lsbOffset = _numOfHMetrics * 4 + lsbIndex * 2;
+                    leftSideBearing = BinaryPrimitives.ReadInt16BigEndian(data.Slice(lsbOffset, 2));
+                }
+
+                if (hasHvar)
+                {
+                    if (hvar!.TryGetAdvanceDelta(glyphIndex, activeCoords, out var advDelta) && advDelta != 0f)
+                    {
+                        var adjusted = advanceWidth + (int)MathF.Round(advDelta);
+                        advanceWidth = adjusted < 0
+                            ? (ushort)0
+                            : (ushort)Math.Min(adjusted, ushort.MaxValue);
                     }
 
-                    int lsbIndex = glyphIndex - _numOfHMetrics;
-                    int lsbOffset = _numOfHMetrics * 4 + lsbIndex * 2;
-
-                    reader.Seek(lsbOffset);
-                    short leftSideBearing = reader.ReadInt16();
-
-                    metrics[i] = new HorizontalGlyphMetric(lastAdvanceWidth.Value, leftSideBearing);
+                    if (hvar.TryGetLeftSideBearingDelta(glyphIndex, activeCoords, out var lsbDelta) && lsbDelta != 0f)
+                    {
+                        var adjusted = leftSideBearing + (int)MathF.Round(lsbDelta);
+                        leftSideBearing = (short)Math.Clamp(adjusted, short.MinValue, short.MaxValue);
+                    }
                 }
+
+                metrics[i] = new HorizontalGlyphMetric(advanceWidth, leftSideBearing);
             }
 
             return true;

--- a/src/Avalonia.Base/Media/Fonts/Tables/Metrics/HorizontalMetricsTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Metrics/HorizontalMetricsTable.cs
@@ -16,7 +16,12 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
         private HorizontalMetricsTable(ReadOnlyMemory<byte> data, ushort numOfHMetrics, int numGlyphs)
         {
             _data = data;
-            _numOfHMetrics = numOfHMetrics;
+
+            // Clamp to what the table can actually hold: a numberOfHMetrics larger than the hmtx
+            // bytes — or an out-of-spec 0 — would otherwise drive negative or out-of-range reads in
+            // the accessors. A well-formed table always holds numberOfHMetrics * 4 bytes, so it is
+            // unaffected.
+            _numOfHMetrics = (ushort)Math.Min((int)numOfHMetrics, data.Length / 4);
             _numGlyphs = numGlyphs;
         }
 
@@ -40,7 +45,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
         {
             metric = default;
 
-            if (glyphIndex >= _numGlyphs)
+            if (glyphIndex >= _numGlyphs || _numOfHMetrics == 0)
             {
                 return false;
             }
@@ -65,9 +70,14 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
                 int lsbIndex = glyphIndex - _numOfHMetrics;
                 int lsbOffset = _numOfHMetrics * 4 + lsbIndex * 2;
 
-                reader.Seek(lsbOffset);
-
-                short leftSideBearing = reader.ReadInt16();
+                // A truncated table may omit some or all of the trailing leftSideBearing array;
+                // treat a missing entry as zero rather than reading past the end.
+                short leftSideBearing = 0;
+                if (lsbOffset + 2 <= _data.Length)
+                {
+                    reader.Seek(lsbOffset);
+                    leftSideBearing = reader.ReadInt16();
+                }
 
                 metric = new HorizontalGlyphMetric(lastAdvanceWidth, leftSideBearing);
             }
@@ -85,7 +95,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
         {
             advance = 0;
 
-            if (glyphIndex >= _numGlyphs)
+            if (glyphIndex >= _numGlyphs || _numOfHMetrics == 0)
             {
                 return false;
             }
@@ -136,6 +146,11 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
             ReadOnlySpan<float> activeCoords = default)
         {
             if (advances.Length < glyphIndices.Length)
+            {
+                return false;
+            }
+
+            if (_numOfHMetrics == 0)
             {
                 return false;
             }
@@ -206,6 +221,11 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
                 return false;
             }
 
+            if (_numOfHMetrics == 0)
+            {
+                return false;
+            }
+
             var data = _data.Span;
 
             // Cache the last advance width for glyphs beyond numOfHMetrics
@@ -241,7 +261,12 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
 
                     var lsbIndex = glyphIndex - _numOfHMetrics;
                     var lsbOffset = _numOfHMetrics * 4 + lsbIndex * 2;
-                    leftSideBearing = BinaryPrimitives.ReadInt16BigEndian(data.Slice(lsbOffset, 2));
+
+                    // A truncated table may omit some or all of the trailing leftSideBearing array;
+                    // treat a missing entry as zero rather than reading past the end.
+                    leftSideBearing = lsbOffset + 2 <= data.Length
+                        ? BinaryPrimitives.ReadInt16BigEndian(data.Slice(lsbOffset, 2))
+                        : (short)0;
                 }
 
                 if (hasHvar)

--- a/src/Avalonia.Base/Media/Fonts/Tables/Metrics/HorizontalMetricsTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Metrics/HorizontalMetricsTable.cs
@@ -120,7 +120,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
 
         /// <summary>
         /// Attempts to retrieve advance widths for multiple glyphs in a single operation.
-        /// When <paramref name="hvar"/> and <paramref name="activeCoords"/> are both
+        /// When <paramref name="hvar"/> and <paramref name="hvarRegionScalers"/> are both
         /// supplied, HVAR's per-glyph delta is applied to each advance in the same
         /// pass — fused so <paramref name="advances"/> is written exactly once per
         /// glyph instead of once by hmtx and again by an HVAR post-pass.
@@ -128,22 +128,21 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
         /// <param name="glyphIndices">Read-only span of glyph indices to query.</param>
         /// <param name="advances">Output span; must be at least as long as <paramref name="glyphIndices"/>.</param>
         /// <param name="hvar">Optional HVAR table. <c>null</c> means no variation adjustment.</param>
-        /// <param name="activeCoords">
-        /// Normalized variation coordinates in fvar axis order. Ignored when
-        /// <paramref name="hvar"/> is <c>null</c>; otherwise must match the font's axis count.
+        /// <param name="hvarRegionScalers">
+        /// Pre-computed per-region scalers for HVAR's <see cref="ItemVariationStore"/>,
+        /// produced once at clone time by
+        /// <see cref="ItemVariationStore.ComputeRegionScalers"/>. Ignored when
+        /// <paramref name="hvar"/> is <c>null</c>; otherwise length must equal
+        /// HVAR's region count. The per-glyph loop never re-projects from active
+        /// coordinates — the scaler vector is constant for the typeface's lifetime
+        /// so the inner lookup is a single array index instead of a per-axis ramp.
         /// </param>
         /// <returns><c>true</c> if all glyph indices are valid and advances were retrieved; otherwise, <c>false</c>.</returns>
-        /// <remarks>
-        /// Reuses the <c>lastAdvanceWidth</c> cache for monospace-tail glyphs, so a
-        /// font where most glyphs share the same advance pays one hmtx read regardless
-        /// of batch size. If any glyph index is invalid, the method returns <c>false</c>
-        /// and the contents of <paramref name="advances"/> are undefined.
-        /// </remarks>
         public bool TryGetAdvances(
             ReadOnlySpan<ushort> glyphIndices,
             Span<ushort> advances,
             HvarTable? hvar = null,
-            ReadOnlySpan<float> activeCoords = default)
+            ReadOnlySpan<float> hvarRegionScalers = default)
         {
             if (advances.Length < glyphIndices.Length)
             {
@@ -159,7 +158,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
 
             // Cache the last advance width for glyphs beyond numOfHMetrics
             ushort? lastAdvanceWidth = null;
-            var hasHvar = hvar is not null && !activeCoords.IsEmpty;
+            var hasHvar = hvar is not null && !hvarRegionScalers.IsEmpty;
 
             for (int i = 0; i < glyphIndices.Length; i++)
             {
@@ -185,7 +184,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
                     raw = lastAdvanceWidth.Value;
                 }
 
-                if (hasHvar && hvar!.TryGetAdvanceDelta(glyphIndex, activeCoords, out var delta) && delta != 0f)
+                if (hasHvar && hvar!.TryGetAdvanceDeltaWithScalers(glyphIndex, hvarRegionScalers, out var delta) && delta != 0f)
                 {
                     var adjusted = raw + (int)MathF.Round(delta);
                     advances[i] = adjusted < 0
@@ -208,13 +207,13 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
         /// <param name="glyphIndices">Read-only span of glyph indices to query.</param>
         /// <param name="metrics">Output span; must be at least as long as <paramref name="glyphIndices"/>.</param>
         /// <param name="hvar">Optional HVAR table for variation-adjusted advances + LSBs.</param>
-        /// <param name="activeCoords">Normalized variation coordinates in fvar axis order.</param>
+        /// <param name="hvarRegionScalers">Pre-computed per-region scalers for HVAR's ItemVariationStore.</param>
         /// <returns><c>true</c> if all glyph indices are valid and metrics were retrieved; otherwise, <c>false</c>.</returns>
         public bool TryGetMetrics(
             ReadOnlySpan<ushort> glyphIndices,
             Span<HorizontalGlyphMetric> metrics,
             HvarTable? hvar = null,
-            ReadOnlySpan<float> activeCoords = default)
+            ReadOnlySpan<float> hvarRegionScalers = default)
         {
             if (metrics.Length < glyphIndices.Length)
             {
@@ -230,7 +229,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
 
             // Cache the last advance width for glyphs beyond numOfHMetrics
             ushort? lastAdvanceWidth = null;
-            var hasHvar = hvar is not null && !activeCoords.IsEmpty;
+            var hasHvar = hvar is not null && !hvarRegionScalers.IsEmpty;
 
             for (int i = 0; i < glyphIndices.Length; i++)
             {
@@ -271,7 +270,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
 
                 if (hasHvar)
                 {
-                    if (hvar!.TryGetAdvanceDelta(glyphIndex, activeCoords, out var advDelta) && advDelta != 0f)
+                    if (hvar!.TryGetAdvanceDeltaWithScalers(glyphIndex, hvarRegionScalers, out var advDelta) && advDelta != 0f)
                     {
                         var adjusted = advanceWidth + (int)MathF.Round(advDelta);
                         advanceWidth = adjusted < 0
@@ -279,7 +278,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
                             : (ushort)Math.Min(adjusted, ushort.MaxValue);
                     }
 
-                    if (hvar.TryGetLeftSideBearingDelta(glyphIndex, activeCoords, out var lsbDelta) && lsbDelta != 0f)
+                    if (hvar.TryGetLeftSideBearingDeltaWithScalers(glyphIndex, hvarRegionScalers, out var lsbDelta) && lsbDelta != 0f)
                     {
                         var adjusted = leftSideBearing + (int)MathF.Round(lsbDelta);
                         leftSideBearing = (short)Math.Clamp(adjusted, short.MinValue, short.MaxValue);

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/DeltaSetIndexMap.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/DeltaSetIndexMap.cs
@@ -86,7 +86,19 @@ namespace Avalonia.Media.Fonts.Tables.Variation
                 {
                     return false;
                 }
-                mapCount = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(2));
+
+                // Keep the raw count unsigned: cast straight to int, a high-bit count turns the
+                // size check below into a negative product and fails open, and TryGetIndices
+                // would then index with a negative position. Entries are at least one byte, so
+                // any count beyond the remaining bytes is malformed (and the int cast is safe).
+                var rawMapCount = BinaryPrimitives.ReadUInt32BigEndian(span.Slice(2));
+
+                if (rawMapCount > (uint)(span.Length - 6))
+                {
+                    return false;
+                }
+
+                mapCount = (int)rawMapCount;
                 entriesStart = 6;
             }
             else

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/DeltaSetIndexMap.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/DeltaSetIndexMap.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Avalonia.Media.Fonts.Tables.Variation
+{
+    /// <summary>
+    /// Parses an OpenType DeltaSetIndexMap. Maps glyph IDs (or other indexable
+    /// items) to <c>(outerIndex, innerIndex)</c> coordinates in an
+    /// <see cref="ItemVariationStore"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// HVAR / VVAR / MVAR each use one of these to map their per-glyph (or per-metric)
+    /// queries onto the shared store's delta sets. The format packs both indices into
+    /// a single fixed-width entry (1-4 bytes), with a configurable number of bits for
+    /// the inner index so a font with thousands of distinct delta sets can be
+    /// indexed compactly.
+    /// </para>
+    /// <para>
+    /// Two formats: format 0 (16-bit mapCount) for smaller fonts and format 1 (32-bit
+    /// mapCount) for fonts with more than 65535 entries. The entry-format byte is
+    /// identical between the two; only the count's width differs.
+    /// </para>
+    /// <para>
+    /// Reference: <see href="https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data"/>.
+    /// </para>
+    /// </remarks>
+    internal sealed class DeltaSetIndexMap
+    {
+        // entryFormat byte layout:
+        //   bits 0-3: innerIndexBitCount - 1   (1..16 bits for the inner index)
+        //   bits 4-5: mapEntrySize - 1         (1..4 bytes per entry)
+        //   bits 6-7: reserved (0)
+        private const byte InnerBitCountMask = 0x0F;
+        private const byte EntrySizeMask = 0x30;
+        private const int EntrySizeShift = 4;
+
+        private readonly ReadOnlyMemory<byte> _data;
+        private readonly int _mapCount;
+        private readonly int _entrySize;
+        private readonly int _innerBitCount;
+        private readonly int _innerMask;
+        private readonly int _entriesStart;
+
+        private DeltaSetIndexMap(
+            ReadOnlyMemory<byte> data,
+            int mapCount,
+            int entrySize,
+            int innerBitCount,
+            int entriesStart)
+        {
+            _data = data;
+            _mapCount = mapCount;
+            _entrySize = entrySize;
+            _innerBitCount = innerBitCount;
+            _innerMask = (1 << innerBitCount) - 1;
+            _entriesStart = entriesStart;
+        }
+
+        public int MapCount => _mapCount;
+
+        public static bool TryLoad(ReadOnlyMemory<byte> data, [NotNullWhen(true)] out DeltaSetIndexMap? map)
+        {
+            map = null;
+
+            var span = data.Span;
+            if (span.Length < 4)
+            {
+                return false;
+            }
+
+            var format = span[0];
+            var entryFormat = span[1];
+
+            int mapCount;
+            int entriesStart;
+            if (format == 0)
+            {
+                mapCount = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(2));
+                entriesStart = 4;
+            }
+            else if (format == 1)
+            {
+                if (span.Length < 6)
+                {
+                    return false;
+                }
+                mapCount = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(2));
+                entriesStart = 6;
+            }
+            else
+            {
+                return false;
+            }
+
+            var innerBitCount = (entryFormat & InnerBitCountMask) + 1;
+            var entrySize = ((entryFormat & EntrySizeMask) >> EntrySizeShift) + 1;
+
+            if (entriesStart + (long)mapCount * entrySize > span.Length)
+            {
+                return false;
+            }
+
+            map = new DeltaSetIndexMap(data, mapCount, entrySize, innerBitCount, entriesStart);
+            return true;
+        }
+
+        /// <summary>
+        /// Reads the entry for the specified glyph index. Glyph indices beyond the
+        /// map's <see cref="MapCount"/> are clamped to the last entry, per spec —
+        /// fonts can use this to provide indices only for the first N glyphs and
+        /// have the remainder default to a shared delta set.
+        /// </summary>
+        public bool TryGetIndices(int glyphIndex, out int outerIndex, out int innerIndex)
+        {
+            outerIndex = 0;
+            innerIndex = 0;
+
+            if (glyphIndex < 0 || _mapCount == 0)
+            {
+                return false;
+            }
+
+            // Clamp beyond mapCount to the last available entry, matching the spec.
+            var effectiveIndex = glyphIndex >= _mapCount ? _mapCount - 1 : glyphIndex;
+            var pos = _entriesStart + effectiveIndex * _entrySize;
+            var span = _data.Span;
+
+            // Read the variable-width entry as a big-endian unsigned integer.
+            int rawEntry = 0;
+            for (var b = 0; b < _entrySize; b++)
+            {
+                rawEntry = (rawEntry << 8) | span[pos + b];
+            }
+
+            innerIndex = rawEntry & _innerMask;
+            outerIndex = rawEntry >> _innerBitCount;
+            return true;
+        }
+    }
+}

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/HvarTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/HvarTable.cs
@@ -78,9 +78,9 @@ namespace Avalonia.Media.Fonts.Tables.Variation
             }
 
             var ivsOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(4));
-            var advanceMapOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(8));
-            var lsbMapOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(12));
-            var rsbMapOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(16));
+            var advanceMapOffset = BinaryPrimitives.ReadUInt32BigEndian(span.Slice(8));
+            var lsbMapOffset = BinaryPrimitives.ReadUInt32BigEndian(span.Slice(12));
+            var rsbMapOffset = BinaryPrimitives.ReadUInt32BigEndian(span.Slice(16));
 
             if (ivsOffset <= 0 || ivsOffset >= data.Length)
             {
@@ -92,14 +92,18 @@ namespace Avalonia.Media.Fonts.Tables.Variation
                 return false;
             }
 
-            // The three index maps are optional — offset 0 means "use direct mapping".
+            // The three index maps are optional — offset 0 means "use direct mapping". The
+            // offsets are attacker-controlled, so validate them unsigned against the table
+            // length before slicing (mirroring the IVS offset check above): a hostile offset
+            // must degrade to "no HVAR" instead of throwing out of the typeface constructor.
             DeltaSetIndexMap? advanceMap = null;
             DeltaSetIndexMap? lsbMap = null;
             DeltaSetIndexMap? rsbMap = null;
 
             if (advanceMapOffset != 0)
             {
-                if (!DeltaSetIndexMap.TryLoad(data.Slice(advanceMapOffset), out advanceMap))
+                if (advanceMapOffset >= (uint)data.Length ||
+                    !DeltaSetIndexMap.TryLoad(data.Slice((int)advanceMapOffset), out advanceMap))
                 {
                     return false;
                 }
@@ -107,7 +111,8 @@ namespace Avalonia.Media.Fonts.Tables.Variation
 
             if (lsbMapOffset != 0)
             {
-                if (!DeltaSetIndexMap.TryLoad(data.Slice(lsbMapOffset), out lsbMap))
+                if (lsbMapOffset >= (uint)data.Length ||
+                    !DeltaSetIndexMap.TryLoad(data.Slice((int)lsbMapOffset), out lsbMap))
                 {
                     return false;
                 }
@@ -115,7 +120,8 @@ namespace Avalonia.Media.Fonts.Tables.Variation
 
             if (rsbMapOffset != 0)
             {
-                if (!DeltaSetIndexMap.TryLoad(data.Slice(rsbMapOffset), out rsbMap))
+                if (rsbMapOffset >= (uint)data.Length ||
+                    !DeltaSetIndexMap.TryLoad(data.Slice((int)rsbMapOffset), out rsbMap))
                 {
                     return false;
                 }

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/HvarTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/HvarTable.cs
@@ -184,5 +184,59 @@ namespace Avalonia.Media.Fonts.Tables.Variation
 
             return _store.TryGetDelta(outerIndex, innerIndex, activeCoords, out delta);
         }
+
+        // -- Scaler-cached overloads (hot-path) --
+        //
+        // The GlyphTypeface clone constructor pre-computes the per-region scaler array
+        // once via ItemVariationStore.ComputeRegionScalers; every per-glyph advance
+        // lookup then hands that array in instead of re-projecting the active coords.
+        // Measured ~9x speedup on AdvanceLookupBenchmark.VariableVaried_Batch200 vs
+        // the activeCoords path because the inner loop's ComputeRegionScaler call
+        // (which read regionIndexCount × axisCount F2DOT14 values plus per-axis
+        // branches) becomes a single array index.
+
+        /// <summary>
+        /// Hot-path overload that uses pre-computed per-region scalers instead of
+        /// projecting from active coordinates per call.
+        /// </summary>
+        public bool TryGetAdvanceDeltaWithScalers(int glyphIndex, ReadOnlySpan<float> regionScalers, out float delta)
+            => TryGetDeltaWithScalers(_advanceMap, glyphIndex, regionScalers, out delta);
+
+        /// <summary>
+        /// Hot-path overload for LSB delta lookups.
+        /// </summary>
+        public bool TryGetLeftSideBearingDeltaWithScalers(int glyphIndex, ReadOnlySpan<float> regionScalers, out float delta)
+        {
+            if (_lsbMap is null)
+            {
+                delta = 0f;
+                return true;
+            }
+
+            return TryGetDeltaWithScalers(_lsbMap, glyphIndex, regionScalers, out delta);
+        }
+
+        private bool TryGetDeltaWithScalers(DeltaSetIndexMap? map, int glyphIndex, ReadOnlySpan<float> regionScalers, out float delta)
+        {
+            delta = 0f;
+
+            int outerIndex;
+            int innerIndex;
+
+            if (map is null)
+            {
+                outerIndex = 0;
+                innerIndex = glyphIndex;
+            }
+            else
+            {
+                if (!map.TryGetIndices(glyphIndex, out outerIndex, out innerIndex))
+                {
+                    return false;
+                }
+            }
+
+            return _store.TryGetDeltaWithScalers(outerIndex, innerIndex, regionScalers, out delta);
+        }
     }
 }

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/HvarTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/HvarTable.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Avalonia.Media.Fonts.Tables.Variation
+{
+    /// <summary>
+    /// Parses the OpenType 'HVAR' (Horizontal Metrics Variations) table. Provides
+    /// per-glyph advance-width, left-side-bearing, and right-side-bearing deltas
+    /// at a given active variation point.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// HVAR is the table that makes variable-text layout work. Without it, a font
+    /// laid out at <c>wght=900</c> uses default-instance (<c>wght=400</c>) advance
+    /// widths, so the bolder glyphs overlap the next-glyph slot. HVAR carries the
+    /// extra width each glyph needs at higher weights.
+    /// </para>
+    /// <para>
+    /// Internally HVAR wraps an <see cref="ItemVariationStore"/> for the actual
+    /// delta math, plus up to three <see cref="DeltaSetIndexMap"/> instances that
+    /// map glyph IDs to <c>(outer, inner)</c> store coordinates — one each for
+    /// advance, LSB, and RSB. When a mapping is absent the glyph ID is used as the
+    /// inner index directly with outer = 0.
+    /// </para>
+    /// <para>
+    /// Reference: <see href="https://learn.microsoft.com/en-us/typography/opentype/spec/hvar"/>.
+    /// </para>
+    /// </remarks>
+    internal sealed class HvarTable
+    {
+        internal const string TableName = "HVAR";
+        internal static OpenTypeTag Tag { get; } = OpenTypeTag.Parse(TableName);
+
+        private const ushort SupportedMajorVersion = 1;
+
+        private readonly ItemVariationStore _store;
+        private readonly DeltaSetIndexMap? _advanceMap;
+        private readonly DeltaSetIndexMap? _lsbMap;
+        private readonly DeltaSetIndexMap? _rsbMap;
+
+        private HvarTable(
+            ItemVariationStore store,
+            DeltaSetIndexMap? advanceMap,
+            DeltaSetIndexMap? lsbMap,
+            DeltaSetIndexMap? rsbMap)
+        {
+            _store = store;
+            _advanceMap = advanceMap;
+            _lsbMap = lsbMap;
+            _rsbMap = rsbMap;
+        }
+
+        public ItemVariationStore Store => _store;
+
+        public static bool TryLoad(
+            GlyphTypeface glyphTypeface,
+            int expectedAxisCount,
+            [NotNullWhen(true)] out HvarTable? hvarTable)
+        {
+            hvarTable = null;
+
+            if (!glyphTypeface.PlatformTypeface.TryGetTable(Tag, out var data))
+            {
+                return false;
+            }
+
+            var span = data.Span;
+            if (span.Length < 20)
+            {
+                return false;
+            }
+
+            var majorVersion = BinaryPrimitives.ReadUInt16BigEndian(span);
+            if (majorVersion != SupportedMajorVersion)
+            {
+                return false;
+            }
+
+            var ivsOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(4));
+            var advanceMapOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(8));
+            var lsbMapOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(12));
+            var rsbMapOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(16));
+
+            if (ivsOffset <= 0 || ivsOffset >= data.Length)
+            {
+                return false;
+            }
+
+            if (!ItemVariationStore.TryLoad(data.Slice(ivsOffset), expectedAxisCount, out var store))
+            {
+                return false;
+            }
+
+            // The three index maps are optional — offset 0 means "use direct mapping".
+            DeltaSetIndexMap? advanceMap = null;
+            DeltaSetIndexMap? lsbMap = null;
+            DeltaSetIndexMap? rsbMap = null;
+
+            if (advanceMapOffset != 0)
+            {
+                if (!DeltaSetIndexMap.TryLoad(data.Slice(advanceMapOffset), out advanceMap))
+                {
+                    return false;
+                }
+            }
+
+            if (lsbMapOffset != 0)
+            {
+                if (!DeltaSetIndexMap.TryLoad(data.Slice(lsbMapOffset), out lsbMap))
+                {
+                    return false;
+                }
+            }
+
+            if (rsbMapOffset != 0)
+            {
+                if (!DeltaSetIndexMap.TryLoad(data.Slice(rsbMapOffset), out rsbMap))
+                {
+                    return false;
+                }
+            }
+
+            hvarTable = new HvarTable(store, advanceMap, lsbMap, rsbMap);
+            return true;
+        }
+
+        /// <summary>
+        /// Computes the advance-width delta for <paramref name="glyphIndex"/> at the
+        /// supplied active variation coordinates. The delta is in font design units
+        /// and is added to the <c>hmtx</c> advance.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if the lookup succeeded; <c>false</c> when the active coords
+        /// are an invalid shape or the underlying store is malformed. A successful
+        /// lookup with no contribution (e.g. variation coords all at default) returns
+        /// <c>true</c> with <c>delta = 0</c>.
+        /// </returns>
+        public bool TryGetAdvanceDelta(int glyphIndex, ReadOnlySpan<float> activeCoords, out float delta)
+            => TryGetDelta(_advanceMap, glyphIndex, activeCoords, out delta);
+
+        /// <summary>
+        /// Computes the left-side-bearing delta for <paramref name="glyphIndex"/>.
+        /// Returns <c>true</c> with <c>delta = 0</c> when the font carries no LSB
+        /// mapping (the common case — most variable fonts only carry advance deltas).
+        /// </summary>
+        public bool TryGetLeftSideBearingDelta(int glyphIndex, ReadOnlySpan<float> activeCoords, out float delta)
+        {
+            if (_lsbMap is null)
+            {
+                delta = 0f;
+                return true;
+            }
+
+            return TryGetDelta(_lsbMap, glyphIndex, activeCoords, out delta);
+        }
+
+        private bool TryGetDelta(DeltaSetIndexMap? map, int glyphIndex, ReadOnlySpan<float> activeCoords, out float delta)
+        {
+            delta = 0f;
+
+            int outerIndex;
+            int innerIndex;
+
+            if (map is null)
+            {
+                // Direct mapping: glyph ID is the inner index, outer = 0.
+                outerIndex = 0;
+                innerIndex = glyphIndex;
+            }
+            else
+            {
+                if (!map.TryGetIndices(glyphIndex, out outerIndex, out innerIndex))
+                {
+                    return false;
+                }
+            }
+
+            return _store.TryGetDelta(outerIndex, innerIndex, activeCoords, out delta);
+        }
+    }
+}

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/ItemVariationStore.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/ItemVariationStore.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Avalonia.Media.Fonts.Tables.Variation
+{
+    /// <summary>
+    /// Parses an OpenType ItemVariationStore. Provides delta lookups by
+    /// (outerIndex, innerIndex) at a given active variation point.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The ItemVariationStore is shared infrastructure: HVAR, VVAR, and MVAR each
+    /// embed one to carry per-glyph or font-wide deltas; COLR v1 also uses one for
+    /// variable paint records. The store consists of a list of <i>variation regions</i>
+    /// (each specifying a per-axis ramp through axis space) and one or more
+    /// <i>ItemVariationData</i> subtables grouping deltas by associated regions.
+    /// </para>
+    /// <para>
+    /// To resolve a delta the caller supplies an <c>outerIndex</c> selecting which
+    /// subtable to use and an <c>innerIndex</c> selecting the item within that
+    /// subtable. The store walks the subtable's region indexes, computes each
+    /// region's scaler against the active variation, multiplies by the corresponding
+    /// delta, and sums.
+    /// </para>
+    /// <para>
+    /// Reference: <see href="https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-subtables"/>.
+    /// </para>
+    /// </remarks>
+    internal sealed class ItemVariationStore
+    {
+        private const ushort SupportedFormat = 1;
+        private const ushort LongWordsFlag = 0x8000;
+        private const ushort WordDeltaCountMask = 0x7FFF;
+
+        // Raw bytes of the ItemVariationStore, sliced so offsets are relative to 0.
+        private readonly ReadOnlyMemory<byte> _data;
+
+        private readonly int _axisCount;
+        private readonly int _regionCount;
+        private readonly int _regionListStart;    // offset of the region records (after axisCount/regionCount header)
+        private readonly int _ivdCount;
+        // Per-subtable absolute byte offsets from _data start. Indexed by outerIndex.
+        private readonly int[] _ivdOffsets;
+
+        private ItemVariationStore(
+            ReadOnlyMemory<byte> data,
+            int axisCount,
+            int regionCount,
+            int regionListStart,
+            int ivdCount,
+            int[] ivdOffsets)
+        {
+            _data = data;
+            _axisCount = axisCount;
+            _regionCount = regionCount;
+            _regionListStart = regionListStart;
+            _ivdCount = ivdCount;
+            _ivdOffsets = ivdOffsets;
+        }
+
+        public int AxisCount => _axisCount;
+
+        public int RegionCount => _regionCount;
+
+        public int ItemVariationDataCount => _ivdCount;
+
+        /// <summary>
+        /// Loads an ItemVariationStore from the given bytes. The data must start at the
+        /// store's own header (the caller should pre-slice the containing table).
+        /// </summary>
+        public static bool TryLoad(
+            ReadOnlyMemory<byte> data,
+            int expectedAxisCount,
+            [NotNullWhen(true)] out ItemVariationStore? store)
+        {
+            store = null;
+
+            var span = data.Span;
+            if (span.Length < 8)
+            {
+                return false;
+            }
+
+            var format = BinaryPrimitives.ReadUInt16BigEndian(span);
+            if (format != SupportedFormat)
+            {
+                return false;
+            }
+
+            var regionListOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(2));
+            var ivdCount = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(6));
+
+            if (regionListOffset + 4 > span.Length)
+            {
+                return false;
+            }
+
+            var axisCount = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(regionListOffset));
+            var regionCount = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(regionListOffset + 2));
+
+            if (axisCount != expectedAxisCount)
+            {
+                // Spec invariant: ItemVariationStore axes must match the host font's
+                // fvar. If they don't, the offsets into the regions array won't line up.
+                return false;
+            }
+
+            var regionListStart = regionListOffset + 4;
+            var regionListEnd = regionListStart + regionCount * axisCount * 6; // each axis has start/peak/end as int16
+
+            if (regionListEnd > span.Length)
+            {
+                return false;
+            }
+
+            // ItemVariationData offsets array follows the store header.
+            var ivdOffsetsStart = 8;
+            if (ivdOffsetsStart + ivdCount * 4 > span.Length)
+            {
+                return false;
+            }
+
+            var ivdOffsets = new int[ivdCount];
+            for (var i = 0; i < ivdCount; i++)
+            {
+                ivdOffsets[i] = (int)BinaryPrimitives.ReadUInt32BigEndian(
+                    span.Slice(ivdOffsetsStart + i * 4, 4));
+
+                if (ivdOffsets[i] + 6 > span.Length)
+                {
+                    return false;
+                }
+            }
+
+            store = new ItemVariationStore(
+                data, axisCount, regionCount, regionListStart, ivdCount, ivdOffsets);
+            return true;
+        }
+
+        /// <summary>
+        /// Computes the variation delta for a given <c>(outerIndex, innerIndex)</c>
+        /// addressing pair at the supplied active variation coordinates.
+        /// </summary>
+        /// <param name="outerIndex">Selects the ItemVariationData subtable.</param>
+        /// <param name="innerIndex">Selects the item (row) within the subtable.</param>
+        /// <param name="activeCoords">Normalized active coords in fvar axis order.</param>
+        /// <param name="delta">
+        /// On success, the computed delta as a float (an int-valued result for HVAR /
+        /// MVAR deltas, but kept as float because the scaler multiplication is the
+        /// natural type).
+        /// </param>
+        /// <returns>
+        /// <c>true</c> when the indices and the active coords are valid and the lookup
+        /// succeeded; <c>false</c> when an index is out of range, the data is
+        /// malformed, or the active coords' axis count doesn't match.
+        /// </returns>
+        public bool TryGetDelta(int outerIndex, int innerIndex, ReadOnlySpan<float> activeCoords, out float delta)
+        {
+            delta = 0f;
+
+            if ((uint)outerIndex >= (uint)_ivdCount)
+            {
+                return false;
+            }
+
+            if (activeCoords.Length < _axisCount)
+            {
+                return false;
+            }
+
+            var span = _data.Span;
+            var subtableStart = _ivdOffsets[outerIndex];
+
+            var itemCount = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(subtableStart, 2));
+            var wordDeltaCountRaw = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(subtableStart + 2, 2));
+            var regionIndexCount = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(subtableStart + 4, 2));
+
+            if ((uint)innerIndex >= (uint)itemCount)
+            {
+                return false;
+            }
+
+            var useLongFormat = (wordDeltaCountRaw & LongWordsFlag) != 0;
+            var wordDeltaCount = wordDeltaCountRaw & WordDeltaCountMask;
+
+            if (wordDeltaCount > regionIndexCount)
+            {
+                return false;
+            }
+
+            // The "wide" delta width is 4 bytes in the long format and 2 bytes
+            // otherwise; the "narrow" width is 2 bytes in the long format and 1
+            // byte otherwise.
+            var wideBytes = useLongFormat ? 4 : 2;
+            var narrowBytes = useLongFormat ? 2 : 1;
+            var rowBytes = wordDeltaCount * wideBytes + (regionIndexCount - wordDeltaCount) * narrowBytes;
+
+            var regionIndexesStart = subtableStart + 6;
+            var deltaDataStart = regionIndexesStart + regionIndexCount * 2;
+            var rowStart = deltaDataStart + innerIndex * rowBytes;
+
+            if (rowStart + rowBytes > span.Length)
+            {
+                return false;
+            }
+
+            // Walk the row's deltas, accumulating scaler × delta per associated region.
+            var sum = 0f;
+            var bytePos = rowStart;
+
+            for (var r = 0; r < regionIndexCount; r++)
+            {
+                var regionIndex = BinaryPrimitives.ReadUInt16BigEndian(
+                    span.Slice(regionIndexesStart + r * 2, 2));
+
+                int rawDelta;
+                if (r < wordDeltaCount)
+                {
+                    // Wide format.
+                    if (useLongFormat)
+                    {
+                        rawDelta = BinaryPrimitives.ReadInt32BigEndian(span.Slice(bytePos, 4));
+                        bytePos += 4;
+                    }
+                    else
+                    {
+                        rawDelta = BinaryPrimitives.ReadInt16BigEndian(span.Slice(bytePos, 2));
+                        bytePos += 2;
+                    }
+                }
+                else
+                {
+                    // Narrow format.
+                    if (useLongFormat)
+                    {
+                        rawDelta = BinaryPrimitives.ReadInt16BigEndian(span.Slice(bytePos, 2));
+                        bytePos += 2;
+                    }
+                    else
+                    {
+                        rawDelta = (sbyte)span[bytePos];
+                        bytePos += 1;
+                    }
+                }
+
+                if ((uint)regionIndex >= (uint)_regionCount)
+                {
+                    // Malformed: region index out of range.
+                    return false;
+                }
+
+                var scaler = ComputeRegionScaler(regionIndex, activeCoords);
+                if (scaler != 0f)
+                {
+                    sum += scaler * rawDelta;
+                }
+            }
+
+            delta = sum;
+            return true;
+        }
+
+        /// <summary>
+        /// Computes a single region's scaler against the active variation coordinates.
+        /// Returns 0 if any axis is outside the region's <c>[start, end]</c> bracket;
+        /// 1 if the active position is exactly at the peak on every axis; a linearly
+        /// interpolated value otherwise. This is the standard OpenType variation-region
+        /// scaling rule, applied per axis and multiplied across axes.
+        /// </summary>
+        private float ComputeRegionScaler(int regionIndex, ReadOnlySpan<float> active)
+        {
+            var span = _data.Span;
+            var regionStart = _regionListStart + regionIndex * _axisCount * 6;
+
+            var scaler = 1f;
+
+            for (var a = 0; a < _axisCount; a++)
+            {
+                var axisStart = regionStart + a * 6;
+                var start = BinaryPrimitives.ReadInt16BigEndian(span.Slice(axisStart, 2)) / 16384f;
+                var peak = BinaryPrimitives.ReadInt16BigEndian(span.Slice(axisStart + 2, 2)) / 16384f;
+                var end = BinaryPrimitives.ReadInt16BigEndian(span.Slice(axisStart + 4, 2)) / 16384f;
+
+                var v = active[a];
+
+                if (peak == 0f)
+                {
+                    // Axis doesn't contribute to this region (peak at default means the
+                    // region is independent of this axis).
+                    continue;
+                }
+
+                if (start > peak || peak > end)
+                {
+                    // Malformed region — treat as no contribution rather than divide by
+                    // zero.
+                    return 0f;
+                }
+
+                if (start > 0f && start > v)
+                {
+                    return 0f;
+                }
+                if (end < 0f && end < v)
+                {
+                    return 0f;
+                }
+
+                if (v < start || v > end)
+                {
+                    return 0f;
+                }
+
+                if (v == peak)
+                {
+                    continue;
+                }
+
+                if (v < peak)
+                {
+                    scaler *= (v - start) / (peak - start);
+                }
+                else
+                {
+                    scaler *= (end - v) / (end - peak);
+                }
+            }
+
+            return scaler;
+        }
+    }
+}

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/ItemVariationStore.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/ItemVariationStore.cs
@@ -207,7 +207,11 @@ namespace Avalonia.Media.Fonts.Tables.Variation
 
             var regionIndexesStart = subtableStart + 6;
             var deltaDataStart = regionIndexesStart + regionIndexCount * 2;
-            var rowStart = deltaDataStart + innerIndex * rowBytes;
+
+            // Widen to long: innerIndex (≤ ~65534) × rowBytes (≤ ~262140) overflows int, and a
+            // negative rowStart would pass the bounds check below only to throw on the slice —
+            // reachable from the public metrics APIs with a ~30-byte crafted store.
+            var rowStart = deltaDataStart + innerIndex * (long)rowBytes;
 
             if (rowStart + rowBytes > span.Length)
             {
@@ -216,7 +220,7 @@ namespace Avalonia.Media.Fonts.Tables.Variation
 
             // Walk the row's deltas, accumulating scaler × delta per associated region.
             var sum = 0f;
-            var bytePos = rowStart;
+            var bytePos = (int)rowStart;
 
             for (var r = 0; r < regionIndexCount; r++)
             {

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/ItemVariationStore.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/ItemVariationStore.cs
@@ -88,16 +88,21 @@ namespace Avalonia.Media.Fonts.Tables.Variation
                 return false;
             }
 
-            var regionListOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(2));
+            // Keep offsets unsigned and compare against a non-overflowing bound: an additive check
+            // like `offset + n > length` lets a high-bit (negative-when-cast) or near-int.MaxValue
+            // offset slip through and then slice out of range.
+            var regionListOffset = BinaryPrimitives.ReadUInt32BigEndian(span.Slice(2));
             var ivdCount = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(6));
 
-            if (regionListOffset + 4 > span.Length)
+            // axisCount + regionCount (4 bytes) live at regionListOffset.
+            if (regionListOffset > (uint)(span.Length - 4))
             {
                 return false;
             }
 
-            var axisCount = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(regionListOffset));
-            var regionCount = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(regionListOffset + 2));
+            var regionListOffsetInt = (int)regionListOffset;
+            var axisCount = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(regionListOffsetInt));
+            var regionCount = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(regionListOffsetInt + 2));
 
             if (axisCount != expectedAxisCount)
             {
@@ -106,9 +111,10 @@ namespace Avalonia.Media.Fonts.Tables.Variation
                 return false;
             }
 
-            var regionListStart = regionListOffset + 4;
-            var regionListEnd = regionListStart + regionCount * axisCount * 6; // each axis has start/peak/end as int16
+            var regionListStart = regionListOffsetInt + 4;
 
+            // Widen to long: regionCount (up to 65535) × axisCount × 6 can exceed int range.
+            var regionListEnd = (long)regionListStart + (long)regionCount * axisCount * 6; // start/peak/end int16 per axis
             if (regionListEnd > span.Length)
             {
                 return false;
@@ -116,7 +122,7 @@ namespace Avalonia.Media.Fonts.Tables.Variation
 
             // ItemVariationData offsets array follows the store header.
             var ivdOffsetsStart = 8;
-            if (ivdOffsetsStart + ivdCount * 4 > span.Length)
+            if (ivdOffsetsStart + (long)ivdCount * 4 > span.Length)
             {
                 return false;
             }
@@ -124,13 +130,16 @@ namespace Avalonia.Media.Fonts.Tables.Variation
             var ivdOffsets = new int[ivdCount];
             for (var i = 0; i < ivdCount; i++)
             {
-                ivdOffsets[i] = (int)BinaryPrimitives.ReadUInt32BigEndian(
-                    span.Slice(ivdOffsetsStart + i * 4, 4));
+                var ivdOffset = BinaryPrimitives.ReadUInt32BigEndian(span.Slice(ivdOffsetsStart + i * 4, 4));
 
-                if (ivdOffsets[i] + 6 > span.Length)
+                // Each ItemVariationData subtable header is at least 6 bytes; reject out-of-range
+                // offsets (including high-bit values) before storing them as int.
+                if (ivdOffset > (uint)(span.Length - 6))
                 {
                     return false;
                 }
+
+                ivdOffsets[i] = (int)ivdOffset;
             }
 
             store = new ItemVariationStore(

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/ItemVariationStore.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/ItemVariationStore.cs
@@ -148,6 +148,143 @@ namespace Avalonia.Media.Fonts.Tables.Variation
         }
 
         /// <summary>
+        /// Pre-computes the per-region scaler for every region declared by the store
+        /// against the supplied active coordinates. Fills <paramref name="output"/>
+        /// with one scaler per region (length must be at least <see cref="RegionCount"/>).
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The store's regions are constant for the lifetime of the font, and the
+        /// active coordinates are constant for the lifetime of a varied
+        /// <see cref="GlyphTypeface"/> clone — so the resulting scaler vector is
+        /// constant per clone. Pre-computing once at clone time saves the per-axis
+        /// region-scaler computation inside <see cref="TryGetDelta(int,int,ReadOnlySpan{float},out float)"/>
+        /// on every per-glyph lookup. The
+        /// <see cref="TryGetDelta(int,int,ReadOnlySpan{float},out float)"/> overload
+        /// then becomes a straight index lookup.
+        /// </para>
+        /// <para>
+        /// Measured win on <c>AdvanceLookupBenchmark.VariableVaried_Batch200</c>:
+        /// per-glyph HVAR lookup drops dramatically because the inner loop's
+        /// <c>ComputeRegionScaler</c> call — which read <c>regionIndexCount × axisCount</c>
+        /// F2DOT14 values plus per-axis branches — is replaced by an array index.
+        /// </para>
+        /// </remarks>
+        public void ComputeRegionScalers(ReadOnlySpan<float> activeCoords, Span<float> output)
+        {
+            for (var r = 0; r < _regionCount; r++)
+            {
+                output[r] = ComputeRegionScaler(r, activeCoords);
+            }
+        }
+
+        /// <summary>
+        /// Computes the variation delta using a pre-computed per-region scaler array.
+        /// Same contract as <see cref="TryGetDelta(int,int,ReadOnlySpan{float},out float)"/>
+        /// but with the active-coords → scaler projection lifted out into
+        /// <see cref="ComputeRegionScalers"/>.
+        /// </summary>
+        public bool TryGetDeltaWithScalers(int outerIndex, int innerIndex, ReadOnlySpan<float> regionScalers, out float delta)
+        {
+            delta = 0f;
+
+            if ((uint)outerIndex >= (uint)_ivdCount)
+            {
+                return false;
+            }
+
+            var span = _data.Span;
+            var subtableStart = _ivdOffsets[outerIndex];
+
+            var itemCount = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(subtableStart, 2));
+            var wordDeltaCountRaw = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(subtableStart + 2, 2));
+            var regionIndexCount = BinaryPrimitives.ReadUInt16BigEndian(span.Slice(subtableStart + 4, 2));
+
+            if ((uint)innerIndex >= (uint)itemCount)
+            {
+                return false;
+            }
+
+            var useLongFormat = (wordDeltaCountRaw & LongWordsFlag) != 0;
+            var wordDeltaCount = wordDeltaCountRaw & WordDeltaCountMask;
+
+            if (wordDeltaCount > regionIndexCount)
+            {
+                return false;
+            }
+
+            var wideBytes = useLongFormat ? 4 : 2;
+            var narrowBytes = useLongFormat ? 2 : 1;
+            var rowBytes = wordDeltaCount * wideBytes + (regionIndexCount - wordDeltaCount) * narrowBytes;
+
+            var regionIndexesStart = subtableStart + 6;
+            var deltaDataStart = regionIndexesStart + regionIndexCount * 2;
+
+            // Widen to long before the bounds check: innerIndex × rowBytes overflows int (see
+            // TryGetDelta) — the scaler-cached path is reachable from the same public metrics
+            // APIs on a varied clone, so it needs the identical guard.
+            var rowStart = deltaDataStart + innerIndex * (long)rowBytes;
+
+            if (rowStart + rowBytes > span.Length)
+            {
+                return false;
+            }
+
+            // Same row walk as TryGetDelta, but the per-region scaler comes from the
+            // precomputed array instead of being computed from activeCoords.
+            var sum = 0f;
+            var bytePos = (int)rowStart;
+
+            for (var r = 0; r < regionIndexCount; r++)
+            {
+                var regionIndex = BinaryPrimitives.ReadUInt16BigEndian(
+                    span.Slice(regionIndexesStart + r * 2, 2));
+
+                int rawDelta;
+                if (r < wordDeltaCount)
+                {
+                    if (useLongFormat)
+                    {
+                        rawDelta = BinaryPrimitives.ReadInt32BigEndian(span.Slice(bytePos, 4));
+                        bytePos += 4;
+                    }
+                    else
+                    {
+                        rawDelta = BinaryPrimitives.ReadInt16BigEndian(span.Slice(bytePos, 2));
+                        bytePos += 2;
+                    }
+                }
+                else
+                {
+                    if (useLongFormat)
+                    {
+                        rawDelta = BinaryPrimitives.ReadInt16BigEndian(span.Slice(bytePos, 2));
+                        bytePos += 2;
+                    }
+                    else
+                    {
+                        rawDelta = (sbyte)span[bytePos];
+                        bytePos += 1;
+                    }
+                }
+
+                if ((uint)regionIndex >= (uint)regionScalers.Length)
+                {
+                    return false;
+                }
+
+                var scaler = regionScalers[regionIndex];
+                if (scaler != 0f)
+                {
+                    sum += scaler * rawDelta;
+                }
+            }
+
+            delta = sum;
+            return true;
+        }
+
+        /// <summary>
         /// Computes the variation delta for a given <c>(outerIndex, innerIndex)</c>
         /// addressing pair at the supplied active variation coordinates.
         /// </summary>

--- a/src/Avalonia.Base/Media/GlyphTypeface.cs
+++ b/src/Avalonia.Base/Media/GlyphTypeface.cs
@@ -54,6 +54,12 @@ namespace Avalonia.Media
         // HVAR / VVAR / MVAR with no outline variation).
         private readonly GvarTable? _gvarTable;
 
+        // HVAR table — per-glyph advance-width and side-bearing deltas. Null on static
+        // fonts and on variable fonts that don't carry HVAR (rare; without it, a
+        // wght=900 layout uses default-instance advances and glyphs overlap their
+        // neighbors). Inter Variable carries HVAR; most production variable fonts do.
+        private readonly HvarTable? _hvarTable;
+
         // Source typeface for variation clones. Null for default-instance typefaces
         // (the source) — every WithVariation clone points back to its source so all
         // variations of the same font share a single cache and resource owner.
@@ -70,6 +76,14 @@ namespace Avalonia.Media
         // Variation point this typeface is bound to. default(NormalizedVariationPosition)
         // for the source and for static fonts; non-default for variation clones.
         private readonly NormalizedVariationPosition _variationPosition;
+
+        // Precomputed projection of _variationPosition onto fvar's axis order. Allocated
+        // once during clone construction and reused by every variation-aware lookup
+        // (GetGlyphOutline, the gvar deformer, HVAR advance / LSB queries) instead of
+        // re-projecting per call. Null on the source typeface and on static fonts —
+        // both have IsDefault == true, and every consumer short-circuits before
+        // touching this field.
+        private readonly float[]? _activeCoords;
 
         // Per-source variation cache. Only populated on the source typeface (clones
         // delegate WithVariation through _sourceTypeface so a single cache is shared).
@@ -314,6 +328,11 @@ namespace Avalonia.Media
                 // GetGlyphOutline only pays a field-access cost when no variation is
                 // active.
                 GvarTable.TryLoad(this, _fvarTable.Axes.Length, GlyphCount, out _gvarTable);
+
+                // HVAR provides per-glyph horizontal-advance deltas (and optionally LSB /
+                // RSB deltas). Loaded once per typeface; per-call TryGetHorizontalGlyphAdvance
+                // pays a field-access + IsDefault check when no variation is active.
+                HvarTable.TryLoad(this, _fvarTable.Axes.Length, out _hvarTable);
             }
 
             static CultureInfo GetCulture(int lcid)
@@ -382,6 +401,7 @@ namespace Avalonia.Media
             _fvarTable = source._fvarTable;
             _avarTable = source._avarTable;
             _gvarTable = source._gvarTable;
+            _hvarTable = source._hvarTable;
 
             _hasOs2Table = source._hasOs2Table;
             _hasHorizontalMetrics = source._hasHorizontalMetrics;
@@ -416,6 +436,18 @@ namespace Avalonia.Media
             // _supportedFeatures is lazy — let each clone materialize independently.
             // _textShaperTypeface is intentionally null so the getter derives a variation-aware
             // shaper from the source's shaper via ITextShaperTypeface.WithVariation.
+
+            // Project the variation settings onto fvar's axis order once. WithVariation
+            // guarantees clones only exist for variable fonts, so _fvarTable is always
+            // non-null when we get here, and IsDefault is always false (default settings
+            // short-circuit to 'return source' before any clone is built).
+            var axes = source._fvarTable!.AxisTags;
+            _activeCoords = new float[axes.Length];
+            for (var i = 0; i < axes.Length; i++)
+            {
+                variation.TryGetCoordinate(axes[i], out var v);
+                _activeCoords[i] = v;
+            }
         }
 
         private static ushort GetFontDesignEmHeight(HeadTable? headTable)
@@ -912,6 +944,19 @@ namespace Avalonia.Media
                 return false;
             }
 
+            // HVAR: variation-aware advance widths. Without this, a bolder glyph keeps
+            // its default-instance advance and overlaps the next slot. The
+            // _activeCoords null check is the fast path that lets static-font and
+            // default-instance callers pay nothing beyond a field access.
+            if (_hvarTable is not null && _activeCoords is not null)
+            {
+                if (_hvarTable.TryGetAdvanceDelta(glyphIndex, _activeCoords, out var delta))
+                {
+                    var adjusted = advance + (int)MathF.Round(delta);
+                    advance = adjusted < 0 ? (ushort)0 : (ushort)Math.Min(adjusted, ushort.MaxValue);
+                }
+            }
+
             return true;
         }
 
@@ -932,7 +977,16 @@ namespace Avalonia.Media
                 return false;
             }
 
-            return _hmTable.TryGetAdvances(glyphIndices, advances);
+            // Fast path: no variation. Dispatch to the plain hmtx batch reader, which
+            // never touches HVAR.
+            if (_hvarTable is null || _activeCoords is null)
+            {
+                return _hmTable.TryGetAdvances(glyphIndices, advances);
+            }
+
+            // Variation path: hand the cached active coords + HVAR table to the fused
+            // single-pass loop inside HorizontalMetricsTable.TryGetAdvances.
+            return _hmTable.TryGetAdvances(glyphIndices, advances, _hvarTable, _activeCoords);
         }
 
         /// <summary>
@@ -1021,6 +1075,26 @@ namespace Avalonia.Media
                 return false;
             }
 
+            var advanceWidth = hMetric.AdvanceWidth;
+            var leftSideBearing = hMetric.LeftSideBearing;
+
+            // HVAR adjusts advance width (and optionally LSB) at the active variation
+            // point. Without it, varied text laid out via these metrics overlaps.
+            if (hasHorizontal && _hvarTable is not null && _activeCoords is not null)
+            {
+                if (_hvarTable.TryGetAdvanceDelta(glyph, _activeCoords, out var advDelta) && advDelta != 0f)
+                {
+                    var adjusted = advanceWidth + (int)MathF.Round(advDelta);
+                    advanceWidth = adjusted < 0 ? (ushort)0 : (ushort)Math.Min(adjusted, ushort.MaxValue);
+                }
+
+                if (_hvarTable.TryGetLeftSideBearingDelta(glyph, _activeCoords, out var lsbDelta) && lsbDelta != 0f)
+                {
+                    var adjusted = leftSideBearing + (int)MathF.Round(lsbDelta);
+                    leftSideBearing = (short)Math.Clamp(adjusted, short.MinValue, short.MaxValue);
+                }
+            }
+
             // Funnel the raw header values through GlyphBounds so the ink extent is computed
             // (and clamped to non-negative) the same way as the batch path below — a malformed
             // header with xMax < xMin must not wrap when narrowed to the ushort Width/Height.
@@ -1029,13 +1103,13 @@ namespace Avalonia.Media
             metrics = new GlyphMetrics
             {
                 // Bounding box (ink extent) from the glyf header; side bearings fall back
-                // to hmtx/vmtx when the glyph has no outline data.
-                XBearing = hasBounds ? box.XMin : (hasHorizontal ? hMetric.LeftSideBearing : (short)0),
+                // to hmtx/vmtx (HVAR-adjusted) when the glyph has no outline data.
+                XBearing = hasBounds ? box.XMin : (hasHorizontal ? leftSideBearing : (short)0),
                 YBearing = hasBounds ? box.YMax : (hasVertical ? vMetric.TopSideBearing : (short)0),
                 Width = hasBounds ? (ushort)box.Width : (ushort)0,
                 Height = hasBounds ? (ushort)box.Height : (ushort)0,
-                // Advances come from the metrics tables.
-                AdvanceWidth = hasHorizontal ? hMetric.AdvanceWidth : (ushort)0,
+                // Advances come from the metrics tables, with HVAR applied to the width.
+                AdvanceWidth = hasHorizontal ? advanceWidth : (ushort)0,
                 AdvanceHeight = hasVertical ? vMetric.AdvanceHeight : (ushort)0,
             };
 
@@ -1080,13 +1154,24 @@ namespace Avalonia.Media
             bool hasHorizontal = false;
             bool hasVertical = false;
 
-            // Batch retrieve horizontal metrics
+            // hmtx + HVAR are fused inside HorizontalMetricsTable.TryGetMetrics — when
+            // variation is active we hand the cached coords + HVAR table through so
+            // hMetrics[i] is written exactly once per glyph rather than
+            // hmtx-writes-then-HVAR-overwrites.
             if (_hasHorizontalMetrics && _hmTable != null)
             {
-                hasHorizontal = _hmTable.TryGetMetrics(glyphIndices, hMetrics);
+                if (_hvarTable is not null && _activeCoords is not null)
+                {
+                    hasHorizontal = _hmTable.TryGetMetrics(glyphIndices, hMetrics, _hvarTable, _activeCoords);
+                }
+                else
+                {
+                    hasHorizontal = _hmTable.TryGetMetrics(glyphIndices, hMetrics);
+                }
             }
 
-            // Batch retrieve vertical metrics
+            // Batch retrieve vertical metrics. Vertical advances are not variation-aware
+            // yet, so the unvaried path is used here.
             if (_hasVerticalMetrics && _vmTable != null)
             {
                 hasVertical = _vmTable.TryGetMetrics(glyphIndices, vMetrics);
@@ -1142,6 +1227,7 @@ namespace Avalonia.Media
 
             return true;
         }
+
 
         /// <summary>
         /// Reads ink bounding boxes for a batch of glyphs from the font's <c>glyf</c> table.
@@ -1206,27 +1292,13 @@ namespace Avalonia.Media
 
             var geometry = _renderInterface.CreateStreamGeometry();
 
-            // Project the variation settings onto an axis-ordered span the gvar deformer
-            // consumes. Static fonts and default-instance lookups skip the projection
-            // and pass an empty span — they pay no per-call cost beyond the original PR2
-            // path.
-            //
-            // The stackalloc is sized to the actual axis count to keep the per-call
-            // footprint minimal; both branches keep the lifetime method-local so the
-            // ref-safety verifier is happy.
-            var hasVariation = _gvarTable is not null && !_variationPosition.IsDefault && _fvarTable is not null;
-            var axisCount = hasVariation ? _fvarTable!.AxisTags.Length : 0;
-            Span<float> activeCoords = stackalloc float[axisCount];
-
-            if (hasVariation)
-            {
-                var axes = _fvarTable!.AxisTags;
-                for (var i = 0; i < axes.Length; i++)
-                {
-                    _variationPosition.TryGetCoordinate(axes[i], out var v);
-                    activeCoords[i] = v;
-                }
-            }
+            // The active variation coords are precomputed once at clone time and stored
+            // on the typeface — see _activeCoords. Static fonts and default-instance
+            // lookups (where _activeCoords is null) pass an empty span and skip the
+            // gvar deformation path entirely.
+            ReadOnlySpan<float> activeCoords = _gvarTable is not null && _activeCoords is not null
+                ? _activeCoords
+                : default;
 
             using (var ctx = geometry.Open())
             {

--- a/src/Avalonia.Base/Media/GlyphTypeface.cs
+++ b/src/Avalonia.Base/Media/GlyphTypeface.cs
@@ -85,6 +85,14 @@ namespace Avalonia.Media
         // touching this field.
         private readonly float[]? _activeCoords;
 
+        // Pre-computed per-region scaler array for HVAR's ItemVariationStore. Built once
+        // at clone construction so per-glyph delta lookups become array indices instead
+        // of per-axis F2DOT14 ramps. The active coordinates are fixed for a clone's
+        // lifetime, and the regions are fixed for the font's, so the scaler vector is
+        // invariant - no point computing it per call. Measured ~4x speedup on a
+        // paragraph-size batch advance lookup.
+        private readonly float[]? _hvarRegionScalers;
+
         // Per-source variation cache. Only populated on the source typeface (clones
         // delegate WithVariation through _sourceTypeface so a single cache is shared).
         // Lazy-allocated on first variation request.
@@ -447,6 +455,15 @@ namespace Avalonia.Media
             {
                 variation.TryGetCoordinate(axes[i], out var v);
                 _activeCoords[i] = v;
+            }
+
+            // Pre-compute per-region scalers for every ItemVariationStore that's likely
+            // to be queried per-glyph. Done once here so HVAR per-glyph delta lookups
+            // become array indices.
+            if (source._hvarTable is not null)
+            {
+                _hvarRegionScalers = new float[source._hvarTable.Store.RegionCount];
+                source._hvarTable.Store.ComputeRegionScalers(_activeCoords, _hvarRegionScalers);
             }
         }
 
@@ -946,11 +963,11 @@ namespace Avalonia.Media
 
             // HVAR: variation-aware advance widths. Without this, a bolder glyph keeps
             // its default-instance advance and overlaps the next slot. The
-            // _activeCoords null check is the fast path that lets static-font and
+            // _hvarRegionScalers null check is the fast path that lets static-font and
             // default-instance callers pay nothing beyond a field access.
-            if (_hvarTable is not null && _activeCoords is not null)
+            if (_hvarTable is not null && _hvarRegionScalers is not null)
             {
-                if (_hvarTable.TryGetAdvanceDelta(glyphIndex, _activeCoords, out var delta))
+                if (_hvarTable.TryGetAdvanceDeltaWithScalers(glyphIndex, _hvarRegionScalers, out var delta))
                 {
                     var adjusted = advance + (int)MathF.Round(delta);
                     advance = adjusted < 0 ? (ushort)0 : (ushort)Math.Min(adjusted, ushort.MaxValue);
@@ -979,14 +996,14 @@ namespace Avalonia.Media
 
             // Fast path: no variation. Dispatch to the plain hmtx batch reader, which
             // never touches HVAR.
-            if (_hvarTable is null || _activeCoords is null)
+            if (_hvarTable is null || _hvarRegionScalers is null)
             {
                 return _hmTable.TryGetAdvances(glyphIndices, advances);
             }
 
-            // Variation path: hand the cached active coords + HVAR table to the fused
+            // Variation path: hand the cached region scalers + HVAR table to the fused
             // single-pass loop inside HorizontalMetricsTable.TryGetAdvances.
-            return _hmTable.TryGetAdvances(glyphIndices, advances, _hvarTable, _activeCoords);
+            return _hmTable.TryGetAdvances(glyphIndices, advances, _hvarTable, _hvarRegionScalers);
         }
 
         /// <summary>
@@ -1080,15 +1097,15 @@ namespace Avalonia.Media
 
             // HVAR adjusts advance width (and optionally LSB) at the active variation
             // point. Without it, varied text laid out via these metrics overlaps.
-            if (hasHorizontal && _hvarTable is not null && _activeCoords is not null)
+            if (hasHorizontal && _hvarTable is not null && _hvarRegionScalers is not null)
             {
-                if (_hvarTable.TryGetAdvanceDelta(glyph, _activeCoords, out var advDelta) && advDelta != 0f)
+                if (_hvarTable.TryGetAdvanceDeltaWithScalers(glyph, _hvarRegionScalers, out var advDelta) && advDelta != 0f)
                 {
                     var adjusted = advanceWidth + (int)MathF.Round(advDelta);
                     advanceWidth = adjusted < 0 ? (ushort)0 : (ushort)Math.Min(adjusted, ushort.MaxValue);
                 }
 
-                if (_hvarTable.TryGetLeftSideBearingDelta(glyph, _activeCoords, out var lsbDelta) && lsbDelta != 0f)
+                if (_hvarTable.TryGetLeftSideBearingDeltaWithScalers(glyph, _hvarRegionScalers, out var lsbDelta) && lsbDelta != 0f)
                 {
                     var adjusted = leftSideBearing + (int)MathF.Round(lsbDelta);
                     leftSideBearing = (short)Math.Clamp(adjusted, short.MinValue, short.MaxValue);
@@ -1155,14 +1172,14 @@ namespace Avalonia.Media
             bool hasVertical = false;
 
             // hmtx + HVAR are fused inside HorizontalMetricsTable.TryGetMetrics — when
-            // variation is active we hand the cached coords + HVAR table through so
+            // variation is active we hand the cached scalers + HVAR table through so
             // hMetrics[i] is written exactly once per glyph rather than
             // hmtx-writes-then-HVAR-overwrites.
             if (_hasHorizontalMetrics && _hmTable != null)
             {
-                if (_hvarTable is not null && _activeCoords is not null)
+                if (_hvarTable is not null && _hvarRegionScalers is not null)
                 {
-                    hasHorizontal = _hmTable.TryGetMetrics(glyphIndices, hMetrics, _hvarTable, _activeCoords);
+                    hasHorizontal = _hmTable.TryGetMetrics(glyphIndices, hMetrics, _hvarTable, _hvarRegionScalers);
                 }
                 else
                 {

--- a/tests/Avalonia.Base.UnitTests/Media/Fonts/MalformedVariationStoreMetricsTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/Fonts/MalformedVariationStoreMetricsTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Buffers.Binary;
+using Avalonia.Media.Fonts.Tables.Variation;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Media.Fonts
+{
+    /// <summary>
+    /// Characterization tests for the ItemVariationStore / HVAR offset validation and the hmtx
+    /// metric-count clamp, using the <see cref="SyntheticFont"/> / <see cref="BigEndianBuffer"/>
+    /// harness. A hostile offset must be rejected without throwing, a corrupt HVAR must degrade to
+    /// "no advance variation", and a degenerate hmtx count must not throw at layout time.
+    /// </summary>
+    public class MalformedVariationStoreMetricsTests
+    {
+        // ── (int)-cast uint32 offsets slip additive length guards ──
+
+        [Fact]
+        public void ItemVariationStore_TryLoad_Returns_False_On_Hostile_RegionListOffset()
+        {
+            // An ItemVariationStore header: format(uint16), regionListOffset(uint32), ivdCount(uint16).
+            // regionListOffset = 0xFFFFFFFF previously cast to int -1, slipped the additive length
+            // guard, and threw on span.Slice(-1).
+            var ivs = new BigEndianBuffer()
+                .UInt16(1)            // format = 1 (the only supported format)
+                .UInt32(0xFFFFFFFF)   // regionListOffset (hostile)
+                .UInt16(0)            // ivdCount = 0
+                .ToArray();
+
+            var loaded = true;
+            var exception = Record.Exception(() => loaded = ItemVariationStore.TryLoad(ivs, expectedAxisCount: 2, out _));
+
+            // Now validated as unsigned / range-safe: TryLoad returns false instead of throwing.
+            Assert.Null(exception);
+            Assert.False(loaded);
+        }
+
+        [Fact]
+        public void Corrupt_Hvar_VariationStore_Does_Not_Deny_The_Font()
+        {
+            // Drive the same input through the real load path: corrupt the regionListOffset *inside*
+            // InterVariable's HVAR ItemVariationStore. The GlyphTypeface constructor loads HVAR eagerly.
+            var font = SyntheticFont.FromAsset(SyntheticFont.Assets.InterVariable);
+
+            var hvar = font.GetTable("HVAR");
+            // HVAR header: majorVersion(2), minorVersion(2), itemVariationStoreOffset(4), ...
+            var ivsOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(hvar.AsSpan(4));
+
+            // regionListOffset is the uint32 at offset +2 within the ItemVariationStore.
+            font.PatchUInt32("HVAR", ivsOffset + 2, 0xFFFFFFFF);
+
+            var typeface = font.TryCreateGlyphTypeface();
+
+            // A malformed HVAR now degrades to "no advance variation" instead of denying the font.
+            Assert.NotNull(typeface);
+        }
+
+        // ── hmtx accessors throw at *layout* time on a degenerate metric count ──
+        //
+        // Unlike the load-time cases, these surface at runtime: the GlyphTypeface constructor stores
+        // the counts without touching the per-glyph arrays, so the throw only fires when text layout
+        // later queries an advance.
+
+        [Fact]
+        public void Zero_NumberOfHMetrics_Does_Not_Throw_From_Advance_Lookup()
+        {
+            // hhea.numberOfHMetrics is the last uint16, at offset 34. Zero previously made the "repeat
+            // last advance" math compute (numberOfHMetrics - 1) * 4 = -4 → a negative slice/seek.
+            var font = SyntheticFont.FromAsset(SyntheticFont.Assets.InterRegular).PatchUInt16("hhea", 34, 0);
+
+            var typeface = font.TryCreateGlyphTypeface();
+            Assert.NotNull(typeface);
+
+            // The accessor now treats a zero metric count as "no horizontal metrics": it returns false
+            // rather than throwing at layout time.
+            var advance = true;
+            var exception = Record.Exception(() => advance = typeface!.TryGetHorizontalGlyphAdvance(3, out _));
+            Assert.Null(exception);
+            Assert.False(advance);
+        }
+
+        [Fact]
+        public void Truncated_Hmtx_Does_Not_Throw_From_Advance_Lookup()
+        {
+            // numberOfHMetrics is unchanged (hundreds) but hmtx is cut to a single metric, so a
+            // lookup of a later glyph would slice past the table.
+            var font = SyntheticFont.FromAsset(SyntheticFont.Assets.InterRegular).Truncate("hmtx", 4);
+
+            var typeface = font.TryCreateGlyphTypeface();
+            Assert.NotNull(typeface);
+
+            var glyph = (ushort)(typeface!.GlyphCount - 1); // well past the surviving metric
+
+            // numberOfHMetrics is clamped to what the table holds, so the lookup reads in range and
+            // returns without throwing.
+            Assert.Null(Record.Exception(() => typeface.TryGetHorizontalGlyphAdvance(glyph, out _)));
+        }
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/Media/Fonts/MalformedVariationStoreMetricsTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/Fonts/MalformedVariationStoreMetricsTests.cs
@@ -37,6 +37,80 @@ namespace Avalonia.Base.UnitTests.Media.Fonts
         }
 
         [Fact]
+        public void ItemVariationStore_TryGetDelta_Does_Not_Throw_On_Overflowing_Row_Offset()
+        {
+            // A minimal but valid store with one region and one ItemVariationData subtable whose
+            // itemCount is huge. innerIndex * rowBytes overflowed int to a negative rowStart that
+            // slipped the `rowStart + rowBytes > length` guard and then threw on the span slice.
+            // The row math is now computed in long.
+            const int regionListOffset = 8 + 4; // header(8) + one ivd offset(4)
+
+            var ivs = new BigEndianBuffer();
+            ivs.UInt16(1);                    // format
+            ivs.UInt32(regionListOffset);     // regionListOffset
+            ivs.UInt16(1);                    // ivdCount
+            ivs.UInt32(regionListOffset + 4 + 1 * 2 * 6); // ivd[0] offset: after the region list
+
+            // VariationRegionList: axisCount(2), regionCount(2), then regionCount*axisCount*6.
+            ivs.UInt16(2);                    // axisCount (matches expectedAxisCount)
+            ivs.UInt16(1);                    // regionCount
+            // One region, two axes: start/peak/end F2Dot14 each.
+            ivs.F2Dot14(0).F2Dot14(1).F2Dot14(1);
+            ivs.F2Dot14(0).F2Dot14(0).F2Dot14(0);
+
+            // ItemVariationData: itemCount(2), wordDeltaCount(2), regionIndexCount(2), regionIndexes[].
+            ivs.UInt16(0xFFFF);               // itemCount (huge — lets innerIndex be large)
+            ivs.UInt16(1);                    // wordDeltaCount
+            ivs.UInt16(1);                    // regionIndexCount
+            ivs.UInt16(0);                    // regionIndexes[0]
+            // No actual delta rows — the bounds guard must reject before reading them.
+
+            Assert.True(ItemVariationStore.TryLoad(ivs.ToArray(), expectedAxisCount: 2, out var store));
+
+            var active = new[] { 1f, 0f };
+            var exception = Record.Exception(
+                () => store!.TryGetDelta(outerIndex: 0, innerIndex: 0xFFFE, active, out _));
+
+            // No throw; the out-of-range row is rejected by the (now long) bounds check.
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DeltaSetIndexMap_Format1_Rejects_Hostile_MapCount()
+        {
+            // Format 1 carries a uint32 mapCount. 0xFFFFFFFF cast straight to int is negative; the
+            // `entriesStart + (long)mapCount * entrySize` guard then computed a negative product and
+            // failed open. The raw count is now range-checked unsigned.
+            var map = new BigEndianBuffer()
+                .UInt8(1)            // format = 1
+                .UInt8(0)            // entryFormat (1 byte/entry, 1-bit inner index)
+                .UInt32(0xFFFFFFFF)  // mapCount (hostile)
+                .ToArray();
+
+            var loaded = true;
+            var exception = Record.Exception(() => loaded = DeltaSetIndexMap.TryLoad(map, out _));
+
+            Assert.Null(exception);
+            Assert.False(loaded);
+        }
+
+        [Fact]
+        public void Corrupt_Hvar_AdvanceMapOffset_Does_Not_Deny_The_Font()
+        {
+            // HVAR header: ..., advanceWidthMappingOffset is the uint32 at offset 8. A high-bit
+            // offset cast to a negative int slipped the slice and threw out of the constructor.
+            var font = SyntheticFont.FromAsset(SyntheticFont.Assets.InterVariable);
+
+            font.PatchUInt32("HVAR", 8, 0xFFFFFFFF);
+
+            var typeface = font.TryCreateGlyphTypeface();
+
+            // The offset is now validated unsigned, so a corrupt advance map degrades to "no HVAR"
+            // rather than denying the font.
+            Assert.NotNull(typeface);
+        }
+
+        [Fact]
         public void Corrupt_Hvar_VariationStore_Does_Not_Deny_The_Font()
         {
             // Drive the same input through the real load path: corrupt the regionListOffset *inside*

--- a/tests/Avalonia.Base.UnitTests/Media/Fonts/Tables/HvarTableTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/Fonts/Tables/HvarTableTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Base.UnitTests.Media.Fonts.Tables;
+using Avalonia.Media;
+using Avalonia.Media.Fonts;
+using Avalonia.Media.Fonts.Tables.Variation;
+using Avalonia.Platform;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Media.Fonts.Tables
+{
+    public class HvarTableTests
+    {
+        private const string InterRegularAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.Inter-Regular.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private const string InterVariableAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.InterVariable.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private static GlyphTypeface LoadTypeface(string assetUri)
+        {
+            var assetLoader = new StandardAssetLoader();
+            using var stream = assetLoader.Open(new Uri(assetUri));
+            return new GlyphTypeface(new CustomPlatformTypeface(stream));
+        }
+
+        [Fact]
+        public void TryLoad_Returns_False_For_Static_Font()
+        {
+            var typeface = LoadTypeface(InterRegularAsset);
+
+            Assert.False(HvarTable.TryLoad(typeface, expectedAxisCount: 0, out var hvar));
+            Assert.Null(hvar);
+        }
+
+        [Fact]
+        public void TryLoad_Returns_True_For_Inter_Variable()
+        {
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            Assert.True(HvarTable.TryLoad(typeface, expectedAxisCount: 2, out var hvar));
+            Assert.NotNull(hvar);
+            Assert.NotNull(hvar!.Store);
+            Assert.Equal(2, hvar.Store.AxisCount);
+        }
+
+        [Fact]
+        public void TryLoad_Rejects_Mismatched_Axis_Count()
+        {
+            // ItemVariationStore must agree with the caller's axis count; the offsets
+            // depend on it.
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            Assert.False(HvarTable.TryLoad(typeface, expectedAxisCount: 5, out _));
+        }
+
+        [Fact]
+        public void TryGetAdvanceDelta_Returns_Zero_At_Default_Variation()
+        {
+            // At the default-instance point (all coords = 0) every region's scaler
+            // contains a zero contribution unless peak == 0 — for HVAR's regions the
+            // peaks are non-zero (each region's peak is at an axis extremum), so the
+            // scaler should be 0 and the cumulative delta should be 0.
+            var typeface = LoadTypeface(InterVariableAsset);
+            Assert.True(HvarTable.TryLoad(typeface, 2, out var hvar));
+
+            var glyph = typeface.CharacterToGlyphMap['A'];
+            Span<float> defaultCoords = stackalloc float[2] { 0f, 0f };
+
+            Assert.True(hvar!.TryGetAdvanceDelta(glyph, defaultCoords, out var delta));
+            Assert.Equal(0f, delta);
+        }
+
+        [Fact]
+        public void TryGetAdvanceDelta_Returns_NonZero_At_Bold_Weight()
+        {
+            // wght=1 (normalized max) → the bolder 'A' should have a positive advance
+            // delta because the glyph is physically wider.
+            var typeface = LoadTypeface(InterVariableAsset);
+            Assert.True(HvarTable.TryLoad(typeface, 2, out var hvar));
+
+            var glyph = typeface.CharacterToGlyphMap['A'];
+            // axis order: opsz, wght. At wght=1.0 (max), advance should grow.
+            Span<float> coords = stackalloc float[2] { 0f, 1f };
+
+            Assert.True(hvar!.TryGetAdvanceDelta(glyph, coords, out var delta));
+            Assert.True(delta > 0f, $"Expected advance delta > 0 at wght=1.0, got {delta}");
+        }
+
+        [Fact]
+        public void TryGetLeftSideBearingDelta_Returns_Zero_When_LSB_Mapping_Absent()
+        {
+            // Inter Variable doesn't ship an LSB mapping in HVAR (advance-only), so
+            // every call returns true with delta=0.
+            var typeface = LoadTypeface(InterVariableAsset);
+            Assert.True(HvarTable.TryLoad(typeface, 2, out var hvar));
+
+            var glyph = typeface.CharacterToGlyphMap['A'];
+            Span<float> coords = stackalloc float[2] { 0f, 1f };
+
+            Assert.True(hvar!.TryGetLeftSideBearingDelta(glyph, coords, out var delta));
+            Assert.Equal(0f, delta);
+        }
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/Media/GlyphTypefaceHvarAdvanceTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/GlyphTypefaceHvarAdvanceTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Base.UnitTests.Media.Fonts.Tables;
+using Avalonia.Media;
+using Avalonia.Media.Fonts;
+using Avalonia.Platform;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Media
+{
+    /// <summary>
+    /// End-to-end tests for HVAR-aware horizontal advance lookups: the values
+    /// returned by <see cref="GlyphTypeface.TryGetHorizontalGlyphAdvance"/> and
+    /// <see cref="GlyphTypeface.TryGetGlyphMetrics(ushort, out GlyphMetrics)"/>
+    /// surfaces reflect the variation point.
+    /// </summary>
+    public class GlyphTypefaceHvarAdvanceTests
+    {
+        private const string InterRegularAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.Inter-Regular.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private const string InterVariableAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.InterVariable.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private static readonly OpenTypeTag s_wghtTag = OpenTypeTag.Parse("wght");
+
+        private static GlyphTypeface LoadTypeface(string assetUri)
+        {
+            var assetLoader = new StandardAssetLoader();
+            using var stream = assetLoader.Open(new Uri(assetUri));
+            return new GlyphTypeface(new CustomPlatformTypeface(stream));
+        }
+
+        private static NormalizedVariationPosition WghtPosition(GlyphTypeface gt, double weight)
+            => gt.CreateNormalizedPosition(new FontVariationSettings(
+                new[] { new FontVariation(s_wghtTag, weight) }));
+
+        [Fact]
+        public void TryGetHorizontalGlyphAdvance_Returns_Same_Value_On_Static_Font_Across_WithVariation_Calls()
+        {
+            // Static fonts have no HVAR; WithVariation returns the same instance, so the
+            // advance is naturally the same. This pins the "no regression" promise.
+            var gt = LoadTypeface(InterRegularAsset);
+            var glyph = gt.CharacterToGlyphMap['A'];
+
+            Assert.True(gt.TryGetHorizontalGlyphAdvance(glyph, out var defaultAdvance));
+
+            // For a static font WithVariation always returns this; both calls should
+            // produce the same advance.
+            var pretendBold = gt.WithVariation(NormalizedVariationPosition.FromCoordinates(
+                new Dictionary<OpenTypeTag, float> { [s_wghtTag] = 0.5f }));
+            Assert.True(pretendBold.TryGetHorizontalGlyphAdvance(glyph, out var pretendBoldAdvance));
+
+            Assert.Equal(defaultAdvance, pretendBoldAdvance);
+        }
+
+        [Fact]
+        public void TryGetHorizontalGlyphAdvance_On_Default_Variable_Equals_hmtx_Value()
+        {
+            // At the default-instance point HVAR contributes 0, so the advance equals
+            // the raw hmtx value. The source typeface (no variation applied) provides
+            // the baseline.
+            var gt = LoadTypeface(InterVariableAsset);
+            var glyph = gt.CharacterToGlyphMap['A'];
+
+            Assert.True(gt.TryGetHorizontalGlyphAdvance(glyph, out var defaultAdvance));
+            Assert.True(defaultAdvance > 0);
+        }
+
+        [Fact]
+        public void TryGetHorizontalGlyphAdvance_At_wght_900_Is_Wider_Than_Default()
+        {
+            // The headline assertion: a bolder glyph has a bigger advance. Without HVAR
+            // this would fail (the advance stays at the default-instance value and
+            // glyphs would overlap when laid out at wght=900).
+            var gt = LoadTypeface(InterVariableAsset);
+            var black = gt.WithVariation(WghtPosition(gt, 900));
+            var glyph = gt.CharacterToGlyphMap['A'];
+
+            Assert.True(gt.TryGetHorizontalGlyphAdvance(glyph, out var regularAdvance));
+            Assert.True(black.TryGetHorizontalGlyphAdvance(glyph, out var blackAdvance));
+
+            Assert.True(blackAdvance > regularAdvance,
+                $"Expected wght=900 advance ({blackAdvance}) > default advance ({regularAdvance})");
+        }
+
+        [Fact]
+        public void Advance_Grows_Monotonically_With_Weight()
+        {
+            // Intermediate weight produces intermediate advance because HVAR's region
+            // scalers are linear ramps through axis space.
+            var gt = LoadTypeface(InterVariableAsset);
+            var semiBold = gt.WithVariation(WghtPosition(gt, 700));
+            var black = gt.WithVariation(WghtPosition(gt, 900));
+            var glyph = gt.CharacterToGlyphMap['A'];
+
+            Assert.True(gt.TryGetHorizontalGlyphAdvance(glyph, out var regularAdvance));
+            Assert.True(semiBold.TryGetHorizontalGlyphAdvance(glyph, out var semiBoldAdvance));
+            Assert.True(black.TryGetHorizontalGlyphAdvance(glyph, out var blackAdvance));
+
+            Assert.True(semiBoldAdvance >= regularAdvance,
+                $"semiBold {semiBoldAdvance} should be >= regular {regularAdvance}");
+            Assert.True(blackAdvance >= semiBoldAdvance,
+                $"black {blackAdvance} should be >= semiBold {semiBoldAdvance}");
+        }
+
+        [Fact]
+        public void Batch_Advances_Match_Single_Calls()
+        {
+            // The batch API must produce the same values as the single-glyph API for
+            // every glyph in the input. Both apply HVAR after the base hmtx read.
+            var gt = LoadTypeface(InterVariableAsset);
+            var black = gt.WithVariation(WghtPosition(gt, 900));
+
+            var glyphs = new ushort[]
+            {
+                gt.CharacterToGlyphMap['A'],
+                gt.CharacterToGlyphMap['B'],
+                gt.CharacterToGlyphMap['M'],
+                gt.CharacterToGlyphMap['i'],
+                gt.CharacterToGlyphMap['W'],
+            };
+
+            var batchAdvances = new ushort[glyphs.Length];
+            Assert.True(black.TryGetHorizontalGlyphAdvances(glyphs, batchAdvances));
+
+            for (var i = 0; i < glyphs.Length; i++)
+            {
+                Assert.True(black.TryGetHorizontalGlyphAdvance(glyphs[i], out var singleAdvance));
+                Assert.Equal(singleAdvance, batchAdvances[i]);
+            }
+        }
+
+        [Fact]
+        public void TryGetGlyphMetrics_Single_Advance_Tracks_TryGetHorizontalGlyphAdvance()
+        {
+            // The single-glyph TryGetGlyphMetrics must report the same advance width as
+            // TryGetHorizontalGlyphAdvance — HVAR application is consistent across both.
+            var gt = LoadTypeface(InterVariableAsset);
+            var black = gt.WithVariation(WghtPosition(gt, 900));
+            var glyph = gt.CharacterToGlyphMap['A'];
+
+            Assert.True(black.TryGetHorizontalGlyphAdvance(glyph, out var advance));
+            Assert.True(black.TryGetGlyphMetrics(glyph, out var metrics));
+
+            Assert.Equal(advance, metrics.AdvanceWidth);
+        }
+
+        [Fact]
+        public void TryGetGlyphMetrics_Batch_Advance_Tracks_Single_Path()
+        {
+            var gt = LoadTypeface(InterVariableAsset);
+            var black = gt.WithVariation(WghtPosition(gt, 900));
+
+            var glyphs = new ushort[]
+            {
+                gt.CharacterToGlyphMap['A'],
+                gt.CharacterToGlyphMap['M'],
+                gt.CharacterToGlyphMap['i'],
+            };
+
+            var batchMetrics = new GlyphMetrics[glyphs.Length];
+            Assert.True(black.TryGetGlyphMetrics(glyphs, batchMetrics));
+
+            for (var i = 0; i < glyphs.Length; i++)
+            {
+                Assert.True(black.TryGetGlyphMetrics(glyphs[i], out var singleMetric));
+                Assert.Equal(singleMetric.AdvanceWidth, batchMetrics[i].AdvanceWidth);
+            }
+        }
+
+        [Fact]
+        public void Default_Variation_Returns_Same_Advance_As_Source()
+        {
+            // WithVariation(default) returns the source; the advance must be identical
+            // to the source's advance even after we walk through WithVariation.
+            var gt = LoadTypeface(InterVariableAsset);
+            var defaultClone = gt.WithVariation(default);
+
+            Assert.Same(gt, defaultClone);
+
+            var glyph = gt.CharacterToGlyphMap['A'];
+            Assert.True(gt.TryGetHorizontalGlyphAdvance(glyph, out var sourceAdvance));
+            Assert.True(defaultClone.TryGetHorizontalGlyphAdvance(glyph, out var cloneAdvance));
+            Assert.Equal(sourceAdvance, cloneAdvance);
+        }
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

**Part 9 of 15** of the glyph-outline / variable-font workstream. Stacked on **Part 8** (`pr4c/gvar-deformation`); please merge that one first. It also adds the shared `ItemVariationStore` that Parts 10 and 11 consume.

## What does the pull request do?

Adds `HVAR`, the per-glyph advance-width and left-side-bearing deltas, together with the `ItemVariationStore` infrastructure that HVAR, VVAR and MVAR all sit on, and wires it into `TryGetHorizontalGlyphAdvance(s)` and `TryGetGlyphMetrics`.

HVAR is the other half of Part 8. Without it, a `wght=900` layout draws correctly thickened glyphs at default-instance advances, so they overlap their neighbours. Every individual outline is right and the line of text is visibly broken.

## What is the updated/expected behavior with this PR?

For a clone from `WithVariations(...)` on a font with an `HVAR` table:

- `TryGetHorizontalGlyphAdvance` and `TryGetHorizontalGlyphAdvances` return advances that include the per-glyph delta.
- `TryGetGlyphMetrics`, single and batch, reports both the deformed advance and the deformed left-side bearing.
- The batch path fuses the `hmtx` read and the delta application into one pass, so each entry is written once rather than written and then overwritten.
- Static fonts and default-instance clones short-circuit on a single null check and are unchanged.

Per-glyph HVAR overhead is 14.6 ns, down from 55 ns before the scaler cache described below, which puts a batch of 200 glyphs at roughly 2.5x the cost of Skia's `GetGlyphWidths` rather than 9x. Static and default-instance lookups are unaffected either way.

Inter Variable ships the common shape, an advance map over about ten variation-data subtables sharing one five-region set, and produces sensible advances at both extreme and intermediate weights: heavier weights never narrow a glyph.

## How was the solution implemented (if it's not obvious)?

- `ItemVariationStore` is the shared piece: region list, variation-data subtables, delta sets, and the optional `DeltaSetIndexMap` that routes a glyph to an `(outer, inner)` delta-set pair. Implementing it under HVAR is the cheapest cut, because Parts 10 and 11 then reuse it unchanged.
- `HvarTable` layers the header, the optional advance and side-bearing maps, and the two delta lookups on top.
- The horizontal metrics batch reader optionally takes the HVAR table and the clone's scalers, so the fused loop and the plain loop are the same method rather than two.
- **Region scalers are computed once per clone.** A store's regions are fixed for the font's lifetime and a clone's position is fixed for the clone's, so the scaler the inner delta loop used to recompute for every glyph is invariant. Computing the vector at clone construction turns the per-glyph lookup into an array index instead of a per-axis F2Dot14 ramp. The coordinate-based lookup stays for callers that have no precomputed vector, notably MVAR's clone-time metric application, which runs before the scalers exist.

## Robustness

`ItemVariationStore` is the core that HVAR, VVAR, MVAR and CFF2 blending all read through, so hardening it hardens the whole variation surface. Against hostile or truncated fonts:

- The delta-row offset is computed in 64-bit arithmetic. A large inner index multiplied by the row size overflowed to a negative offset, slipped past the bounds guard and threw on the negative span index, reachable from the public metrics APIs with a roughly 30-byte crafted store.
- `DeltaSetIndexMap` format 1 range-checks its 32-bit map count as unsigned. A high-bit count cast to a signed integer made the size guard compute a negative product and fail open.
- `HvarTable` validates its three optional index-map offsets against the table length before slicing, so a hostile offset degrades to "this font has no HVAR" rather than throwing out of the `GlyphTypeface` constructor and rejecting a font that is otherwise fine.
- `hmtx` accessors clamp against a zero or truncated metric count instead of indexing past the table.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None. HVAR fires only for varied clones on fonts that declare it; static and default-instance paths are unchanged.

## Obsoletions / Deprecations

None.

## Fixed issues

None.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
