### PR TITLE
.NET 11 WASM support

### DIFF
--- a/Avalonia.slnx
+++ b/Avalonia.slnx
@@ -39,14 +39,12 @@
     <File Path="build/CoreLibraries.props" />
     <File Path="build/DevAnalyzers.props" />
     <File Path="build/EmbedXaml.props" />
-    <File Path="build/HarfBuzzSharp.props" />
     <File Path="build/MicroCOM.props" />
     <File Path="build/NetAnalyzers.props" />
     <File Path="build/NullableEnable.props" />
     <File Path="build/ReferenceCoreLibraries.props" />
     <File Path="build/SampleApp.props" />
     <File Path="build/SharedVersion.props" />
-    <File Path="build/SkiaSharp.props" />
     <File Path="build/SourceGenerators.props" />
     <File Path="build/SourceLink.props" />
     <File Path="build/TargetFrameworks.props" />

--- a/azure-pipelines-integrationtests.yml
+++ b/azure-pipelines-integrationtests.yml
@@ -2,6 +2,9 @@ jobs:
 - job: Mac
   pool:
     name: 'AvaloniaMacPool'
+  variables:
+      # Our macOS runner is very old and is not compatible with .NET 11 CLI compiled with AOT
+      DOTNET_CLI_ENABLEAOT: 'false'
 
   steps:
   - task: UseDotNet@2

--- a/azure-pipelines-integrationtests.yml
+++ b/azure-pipelines-integrationtests.yml
@@ -11,7 +11,7 @@ jobs:
       version: 8.0.x
 
   - task: UseDotNet@2
-    displayName: 'Use .NET 10.0 SDK'
+    displayName: 'Use .NET SDK'
     inputs:
       packageType: sdk
       useGlobalJson: true
@@ -66,7 +66,7 @@ jobs:
       version: 8.0.x
 
   - task: UseDotNet@2
-    displayName: 'Use .NET 10.0 SDK'
+    displayName: 'Use .NET SDK'
     inputs:
       packageType: sdk
       useGlobalJson: true

--- a/azure-pipelines-integrationtests.yml
+++ b/azure-pipelines-integrationtests.yml
@@ -15,6 +15,7 @@ jobs:
     inputs:
       packageType: sdk
       useGlobalJson: true
+      includePreviewVersions: true
 
   - script: system_profiler SPDisplaysDataType |grep Resolution
     displayName: 'Get Resolution'
@@ -70,6 +71,7 @@ jobs:
     inputs:
       packageType: sdk
       useGlobalJson: true
+      includePreviewVersions: true
 
   - task: Windows Application Driver@0
     inputs:

--- a/azure-pipelines-integrationtests.yml
+++ b/azure-pipelines-integrationtests.yml
@@ -11,6 +11,12 @@ jobs:
       version: 8.0.x
 
   - task: UseDotNet@2
+    displayName: 'Use .NET 10.0 Runtime'
+    inputs:
+        packageType: runtime
+        version: 10.0.x
+
+  - task: UseDotNet@2
     displayName: 'Use .NET SDK'
     inputs:
       packageType: sdk
@@ -65,6 +71,12 @@ jobs:
     inputs:
       packageType: runtime
       version: 8.0.x
+
+  - task: UseDotNet@2
+    displayName: 'Use .NET 10.0 Runtime'
+    inputs:
+        packageType: runtime
+        version: 10.0.x
 
   - task: UseDotNet@2
     displayName: 'Use .NET SDK'

--- a/azure-pipelines-integrationtests.yml
+++ b/azure-pipelines-integrationtests.yml
@@ -8,12 +8,6 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET 8.0 Runtime'
-    inputs:
-      packageType: runtime
-      version: 8.0.x
-
-  - task: UseDotNet@2
     displayName: 'Use .NET 10.0 Runtime'
     inputs:
         packageType: runtime
@@ -69,12 +63,6 @@ jobs:
     vmImage: 'windows-2025'
 
   steps:
-  - task: UseDotNet@2
-    displayName: 'Use .NET 8.0 Runtime'
-    inputs:
-      packageType: runtime
-      version: 8.0.x
-
   - task: UseDotNet@2
     displayName: 'Use .NET 10.0 Runtime'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,12 @@ jobs:
       version: 8.0.x
 
   - task: UseDotNet@2
