### PR TITLE
Make word segmentation linear in the length of a regional indicator run

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/WordBreakEnumerator.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/WordBreakEnumerator.cs
@@ -11,11 +11,17 @@ namespace Avalonia.Media.TextFormatting.Unicode
         private int _offset;
         private int _codepointOffset;
 
+        // Whether an odd number of regional indicators precedes the position the walk has
+        // reached. WB15 and WB16 need only that parity, so it is carried along with the walk
+        // instead of being recounted from the start of the run at every indicator.
+        private bool _oddRegionalIndicatorRun;
+
         public WordBreakEnumerator(ReadOnlySpan<char> text)
         {
             _text = text;
             _offset = 0;
             _codepointOffset = 0;
+            _oddRegionalIndicatorRun = false;
         }
 
         /// <summary>
@@ -35,6 +41,9 @@ namespace Avalonia.Media.TextFormatting.Unicode
             var segmentStart = _offset;
             var segmentCodepointStart = _codepointOffset;
             var current = ReadForward(_offset);
+
+            Consume(current.WordBreakClass);
+
             var currentEnd = current.End;
             var boundaryCodepoint = _codepointOffset + 1;
 
@@ -48,6 +57,9 @@ namespace Avalonia.Media.TextFormatting.Unicode
                 }
 
                 current = next;
+
+                Consume(current.WordBreakClass);
+
                 currentEnd = current.End;
                 boundaryCodepoint++;
             }
@@ -194,12 +206,25 @@ namespace Avalonia.Media.TextFormatting.Unicode
 
             if (left.WordBreakClass == WordBreakClass.RegionalIndicator &&
                 right == WordBreakClass.RegionalIndicator &&
-                (CountRegionalIndicatorsBefore(next.Start) & 1) == 1)
+                _oddRegionalIndicatorRun)
             {
                 return false;
             }
 
             return true;
+        }
+
+        // Extends the left-hand context by one code point. WB4 treats Extend, Format and ZWJ as
+        // transparent, so they leave the regional indicator run they sit inside intact.
+        private void Consume(WordBreakClass wordBreakClass)
+        {
+            if (IsIgnored(wordBreakClass))
+            {
+                return;
+            }
+
+            _oddRegionalIndicatorRun = wordBreakClass == WordBreakClass.RegionalIndicator &&
+                !_oddRegionalIndicatorRun;
         }
 
         private readonly WordBreakUnit GetEffectivePrevious(in WordBreakUnit current)
@@ -224,25 +249,6 @@ namespace Avalonia.Media.TextFormatting.Unicode
             }
 
             return current;
-        }
-
-        private readonly int CountRegionalIndicatorsBefore(int end)
-        {
-            var count = 0;
-            var scanEnd = end;
-
-            while (TryGetPreviousSignificant(scanEnd, out var previous))
-            {
-                if (previous.WordBreakClass != WordBreakClass.RegionalIndicator)
-                {
-                    break;
-                }
-
-                count++;
-                scanEnd = previous.Start;
-            }
-
-            return count;
         }
 
         private readonly bool TryGetPreviousSignificant(int end, out WordBreakUnit codepoint)

--- a/tests/Avalonia.Base.UnitTests/Media/TextFormatting/WordBreakEnumeratorTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/TextFormatting/WordBreakEnumeratorTests.cs
@@ -68,6 +68,79 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
             Assert.True(pass);
         }
 
