### PR TITLE
Fix use-after-free from non-idempotent SmcCloseConnection on X11

### DIFF
--- a/src/Avalonia.X11/X11PlatformLifetimeEvents.cs
+++ b/src/Avalonia.X11/X11PlatformLifetimeEvents.cs
@@ -45,7 +45,7 @@ namespace Avalonia.X11
 
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
         private readonly IntPtr _currentIceConn;
-        private readonly IntPtr _currentSmcConn;
+        private IntPtr _currentSmcConn;
 
         private bool _saveYourselfPhase;
 
@@ -106,11 +106,17 @@ namespace Avalonia.X11
 
         public void Dispose()
         {
-            if (_currentSmcConn == IntPtr.Zero) return;
+            // Reachable from the Die callback, from HandleRequests() and from platform teardown,
+            // but SmcCloseConnection frees both the SmcConn and its IceConn.
+            var smcConn = Interlocked.Exchange(ref _currentSmcConn, IntPtr.Zero);
+            if (smcConn == IntPtr.Zero) return;
 
-            s_nativeToManagedMapper.TryRemove(_currentSmcConn, out _);
+            // The pump would otherwise keep using the IceConn we are about to free.
+            _cancellationTokenSource.Cancel();
 
-            _ = SMLib.SmcCloseConnection(_currentSmcConn, 1,
+            s_nativeToManagedMapper.TryRemove(smcConn, out _);
+
+            _ = SMLib.SmcCloseConnection(smcConn, 1,
                 new[] { $"{nameof(X11PlatformLifetimeEvents)} was disposed in managed code." });
         }
 
@@ -172,6 +178,8 @@ namespace Avalonia.X11
 
         private void HandleRequests()
         {
+            if (_cancellationTokenSource.IsCancellationRequested) return;
+
             if (ICELib.IceProcessMessages(_currentIceConn, out _, out _) ==
                 ICELib.IceProcessMessagesStatus.IceProcessMessagesIoError)
             {
@@ -188,8 +196,9 @@ namespace Avalonia.X11
 
         private void ShutdownCancelledHandler()
         {
-            if (_saveYourselfPhase)
-                SMLib.SmcSaveYourselfDone(_currentSmcConn, true);
+            var smcConn = _currentSmcConn;
+            if (_saveYourselfPhase && smcConn != IntPtr.Zero)
+                SMLib.SmcSaveYourselfDone(smcConn, true);
             _saveYourselfPhase = false;
         }
 


### PR DESCRIPTION
Fixes #22188.

`_currentSmcConn` is `readonly`, so the `IntPtr.Zero` guard in `Dispose()` never fires after a successful connect — but `SmcCloseConnection` frees both the `SmcConn` and its `IceConn`. `Dispose()` is reachable from the `Die` callback, from `HandleRequests()` on `IceProcessMessagesIoError`, and from platform teardown, and it never cancelled `_cancellationTokenSource`, so the pump kept calling `IceProcessMessages` on the freed `IceConn` and re-entered `Dispose()` on every iteration. Losing the ICE connection therefore ends in a use-after-free rather than in a narrow race.

`Dispose()` now claims the handle once with `Interlocked.Exchange` and cancels the pump before closing. Core dump analysis is in #22188.

---

Code written by Claude (Claude Code); reviewed and verified by @hartmark, who will respond to review comments. The equivalent change is currently running hot-patched into JetBrains Rider's bundled Avalonia 11.3.11 on the affected machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