+    displayName: 'Use .NET 10.0 Runtime'
+    inputs:
+        packageType: runtime
+        version: 10.0.x
+
+  - task: UseDotNet@2
     displayName: 'Use .NET SDK'
     inputs:
       packageType: sdk
@@ -71,6 +77,12 @@ jobs:
     inputs:
       packageType: runtime
       version: 8.0.x
+
+  - task: UseDotNet@2
+    displayName: 'Use .NET 10.0 Runtime'
+    inputs:
+        packageType: runtime
+        version: 10.0.x
 
   - task: UseDotNet@2
     displayName: 'Use .NET SDK'
@@ -152,6 +164,12 @@ jobs:
     inputs:
       packageType: runtime
       version: 8.0.x
+
+  - task: UseDotNet@2
+    displayName: 'Use .NET 10.0 Runtime'
+    inputs:
+        packageType: runtime
+        version: 10.0.x
 
   - task: UseDotNet@2
     displayName: 'Use .NET SDK'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,11 @@ jobs:
     SolutionDir: '$(Build.SourcesDirectory)'
   steps:
   - task: UseDotNet@2
+    displayName: 'Use .NET 10.0 Runtime'
+    inputs:
+        packageType: runtime
+        version: 10.0.x
+  - task: UseDotNet@2
     displayName: 'Use .NET SDK'
     inputs:
       packageType: sdk
@@ -166,9 +171,11 @@ jobs:
       version: 8.0.x
 
   - task: UseDotNet@2
-    displayName: 'Use .NET 10.0 Runtime'
+    displayName: 'Use .NET 10.0 SDK'
     inputs:
-        packageType: runtime
+        # We need SDK on Windows machine to get windowsdesktop runtime included
+        # It's not installed with plain "packageType: runtime" 
+        packageType: sdk
         version: 10.0.x
 
   - task: UseDotNet@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ jobs:
     SolutionDir: '$(Build.SourcesDirectory)'
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET 10.0 SDK'
+    displayName: 'Use .NET SDK'
     inputs:
       packageType: sdk
       useGlobalJson: true
@@ -32,7 +32,7 @@ jobs:
       version: 8.0.x
 
   - task: UseDotNet@2
-    displayName: 'Use .NET 10.0 SDK'
+    displayName: 'Use .NET SDK'
     inputs:
       packageType: sdk
       useGlobalJson: true
@@ -71,7 +71,7 @@ jobs:
       version: 8.0.x
 
   - task: UseDotNet@2
-    displayName: 'Use .NET 10.0 SDK'
+    displayName: 'Use .NET SDK'
     inputs:
       packageType: sdk
       useGlobalJson: true
@@ -151,7 +151,7 @@ jobs:
       version: 8.0.x
 
   - task: UseDotNet@2
-    displayName: 'Use .NET 10.0 SDK'
+    displayName: 'Use .NET SDK'
     inputs:
       packageType: sdk
       useGlobalJson: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,26 @@ jobs:
   pool:
     vmImage: 'ubuntu-24.04'
   steps:
+ 
+  - script: df -h .
+    displayName: 'Check disk space'
+  - script: sudo rm -rf \
+      /usr/local/lib/android \
+      /opt/ghc \
+      /usr/share/swift \
+      /usr/local/.ghcup \
+      /usr/lib/jvm
+      /usr/share/miniconda \
+      /usr/local/lib/node_modules \
+      /usr/local/share/powershell \
+      /usr/local/share/chromedriver \
+      /usr/local/share/gecko_driver \
+      /usr/local/share/edge_driver \
+      /opt/hostedtoolcache/CodeQL
+    displayName: 'Free disk space'
+  - script: df -h .
+    displayName: 'Check disk space after cleanup'
+
   - task: UseDotNet@2
     displayName: 'Use .NET 10.0 Runtime'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ jobs:
     inputs:
       packageType: sdk
       useGlobalJson: true
+      includePreviewVersions: true
   - task: CmdLine@2
     displayName: 'Run Build'
     inputs:
@@ -36,6 +37,7 @@ jobs:
     inputs:
       packageType: sdk
       useGlobalJson: true
+      includePreviewVersions: true
 
   - task: CmdLine@2
     displayName: 'Install Workloads'
@@ -75,6 +77,7 @@ jobs:
     inputs:
       packageType: sdk
       useGlobalJson: true
