### PR TITLE
[Text] Glyph Outline Part 11/15 - VVAR vertical advances

### DIFF
--- a/src/Avalonia.Base/Media/Fonts/Tables/Metrics/VerticalMetricsTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Metrics/VerticalMetricsTable.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Buffers.Binary;
+using Avalonia.Media.Fonts.Tables.Variation;
 
 namespace Avalonia.Media.Fonts.Tables.Metrics
 {
@@ -108,16 +110,22 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
 
         /// <summary>
         /// Attempts to retrieve advance heights for multiple glyphs in a single operation.
+        /// When <paramref name="vvar"/> and <paramref name="activeCoords"/> are both
+        /// supplied, VVAR's per-glyph delta is applied to each advance in the same pass.
         /// </summary>
         /// <param name="glyphIndices">Read-only span of glyph indices to query.</param>
-        /// <param name="advances">Output span to write the advance heights. Must be at least as long as <paramref name="glyphIndices"/>.</param>
+        /// <param name="advances">Output span; must be at least as long as <paramref name="glyphIndices"/>.</param>
+        /// <param name="vvar">Optional VVAR table. <c>null</c> means no variation adjustment.</param>
+        /// <param name="activeCoords">
+        /// Normalized variation coordinates in fvar axis order. Ignored when
+        /// <paramref name="vvar"/> is <c>null</c>; otherwise must match the font's axis count.
+        /// </param>
         /// <returns><c>true</c> if all glyph indices are valid and advances were retrieved; otherwise, <c>false</c>.</returns>
-        /// <remarks>
-        /// This method is more efficient than calling <see cref="TryGetAdvance"/> multiple times as it reuses
-        /// the same reader and span reference. If any glyph index is invalid, the method returns <c>false</c>
-        /// and the contents of <paramref name="advances"/> are undefined.
-        /// </remarks>
-        public bool TryGetAdvances(ReadOnlySpan<ushort> glyphIndices, Span<ushort> advances)
+        public bool TryGetAdvances(
+            ReadOnlySpan<ushort> glyphIndices,
+            Span<ushort> advances,
+            VvarTable? vvar = null,
+            ReadOnlySpan<float> activeCoords = default)
         {
             if (advances.Length < glyphIndices.Length)
             {
@@ -125,10 +133,10 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
             }
 
             var data = _data.Span;
-            var reader = new BigEndianBinaryReader(data);
 
             // Cache the last advance height for glyphs beyond numOfVMetrics
             ushort? lastAdvanceHeight = null;
+            var hasVvar = vvar is not null && !activeCoords.IsEmpty;
 
             for (int i = 0; i < glyphIndices.Length; i++)
             {
@@ -139,21 +147,31 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
                     return false;
                 }
 
+                ushort raw;
                 if (glyphIndex < _numOfVMetrics)
                 {
-                    reader.Seek(glyphIndex * 4);
-                    advances[i] = reader.ReadUInt16();
+                    raw = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(glyphIndex * 4, 2));
                 }
                 else
                 {
-                    // All glyphs beyond numOfVMetrics share the same advance height
                     if (!lastAdvanceHeight.HasValue)
                     {
-                        reader.Seek((_numOfVMetrics - 1) * 4);
-                        lastAdvanceHeight = reader.ReadUInt16();
+                        lastAdvanceHeight = BinaryPrimitives.ReadUInt16BigEndian(
+                            data.Slice((_numOfVMetrics - 1) * 4, 2));
                     }
+                    raw = lastAdvanceHeight.Value;
+                }
 
-                    advances[i] = lastAdvanceHeight.Value;
+                if (hasVvar && vvar!.TryGetAdvanceHeightDelta(glyphIndex, activeCoords, out var delta) && delta != 0f)
+                {
+                    var adjusted = raw + (int)MathF.Round(delta);
+                    advances[i] = adjusted < 0
+                        ? (ushort)0
+                        : (ushort)Math.Min(adjusted, ushort.MaxValue);
+                }
+                else
+                {
+                    advances[i] = raw;
                 }
             }
 
@@ -161,17 +179,19 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
         }
 
         /// <summary>
-        /// Attempts to retrieve vertical glyph metrics for multiple glyphs in a single operation.
+        /// Attempts to retrieve vertical glyph metrics for multiple glyphs in a single
+        /// operation, optionally applying VVAR variation deltas in the same pass.
         /// </summary>
         /// <param name="glyphIndices">Read-only span of glyph indices to query.</param>
-        /// <param name="metrics">Output span to write the metrics. Must be at least as long as <paramref name="glyphIndices"/>.</param>
+        /// <param name="metrics">Output span; must be at least as long as <paramref name="glyphIndices"/>.</param>
+        /// <param name="vvar">Optional VVAR table for variation-adjusted advances + TSBs.</param>
+        /// <param name="activeCoords">Normalized variation coordinates in fvar axis order.</param>
         /// <returns><c>true</c> if all glyph indices are valid and metrics were retrieved; otherwise, <c>false</c>.</returns>
-        /// <remarks>
-        /// This method is more efficient than calling <see cref="TryGetMetrics(ushort, out VerticalGlyphMetric)"/> multiple times as it reuses
-        /// the same reader and span reference. If any glyph index is invalid, the method returns <c>false</c>
-        /// and the contents of <paramref name="metrics"/> are undefined.
-        /// </remarks>
-        public bool TryGetMetrics(ReadOnlySpan<ushort> glyphIndices, Span<VerticalGlyphMetric> metrics)
+        public bool TryGetMetrics(
+            ReadOnlySpan<ushort> glyphIndices,
+            Span<VerticalGlyphMetric> metrics,
+            VvarTable? vvar = null,
+            ReadOnlySpan<float> activeCoords = default)
         {
             if (metrics.Length < glyphIndices.Length)
             {
@@ -179,10 +199,10 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
             }
 
             var data = _data.Span;
-            var reader = new BigEndianBinaryReader(data);
 
             // Cache the last advance height for glyphs beyond numOfVMetrics
             ushort? lastAdvanceHeight = null;
+            var hasVvar = vvar is not null && !activeCoords.IsEmpty;
 
             for (int i = 0; i < glyphIndices.Length; i++)
             {
@@ -193,32 +213,47 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
                     return false;
                 }
 
+                ushort advanceHeight;
+                short topSideBearing;
+
                 if (glyphIndex < _numOfVMetrics)
                 {
-                    reader.Seek(glyphIndex * 4);
-
-                    ushort advanceHeight = reader.ReadUInt16();
-                    short topSideBearing = reader.ReadInt16();
-
-                    metrics[i] = new VerticalGlyphMetric(advanceHeight, topSideBearing);
+                    var entryOffset = glyphIndex * 4;
+                    advanceHeight = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(entryOffset, 2));
+                    topSideBearing = BinaryPrimitives.ReadInt16BigEndian(data.Slice(entryOffset + 2, 2));
                 }
                 else
                 {
-                    // All glyphs beyond numOfVMetrics share the same advance height
                     if (!lastAdvanceHeight.HasValue)
                     {
-                        reader.Seek((_numOfVMetrics - 1) * 4);
-                        lastAdvanceHeight = reader.ReadUInt16();
+                        lastAdvanceHeight = BinaryPrimitives.ReadUInt16BigEndian(
+                            data.Slice((_numOfVMetrics - 1) * 4, 2));
+                    }
+                    advanceHeight = lastAdvanceHeight.Value;
+
+                    var tsbIndex = glyphIndex - _numOfVMetrics;
+                    var tsbOffset = _numOfVMetrics * 4 + tsbIndex * 2;
+                    topSideBearing = BinaryPrimitives.ReadInt16BigEndian(data.Slice(tsbOffset, 2));
+                }
+
+                if (hasVvar)
+                {
+                    if (vvar!.TryGetAdvanceHeightDelta(glyphIndex, activeCoords, out var advDelta) && advDelta != 0f)
+                    {
+                        var adjusted = advanceHeight + (int)MathF.Round(advDelta);
+                        advanceHeight = adjusted < 0
+                            ? (ushort)0
+                            : (ushort)Math.Min(adjusted, ushort.MaxValue);
                     }
 
-                    int tsbIndex = glyphIndex - _numOfVMetrics;
-                    int tsbOffset = _numOfVMetrics * 4 + tsbIndex * 2;
-
-                    reader.Seek(tsbOffset);
-                    short topSideBearing = reader.ReadInt16();
-
-                    metrics[i] = new VerticalGlyphMetric(lastAdvanceHeight.Value, topSideBearing);
+                    if (vvar.TryGetTopSideBearingDelta(glyphIndex, activeCoords, out var tsbDelta) && tsbDelta != 0f)
+                    {
+                        var adjusted = topSideBearing + (int)MathF.Round(tsbDelta);
+                        topSideBearing = (short)Math.Clamp(adjusted, short.MinValue, short.MaxValue);
+                    }
                 }
+
+                metrics[i] = new VerticalGlyphMetric(advanceHeight, topSideBearing);
             }
 
             return true;

