### PR TITLE
Remove unused internal members

### DIFF
--- a/src/Avalonia.Base/Data/BindingValue.cs
+++ b/src/Avalonia.Base/Data/BindingValue.cs
@@ -415,45 +415,6 @@ namespace Avalonia.Data
                 e);
         }
 
-        /// <summary>
-        /// Creates a <see cref="BindingValue{T}"/> from an object, handling the special values
-        /// <see cref="AvaloniaProperty.UnsetValue"/>, <see cref="BindingOperations.DoNothing"/> and
-        /// <see cref="BindingNotification"/> without type conversion.
-        /// </summary>
-        /// <param name="value">The untyped value.</param>
-        /// <returns>The typed binding value.</returns>
-        internal static BindingValue<T> FromUntypedStrict(object? value)
-        {
-            if (value == AvaloniaProperty.UnsetValue)
-                return Unset;
-            else if (value == BindingOperations.DoNothing)
-                return DoNothing;
-
-            var type = BindingValueType.Value;
-            T? v = default;
-            Exception? error = null;
-
-            if (value is BindingNotification n)
-            {
-                error = n.Error;
-                type = n.ErrorType switch
-                {
-                    BindingErrorType.Error => BindingValueType.BindingError,
-                    BindingErrorType.DataValidationError => BindingValueType.DataValidationError,
-                    _ => BindingValueType.Value,
-                };
-
-                if (n.HasValue)
-                    type |= BindingValueType.HasValue;
-                value = n.Value;
-            }
-
-            if ((type & BindingValueType.HasValue) != 0)
-                v = (T)value!;
-
-            return new BindingValue<T>(type, v, error);
-        }
-
         [Conditional("DEBUG")]
         private static void ValidateValue(T value)
         {

--- a/src/Avalonia.Base/Input/Navigation/XYFocus.Impl.cs
+++ b/src/Avalonia.Base/Input/Navigation/XYFocus.Impl.cs
@@ -28,12 +28,6 @@ public partial class XYFocus
 
     private static readonly XYFocus _instance = new();
     
-    internal XYFocusAlgorithms.XYFocusManifolds ResetManifolds()
-    {
-        _manifolds.Reset();
-        return _manifolds;
-    }
-
     internal void SetManifoldsFromBounds(Rect bounds)
     {
         _manifolds.VManifold = (bounds.Left, bounds.Right);

--- a/src/Avalonia.Base/PixelSize.cs
+++ b/src/Avalonia.Base/PixelSize.cs
@@ -193,16 +193,6 @@ namespace Avalonia
             (int)Math.Ceiling(size.Width * scale),
             (int)Math.Ceiling(size.Height * scale));
         
-        /// <summary>
-        /// A reversible variant of <see cref="FromSize(Size, double)"/> that uses Round instead of Ceiling to make it reversible from ToSize
-        /// </summary>
-        /// <param name="size">The size.</param>
-        /// <param name="scale">The scaling factor.</param>
-        /// <returns>The device-independent size.</returns>
-        internal static PixelSize FromSizeRounded(Size size, double scale) => new PixelSize(
-            (int)Math.Round(size.Width * scale),
-            (int)Math.Round(size.Height * scale));
-
         private const double FromSizeCeilingEpsilon = 1e-6;
 
         /// <summary>

--- a/src/Avalonia.Controls/Calendar/CalendarItem.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarItem.cs
@@ -52,7 +52,6 @@ namespace Avalonia.Controls.Primitives
         private readonly System.Globalization.Calendar _calendar = new GregorianCalendar();
 
         internal Calendar? Owner { get; set; }
-        internal CalendarDayButton? CurrentButton { get; set; }
 
         public static readonly StyledProperty<IBrush?> HeaderBackgroundProperty = Calendar.HeaderBackgroundProperty.AddOwner<CalendarItem>();
 

--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -279,8 +279,6 @@ namespace Avalonia.Controls.Platform
             Menu?.Close();
         }
 
-        internal static MenuItem? GetMenuItem(StyledElement? item) => (MenuItem?)GetMenuItemCore(item);
-
         internal void AttachCore(IMenu menu)
         {
             if (Menu != null)

--- a/src/Avalonia.Controls/TopLevelHost.Decorations.cs
+++ b/src/Avalonia.Controls/TopLevelHost.Decorations.cs
@@ -200,11 +200,6 @@ internal partial class TopLevelHost
             frame.Bottom + shadow.Bottom);
     }
 
-    internal void UpdateResizeGrips()
-    {
-        UpdateResizeGripThickness();
-    }
-
     private void OnDecorationsGeometryChanged()
     {
         UpdateResizeGripThickness();

--- a/src/Skia/Avalonia.Skia/SkiaSharpExtensions.cs
+++ b/src/Skia/Avalonia.Skia/SkiaSharpExtensions.cs
@@ -116,11 +116,6 @@ namespace Avalonia.Skia
             return new Rect(r.Left, r.Top, r.Right - r.Left, r.Bottom - r.Top);
         }
 
-        internal static LtrbRect ToAvaloniaLtrbRect(this SKRect r)
-        {
-            return new LtrbRect(r.Left, r.Top, r.Right, r.Bottom);
-        }
-
         public static PixelRect ToAvaloniaPixelRect(this SKRectI r)
         {
             return new PixelRect(r.Left, r.Top, r.Right - r.Left, r.Bottom - r.Top);


### PR DESCRIPTION
## What does the pull request do?

Removes seven `internal` members that nothing references.

- `BindingValue<T>.FromUntypedStrict`
- `SkiaSharpExtensions.ToAvaloniaLtrbRect`
- `XYFocus.ResetManifolds`
- `PixelSize.FromSizeRounded`
- `CalendarItem.CurrentButton`
- `DefaultMenuInteractionHandler.GetMenuItem`
- `TopLevelHost.UpdateResizeGrips`

Deletions only, no other changes.

## How was the solution implemented (if it's not obvious)?

Each name occurs exactly once in the repository, the declaration itself. That search covered every file type, not just `.cs`, so anything named from XAML, MSBuild files or a string literal for reflection would have shown up.

Nothing public is touched, so this can't affect anyone's API. Everything here is `internal`, which means a use I missed inside the repo is a compile error rather than a silent break.

I left alone several other unreferenced members that exist deliberately: the ones in `ItemsSourceView` marked "preserved here for ItemsRepeater's usage", `ImageSavingHelper.SavePicture` which is kept for debugging, the `[GetProcAddress]` partial methods in `GlInterface`, `CallerArgumentExpressionAttribute`, and the vendored `ThrowHelper` and `FrugalList` helpers where being complete is the point.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

No tests, since nothing changes behaviour. `Avalonia.Desktop.slnf` builds and the Base, Controls and Skia suites pass.

I can only build the desktop targets locally, so the mobile and browser targets are on CI. Nothing in those trees references any of these names.

## Breaking changes

None, all `internal`.