+      includePreviewVersions: true
 
   - task: CmdLine@2
     displayName: 'Install Workloads'
@@ -155,6 +158,7 @@ jobs:
     inputs:
       packageType: sdk
       useGlobalJson: true
+      includePreviewVersions: true
 
   - task: CmdLine@2
     displayName: 'Install Workloads'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,12 +32,6 @@ jobs:
     vmImage: 'ubuntu-24.04'
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET 8.0 Runtime'
-    inputs:
-      packageType: runtime
-      version: 8.0.x
-
-  - task: UseDotNet@2
     displayName: 'Use .NET 10.0 Runtime'
     inputs:
         packageType: runtime
@@ -77,12 +71,6 @@ jobs:
   pool:
     vmImage: 'macos-15'
   steps:
-  - task: UseDotNet@2
-    displayName: 'Use .NET 8.0 Runtime'
-    inputs:
-      packageType: runtime
-      version: 8.0.x
-
   - task: UseDotNet@2
     displayName: 'Use .NET 10.0 Runtime'
     inputs:
@@ -164,12 +152,6 @@ jobs:
   variables:
     SolutionDir: '$(Build.SourcesDirectory)'
   steps:
-  - task: UseDotNet@2
-    displayName: 'Use .NET 8.0 Runtime'
-    inputs:
-      packageType: runtime
-      version: 8.0.x
-
   - task: UseDotNet@2
     displayName: 'Use .NET 10.0 SDK'
     inputs:

--- a/build/HarfBuzzSharp.props
+++ b/build/HarfBuzzSharp.props
@@ -1,7 +1,0 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" />
-    <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="HarfBuzzSharp.NativeAssets.Linux" />
-    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
-  </ItemGroup>
-</Project>

--- a/build/SkiaSharp.props
+++ b/build/SkiaSharp.props
@@ -1,7 +1,0 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="SkiaSharp.NativeAssets.Linux" />
-    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="SkiaSharp.NativeAssets.WebAssembly" />
-  </ItemGroup>
-</Project>

--- a/build/TargetFrameworks.props
+++ b/build/TargetFrameworks.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <AvsCurrentTargetFramework>net10.0</AvsCurrentTargetFramework>
-    <AvsNextTargetFramework>net11.0</AvsNextTargetFramework>
     <AvsCurrentWindowsTargetFramework>$(AvsCurrentTargetFramework)-windows</AvsCurrentWindowsTargetFramework>
     <AvsCurrentMacOSTargetFramework>$(AvsCurrentTargetFramework)-macos</AvsCurrentMacOSTargetFramework>
     <AvsCurrentAndroidTargetFramework>$(AvsCurrentTargetFramework)-android36.0</AvsCurrentAndroidTargetFramework>
@@ -9,8 +8,11 @@
     <AvsCurrentIOSTargetFramework>$(AvsCurrentTargetFramework)-ios26.0</AvsCurrentIOSTargetFramework>
     <AvsCurrentTvOSTargetFramework>$(AvsCurrentTargetFramework)-tvos26.0</AvsCurrentTvOSTargetFramework>
     <AvsCurrentBrowserTargetFramework>$(AvsCurrentTargetFramework)-browser</AvsCurrentBrowserTargetFramework>
-    <AvsNextBrowserTargetFramework>$(AvsNextTargetFramework)-browser</AvsNextBrowserTargetFramework>
     <AvsCurrentWinUITargetFramework>$(AvsCurrentTargetFramework)-windows10.0.19041.0</AvsCurrentWinUITargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(AvsSkipBuildingNextTargetFrameworks)' != 'True'">
+    <AvsNextTargetFramework>net11.0</AvsNextTargetFramework>
+    <AvsNextBrowserTargetFramework>$(AvsNextTargetFramework)-browser</AvsNextBrowserTargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(AvsSkipBuildingLegacyTargetFrameworks)' != 'True'">
     <AvsLegacyTargetFrameworks>net8.0</AvsLegacyTargetFrameworks>

--- a/build/TargetFrameworks.props
+++ b/build/TargetFrameworks.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <AvsCurrentTargetFramework>net10.0</AvsCurrentTargetFramework>
+    <AvsNextTargetFramework>net11.0</AvsNextTargetFramework>
     <AvsCurrentWindowsTargetFramework>$(AvsCurrentTargetFramework)-windows</AvsCurrentWindowsTargetFramework>
     <AvsCurrentMacOSTargetFramework>$(AvsCurrentTargetFramework)-macos</AvsCurrentMacOSTargetFramework>
     <AvsCurrentAndroidTargetFramework>$(AvsCurrentTargetFramework)-android36.0</AvsCurrentAndroidTargetFramework>