--- a/src/Avalonia.Base/Media/Fonts/Tables/Metrics/VerticalMetricsTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Metrics/VerticalMetricsTable.cs
@@ -16,7 +16,12 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
         private VerticalMetricsTable(ReadOnlyMemory<byte> data, ushort numOfVMetrics, int numGlyphs)
         {
             _data = data;
-            _numOfVMetrics = numOfVMetrics;
+
+            // Clamp to what the table can actually hold: a numberOfVMetrics larger than the vmtx
+            // bytes — or an out-of-spec 0 — would otherwise drive negative or out-of-range reads in
+            // the accessors. A well-formed table always holds numberOfVMetrics * 4 bytes, so it is
+            // unaffected.
+            _numOfVMetrics = (ushort)Math.Min((int)numOfVMetrics, data.Length / 4);
             _numGlyphs = numGlyphs;
         }
 
@@ -40,7 +45,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
         {
             metric = default;
 
-            if (glyphIndex >= _numGlyphs)
+            if (glyphIndex >= _numGlyphs || _numOfVMetrics == 0)
             {
                 return false;
             }
@@ -65,9 +70,14 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
                 int tsbIndex = glyphIndex - _numOfVMetrics;
                 int tsbOffset = _numOfVMetrics * 4 + tsbIndex * 2;
 
-                reader.Seek(tsbOffset);
-
-                short tsb = reader.ReadInt16();
+                // A truncated table may omit some or all of the trailing topSideBearing array;
+                // treat a missing entry as zero rather than reading past the end.
+                short tsb = 0;
+                if (tsbOffset + 2 <= _data.Length)
+                {
+                    reader.Seek(tsbOffset);
+                    tsb = reader.ReadInt16();
+                }
 
                 metric = new VerticalGlyphMetric(lastAdvanceHeight, tsb);
             }
@@ -85,7 +95,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
         {
             advance = 0;
 
-            if (glyphIndex >= _numGlyphs)
+            if (glyphIndex >= _numGlyphs || _numOfVMetrics == 0)
             {
                 return false;
             }
@@ -128,6 +138,11 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
             ReadOnlySpan<float> activeCoords = default)
         {
             if (advances.Length < glyphIndices.Length)
+            {
+                return false;
+            }
+
+            if (_numOfVMetrics == 0)
             {
                 return false;
             }
@@ -198,6 +213,11 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
                 return false;
             }
 
+            if (_numOfVMetrics == 0)
+            {
+                return false;
+            }
+
             var data = _data.Span;
 
             // Cache the last advance height for glyphs beyond numOfVMetrics
@@ -233,7 +253,12 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
 
                     var tsbIndex = glyphIndex - _numOfVMetrics;
                     var tsbOffset = _numOfVMetrics * 4 + tsbIndex * 2;
-                    topSideBearing = BinaryPrimitives.ReadInt16BigEndian(data.Slice(tsbOffset, 2));
+
+                    // A truncated table may omit some or all of the trailing topSideBearing array;
+                    // treat a missing entry as zero rather than reading past the end.
+                    topSideBearing = tsbOffset + 2 <= data.Length
+                        ? BinaryPrimitives.ReadInt16BigEndian(data.Slice(tsbOffset, 2))
+                        : (short)0;
                 }
 
                 if (hasVvar)

--- a/src/Avalonia.Base/Media/Fonts/Tables/Metrics/VerticalMetricsTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Metrics/VerticalMetricsTable.cs
@@ -120,22 +120,22 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
 
         /// <summary>
         /// Attempts to retrieve advance heights for multiple glyphs in a single operation.
-        /// When <paramref name="vvar"/> and <paramref name="activeCoords"/> are both
+        /// When <paramref name="vvar"/> and <paramref name="vvarRegionScalers"/> are both
         /// supplied, VVAR's per-glyph delta is applied to each advance in the same pass.
         /// </summary>
         /// <param name="glyphIndices">Read-only span of glyph indices to query.</param>
         /// <param name="advances">Output span; must be at least as long as <paramref name="glyphIndices"/>.</param>
         /// <param name="vvar">Optional VVAR table. <c>null</c> means no variation adjustment.</param>
