### PR TITLE
Fixed "TESTAPP" window sometimes appearing when Avalonia solution is open in Visual Studio

### DIFF
--- a/tests/Avalonia.DesignerSupport.TestApp/Avalonia.DesignerSupport.TestApp.csproj
+++ b/tests/Avalonia.DesignerSupport.TestApp/Avalonia.DesignerSupport.TestApp.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(AvsCurrentTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
+    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="**\*.xaml.cs">


### PR DESCRIPTION
This PR disables `Microsoft.Testing.Platform` test discovery for `Avalonia.DesignerSupport.TestApp`, which is in the test directory but does not actually contain tests.

The project opens a window called "TESTAPP" when executed...and MTP executes test projects in order to discover their tests.

## What is the current behavior?
An annoying window sometimes opens when the Avalonia solution is open in Visual Studio.

## Breaking changes
None.

## Obsoletions / Deprecations
None.