@@ -8,6 +9,7 @@
     <AvsCurrentIOSTargetFramework>$(AvsCurrentTargetFramework)-ios26.0</AvsCurrentIOSTargetFramework>
     <AvsCurrentTvOSTargetFramework>$(AvsCurrentTargetFramework)-tvos26.0</AvsCurrentTvOSTargetFramework>
     <AvsCurrentBrowserTargetFramework>$(AvsCurrentTargetFramework)-browser</AvsCurrentBrowserTargetFramework>
+    <AvsNextBrowserTargetFramework>$(AvsNextTargetFramework)-browser</AvsNextBrowserTargetFramework>
     <AvsCurrentWinUITargetFramework>$(AvsCurrentTargetFramework)-windows10.0.19041.0</AvsCurrentWinUITargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(AvsSkipBuildingLegacyTargetFrameworks)' != 'True'">

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.201",
+    "version": "11.0.*",
     "rollForward": "latestFeature"
   },
   "test": {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-rc.1",
+    "version": "11.0.100-rc.1.26425.128",
     "rollForward": "disable",
     "allowPrerelease": true
   },

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.0",
+    "version": "11.0.100-rc.1",
     "rollForward": "latestFeature",
     "allowPrerelease": true
   },

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "11.0.100-rc.1",
-    "rollForward": "latestFeature",
+    "rollForward": "disable",
     "allowPrerelease": true
   },
   "test": {

--- a/global.json
+++ b/global.json
@@ -1,7 +1,8 @@
 {
   "sdk": {
-    "version": "11.0.*",
-    "rollForward": "latestFeature"
+    "version": "11.0.0",
+    "rollForward": "latestFeature",
+    "allowPrerelease": true
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/samples/ControlCatalog.Browser/ControlCatalog.Browser.csproj
+++ b/samples/ControlCatalog.Browser/ControlCatalog.Browser.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WebAssembly">
   <PropertyGroup>
-    <TargetFramework>$(AvsCurrentBrowserTargetFramework)</TargetFramework>
+    <TargetFramework>$(AvsNextBrowserTargetFramework)</TargetFramework>
     <WasmEnableThreads>false</WasmEnableThreads>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UseMonoRuntime>true</UseMonoRuntime>
     <DebuggerSupport>true</DebuggerSupport>
     <WasmDebugLevel>5</WasmDebugLevel>
   </PropertyGroup>

--- a/samples/ControlCatalog.Browser/Program.cs
+++ b/samples/ControlCatalog.Browser/Program.cs
@@ -90,6 +90,11 @@ internal partial class Program
                 options.PreferFileDialogPolyfill = preferDialogsPolyfill;
             }
 
+            if (bool.TryParse(queryParams[nameof(options.PreferManagedThreadDispatcher)], out var preferManagedDispatcher))
+            {
+                options.PreferManagedThreadDispatcher = preferManagedDispatcher;
+            }
+
             if (queryParams[nameof(options.RenderingMode)] is { } renderingModePairs)
             {
                 options.RenderingMode = renderingModePairs

--- a/samples/ControlCatalog/ControlCatalog.csproj
+++ b/samples/ControlCatalog/ControlCatalog.csproj
@@ -34,5 +34,4 @@
 
   <Import Project="..\..\build\BuildTargets.targets" />
   <Import Project="..\..\build\SourceGenerators.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
 </Project>

--- a/samples/ControlCatalog/Models/PageItem.cs
+++ b/samples/ControlCatalog/Models/PageItem.cs
@@ -28,7 +28,8 @@ public class PageItem(string header, Func<Page> factory, StreamGeometry iconData
 
         foreach (var value in values)
         {
-            var normalizedValue = value.Normalize(NormalizationForm.FormKD);
+            // FormKD would be ideal for the search, but it's not supported on Browser.
+            var normalizedValue = value.Normalize(NormalizationForm.FormD);
 
             foreach (var c in normalizedValue)
             {

--- a/src/Browser/Avalonia.Browser/Avalonia.Browser.csproj
+++ b/src/Browser/Avalonia.Browser/Avalonia.Browser.csproj
@@ -12,8 +12,6 @@
   </ItemGroup>
 
   <Import Project="../../../build/BuildTargets.targets" />
-  <Import Project="../../../build/SkiaSharp.props" />
-  <Import Project="../../../build/HarfBuzzSharp.props" />
   <Import Project="../../../build/NullableEnable.props" />
   <Import Project="../../../build/TrimmingEnable.props" />
 

--- a/src/Browser/Avalonia.Browser/Avalonia.Browser.csproj
+++ b/src/Browser/Avalonia.Browser/Avalonia.Browser.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsCurrentBrowserTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsCurrentBrowserTargetFramework);$(AvsNextBrowserTargetFramework)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <WebAppDir>$(MSBuildThisFileDirectory)webapp</WebAppDir>
@@ -19,6 +19,17 @@
     <ProjectReference Include="../../../packages/Avalonia/Avalonia.csproj" />
     <ProjectReference Include="../../Skia/Avalonia.Skia/Avalonia.Skia.csproj" />
     <ProjectReference Include="../../HarfBuzz/Avalonia.HarfBuzz/Avalonia.HarfBuzz.csproj" />
+  </ItemGroup>
+
+  <!-- .NET 11 requires Skia/HarfBuzz compiled with EMSDK 5.0.6 -->
+  <!-- These Skia/HarfBuzz versions are newer than what we ship with Avalonia.Skia and Avalonia.HarfBuzz -->
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+    <PackageReference Include="SkiaSharp" VersionOverride="4.151.2" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" VersionOverride="4.151.2" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" VersionOverride="4.151.2" />
+    <PackageReference Include="HarfBuzzSharp" VersionOverride="14.2.1.200" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" VersionOverride="14.2.1.200" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" VersionOverride="14.2.1.200" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Browser/Avalonia.Browser/WindowingPlatform.cs
+++ b/src/Browser/Avalonia.Browser/WindowingPlatform.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.JavaScript;
 using System.Threading;
 using Avalonia.Browser.Interop;
@@ -32,9 +33,11 @@ internal class BrowserWindowingPlatform : IWindowingPlatform
         set => s_globalThis = value;
     }
 
-    static bool DetectThreadSupport()
+    private static bool DetectThreadSupport()
     {
-        // TODO Replace with public API https://github.com/dotnet/runtime/issues/77541.
+#if NET11_0_OR_GREATER
+        return RuntimeFeature.IsMultithreadingSupported;
+#else
         var prop = typeof(System.Threading.Thread).GetProperty("IsThreadStartSupported",
             BindingFlags.Static | BindingFlags.NonPublic);
         if (prop != null && prop.GetValue(null) is bool value)
@@ -51,7 +54,7 @@ internal class BrowserWindowingPlatform : IWindowingPlatform
         {
             return false;
         }
-
+#endif
     }
     
     private static KeyboardDevice? s_keyboard;

--- a/src/Browser/Avalonia.Browser/build/Avalonia.Browser.props
+++ b/src/Browser/Avalonia.Browser/build/Avalonia.Browser.props
@@ -4,9 +4,6 @@
     <ShouldIncludeAvaloniaAssets Condition=" '$(ShouldIncludeAvaloniaAssets)' == '' ">true</ShouldIncludeAvaloniaAssets>
     <ShouldIncludeAvaloniaLegacyAssets Condition=" '$(ShouldIncludeAvaloniaLegacyAssets)' == '' AND '$(ShouldIncludeAvaloniaAssets)' == 'true'">true</ShouldIncludeAvaloniaLegacyAssets>
     <ShouldIncludeAvaloniaStaticAssets Condition=" '$(ShouldIncludeAvaloniaStaticAssets)' == '' AND '$(ShouldIncludeAvaloniaAssets)' == 'true'">true</ShouldIncludeAvaloniaStaticAssets>
-    
-    <ShouldIncludeNativeSkiaSharp Condition=" '$(ShouldIncludeNativeSkiaSharp)' == '' ">true</ShouldIncludeNativeSkiaSharp>
-    <ShouldIncludeNativeHarfBuzzSharp Condition=" '$(ShouldIncludeNativeHarfBuzzSharp)' == '' ">true</ShouldIncludeNativeHarfBuzzSharp>
 
     <_AvaloniaRuntimeAssetsLocation>$(WasmRuntimeAssetsLocation)</_AvaloniaRuntimeAssetsLocation>
     <_AvaloniaRuntimeAssetsLocation Condition="'$(_AvaloniaRuntimeAssetsLocation)' == ''">_framework</_AvaloniaRuntimeAssetsLocation>

--- a/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
+++ b/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
@@ -17,23 +17,10 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(ShouldIncludeNativeSkiaSharp)' == 'true' or '$(ShouldIncludeNativeHarfBuzzSharp)' == 'true'">
-    <WasmBuildNative Condition="'$(WasmBuildNative)' == ''">true</WasmBuildNative>
+    <!-- SkiaSharp/HarfBuzz require WASM to be compiled with native link -->
+    <WasmBuildNative>true</WasmBuildNative>
   </PropertyGroup>
 
-  <!-- Revisit after https://github.com/mono/SkiaSharp/pull/2620 is merged and released. -->
-  <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeSkiaSharp)' == 'true'">
-    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.34\$(_AvNativeBinaryType)\*.a"
-                         Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0'))" />
-    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.56\$(_AvNativeBinaryType)\*.a"
-                         Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeHarfBuzzSharp)' == 'True'">
-    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.34\$(_AvNativeBinaryType)\*.a"
-                         Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0'))" />
-    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.56\$(_AvNativeBinaryType)\*.a"
-                         Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))" />
-  </ItemGroup>
 
   <!-- https://github.com/dotnet/runtime/issues/109289 -->
   <Target Name="Issue109289_Workaround"