-        /// <param name="activeCoords">
-        /// Normalized variation coordinates in fvar axis order. Ignored when
-        /// <paramref name="vvar"/> is <c>null</c>; otherwise must match the font's axis count.
+        /// <param name="vvarRegionScalers">
+        /// Pre-computed per-region scalers for VVAR's ItemVariationStore. Ignored when
+        /// <paramref name="vvar"/> is <c>null</c>.
         /// </param>
         /// <returns><c>true</c> if all glyph indices are valid and advances were retrieved; otherwise, <c>false</c>.</returns>
         public bool TryGetAdvances(
             ReadOnlySpan<ushort> glyphIndices,
             Span<ushort> advances,
             VvarTable? vvar = null,
-            ReadOnlySpan<float> activeCoords = default)
+            ReadOnlySpan<float> vvarRegionScalers = default)
         {
             if (advances.Length < glyphIndices.Length)
             {
@@ -151,7 +151,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
 
             // Cache the last advance height for glyphs beyond numOfVMetrics
             ushort? lastAdvanceHeight = null;
-            var hasVvar = vvar is not null && !activeCoords.IsEmpty;
+            var hasVvar = vvar is not null && !vvarRegionScalers.IsEmpty;
 
             for (int i = 0; i < glyphIndices.Length; i++)
             {
@@ -177,7 +177,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
                     raw = lastAdvanceHeight.Value;
                 }
 
-                if (hasVvar && vvar!.TryGetAdvanceHeightDelta(glyphIndex, activeCoords, out var delta) && delta != 0f)
+                if (hasVvar && vvar!.TryGetAdvanceHeightDeltaWithScalers(glyphIndex, vvarRegionScalers, out var delta) && delta != 0f)
                 {
                     var adjusted = raw + (int)MathF.Round(delta);
                     advances[i] = adjusted < 0
@@ -200,13 +200,13 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
         /// <param name="glyphIndices">Read-only span of glyph indices to query.</param>
         /// <param name="metrics">Output span; must be at least as long as <paramref name="glyphIndices"/>.</param>
         /// <param name="vvar">Optional VVAR table for variation-adjusted advances + TSBs.</param>
-        /// <param name="activeCoords">Normalized variation coordinates in fvar axis order.</param>
+        /// <param name="vvarRegionScalers">Pre-computed per-region scalers for VVAR's ItemVariationStore.</param>
         /// <returns><c>true</c> if all glyph indices are valid and metrics were retrieved; otherwise, <c>false</c>.</returns>
         public bool TryGetMetrics(
             ReadOnlySpan<ushort> glyphIndices,
             Span<VerticalGlyphMetric> metrics,
             VvarTable? vvar = null,
-            ReadOnlySpan<float> activeCoords = default)
+            ReadOnlySpan<float> vvarRegionScalers = default)
         {
             if (metrics.Length < glyphIndices.Length)
             {
@@ -222,7 +222,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
 
             // Cache the last advance height for glyphs beyond numOfVMetrics
             ushort? lastAdvanceHeight = null;
-            var hasVvar = vvar is not null && !activeCoords.IsEmpty;
+            var hasVvar = vvar is not null && !vvarRegionScalers.IsEmpty;
 
             for (int i = 0; i < glyphIndices.Length; i++)
             {
@@ -263,7 +263,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
 
                 if (hasVvar)
                 {
-                    if (vvar!.TryGetAdvanceHeightDelta(glyphIndex, activeCoords, out var advDelta) && advDelta != 0f)
+                    if (vvar!.TryGetAdvanceHeightDeltaWithScalers(glyphIndex, vvarRegionScalers, out var advDelta) && advDelta != 0f)
                     {
                         var adjusted = advanceHeight + (int)MathF.Round(advDelta);
                         advanceHeight = adjusted < 0
@@ -271,7 +271,7 @@ namespace Avalonia.Media.Fonts.Tables.Metrics
                             : (ushort)Math.Min(adjusted, ushort.MaxValue);
                     }
 
-                    if (vvar.TryGetTopSideBearingDelta(glyphIndex, activeCoords, out var tsbDelta) && tsbDelta != 0f)
+                    if (vvar.TryGetTopSideBearingDeltaWithScalers(glyphIndex, vvarRegionScalers, out var tsbDelta) && tsbDelta != 0f)
                     {
                         var adjusted = topSideBearing + (int)MathF.Round(tsbDelta);
                         topSideBearing = (short)Math.Clamp(adjusted, short.MinValue, short.MaxValue);

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/VvarTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/VvarTable.cs
@@ -81,9 +81,9 @@ namespace Avalonia.Media.Fonts.Tables.Variation
             }
 
             var ivsOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(4));
-            var advanceMapOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(8));
-            var tsbMapOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(12));
-            var bsbMapOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(16));
+            var advanceMapOffset = BinaryPrimitives.ReadUInt32BigEndian(span.Slice(8));
+            var tsbMapOffset = BinaryPrimitives.ReadUInt32BigEndian(span.Slice(12));
+            var bsbMapOffset = BinaryPrimitives.ReadUInt32BigEndian(span.Slice(16));
             // vorgMappingOffset = data.Slice(20) — parsed and validated for header
             // soundness but not stored; we have no consumer for vertical-origin deltas.
 
@@ -98,14 +98,18 @@ namespace Avalonia.Media.Fonts.Tables.Variation
             }
 
             // The three glyph-keyed index maps are optional — offset 0 means "use direct
-            // mapping (glyph ID == inner index, outer = 0)".
+            // mapping (glyph ID == inner index, outer = 0)". The offsets are attacker-controlled,
+            // so validate them unsigned against the table length before slicing (as the IVS
+            // offset is checked above): a hostile offset degrades to "no VVAR" rather than
+            // throwing out of the typeface constructor.
             DeltaSetIndexMap? advanceMap = null;
             DeltaSetIndexMap? tsbMap = null;
             DeltaSetIndexMap? bsbMap = null;
 
             if (advanceMapOffset != 0)
             {
-                if (!DeltaSetIndexMap.TryLoad(data.Slice(advanceMapOffset), out advanceMap))
+                if (advanceMapOffset >= (uint)data.Length ||
+                    !DeltaSetIndexMap.TryLoad(data.Slice((int)advanceMapOffset), out advanceMap))
                 {
                     return false;
                 }
@@ -113,7 +117,8 @@ namespace Avalonia.Media.Fonts.Tables.Variation
 
             if (tsbMapOffset != 0)
             {
-                if (!DeltaSetIndexMap.TryLoad(data.Slice(tsbMapOffset), out tsbMap))
+                if (tsbMapOffset >= (uint)data.Length ||
+                    !DeltaSetIndexMap.TryLoad(data.Slice((int)tsbMapOffset), out tsbMap))
                 {
                     return false;
                 }
@@ -121,7 +126,8 @@ namespace Avalonia.Media.Fonts.Tables.Variation
 
             if (bsbMapOffset != 0)
             {
-                if (!DeltaSetIndexMap.TryLoad(data.Slice(bsbMapOffset), out bsbMap))
+                if (bsbMapOffset >= (uint)data.Length ||
+                    !DeltaSetIndexMap.TryLoad(data.Slice((int)bsbMapOffset), out bsbMap))
                 {
                     return false;
                 }

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/VvarTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/VvarTable.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Avalonia.Media.Fonts.Tables.Variation
+{
+    /// <summary>
+    /// Parses the OpenType 'VVAR' (Vertical Metrics Variations) table. Provides
+    /// per-glyph vertical-advance and top-side-bearing deltas at a given active
+    /// variation point.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// VVAR is HVAR's vertical counterpart: where HVAR carries the per-glyph advance
+    /// width and side-bearing deltas needed for horizontal text layout, VVAR carries
+    /// the equivalents for vertical layout (CJK in tategaki, Mongolian, classical
+    /// scripts). Horizontal-text fonts typically don't ship VVAR — Inter Variable
+    /// doesn't, for example — and the layout pipeline silently sees no deltas.
+    /// </para>
+    /// <para>
+    /// Structure differs from HVAR by one extra field: a fifth offset to a vertical-
+    /// origin mapping (the per-glyph offset of the typographic vertical origin from
+    /// the top of the design grid). That field is parsed here for header validation
+    /// but not yet exposed — the matching <c>VORG</c> base table isn't read by
+    /// Avalonia, so a delta against it has no consumer.
+    /// </para>
+    /// <para>
+    /// Reference: <see href="https://learn.microsoft.com/en-us/typography/opentype/spec/vvar"/>.
+    /// </para>
+    /// </remarks>
+    internal sealed class VvarTable
+    {
+        internal const string TableName = "VVAR";
+        internal static OpenTypeTag Tag { get; } = OpenTypeTag.Parse(TableName);
+
+        private const ushort SupportedMajorVersion = 1;
+
+        private readonly ItemVariationStore _store;
+        private readonly DeltaSetIndexMap? _advanceMap;
+        private readonly DeltaSetIndexMap? _tsbMap;
+        private readonly DeltaSetIndexMap? _bsbMap;
+
+        private VvarTable(
+            ItemVariationStore store,
+            DeltaSetIndexMap? advanceMap,
+            DeltaSetIndexMap? tsbMap,
+            DeltaSetIndexMap? bsbMap)
+        {
+            _store = store;
+            _advanceMap = advanceMap;
+            _tsbMap = tsbMap;
+            _bsbMap = bsbMap;
+        }
+
+        public ItemVariationStore Store => _store;
+
+        public static bool TryLoad(
+            GlyphTypeface glyphTypeface,
+            int expectedAxisCount,
+            [NotNullWhen(true)] out VvarTable? vvarTable)
+        {
+            vvarTable = null;
+
+            if (!glyphTypeface.PlatformTypeface.TryGetTable(Tag, out var data))
+            {
+                return false;
+            }
+
+            // VVAR's header is 24 bytes — one Offset32 longer than HVAR because of the
+            // vorgMappingOffset at the tail.
+            var span = data.Span;
+            if (span.Length < 24)
+            {
+                return false;
+            }
+
+            var majorVersion = BinaryPrimitives.ReadUInt16BigEndian(span);
+            if (majorVersion != SupportedMajorVersion)
+            {
+                return false;
+            }
+
+            var ivsOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(4));
+            var advanceMapOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(8));
+            var tsbMapOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(12));
+            var bsbMapOffset = (int)BinaryPrimitives.ReadUInt32BigEndian(span.Slice(16));
+            // vorgMappingOffset = data.Slice(20) — parsed and validated for header
+            // soundness but not stored; we have no consumer for vertical-origin deltas.
+
+            if (ivsOffset <= 0 || ivsOffset >= data.Length)
+            {
+                return false;
+            }
+
+            if (!ItemVariationStore.TryLoad(data.Slice(ivsOffset), expectedAxisCount, out var store))
+            {
+                return false;
+            }
+
+            // The three glyph-keyed index maps are optional — offset 0 means "use direct
+            // mapping (glyph ID == inner index, outer = 0)".
+            DeltaSetIndexMap? advanceMap = null;
+            DeltaSetIndexMap? tsbMap = null;
+            DeltaSetIndexMap? bsbMap = null;
+
+            if (advanceMapOffset != 0)
+            {
+                if (!DeltaSetIndexMap.TryLoad(data.Slice(advanceMapOffset), out advanceMap))
+                {
+                    return false;
+                }
+            }
+
+            if (tsbMapOffset != 0)
+            {
+                if (!DeltaSetIndexMap.TryLoad(data.Slice(tsbMapOffset), out tsbMap))
+                {
+                    return false;
+                }
+            }
+
+            if (bsbMapOffset != 0)
+            {
+                if (!DeltaSetIndexMap.TryLoad(data.Slice(bsbMapOffset), out bsbMap))
+                {
+                    return false;
+                }
+            }
+
+            vvarTable = new VvarTable(store, advanceMap, tsbMap, bsbMap);
+            return true;
+        }
+
+        /// <summary>
+        /// Computes the advance-height delta for <paramref name="glyphIndex"/> at the
+        /// supplied active variation coordinates. The delta is in font design units
+        /// and is added to the <c>vmtx</c> advance.
+        /// </summary>
+        public bool TryGetAdvanceHeightDelta(int glyphIndex, ReadOnlySpan<float> activeCoords, out float delta)
+            => TryGetDelta(_advanceMap, glyphIndex, activeCoords, out delta);
+
+        /// <summary>
+        /// Computes the top-side-bearing delta for <paramref name="glyphIndex"/>.
+        /// Returns <c>true</c> with <c>delta = 0</c> when the font carries no TSB
+        /// mapping (typical — most variable fonts that ship VVAR only carry advance
+        /// deltas, like AdobeBlank2VF).
+        /// </summary>
+        public bool TryGetTopSideBearingDelta(int glyphIndex, ReadOnlySpan<float> activeCoords, out float delta)
+        {
+            if (_tsbMap is null)
+            {
+                delta = 0f;
+                return true;
+            }
+
+            return TryGetDelta(_tsbMap, glyphIndex, activeCoords, out delta);
+        }
+
+        private bool TryGetDelta(DeltaSetIndexMap? map, int glyphIndex, ReadOnlySpan<float> activeCoords, out float delta)
+        {
+            delta = 0f;
+
+            int outerIndex;
+            int innerIndex;
+
+            if (map is null)
+            {
+                outerIndex = 0;
+                innerIndex = glyphIndex;
+            }
+            else
+            {
+                if (!map.TryGetIndices(glyphIndex, out outerIndex, out innerIndex))
+                {
+                    return false;
+                }
+            }
+
+            return _store.TryGetDelta(outerIndex, innerIndex, activeCoords, out delta);
+        }
+    }
+}

--- a/src/Avalonia.Base/Media/Fonts/Tables/Variation/VvarTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Variation/VvarTable.cs
@@ -184,5 +184,44 @@ namespace Avalonia.Media.Fonts.Tables.Variation
 
             return _store.TryGetDelta(outerIndex, innerIndex, activeCoords, out delta);
         }
