### PR TITLE
Fix: Switching themes may crash the App

### DIFF
--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -330,6 +330,15 @@ namespace Avalonia.Controls.Presenters
             AttachToScrollViewer();
         }
 
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+
+            // A replaced template no longer has the ScrollViewer as an ancestor and must
+            // release its content. Keep the bindings when the entire owner is detached.
+            AttachToScrollViewer();
+        }
+
         /// <summary>
         /// Locates the first <see cref="ScrollViewer"/> ancestor and binds to it. Properties which have been set through other means are not bound.
         /// </summary>

--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -336,7 +336,10 @@ namespace Avalonia.Controls.Presenters
 
             // A replaced template no longer has the ScrollViewer as an ancestor and must
             // release its content. Keep the bindings when the entire owner is detached.
-            AttachToScrollViewer();
+            if (this.FindAncestorOfType<ScrollViewer>() == null)
+            {
+                DetachFromScrollViewer();
+            }
         }
 
         /// <summary>
@@ -351,9 +354,7 @@ namespace Avalonia.Controls.Presenters
 
             if (owner == null)
             {
-                _owner = null;
-                _ownerSubscriptions?.Dispose();
-                _ownerSubscriptions = null;
+                DetachFromScrollViewer();
                 return;
             }
 
@@ -379,6 +380,16 @@ namespace Avalonia.Controls.Presenters
             static bool NotDisabled(ScrollBarVisibility v) => v != ScrollBarVisibility.Disabled;
 
             IDisposable? IfUnset<T>(T property, Func<T, IDisposable> func) where T : AvaloniaProperty => IsSet(property) ? null : func(property);
+        }
+
+        /// <summary>
+        /// Clears the owning <see cref="ScrollViewer"/> and disposes the bindings to it.
+        /// </summary>
+        private void DetachFromScrollViewer()
+        {
+            _owner = null;
+            _ownerSubscriptions?.Dispose();
+            _ownerSubscriptions = null;
         }
 
         /// <inheritdoc/>

--- a/tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj
+++ b/tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\src\Avalonia.Controls.ColorPicker\Avalonia.Controls.ColorPicker.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Base\Avalonia.Base.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Controls\Avalonia.Controls.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.Themes.Fluent\Avalonia.Themes.Fluent.csproj" />
     <ProjectReference Include="..\Avalonia.UnitTests\Avalonia.UnitTests.csproj" />
     <Compile Include="../Shared/ScopedSanityCheck.cs"/>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/tests/Avalonia.Controls.UnitTests/ComboBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ComboBoxTests.cs
@@ -44,6 +44,7 @@ namespace Avalonia.Controls.UnitTests
                 target.IsDropDownOpen = true;
                 window.LayoutManager.ExecuteLayoutPass();
                 target.IsDropDownOpen = false;
+                window.LayoutManager.ExecuteLayoutPass();
 
                 Application.Current!.Styles.Clear();
                 Application.Current.Styles.Add(CreateTheme());
@@ -55,6 +56,7 @@ namespace Avalonia.Controls.UnitTests
                 Assert.NotNull(target.ContainerFromIndex(0));
                 Assert.Equal(0, target.SelectedIndex);
                 target.IsDropDownOpen = false;
+                window.LayoutManager.ExecuteLayoutPass();
             }
             window.Close();
         }

--- a/tests/Avalonia.Controls.UnitTests/ComboBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ComboBoxTests.cs
@@ -10,6 +10,9 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.Themes.Fluent;
+using Avalonia.Themes.Simple;
 using Avalonia.VisualTree;
 using Avalonia.UnitTests;
 using Xunit;
@@ -19,6 +22,42 @@ namespace Avalonia.Controls.UnitTests
     public class ComboBoxTests : ScopedTestBase
     {
         MouseTestHelper _helper = new MouseTestHelper();
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Can_Open_DropDown_After_Replacing_Application_Theme(bool fluent)
+        {
+            IStyle CreateTheme() => fluent ? new FluentTheme() : new SimpleTheme();
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow.With(theme: CreateTheme));
+            var target = new ComboBox
+            {
+                ItemsSource = new[] { "Foo", "Bar" },
+                SelectedIndex = 0,
+            };
+            var window = new Window { Content = target };
+            window.Show();
+            window.LayoutManager.ExecuteInitialLayoutPass();
+
+            for (var i = 0; i < 3; ++i)
+            {
+                target.IsDropDownOpen = true;
+                window.LayoutManager.ExecuteLayoutPass();
+                target.IsDropDownOpen = false;
+
+                Application.Current!.Styles.Clear();
+                Application.Current.Styles.Add(CreateTheme());
+                Application.Current.RequestedThemeVariant = i % 2 == 0 ? ThemeVariant.Dark : ThemeVariant.Light;
+                window.LayoutManager.ExecuteLayoutPass();
+
+                target.IsDropDownOpen = true;
+                window.LayoutManager.ExecuteLayoutPass();
+                Assert.NotNull(target.ContainerFromIndex(0));
+                Assert.Equal(0, target.SelectedIndex);
+                target.IsDropDownOpen = false;
+            }
+            window.Close();
+        }
 
         [Fact]
         public void Clicking_On_Control_Toggles_IsDropDownOpen()

--- a/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
@@ -19,6 +19,34 @@ namespace Avalonia.Controls.UnitTests
         private readonly MouseTestHelper _mouse = new();
 
         [Fact]
+        public void Presenter_Preserves_Owner_Bindings_When_ScrollViewer_Is_Reattached()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+            var content = new Border { Width = 200, Height = 200 };
+            var target = new ScrollViewer { Content = content };
+            var window = new Window { Content = target, Width = 100, Height = 100 };
+            window.Show();
+            window.LayoutManager.ExecuteInitialLayoutPass();
+            var presenter = Assert.IsType<ScrollContentPresenter>(target.Presenter);
+            Assert.Same(content, presenter.Child);
+
+            window.Content = null;
+            Assert.Same(content, presenter.Child);
+            var replacement = new Border { Width = 300, Height = 300 };
+            target.Content = replacement;
+            Assert.Null(presenter.Child);
+
+            window.Content = target;
+            window.LayoutManager.ExecuteLayoutPass();
+            Assert.Same(presenter, target.Presenter);
+            Assert.Same(replacement, presenter.Child);
+            target.Offset = new Vector(0, 20);
+            Assert.Equal(target.Offset, presenter.Offset);
+            Assert.Equal(20, presenter.Offset.Y);
+            window.Close();
+        }
+
+        [Fact]
         public void Content_Is_Created()
         {
             var target = new ScrollViewer


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes an issue where switching from `SimpleTheme` to `FluentTheme` the App may crash. 


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
A crash can occour

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Theme switching at runtime is possible

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
We need to detach the parent from a `ScrollViewer`. 

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->

## Fixed issues
Fixes #15115