--- a/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
+++ b/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
@@ -21,23 +21,4 @@
     <WasmBuildNative>true</WasmBuildNative>
   </PropertyGroup>
 
-
-  <!-- https://github.com/dotnet/runtime/issues/109289 -->
-  <Target Name="Issue109289_Workaround"
-          Condition="'$(DisableIssue109289Workaround)' != 'true' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))"
-          AfterTargets="_BrowserWasmWriteRspForLinking">
-    <ItemGroup>
-      <_WasmLinkStepArgs Remove="@(_EmccLinkStepArgs)" />
-      <_EmccLinkStepArgs Remove="&quot;%(_WasmNativeFileForLinking.Identity)&quot;" />
-      <_WasmLinkDependencies Remove="@(_WasmNativeFileForLinking)" />
-
-      <_SkiaSharpToReorder Include="@(_WasmNativeFileForLinking)" Condition="$([System.String]::Copy('%(FullPath)').Contains('SkiaSharp'))" />
-      <_WasmNativeFileForLinking Remove="@(_SkiaSharpToReorder)" />
-      <_WasmNativeFileForLinking Include="@(_SkiaSharpToReorder)" />
-
-      <_EmccLinkStepArgs Include="&quot;%(_WasmNativeFileForLinking.Identity)&quot;" />
-      <_WasmLinkDependencies Include="@(_WasmNativeFileForLinking)" />
-      <_WasmLinkStepArgs Include="@(_EmccLinkStepArgs)" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/HarfBuzz/Avalonia.HarfBuzz/Avalonia.HarfBuzz.csproj
+++ b/src/HarfBuzz/Avalonia.HarfBuzz/Avalonia.HarfBuzz.csproj
@@ -1,15 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks)</TargetFrameworks>
-        <IncludeLinuxSkia>true</IncludeLinuxSkia>
-        <IncludeWasmSkia>true</IncludeWasmSkia>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />
     </ItemGroup>
 