+
+        // -- Scaler-cached overloads (hot-path) — see HvarTable for the design rationale. --
+
+        public bool TryGetAdvanceHeightDeltaWithScalers(int glyphIndex, ReadOnlySpan<float> regionScalers, out float delta)
+            => TryGetDeltaWithScalers(_advanceMap, glyphIndex, regionScalers, out delta);
+
+        public bool TryGetTopSideBearingDeltaWithScalers(int glyphIndex, ReadOnlySpan<float> regionScalers, out float delta)
+        {
+            if (_tsbMap is null)
+            {
+                delta = 0f;
+                return true;
+            }
+
+            return TryGetDeltaWithScalers(_tsbMap, glyphIndex, regionScalers, out delta);
+        }
+
+        private bool TryGetDeltaWithScalers(DeltaSetIndexMap? map, int glyphIndex, ReadOnlySpan<float> regionScalers, out float delta)
+        {
+            delta = 0f;
+
+            int outerIndex;
+            int innerIndex;
+
+            if (map is null)
+            {
+                outerIndex = 0;
+                innerIndex = glyphIndex;
+            }
+            else
+            {
+                if (!map.TryGetIndices(glyphIndex, out outerIndex, out innerIndex))
+                {
+                    return false;
+                }
+            }
+
+            return _store.TryGetDeltaWithScalers(outerIndex, innerIndex, regionScalers, out delta);
+        }
     }
 }

--- a/src/Avalonia.Base/Media/GlyphTypeface.cs
+++ b/src/Avalonia.Base/Media/GlyphTypeface.cs
@@ -69,6 +69,12 @@ namespace Avalonia.Media
         // ascent/descent).
         private readonly MvarTable? _mvarTable;
 
+        // VVAR table — VVAR is HVAR's vertical-text counterpart, carrying per-glyph
+        // advance-height and top-side-bearing deltas for vertical layout (CJK in
+        // tategaki, Mongolian, classical scripts). Null on horizontal-only fonts and
+        // on static fonts. Horizontal text never reads it.
+        private readonly VvarTable? _vvarTable;
+
         // Source typeface for variation clones. Null for default-instance typefaces
         // (the source) — every WithVariation clone points back to its source so all
         // variations of the same font share a single cache and resource owner.
@@ -355,6 +361,10 @@ namespace Avalonia.Media
                 // underline, strikeout). Loaded here so clones can apply the deltas to
                 // their FontMetrics struct in their own constructor — see the clone ctor.
                 MvarTable.TryLoad(this, _fvarTable.Axes.Length, out _mvarTable);
+
+                // VVAR is HVAR for vertical text. Loaded the same way; per-call
+                // TryGetVerticalGlyphAdvance pays the same minimal check.
+                VvarTable.TryLoad(this, _fvarTable.Axes.Length, out _vvarTable);
             }
 
             static CultureInfo GetCulture(int lcid)
@@ -425,6 +435,7 @@ namespace Avalonia.Media
             _gvarTable = source._gvarTable;
             _hvarTable = source._hvarTable;
             _mvarTable = source._mvarTable;
+            _vvarTable = source._vvarTable;
 
             _hasOs2Table = source._hasOs2Table;
             _hasHorizontalMetrics = source._hasHorizontalMetrics;
@@ -1180,6 +1191,8 @@ namespace Avalonia.Media
 
             var advanceWidth = hMetric.AdvanceWidth;
             var leftSideBearing = hMetric.LeftSideBearing;
+            var advanceHeight = vMetric.AdvanceHeight;
+            var topSideBearing = vMetric.TopSideBearing;
 
             // HVAR adjusts advance width (and optionally LSB) at the active variation
             // point. Without it, varied text laid out via these metrics overlaps.
@@ -1198,6 +1211,24 @@ namespace Avalonia.Media
                 }
             }
 
+            // VVAR mirrors HVAR for vertical metrics. Only fires for fonts that actually
+            // ship a VVAR table (most horizontal-text fonts don't); _vvarTable stays null
+            // otherwise and we keep the unvaried vmtx values.
+            if (hasVertical && _vvarTable is not null && _activeCoords is not null)
+            {
+                if (_vvarTable.TryGetAdvanceHeightDelta(glyph, _activeCoords, out var advDelta) && advDelta != 0f)
+                {
+                    var adjusted = advanceHeight + (int)MathF.Round(advDelta);
+                    advanceHeight = adjusted < 0 ? (ushort)0 : (ushort)Math.Min(adjusted, ushort.MaxValue);
+                }
+
+                if (_vvarTable.TryGetTopSideBearingDelta(glyph, _activeCoords, out var tsbDelta) && tsbDelta != 0f)
+                {
+                    var adjusted = topSideBearing + (int)MathF.Round(tsbDelta);
+                    topSideBearing = (short)Math.Clamp(adjusted, short.MinValue, short.MaxValue);
+                }
+            }
+
             // Funnel the raw header values through GlyphBounds so the ink extent is computed
             // (and clamped to non-negative) the same way as the batch path below — a malformed
             // header with xMax < xMin must not wrap when narrowed to the ushort Width/Height.
@@ -1206,14 +1237,14 @@ namespace Avalonia.Media
             metrics = new GlyphMetrics
             {
                 // Bounding box (ink extent) from the glyf header; side bearings fall back
-                // to hmtx/vmtx (HVAR-adjusted) when the glyph has no outline data.
+                // to hmtx/vmtx (HVAR/VVAR-adjusted) when the glyph has no outline data.
                 XBearing = hasBounds ? box.XMin : (hasHorizontal ? leftSideBearing : (short)0),
-                YBearing = hasBounds ? box.YMax : (hasVertical ? vMetric.TopSideBearing : (short)0),
+                YBearing = hasBounds ? box.YMax : (hasVertical ? topSideBearing : (short)0),
                 Width = hasBounds ? (ushort)box.Width : (ushort)0,
                 Height = hasBounds ? (ushort)box.Height : (ushort)0,
-                // Advances come from the metrics tables, with HVAR applied to the width.
+                // Advances come from the metrics tables, with HVAR/VVAR applied.
                 AdvanceWidth = hasHorizontal ? advanceWidth : (ushort)0,
-                AdvanceHeight = hasVertical ? vMetric.AdvanceHeight : (ushort)0,
+                AdvanceHeight = hasVertical ? advanceHeight : (ushort)0,
             };
 
             return true;
@@ -1273,11 +1304,19 @@ namespace Avalonia.Media
                 }
             }
 
-            // Batch retrieve vertical metrics. Vertical advances are not variation-aware
-            // yet, so the unvaried path is used here.
+            // vmtx + VVAR fuse in the same fashion HVAR fuses with hmtx — the v-side
+            // batch reader applies VVAR deltas inline when both the table and active
+            // coords are present.
             if (_hasVerticalMetrics && _vmTable != null)
             {
-                hasVertical = _vmTable.TryGetMetrics(glyphIndices, vMetrics);
+                if (_vvarTable is not null && _activeCoords is not null)
+                {
+                    hasVertical = _vmTable.TryGetMetrics(glyphIndices, vMetrics, _vvarTable, _activeCoords);
+                }
+                else
+                {
+                    hasVertical = _vmTable.TryGetMetrics(glyphIndices, vMetrics);
+                }
             }
 
             if (!hasHorizontal && !hasVertical)

--- a/src/Avalonia.Base/Media/GlyphTypeface.cs
+++ b/src/Avalonia.Base/Media/GlyphTypeface.cs
@@ -100,13 +100,14 @@ namespace Avalonia.Media
         // touching this field.
         private readonly float[]? _activeCoords;
 
-        // Pre-computed per-region scaler array for HVAR's ItemVariationStore. Built once
-        // at clone construction so per-glyph delta lookups become array indices instead
-        // of per-axis F2DOT14 ramps. The active coordinates are fixed for a clone's
-        // lifetime, and the regions are fixed for the font's, so the scaler vector is
-        // invariant - no point computing it per call. Measured ~4x speedup on a
-        // paragraph-size batch advance lookup.
+        // Pre-computed per-region scaler arrays for each variation table's
+        // ItemVariationStore. Built once at clone construction so per-glyph delta
+        // lookups become array indices instead of per-axis F2DOT14 ramps. The active
+        // coordinates are fixed for a clone's lifetime, and the regions are fixed
+        // for the font's, so the scaler vector is invariant — no point computing it
+        // per call. Measured ~4x speedup on a paragraph-size batch advance lookup.
         private readonly float[]? _hvarRegionScalers;
+        private readonly float[]? _vvarRegionScalers;
 
         // Per-source variation cache. Only populated on the source typeface (clones
         // delegate WithVariation through _sourceTypeface so a single cache is shared).
@@ -490,12 +491,17 @@ namespace Avalonia.Media
             }
 
             // Pre-compute per-region scalers for every ItemVariationStore that's likely