+        // Regional indicators pair up from the start of their run (WB15, WB16), so where a
+        // boundary falls depends on how many of them precede the current one.
+        private const string RegionalD = "\U0001F1E9";
+        private const string RegionalE = "\U0001F1EA";
+        private const string RegionalF = "\U0001F1EB";
+        private const string RegionalR = "\U0001F1F7";
+
+        [Fact]
+        public void TwoFlags_AreTwoSegments()
+        {
+            var segments = CollectSegments(RegionalD + RegionalE + RegionalF + RegionalR);
+
+            Assert.Equal([RegionalD + RegionalE, RegionalF + RegionalR], segments);
+        }
+
+        [Fact]
+        public void OddRegionalIndicatorRun_LeavesTheLastIndicatorOnItsOwn()
+        {
+            var segments = CollectSegments(RegionalD + RegionalE + RegionalF);
+
+            Assert.Equal([RegionalD + RegionalE, RegionalF], segments);
+        }
+
+        [Fact]
+        public void RegionalIndicatorsAfterALetter_PairFromTheStartOfTheirRun()
+        {
+            var segments = CollectSegments("A" + RegionalD + RegionalE + RegionalF + RegionalR);
+
+            Assert.Equal(["A", RegionalD + RegionalE, RegionalF + RegionalR], segments);
+        }
+
+        [Fact]
+        public void RegionalIndicatorRunInterruptedBySpace_StartsPairingAgain()
+        {
+            var segments = CollectSegments(RegionalD + " " + RegionalE + RegionalF);
+
+            Assert.Equal([RegionalD, " ", RegionalE + RegionalF], segments);
+        }
+
+        [Fact]
+        public void CombiningMarkBetweenRegionalIndicators_DoesNotSplitThePair()
+        {
+            var text = RegionalD + "\u0301" + RegionalE;
+
+            var segments = CollectSegments(text);
+
+            Assert.Equal([text], segments);
+        }
+
+        [Fact]
+        public void LongRegionalIndicatorRun_PairsAllTheWayThrough()
+        {
+            var flag = RegionalD + RegionalE;
+
+            var segments = CollectSegments(string.Concat(Enumerable.Repeat(flag, 8)));
+
+            Assert.Equal(8, segments.Count);
+            Assert.All(segments, segment => Assert.Equal(flag, segment));
+        }
+
+        private static List<string> CollectSegments(string text)
+        {
+            var result = new List<string>();
+            var enumerator = new WordBreakEnumerator(text.AsSpan());
+
+            while (enumerator.MoveNext(out var segment))
+            {
+                result.Add(text.Substring(segment.Offset, segment.Length));
+            }
+
+            return result;
+        }
+
         public class WordBreakTestDataGenerator : IEnumerable<object[]>
         {
             private readonly List<object[]> _testData;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Makes `WordBreakEnumerator` linear in the length of a regional indicator run. WB15 and WB16 pair regional indicators off from the start of their run, and the enumerator recounted that run from its start at every indicator, so word segmentation over a sequence of flag emoji was quadratic.

- Track whether an odd number of regional indicators precedes the position the walk has reached, updating it as each code point is consumed.
- Drop `CountRegionalIndicatorsBefore`, which was the only backward scan in the enumerator not bounded by the first significant code point.

## What is the current behavior?

Word segmentation slows quadratically as an unbroken run of regional indicators grows. Measured over contiguous flags, nanoseconds per UTF-16 code unit:

| code units | before | after |
| ---------: | -----: | ----: |
| 1024 | 509.24 | 4.64 |
| 2048 | 1013.30 | 4.63 |
| 4096 | 2043.47 | 4.62 |
| 8192 | 4052.69 | 4.62 |
| 16384 | 8204.67 | 4.63 |

The cost per character doubles on every doubling of the length. One pass over 4096 flags takes 134 ms; the same text with a space between each flag takes 98 us, because the space ends the run and bounds the scan. Text layout word-breaks per line, so an emoji-heavy line pays this on every re-layout.

## What is the updated/expected behavior with this PR?

Segment boundaries are unchanged. Cost per character is flat across the same range, and short runs get faster too (5.94 to 5.55 ns per code unit for flags separated by spaces) because the recount ran on every pair, not only on long ones.

Other text shapes measure within the noise band of this method. Adding two never-read fields to the unmodified enumerator moves prose from 7.30 to 9.10 ns per code unit on its own, so per-character differences of that size here reflect struct and code layout rather than work done.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