-    <Import Project="..\..\..\build\HarfBuzzSharp.props" />
+    <ItemGroup>
+      <PackageReference Include="HarfBuzzSharp" />
+      <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" />
+      <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
+    </ItemGroup>
+
     <Import Project="..\..\..\build\DevAnalyzers.props" />
     <Import Project="..\..\..\build\TrimmingEnable.props" />
     <Import Project="..\..\..\build\NullableEnable.props" />

--- a/src/Skia/Avalonia.Skia/Avalonia.Skia.csproj
+++ b/src/Skia/Avalonia.Skia/Avalonia.Skia.csproj
@@ -1,19 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks)</TargetFrameworks>
-    <IncludeLinuxSkia>true</IncludeLinuxSkia>
-    <IncludeWasmSkia>true</IncludeWasmSkia>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Assets\NoiseAsset_256X256_PNG.png" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />
   </ItemGroup>
-  
-  <Import Project="..\..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\..\build\HarfBuzzSharp.props" />
+
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
+  </ItemGroup>
+
   <Import Project="..\..\..\build\DevAnalyzers.props" />
   <Import Project="..\..\..\build\TrimmingEnable.props" />
   <Import Project="..\..\..\build\NullableEnable.props" />

--- a/tests/Avalonia.Build.Tasks.UnitTest/Avalonia.Build.Tasks.UnitTest.csproj
+++ b/tests/Avalonia.Build.Tasks.UnitTest/Avalonia.Build.Tasks.UnitTest.csproj
@@ -9,7 +9,6 @@
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
   </PropertyGroup>
 