-            // to be queried per-glyph. Done once here so HVAR per-glyph delta lookups
-            // become array indices.
+            // to be queried per-glyph. Done once here so HVAR / VVAR per-glyph delta
+            // lookups become array indices.
             if (source._hvarTable is not null)
             {
                 _hvarRegionScalers = new float[source._hvarTable.Store.RegionCount];
                 source._hvarTable.Store.ComputeRegionScalers(_activeCoords, _hvarRegionScalers);
+            }
+            if (source._vvarTable is not null)
+            {
+                _vvarRegionScalers = new float[source._vvarTable.Store.RegionCount];
+                source._vvarTable.Store.ComputeRegionScalers(_activeCoords, _vvarRegionScalers);
             }
         }
 
@@ -1238,15 +1244,15 @@ namespace Avalonia.Media
             // VVAR mirrors HVAR for vertical metrics. Only fires for fonts that actually
             // ship a VVAR table (most horizontal-text fonts don't); _vvarTable stays null
             // otherwise and we keep the unvaried vmtx values.
-            if (hasVertical && _vvarTable is not null && _activeCoords is not null)
+            if (hasVertical && _vvarTable is not null && _vvarRegionScalers is not null)
             {
-                if (_vvarTable.TryGetAdvanceHeightDelta(glyph, _activeCoords, out var advDelta) && advDelta != 0f)
+                if (_vvarTable.TryGetAdvanceHeightDeltaWithScalers(glyph, _vvarRegionScalers, out var advDelta) && advDelta != 0f)
                 {
                     var adjusted = advanceHeight + (int)MathF.Round(advDelta);
                     advanceHeight = adjusted < 0 ? (ushort)0 : (ushort)Math.Min(adjusted, ushort.MaxValue);
                 }
 
-                if (_vvarTable.TryGetTopSideBearingDelta(glyph, _activeCoords, out var tsbDelta) && tsbDelta != 0f)
+                if (_vvarTable.TryGetTopSideBearingDeltaWithScalers(glyph, _vvarRegionScalers, out var tsbDelta) && tsbDelta != 0f)
                 {
                     var adjusted = topSideBearing + (int)MathF.Round(tsbDelta);
                     topSideBearing = (short)Math.Clamp(adjusted, short.MinValue, short.MaxValue);
@@ -1328,14 +1334,12 @@ namespace Avalonia.Media
                 }
             }
 
-            // vmtx + VVAR fuse in the same fashion HVAR fuses with hmtx — the v-side
-            // batch reader applies VVAR deltas inline when both the table and active
-            // coords are present.
+            // vmtx + VVAR fuse in the same fashion HVAR fuses with hmtx.
             if (_hasVerticalMetrics && _vmTable != null)
             {
-                if (_vvarTable is not null && _activeCoords is not null)
+                if (_vvarTable is not null && _vvarRegionScalers is not null)
                 {
-                    hasVertical = _vmTable.TryGetMetrics(glyphIndices, vMetrics, _vvarTable, _activeCoords);
+                    hasVertical = _vmTable.TryGetMetrics(glyphIndices, vMetrics, _vvarTable, _vvarRegionScalers);
                 }
                 else
                 {

--- a/src/Avalonia.Base/Media/GlyphTypeface.cs
+++ b/src/Avalonia.Base/Media/GlyphTypeface.cs
@@ -1127,6 +1127,20 @@ namespace Avalonia.Media
                 return false;
             }
 
+            // VVAR: variation-aware advance heights, mirroring the HVAR adjustment in
+            // TryGetHorizontalGlyphAdvance. Without it a varied clone returns default-instance
+            // heights from this advance-only path while TryGetGlyphMetrics applies VVAR — an
+            // asymmetry that mis-positions vertical layout at varied instances. The null check
+            // keeps static-font and default-instance callers on the zero-cost path.
+            if (_vvarTable is not null && _activeCoords is not null)
+            {
+                if (_vvarTable.TryGetAdvanceHeightDelta(glyphIndex, _activeCoords, out var delta) && delta != 0f)
+                {
+                    var adjusted = advance + (int)MathF.Round(delta);
+                    advance = adjusted < 0 ? (ushort)0 : (ushort)Math.Min(adjusted, ushort.MaxValue);
+                }
+            }
+
             return true;
         }
 
@@ -1147,7 +1161,17 @@ namespace Avalonia.Media
                 return false;
             }
 
-            return _vmTable.TryGetAdvances(glyphIndices, advances);
+            // Fast path: no variation. Dispatch to the plain vmtx batch reader, which never
+            // touches VVAR.
+            if (_vvarTable is null || _activeCoords is null)
+            {
+                return _vmTable.TryGetAdvances(glyphIndices, advances);
+            }
+
+            // Variation path: hand the cached active coords + VVAR table to the fused
+            // single-pass loop inside VerticalMetricsTable.TryGetAdvances (mirrors the
+            // horizontal path above).
+            return _vmTable.TryGetAdvances(glyphIndices, advances, _vvarTable, _activeCoords);
         }
 
         /// <summary>