-  <Import Project="..\..\build\HarfBuzzSharp.props" />
   <Import Project="..\..\build\XUnit.props" />
   <Import Project="..\..\build\SharedVersion.props" />
   <Import Project="..\..\build\NullableEnable.props" />

--- a/tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj
+++ b/tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj
@@ -9,7 +9,6 @@
   <Import Project="..\..\build\XUnit.props" />
   <Import Project="..\..\build\Base.props" />
   <Import Project="..\..\build\SharedVersion.props" />
-  <Import Project="..\..\build\HarfBuzzSharp.props" />
   <Import Project="..\..\build\NullableEnable.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.Reactive.Testing" />

--- a/tests/Avalonia.RenderTests.WpfCompare/Avalonia.RenderTests.WpfCompare.csproj
+++ b/tests/Avalonia.RenderTests.WpfCompare/Avalonia.RenderTests.WpfCompare.csproj
@@ -18,10 +18,10 @@
   <ItemGroup>
     <PackageReference Include="Moq" />
     <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="SkiaSharp" />
     <PackageReference Include="System.Reactive" />
     <PackageReference Include="Xunit.StaFact" />
   </ItemGroup>
   <Import Project="..\..\build\XUnit.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
   <Import Project="..\..\build\SharedVersion.props" />
 </Project>

--- a/tests/Avalonia.Skia.RenderTests/Avalonia.Skia.RenderTests.csproj
+++ b/tests/Avalonia.Skia.RenderTests/Avalonia.Skia.RenderTests.csproj
@@ -4,8 +4,6 @@
     <OutputType>Exe</OutputType>
     <DefineConstants>$(DefineConstants);AVALONIA_SKIA</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IncludeLinuxSkia>true</IncludeLinuxSkia>
-    <IncludeWasmSkia>true</IncludeWasmSkia>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Avalonia.RenderTests\**\*.cs" />
@@ -38,7 +36,6 @@
     <PackageReference Include="unofficial.mesa.softwarerenderer" />
   </ItemGroup>
   <Import Project="..\..\build\XUnit.props" />
-  <Import Project="..\..\build\SkiaSharp.props" />
   <Import Project="..\..\build\SharedVersion.props" />
   <Import Project="..\..\build\NullableEnable.props" />
 </Project>

--- a/tests/Avalonia.UnitTests/Avalonia.UnitTests.csproj
+++ b/tests/Avalonia.UnitTests/Avalonia.UnitTests.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="System.Reactive" />
   </ItemGroup>
-  <Import Project="..\..\build\HarfBuzzSharp.props" />
   <Import Project="..\..\build\XUnit.props" />
   <Import Project="..\..\build\SharedVersion.props" />
   <Import Project="..\..\build\NullableEnable.props" />


### PR DESCRIPTION
## What does the pull request do?

This PR bumps this repository SDK to .NET 11 rc1.
And adds .NET 11 target framework for the Avalonia.Browser project only.

`Avalonia.Browser` is the only one needed a new TFM, because .NET 11 WASM requires SkiaSharp to be compiled with the latest EMSDK. And only SkiaSharp 4.x does it, which we don't currently target in the core framework.

.NET 10 WASM tfm is unchanged and still targets SkiaSharp 3.x as the rest of Avalonia.

This PR also simplifies how we reference SkiaSharp across all projects, now relying on centralized package versioning.

Note: marking as a WIP, until we are ready to retarget this repository to .NET 11 SDK. cc @MrJul 
We technically can keep this repository .NET 10 SDK and only install 11 on the CI. But that might be more confusing than convenient.