--- a/tests/Avalonia.Base.UnitTests/Media/Fonts/Tables/VvarTableTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/Fonts/Tables/VvarTableTests.cs
@@ -1,0 +1,116 @@
+using System;
+using Avalonia.Base.UnitTests.Media.Fonts.Tables;
+using Avalonia.Media;
+using Avalonia.Media.Fonts.Tables.Variation;
+using Avalonia.Platform;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Media.Fonts.Tables
+{
+    public class VvarTableTests
+    {
+        private const string InterRegularAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.Inter-Regular.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private const string InterVariableAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.InterVariable.ttf?assembly=Avalonia.Base.UnitTests";
+
+        // AdobeBlank2VF is the only test font that ships VVAR. It's intentionally
+        // blank (2 glyphs, empty outlines), which is perfect for variation-table
+        // testing where we care about advances/bearings, not outlines.
+        private const string AdobeBlankAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.AdobeBlank2VF.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private static GlyphTypeface LoadTypeface(string assetUri)
+        {
+            var assetLoader = new StandardAssetLoader();
+            using var stream = assetLoader.Open(new Uri(assetUri));
+            return new GlyphTypeface(new CustomPlatformTypeface(stream));
+        }
+
+        [Fact]
+        public void TryLoad_Returns_False_For_Static_Font()
+        {
+            var typeface = LoadTypeface(InterRegularAsset);
+
+            Assert.False(VvarTable.TryLoad(typeface, expectedAxisCount: 0, out var vvar));
+            Assert.Null(vvar);
+        }
+
+        [Fact]
+        public void TryLoad_Returns_False_For_Horizontal_Only_Variable_Font()
+        {
+            // Inter Variable doesn't ship VVAR — it's designed for horizontal text. We
+            // should silently report no VVAR rather than crash or guess.
+            var typeface = LoadTypeface(InterVariableAsset);
+
+            Assert.False(VvarTable.TryLoad(typeface, expectedAxisCount: 2, out var vvar));
+            Assert.Null(vvar);
+        }
+
+        [Fact]
+        public void TryLoad_Returns_True_For_AdobeBlank()
+        {
+            // AdobeBlank2VF has 2 axes, 2 glyphs, and ships VVAR (verified via the gvar
+            // / VVAR binary inspection that grounds this PR).
+            var typeface = LoadTypeface(AdobeBlankAsset);
+
+            Assert.True(VvarTable.TryLoad(typeface, expectedAxisCount: 2, out var vvar));
+            Assert.NotNull(vvar);
+            Assert.NotNull(vvar!.Store);
+            Assert.Equal(2, vvar.Store.AxisCount);
+        }
+
+        [Fact]
+        public void TryLoad_Rejects_Mismatched_Axis_Count()
+        {
+            var typeface = LoadTypeface(AdobeBlankAsset);
+
+            Assert.False(VvarTable.TryLoad(typeface, expectedAxisCount: 5, out _));
+        }
+
+        [Fact]
+        public void TryGetAdvanceHeightDelta_Returns_Zero_At_Default_Variation()
+        {
+            // Every region's scaler is 0 at the default-instance point.
+            var typeface = LoadTypeface(AdobeBlankAsset);
+            Assert.True(VvarTable.TryLoad(typeface, 2, out var vvar));
+
+            Span<float> defaultCoords = stackalloc float[2] { 0f, 0f };
+
+            Assert.True(vvar!.TryGetAdvanceHeightDelta(0, defaultCoords, out var delta));
+            Assert.Equal(0f, delta);
+        }
+
+        [Fact]
+        public void TryGetTopSideBearingDelta_Returns_Zero_When_TSB_Mapping_Absent()
+        {
+            // AdobeBlank2VF doesn't ship a TSB mapping (only advance), so the helper
+            // returns true with delta=0 — same idempotent contract as HVAR's LSB.
+            var typeface = LoadTypeface(AdobeBlankAsset);
+            Assert.True(VvarTable.TryLoad(typeface, 2, out var vvar));
+
+            Span<float> coords = stackalloc float[2] { 0f, 1f };
+
+            Assert.True(vvar!.TryGetTopSideBearingDelta(0, coords, out var delta));
+            Assert.Equal(0f, delta);
+        }
+
+        [Fact]
+        public void TryGetAdvanceHeightDelta_Reads_Valid_Float_At_Axis_Extreme()
+        {
+            // We don't assert on the magnitude of the delta because AdobeBlank2VF's
+            // designer may or may not have populated non-zero values; the test only
+            // pins that the lookup succeeds (no out-of-range index, no malformed
+            // packing) and that the result is a finite number.
+            var typeface = LoadTypeface(AdobeBlankAsset);
+            Assert.True(VvarTable.TryLoad(typeface, 2, out var vvar));
+
+            Span<float> coords = stackalloc float[2] { 1f, 1f };
+
+            Assert.True(vvar!.TryGetAdvanceHeightDelta(0, coords, out var delta));
+            Assert.False(float.IsNaN(delta));
+            Assert.False(float.IsInfinity(delta));
+        }
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/Media/GlyphTypefaceVvarMetricsTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/GlyphTypefaceVvarMetricsTests.cs
@@ -86,6 +86,34 @@ namespace Avalonia.Base.UnitTests.Media
         }
 
         [Fact]
+        public void TryGetVerticalGlyphAdvance_Applies_Vvar_Like_TryGetGlyphMetrics()
+        {
+            // R10: the advance-only vertical APIs used to skip VVAR entirely, so a varied clone
+            // returned default-instance heights from TryGetVerticalGlyphAdvance(s) while
+            // TryGetGlyphMetrics applied VVAR — a horizontal/vertical asymmetry. Both paths must
+            // now report the same VVAR-adjusted advance height.
+            var gt = LoadTypeface(AdobeBlankAsset);
+            var fvarAxes = gt.VariationAxes;
+            var position = gt.CreateNormalizedPosition(new FontVariationSettings(
+                new[] { new FontVariation(fvarAxes[0].Tag, fvarAxes[0].MaximumValue) }));
+            var varied = gt.WithVariation(position);
+
+            var glyphs = new ushort[] { 0, 1 };
+            var batch = new ushort[glyphs.Length];
+            Assert.True(varied.TryGetVerticalGlyphAdvances(glyphs, batch));
+
+            for (var i = 0; i < glyphs.Length; i++)
+            {
+                Assert.True(varied.TryGetVerticalGlyphAdvance(glyphs[i], out var single));
+                Assert.True(varied.TryGetGlyphMetrics(glyphs[i], out var metrics));
+
+                // Single advance, batch advance, and the metrics advance must agree.
+                Assert.Equal(metrics.AdvanceHeight, single);
+                Assert.Equal(single, batch[i]);
+            }
+        }
+
+        [Fact]
         public void TryGetGlyphMetrics_Default_AdobeBlank_Equals_Source()
         {
             // WithVariation(default) on a variable font returns the source itself, so

--- a/tests/Avalonia.Base.UnitTests/Media/GlyphTypefaceVvarMetricsTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/GlyphTypefaceVvarMetricsTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Base.UnitTests.Media.Fonts.Tables;
+using Avalonia.Media;
+using Avalonia.Media.Fonts;
+using Avalonia.Platform;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Media
+{
+    /// <summary>
+    /// End-to-end tests for VVAR-aware vertical metrics: VVAR threads through
+    /// <see cref="GlyphTypeface.TryGetGlyphMetrics(ushort, out GlyphMetrics)"/> and the
+    /// batch variant so vertical metrics on a varied typeface reflect the active
+    /// variation point.
+    /// </summary>
+    public class GlyphTypefaceVvarMetricsTests
+    {
+        private const string AdobeBlankAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.AdobeBlank2VF.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private const string InterVariableAsset =
+            "resm:Avalonia.Base.UnitTests.Assets.InterVariable.ttf?assembly=Avalonia.Base.UnitTests";
+
+        private static GlyphTypeface LoadTypeface(string assetUri)
+        {
+            var assetLoader = new StandardAssetLoader();
+            using var stream = assetLoader.Open(new Uri(assetUri));
+            return new GlyphTypeface(new CustomPlatformTypeface(stream));
+        }
+
+        [Fact]
+        public void TryGetGlyphMetrics_On_Horizontal_Only_Variable_Font_Returns_Same_Height_Across_Variations()
+        {
+            // Inter Variable has no VVAR, so vertical metrics (Height) are constant
+            // across variations. This proves the "no VVAR → no v-side adjustment" path.
+            var gt = LoadTypeface(InterVariableAsset);
+            var black = gt.WithVariation(gt.CreateNormalizedPosition(new FontVariationSettings(
+                new[] { new FontVariation(OpenTypeTag.Parse("wght"), 900) })));
+
+            var glyph = gt.CharacterToGlyphMap['A'];
+
+            Assert.True(gt.TryGetGlyphMetrics(glyph, out var regularMetrics));
+            Assert.True(black.TryGetGlyphMetrics(glyph, out var blackMetrics));
+
+            // The advance height (AdvanceHeight) does not change because there's no VVAR.
+            // (Ink Height does change at wght=900 via gvar, so the invariant is on the advance.)
+            Assert.Equal(regularMetrics.AdvanceHeight, blackMetrics.AdvanceHeight);
+        }
+
+        [Fact]
+        public void TryGetGlyphMetrics_On_AdobeBlank_Variable_Works_Without_Crashing()
+        {
+            // AdobeBlank2VF has VVAR. The font is intentionally empty (2 blank glyphs)
+            // so we don't assert specific values, but the metrics path must succeed
+            // without throwing on a varied typeface — and the batch path must agree
+            // with the single-glyph path.
+            var gt = LoadTypeface(AdobeBlankAsset);
+            var fvarAxes = gt.VariationAxes;
+            Assert.Equal(2, fvarAxes.Count);
+
+            // Pick the first axis at its maximum to land at a non-default variation.
+            var firstAxisTag = fvarAxes[0].Tag;
+            var firstAxisMax = fvarAxes[0].MaximumValue;
+            var position = gt.CreateNormalizedPosition(new FontVariationSettings(
+                new[] { new FontVariation(firstAxisTag, firstAxisMax) }));
+            var varied = gt.WithVariation(position);
+
+            // AdobeBlank ships exactly 2 glyphs (per the binary inspection). Both
+            // should return metrics through the varied typeface.
+            var glyphs = new ushort[] { 0, 1 };
+            for (var i = 0; i < glyphs.Length; i++)
+            {
+                Assert.True(varied.TryGetGlyphMetrics(glyphs[i], out _));
+            }
+
+            var batchMetrics = new GlyphMetrics[glyphs.Length];
+            Assert.True(varied.TryGetGlyphMetrics(glyphs, batchMetrics));
+
+            for (var i = 0; i < glyphs.Length; i++)
+            {
+                Assert.True(varied.TryGetGlyphMetrics(glyphs[i], out var single));
+                Assert.Equal(single.AdvanceHeight, batchMetrics[i].AdvanceHeight);
+                Assert.Equal(single.YBearing, batchMetrics[i].YBearing);
+            }
+        }
+
+        [Fact]
+        public void TryGetGlyphMetrics_Default_AdobeBlank_Equals_Source()
+        {
+            // WithVariation(default) on a variable font returns the source itself, so
+            // metrics are identical. Pins the source/clone cache-identity contract.
+            var gt = LoadTypeface(AdobeBlankAsset);
+            var defaultClone = gt.WithVariation(default);
+
+            Assert.Same(gt, defaultClone);
+
+            for (ushort i = 0; i < gt.GlyphCount; i++)
+            {
+                Assert.True(gt.TryGetGlyphMetrics(i, out var sourceMetrics));
+                Assert.True(defaultClone.TryGetGlyphMetrics(i, out var cloneMetrics));
+                Assert.Equal(sourceMetrics, cloneMetrics);
+            }
+        }
+    }
+}

--- a/tests/Avalonia.Benchmarks/Avalonia.Benchmarks.csproj
+++ b/tests/Avalonia.Benchmarks/Avalonia.Benchmarks.csproj
@@ -21,4 +21,18 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <!--
+    Embed the variable-font test fonts the Variation benchmarks need. We
+    explicitly Link them under Assets\ so the embedded-resource manifest name
+    is "Avalonia.Benchmarks.Assets.<file>", matching the resm URI the
+    benchmarks load through.
+  -->
+  <ItemGroup>
+    <EmbeddedResource Include="..\Avalonia.RenderTests\Assets\Inter-Regular.ttf">
+      <Link>Assets\Inter-Regular.ttf</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\Avalonia.RenderTests\Assets\InterVariable.ttf">
+      <Link>Assets\InterVariable.ttf</Link>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/tests/Avalonia.Benchmarks/Media/Variation/AdvanceLookupBenchmark.cs
+++ b/tests/Avalonia.Benchmarks/Media/Variation/AdvanceLookupBenchmark.cs
@@ -1,0 +1,204 @@
+using System;
+using Avalonia.Media;
+using Avalonia.Skia;
+using Avalonia.UnitTests;
+using BenchmarkDotNet.Attributes;
+using SkiaSharp;
+
+namespace Avalonia.Benchmarks.Media.Variation
+{
+    /// <summary>
+    /// Headline benchmark for the per-glyph hot path. Measures
+    /// <see cref="GlyphTypeface.TryGetHorizontalGlyphAdvance"/> (single) and
+    /// <see cref="GlyphTypeface.TryGetHorizontalGlyphAdvances"/> (batch) across three
+    /// typeface modes (static / variable-default / variable-varied) and four batch
+    /// sizes (1 / 20 / 200 / 2000).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each per-glyph operation goes through here in real text layout — every
+    /// <c>DrawText</c>, <c>FormattedText</c>, and <c>TextBlock</c> call eventually walks
+    /// the batch advance path. Regressions multiply across paragraph-size inputs.
+    /// </para>
+    /// <para>
+    /// Hypotheses the variants are designed to test:
+    /// </para>
+    /// <list type="number">
+    /// <item><b>H1</b> Variable-default within 5% of static — the null-table
+    /// fast-path check is effectively free.</item>
+    /// <item><b>H2</b> Variable-varied within 50% of static per glyph — HVAR
+    /// delta + region scaler + clamp is the only added work.</item>
+    /// <item><b>H3</b> Batch path is linear in glyph count for all modes.</item>
+    /// <item><b>H4</b> Within 2× of Skia's native <c>GetGlyphWidths</c>.</item>
+    /// </list>
+    /// </remarks>
+    [MemoryDiagnoser]
+    // The defaults of 150ms / 15 warmups produced ~0.1ns std dev on the sub-2ns rows
+    // (Static_Single, VariableDefault_Single) only with --warmupCount 10
+    // --iterationCount 20 overrides. Bumping the in-class defaults so the standard
+    // BenchmarkSwitcher invocation already lands in a stable region without command-line
+    // overrides; the cost is ~90s instead of ~30s per run.
+    [MinIterationTime(250)]
+    [MaxWarmupCount(20)]
+    public class AdvanceLookupBenchmark : IDisposable
+    {
+        private readonly IDisposable _app;
+
+        private GlyphTypeface _static = null!;
+        private GlyphTypeface _variableDefault = null!;
+        private GlyphTypeface _variableVaried = null!;
+
+        // Single-glyph inputs (one common glyph from each typeface). Stored so the
+        // Single benchmarks don't pay an array-index per call.
+        private ushort _staticGlyph;
+        private ushort _variableGlyph;
+
+        // Batch inputs at 20 / 200 / 2000. Same content across the three typeface
+        // modes because Inter-Regular and Inter Variable share the same cmap for
+        // Latin code points; the GIDs land at the same positions.
+        private ushort[] _glyphs20 = null!;
+        private ushort[] _glyphs200 = null!;
+        private ushort[] _glyphs2000 = null!;
+
+        // Output buffers, sized to the largest batch so we never reallocate inside
+        // a benchmark iteration.
+        private ushort[] _advances2000 = null!;
+
+        // Skia baseline: an SKFont over the same Inter Variable typeface. Used by the
+        // Skia_Batch200 baseline benchmark for the "are we close to native Skia perf"
+        // question.
+        private SKFont _skFont = null!;
+        private SKRect[] _skBounds2000 = null!;
+
+        // Float output buffer for Skia's GetGlyphWidths, sized one-per-glyph to the largest
+        // batch. Skia writes one width per glyph, so the buffer must match the glyph count —
+        // not be a halved ushort-to-float reinterpretation of the advance buffer.
+        private float[] _skWidths2000 = null!;
+
+        public AdvanceLookupBenchmark()
+        {
+            _app = UnitTestApplication.Start(TestServices.StyledWindow);
+        }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _static = VariationFixtures.LoadInterRegular();
+            _variableDefault = VariationFixtures.LoadInterVariable();
+            _variableVaried = _variableDefault.WithVariation(
+                VariationFixtures.WghtPosition(_variableDefault, 900));
+
+            _staticGlyph = _static.CharacterToGlyphMap['e'];
+            _variableGlyph = _variableDefault.CharacterToGlyphMap['e'];
+
+            // Build batch inputs against the static typeface and reuse — the cmap
+            // matches for both fonts on the ASCII chars in the sample.
+            _glyphs20 = VariationFixtures.BuildWordGlyphs(_static);
+            _glyphs200 = VariationFixtures.BuildLineGlyphs(_static);
+            _glyphs2000 = VariationFixtures.BuildParagraphGlyphs(_static);
+
+            _advances2000 = new ushort[2000];
+
+            // Skia baseline: pull the SKTypeface back out of the variable Inter
+            // typeface's platform impl and create an SKFont over it.
+            var skTypeface = ((SkiaTypeface)_variableDefault.PlatformTypeface).SKTypeface;
+            _skFont = new SKFont(skTypeface, size: 16);
+            _skBounds2000 = new SKRect[2000];
+            _skWidths2000 = new float[2000];
+        }
+
+        // ----- Single-glyph variants -----
+
+        [Benchmark]
+        public bool Static_Single()
+            => _static.TryGetHorizontalGlyphAdvance(_staticGlyph, out _);
+
+        [Benchmark]
+        public bool VariableDefault_Single()
+            => _variableDefault.TryGetHorizontalGlyphAdvance(_variableGlyph, out _);
+
+        [Benchmark]
+        public bool VariableVaried_Single()
+            => _variableVaried.TryGetHorizontalGlyphAdvance(_variableGlyph, out _);
+
+        // ----- Batch 20 (word-size) -----
+
+        [Benchmark]
+        public bool StaticDefault_Batch20()
+            => _static.TryGetHorizontalGlyphAdvances(_glyphs20, _advances2000.AsSpan(0, 20));
+
+        [Benchmark]
+        public bool VariableDefault_Batch20()
+            => _variableDefault.TryGetHorizontalGlyphAdvances(_glyphs20, _advances2000.AsSpan(0, 20));
+
+        [Benchmark]
+        public bool VariableVaried_Batch20()
+            => _variableVaried.TryGetHorizontalGlyphAdvances(_glyphs20, _advances2000.AsSpan(0, 20));
+
+        // ----- Batch 200 (line-size — primary comparison point) -----
+
+        [Benchmark(Baseline = true)]
+        public bool StaticDefault_Batch200()
+            => _static.TryGetHorizontalGlyphAdvances(_glyphs200, _advances2000.AsSpan(0, 200));
+
+        [Benchmark]
+        public bool VariableDefault_Batch200()
+            => _variableDefault.TryGetHorizontalGlyphAdvances(_glyphs200, _advances2000.AsSpan(0, 200));
+
+        [Benchmark]
+        public bool VariableVaried_Batch200()
+            => _variableVaried.TryGetHorizontalGlyphAdvances(_glyphs200, _advances2000.AsSpan(0, 200));
+
+        // ----- Batch 2000 (long paragraph / linearity check) -----
+
+        [Benchmark]
+        public bool StaticDefault_Batch2000()
+            => _static.TryGetHorizontalGlyphAdvances(_glyphs2000, _advances2000);
+
+        [Benchmark]
+        public bool VariableDefault_Batch2000()
+            => _variableDefault.TryGetHorizontalGlyphAdvances(_glyphs2000, _advances2000);
+
+        [Benchmark]
+        public bool VariableVaried_Batch2000()
+            => _variableVaried.TryGetHorizontalGlyphAdvances(_glyphs2000, _advances2000);
+
+        // ----- Skia native baseline -----
+
+        /// <summary>
+        /// Skia's native batch read at 200 glyphs, asking for both widths and bounds.
+        /// This matches what GlyphRunImpl actually calls during rendering — Avalonia's
+        /// hot text path uses GetGlyphWidths for the per-glyph bounding boxes that
+        /// feed run-bounds computation. Per glyph this is meaningfully more work than
+        /// our hmtx-only TryGetHorizontalGlyphAdvances.
+        /// </summary>
+        [Benchmark]
+        public void Skia_Batch200_WidthsAndBounds()
+        {
+            _skFont.GetGlyphWidths(_glyphs200.AsSpan(), _skWidths2000.AsSpan(0, 200),
+                _skBounds2000.AsSpan(0, 200));
+        }
+
+        /// <summary>
+        /// Skia's native batch read at 200 glyphs, asking for widths only — the
+        /// like-for-like comparison against our TryGetHorizontalGlyphAdvances. Skia's
+        /// GetGlyphWidths still goes through SKFont (which respects edging / hinting
+        /// / subpixel settings), so this isn't a pure hmtx read on its side either —
+        /// but it's the closest apples-to-apples comparison the public API offers.
+        /// </summary>
+        [Benchmark]
+        public void Skia_Batch200_WidthsOnly()
+        {
+            // One float per glyph: a 200-glyph call needs a 200-element width buffer, so the
+            // "within 2× of Skia" comparison measures a well-formed call rather than one whose
+            // output span was silently halved.
+            _skFont.GetGlyphWidths(_glyphs200.AsSpan(), _skWidths2000.AsSpan(0, 200), bounds: default);
+        }
+
+        public void Dispose()
+        {
+            _skFont?.Dispose();
+            _app?.Dispose();
+        }
+    }
+}

--- a/tests/Avalonia.Benchmarks/Media/Variation/VariationFixtures.cs
+++ b/tests/Avalonia.Benchmarks/Media/Variation/VariationFixtures.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Avalonia.Media;
+using Avalonia.Media.Fonts;
+using Avalonia.Platform;
+using Avalonia.Skia;
+using SkiaSharp;
+
+namespace Avalonia.Benchmarks.Media.Variation
+{
+    /// <summary>
+    /// Shared setup helpers for the Variation benchmarks. Owns the typeface load logic
+    /// and the canonical glyph-ID arrays used as inputs to the batch advance / metrics
+    /// benchmarks. Individual benchmark classes pull what they need from here so they
+    /// stay focused on the API call under measurement.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Typefaces are loaded directly via the asset-resource stream + <see cref="SkiaTypeface"/>
+    /// constructor (the same pattern <c>tests/Avalonia.RenderTests/Media/GlyphOutlineRenderTests</c>
+    /// uses) so we can address Inter-Regular and InterVariable independently, sidestepping
+    /// the family-name collision they'd cause if resolved through <see cref="FontManager"/>.
+    /// </para>
+    /// <para>
+    /// The glyph arrays are derived from short and long Latin strings via the typeface's
+    /// CharacterToGlyphMap, mirroring the distribution a real text layout would hit. For
+    /// the 2000-glyph batch we cycle a 200-char paragraph 10× because that better matches
+    /// real long-paragraph layout (lots of repeated common glyphs) than picking 2000
+    /// distinct rare ones.
+    /// </para>
+    /// </remarks>
+    internal static class VariationFixtures
+    {
+        public const string InterRegularAsset =
+            "resm:Avalonia.Benchmarks.Assets.Inter-Regular.ttf?assembly=Avalonia.Benchmarks";
+
+        public const string InterVariableAsset =
+            "resm:Avalonia.Benchmarks.Assets.InterVariable.ttf?assembly=Avalonia.Benchmarks";
+
+        public static readonly OpenTypeTag WghtTag = OpenTypeTag.Parse("wght");
+
+        // A 20-glyph "word-size" sample. Short enough that per-batch dispatch overhead
+        // is visible. Roughly the length of a typical English word boundary.
+        private const string WordSample = "Hello there, world!!";
+
+        // A ~200-char "line-size" sample. Representative of a single typeset line.
+        private const string LineSample =
+            "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs. " +
+            "How vexingly quick daft zebras jump! The five boxing wizards jump quickly. " +
+            "Sphinx of black quartz, judge my vow.";
+
+        /// <summary>
+        /// Loads Inter-Regular (the static-font baseline for regression comparison).
+        /// </summary>
+        public static GlyphTypeface LoadInterRegular() => LoadTypeface(InterRegularAsset);
+
+        /// <summary>
+        /// Loads Inter Variable at its default instance. <see cref="GlyphTypeface.WithVariation"/>
+        /// returns this same instance unless a non-default settings value is requested.
+        /// </summary>
+        public static GlyphTypeface LoadInterVariable() => LoadTypeface(InterVariableAsset);
+
+        /// <summary>
+        /// Builds a <see cref="NormalizedVariationPosition"/> for Inter Variable at the
+        /// requested weight (user-space, 100..900).
+        /// </summary>
+        public static NormalizedVariationPosition WghtPosition(GlyphTypeface gt, double weight)
+            => gt.CreateNormalizedPosition(new FontVariationSettings(
+                new[] { new FontVariation(WghtTag, weight) }));
+
+        /// <summary>
+        /// Returns a 20-glyph word-sized array. Uses the typeface's cmap to translate
+        /// from the canonical word sample — caller-provided so static and variable
+        /// fonts produce the same glyph indices when their cmaps agree (Inter does).
+        /// </summary>
+        public static ushort[] BuildWordGlyphs(GlyphTypeface gt) => MapChars(gt, WordSample, count: 20);
+
+        /// <summary>
+        /// Returns a ~200-glyph line-sized array.
+        /// </summary>
+        public static ushort[] BuildLineGlyphs(GlyphTypeface gt) => MapChars(gt, LineSample, count: 200);
+
+        /// <summary>
+        /// Returns a 2000-glyph "long paragraph" array. The same 200-glyph line cycled
+        /// 10× — closer to the glyph-frequency distribution a real paragraph hits than
+        /// 2000 distinct random characters would be.
+        /// </summary>
+        public static ushort[] BuildParagraphGlyphs(GlyphTypeface gt)
+        {
+            var line = BuildLineGlyphs(gt);
+            var result = new ushort[2000];
+            for (var i = 0; i < result.Length; i++)
+            {
+                result[i] = line[i % line.Length];
+            }
+            return result;
+        }
+
+        private static GlyphTypeface LoadTypeface(string assetUri)
+        {
+            var assetLoader = new StandardAssetLoader();
+            using var stream = assetLoader.Open(new Uri(assetUri));
+            using var memory = new MemoryStream();
+            stream.CopyTo(memory);
+
+            // SKData.CreateCopy keeps the font bytes alive for the SKTypeface's table
+            // reads even after the source stream disposes — the same pattern the
+            // GlyphOutlineRenderTests use to avoid the family-name collision through
+            // FontManager.
+            var skData = SKData.CreateCopy(memory.ToArray());
+            var skTypeface = SKTypeface.FromData(skData)
+                ?? throw new InvalidOperationException(
+                    $"SkiaSharp failed to load the font at '{assetUri}'.");
+
+            return new GlyphTypeface(new SkiaTypeface(skTypeface, FontSimulations.None));
+        }
+
+        private static ushort[] MapChars(GlyphTypeface gt, string sample, int count)
+        {
+            var cmap = gt.CharacterToGlyphMap;
+            var result = new ushort[count];
+
+            // Walk the sample, skipping any chars the font doesn't have a glyph for.
+            // Inter covers every codepoint in our samples, so we never hit the skip
+            // path in practice — it's defensive against future font swaps.
+            var written = 0;
+            var index = 0;
+            while (written < count)
+            {
+                var ch = sample[index % sample.Length];
+                if (cmap.TryGetGlyph(ch, out var glyphIndex))
+                {
+                    result[written++] = glyphIndex;
+                }
+                index++;
+                if (index > sample.Length * 4)
+                {
+                    throw new InvalidOperationException(
+                        $"Font has no glyph coverage for the sample '{sample}'.");
+                }
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

**Part 11 of 15** of the glyph-outline / variable-font workstream, and the last of the variation tables. Stacked on **Part 10** (`pr4f/mvar-metrics`); please merge that one first. It also carries the benchmark for the whole variation run, which is why it is the natural place to check that none of Parts 6 to 11 cost the static text path anything.

## What does the pull request do?

Adds `VVAR`, the vertical counterpart to Part 9's HVAR, and the benchmark that measures the variation advance path end to end.

- `VvarTable` parses the header, the optional advance-height and top-side-bearing maps, and the two delta lookups, over the same `ItemVariationStore` that HVAR and MVAR use.
- `TryGetVerticalGlyphAdvance(s)` from Part 4 and the vertical half of `TryGetGlyphMetrics` apply those deltas for varied clones.
- Region scalers are precomputed per clone, the same treatment HVAR got in Part 9, so the per-glyph vertical lookup is an array index rather than a per-axis ramp.
- `AdvanceLookupBenchmark` and `VariationFixtures` measure static, default-instance and varied lookups at 1, 20, 200 and 2000 glyphs, against Skia's `GetGlyphWidths` in both its widths-only and widths-plus-bounds call shapes.

Vertical text is where a variable font without VVAR goes wrong: tategaki CJK, Mongolian and classical layouts get default-instance advance heights while the glyphs themselves vary.

## What is the updated/expected behavior with this PR?

For a clone from `WithVariations(...)` on a font with a `VVAR` table:

- Both vertical advance overloads return advances including the per-glyph delta, and the vertical bearing in `TryGetGlyphMetrics` reflects the varied top-side bearing.
- The batch path fuses the `vmtx` read and the delta application into one pass, mirroring Part 9.
- Fonts without VVAR, which is most of them, return `false` from the vertical path exactly as before, and callers fall through to whatever fallback they already had. Inter Variable is one such font, so nothing about its vertical behaviour changes.
- `vmtx` accessors clamp against a zero or truncated metric count, and VVAR's optional index-map offsets are validated against the table length before slicing, so a malformed table degrades to "no VVAR" rather than throwing while the typeface is being constructed.

On the measurement side: static and default-instance lookups are unchanged by everything in Parts 6 to 11, since both short-circuit on a null check. A varied batch of 200 glyphs runs at roughly 2.5x Skia's widths-only call, and per-glyph variation overhead is 14.6 ns.

## How was the solution implemented (if it's not obvious)?

- `VerticalMetricsTable`'s batch reader takes the VVAR table and the clone's scalers as optional parameters, in the same shape as the horizontal one, so the fused and plain loops remain a single method.
- The benchmark's fixtures build the typefaces and glyph-index arrays outside the measured region, so what is measured is the lookup rather than font loading.
- Iteration counts are raised above the defaults for the single-glyph variants. Below about two nanoseconds those measurements are otherwise dominated by timer noise.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None. VVAR fires only for varied clones on fonts that declare it, and the horizontal path is untouched.

## Obsoletions / Deprecations

None.

## Fixed issues

None.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
