### PR TITLE
XamlX: Compile time StreamGeometry parsing

### DIFF
--- a/src/Avalonia.Base/Media/FillRule.cs
+++ b/src/Avalonia.Base/Media/FillRule.cs
@@ -1,6 +1,9 @@
 namespace Avalonia.Media
 {
-    public enum FillRule
+#if !BUILDTASK
+    public
+#endif
+    enum FillRule
     {
         EvenOdd,
         NonZero

--- a/src/Avalonia.Base/Media/PathMarkupParser.cs
+++ b/src/Avalonia.Base/Media/PathMarkupParser.cs
@@ -10,7 +10,10 @@ namespace Avalonia.Media
     /// <summary>
     /// Parses a path markup string.
     /// </summary>
-    public class PathMarkupParser : IDisposable
+#if !BUILDTASK
+    public
+#endif
+    class PathMarkupParser : IDisposable
     {
         private static readonly Dictionary<char, Command> s_commands =
             new Dictionary<char, Command>

--- a/src/Avalonia.Base/Media/SweepDirection.cs
+++ b/src/Avalonia.Base/Media/SweepDirection.cs
@@ -3,7 +3,10 @@ namespace Avalonia.Media
     /// <summary>
     /// Defines the direction an which elliptical arc is drawn.
     /// </summary>
-    public enum SweepDirection
+#if !BUILDTASK
+    public
+#endif
+    enum SweepDirection
     {
         /// <summary>
         /// Specifies that arcs are drawn in a counter clockwise (negative-angle) direction.

--- a/src/Avalonia.Base/Platform/IGeometryContext.cs
+++ b/src/Avalonia.Base/Platform/IGeometryContext.cs
@@ -6,7 +6,10 @@ namespace Avalonia.Platform
     /// <summary>
     /// Describes a geometry using drawing commands.
     /// </summary>
-    public interface IGeometryContext : IDisposable
+#if !BUILDTASK
+    public
+#endif
+    interface IGeometryContext : IDisposable
     {
         /// <summary>
         /// Draws an arc to the specified point.

--- a/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
+++ b/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
@@ -123,6 +123,18 @@
       <Compile Include="../Avalonia.Base/RelativePoint.cs">
         <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
       </Compile>
+      <Compile Include="../Avalonia.Base/Media/FillRule.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
+      <Compile Include="../Avalonia.Base/Media/SweepDirection.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
+      <Compile Include="../Avalonia.Base/Platform/IGeometryContext.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
+      <Compile Include="../Avalonia.Base/Media/PathMarkupParser.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
       <Compile Include="../Avalonia.Base/Compatibility/NullableAttributes.cs" Link="Compatibility/NullableAttributes.cs" />
       <Compile Include="../Avalonia.Base/Compatibility/TrimmingAttributes.cs" Link="Compatibility/TrimmingAttributes.cs" />
       <Compile Include="../Avalonia.Base/Utilities/SpanHelpers.cs" Link="Utilities/SpanHelpers.cs" />

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AstNodes/AvaloniaXamlIlStreamGeometryAstNode.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AstNodes/AvaloniaXamlIlStreamGeometryAstNode.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers;
+using XamlX.Ast;
+using XamlX.Emit;
+using XamlX.IL;
+using XamlX.TypeSystem;
+
+namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.AstNodes;
+
+/// <summary>
+/// Emits a <c>StreamGeometry</c> built from path markup which was already parsed at compile time.
+/// </summary>
+internal class AvaloniaXamlIlStreamGeometryAstNode(
+    IXamlLineInfo lineInfo,
+    AvaloniaXamlIlWellKnownTypes types,
+    IReadOnlyList<GeometryCommand> commands)
+    : XamlAstNode(lineInfo), IXamlAstValueNode, IXamlAstILEmitableNode
+{
+    private readonly IXamlConstructor _streamGeometryCtor = types.StreamGeometry.GetConstructor();
+    private readonly IXamlMethod _streamGeometryOpen = types.StreamGeometry.GetMethod("Open", types.StreamGeometryContext, false);
+    private readonly IXamlMethod _streamGeometryContextSetFillRule = types.StreamGeometryContext.GetMethod(new FindMethodMethodSignature("SetFillRule", types.XamlIlTypes.Void, types.FillRule));
+    private readonly IXamlMethod _streamGeometryContextBeginFigure = types.StreamGeometryContext.GetMethod(new FindMethodMethodSignature("BeginFigure", types.XamlIlTypes.Void, types.Point, types.XamlIlTypes.Boolean));
+    private readonly IXamlMethod _streamGeometryContextLineTo = types.StreamGeometryContext.GetMethod(new FindMethodMethodSignature("LineTo", types.XamlIlTypes.Void, types.Point, types.XamlIlTypes.Boolean));
+    private readonly IXamlMethod _streamGeometryContextQuadraticBezierTo = types.StreamGeometryContext.GetMethod(new FindMethodMethodSignature("QuadraticBezierTo", types.XamlIlTypes.Void, types.Point, types.Point, types.XamlIlTypes.Boolean));
+    private readonly IXamlMethod _streamGeometryContextCubicBezierTo = types.StreamGeometryContext.GetMethod(new FindMethodMethodSignature("CubicBezierTo", types.XamlIlTypes.Void, types.Point, types.Point, types.Point, types.XamlIlTypes.Boolean));
+    private readonly IXamlMethod _streamGeometryContextArcTo = types.StreamGeometryContext.GetMethod(new FindMethodMethodSignature("ArcTo", types.XamlIlTypes.Void, types.Point, types.Size, types.XamlIlTypes.Double, types.XamlIlTypes.Boolean, types.SweepDirection, types.XamlIlTypes.Boolean));
+    private readonly IXamlMethod _streamGeometryContextEndFigure = types.StreamGeometryContext.GetMethod(new FindMethodMethodSignature("EndFigure", types.XamlIlTypes.Void, types.XamlIlTypes.Boolean));
+    private readonly IXamlMethod _streamGeometryContextDispose = types.StreamGeometryContext.GetMethod(new FindMethodMethodSignature("Dispose", types.XamlIlTypes.Void));
+
+    public IXamlAstTypeReference Type { get; } = new XamlAstClrTypeReference(lineInfo, types.StreamGeometry, false);
+
+    public XamlILNodeEmitResult Emit(XamlEmitContext<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter codeGen)
+    {
+        codeGen
+            .Newobj(_streamGeometryCtor)
+            .Dup()
+            .EmitCall(_streamGeometryOpen);
+
+        using (var pooledContext = codeGen.LocalsPool.GetLocal(types.StreamGeometryContext))
+        {
+            var contextLocal = pooledContext.Local;
+
+            codeGen.Stloc(contextLocal);
+
+            foreach (var command in commands)
+            {
+                codeGen.Ldloc(contextLocal);
+
+                switch (command.Kind)
+                {
+                    case GeometryCommandKind.SetFillRule:
+                        codeGen
+                            .Ldc_I4((int)command.FillRule)
+                            .EmitCall(_streamGeometryContextSetFillRule);
+                        break;
+
+                    case GeometryCommandKind.BeginFigure:
+                        EmitPoint(codeGen, command.Point1);
+                        codeGen
+                            .Ldc_I4(command.IsFilled ? 1 : 0)
+                            .EmitCall(_streamGeometryContextBeginFigure);
+                        break;
+
+                    case GeometryCommandKind.LineTo:
+                        EmitPoint(codeGen, command.Point1);
+                        codeGen
+                            .Ldc_I4(command.IsStroked ? 1 : 0)
+                            .EmitCall(_streamGeometryContextLineTo);
+                        break;
+
+                    case GeometryCommandKind.QuadraticBezierTo:
+                        EmitPoint(codeGen, command.Point1);
+                        EmitPoint(codeGen, command.Point2);
+                        codeGen
+                            .Ldc_I4(command.IsStroked ? 1 : 0)
+                            .EmitCall(_streamGeometryContextQuadraticBezierTo);
+                        break;
+
+                    case GeometryCommandKind.CubicBezierTo:
+                        EmitPoint(codeGen, command.Point1);
+                        EmitPoint(codeGen, command.Point2);
+                        EmitPoint(codeGen, command.Point3);
+                        codeGen
+                            .Ldc_I4(command.IsStroked ? 1 : 0)
+                            .EmitCall(_streamGeometryContextCubicBezierTo);
+                        break;
+
+                    case GeometryCommandKind.ArcTo:
+                        EmitPoint(codeGen, command.Point1);
+                        codeGen
+                            .Ldc_R8(command.Size.Width)
+                            .Ldc_R8(command.Size.Height)
+                            .Newobj(types.SizeFullConstructor)
+                            .Ldc_R8(command.RotationAngle)
+                            .Ldc_I4(command.IsLargeArc ? 1 : 0)
+                            .Ldc_I4((int)command.SweepDirection)
+                            .Ldc_I4(command.IsStroked ? 1 : 0)
+                            .EmitCall(_streamGeometryContextArcTo);
+                        break;
+
+                    case GeometryCommandKind.EndFigure:
+                        codeGen
+                            .Ldc_I4(command.IsClosed ? 1 : 0)
+                            .EmitCall(_streamGeometryContextEndFigure);
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(command), $"Unsupported geometry command {command.Kind}");
+                }
+            }
+
+            codeGen
+                .Ldloc(contextLocal)
+                .EmitCall(_streamGeometryContextDispose);
+        }
+
+        return XamlILNodeEmitResult.Type(0, types.StreamGeometry);
+    }
+
+    private void EmitPoint(IXamlILEmitter codeGen, Point point)
+        => codeGen
+            .Ldc_R8(point.X)
+            .Ldc_R8(point.Y)
+            .Newobj(types.PointFullConstructor);
+}

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlGeometryCommandRecorder.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlGeometryCommandRecorder.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using Avalonia.Media;
+using Avalonia.Platform;
+
+namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions;
+
+internal enum GeometryCommandKind
+{
+    SetFillRule,
+    BeginFigure,
+    LineTo,
+    QuadraticBezierTo,
+    CubicBezierTo,
+    ArcTo,
+    EndFigure
+}
+
+/// <summary>
+/// A single recorded geometry drawing call.
+/// </summary>
+internal readonly struct GeometryCommand
+{
+    private GeometryCommand(GeometryCommandKind kind, Point point1, Point point2, Point point3,
+        Size size, double rotationAngle, bool value, bool secondaryValue, int enumValue)
+    {
+        Kind = kind;
+        Point1 = point1;
+        Point2 = point2;
+        Point3 = point3;
+        Size = size;
+        RotationAngle = rotationAngle;
+        _value = value;
+        _secondaryValue = secondaryValue;
+        _enumValue = enumValue;
+    }
+
+    public GeometryCommandKind Kind { get; }
+
+    public Point Point1 { get; }
+
+    public Point Point2 { get; }
+
+    public Point Point3 { get; }
+
+    public Size Size { get; }
+
+    public double RotationAngle { get; }
+
+    private readonly bool _value;
+    private readonly bool _secondaryValue;
+    private readonly int _enumValue;
+
+    public bool IsFilled => _value;
+
+    public bool IsStroked => Kind == GeometryCommandKind.ArcTo ? _secondaryValue : _value;
+
+    public bool IsClosed => _value;
+
+    public bool IsLargeArc => _value;
+
+    public FillRule FillRule => (FillRule)_enumValue;
+
+    public SweepDirection SweepDirection => (SweepDirection)_enumValue;
+
+    public static GeometryCommand SetFillRule(FillRule fillRule)
+        => new(GeometryCommandKind.SetFillRule, default, default, default, default, 0,
+            false, false, (int)fillRule);
+
+    public static GeometryCommand BeginFigure(Point startPoint, bool isFilled)
+        => new(GeometryCommandKind.BeginFigure, startPoint, default, default, default, 0,
+            isFilled, false, 0);
+
+    public static GeometryCommand LineTo(Point point, bool isStroked)
+        => new(GeometryCommandKind.LineTo, point, default, default, default, 0,
+            isStroked, false, 0);
+
+    public static GeometryCommand QuadraticBezierTo(Point controlPoint, Point endPoint, bool isStroked)
+        => new(GeometryCommandKind.QuadraticBezierTo, controlPoint, endPoint, default, default, 0,
+            isStroked, false, 0);
+
+    public static GeometryCommand CubicBezierTo(Point controlPoint1, Point controlPoint2, Point endPoint, bool isStroked)
+        => new(GeometryCommandKind.CubicBezierTo, controlPoint1, controlPoint2, endPoint, default, 0,
+            isStroked, false, 0);
+
+    public static GeometryCommand ArcTo(Point point, Size size, double rotationAngle, bool isLargeArc,
+        SweepDirection sweepDirection, bool isStroked)
+        => new(GeometryCommandKind.ArcTo, point, default, default, size, rotationAngle,
+            isLargeArc, isStroked, (int)sweepDirection);
+
+    public static GeometryCommand EndFigure(bool isClosed)
+        => new(GeometryCommandKind.EndFigure, default, default, default, default, 0,
+            isClosed, false, 0);
+}
+
+/// <summary>
+/// A compile-time <see cref="IGeometryContext"/> which records the drawing calls made by <see cref="PathMarkupParser"/>.
+/// The recorded commands are then emitted as IL by <see cref="AstNodes.AvaloniaXamlIlStreamGeometryAstNode"/>.
+/// </summary>
+internal sealed class AvaloniaXamlIlGeometryCommandRecorder : IGeometryContext
+{
+    private readonly List<GeometryCommand> _commands = [];
+
+    public IReadOnlyList<GeometryCommand> Commands => _commands;
+
+    public void SetFillRule(FillRule fillRule)
+        => _commands.Add(GeometryCommand.SetFillRule(fillRule));
+
+    public void BeginFigure(Point startPoint, bool isFilled = true)
+        => _commands.Add(GeometryCommand.BeginFigure(startPoint, isFilled));
+
+    public void LineTo(Point point, bool isStroked = true)
+        => _commands.Add(GeometryCommand.LineTo(point, isStroked));
+
+    public void QuadraticBezierTo(Point controlPoint, Point endPoint, bool isStroked = true)
+        => _commands.Add(GeometryCommand.QuadraticBezierTo(controlPoint, endPoint, isStroked));
+
+    public void CubicBezierTo(Point controlPoint1, Point controlPoint2, Point endPoint, bool isStroked = true)
+        => _commands.Add(GeometryCommand.CubicBezierTo(controlPoint1, controlPoint2, endPoint, isStroked));
+
+    public void ArcTo(Point point, Size size, double rotationAngle, bool isLargeArc,
+        SweepDirection sweepDirection, bool isStroked = true)
+        => _commands.Add(GeometryCommand.ArcTo(point, size, rotationAngle, isLargeArc, sweepDirection, isStroked));
+
+    public void EndFigure(bool isClosed)
+        => _commands.Add(GeometryCommand.EndFigure(isClosed));
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
@@ -260,6 +260,25 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 }
             }
 
+            if (type.Equals(types.Geometry) || type.Equals(types.StreamGeometry))
+            {
+                var recorder = new AvaloniaXamlIlGeometryCommandRecorder();
+
+                try
+                {
+                    using var parser = new PathMarkupParser(recorder);
+                    parser.Parse(text);
+                }
+                catch
+                {
+                    return ReturnOnParseError($"Unable to parse \"{text}\" as a geometry", out result);
+                }
+
+                result = new AvaloniaXamlIlStreamGeometryAstNode(node, types, recorder.Commands);
+
+                return true;
+            }
+
             if (types.IBrush.IsAssignableFrom(type))
             {
                 if (Color.TryParse(text, out Color color))

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -112,6 +112,11 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType IBrush { get; }
         public IXamlType ImmutableSolidColorBrush { get; }
         public IXamlConstructor ImmutableSolidColorBrushConstructorColor { get; }
+        public IXamlType Geometry { get; }
+        public IXamlType StreamGeometry { get; }
+        public IXamlType StreamGeometryContext { get; }
+        public IXamlType FillRule { get; }
+        public IXamlType SweepDirection { get; }
         public IXamlType TypeUtilities { get; }
         public IXamlType TextDecorationCollection { get; }
         public IXamlType TextDecorations { get; }
@@ -320,6 +325,11 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             IBrush = typeSystem.GetType("Avalonia.Media.IBrush");
             ImmutableSolidColorBrush = typeSystem.GetType("Avalonia.Media.Immutable.ImmutableSolidColorBrush");
             ImmutableSolidColorBrushConstructorColor = ImmutableSolidColorBrush.GetConstructor(new List<IXamlType> { UInt });
+            Geometry = typeSystem.GetType("Avalonia.Media.Geometry");
+            StreamGeometry = typeSystem.GetType("Avalonia.Media.StreamGeometry");
+            StreamGeometryContext = typeSystem.GetType("Avalonia.Media.StreamGeometryContext");
+            FillRule = typeSystem.GetType("Avalonia.Media.FillRule");
+            SweepDirection = typeSystem.GetType("Avalonia.Media.SweepDirection");
             TypeUtilities = typeSystem.GetType("Avalonia.Utilities.TypeUtilities");
             TextDecorationCollection = typeSystem.GetType("Avalonia.Media.TextDecorationCollection");
             TextDecorations = typeSystem.GetType("Avalonia.Media.TextDecorations");

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/GeometryIntrinsicsTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/GeometryIntrinsicsTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Controls.Shapes;
+using Avalonia.Media;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Markup.Xaml.UnitTests.Xaml;
+
+public class GeometryIntrinsicsTests : XamlTestBase
+{
+    [Fact]
+    public void Element_Syntax_Geometry_Is_Compiled()
+    {
+        // We don't verify IL output to be sure it's geometry is compile-time parsed.
+        using var _ = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+        var path = AvaloniaRuntimeXamlLoader.Parse<Path>(
+            """
+            <Path xmlns='https://github.com/avaloniaui'>
+                <Path.Data>
+                    <StreamGeometry>M 0 0 L 10 10 Z</StreamGeometry>
+                </Path.Data>
+            </Path>
+            """);
+
+        Assert.IsType<StreamGeometry>(path.Data);
+    }
+
+    [Fact]
+    public void Invalid_Geometry_Reports_Diagnostic()
+    {
+        var diagnostics = new List<RuntimeXamlDiagnostic>();
+
+        var xamlDocument = new RuntimeXamlLoaderDocument(
+            """
+            <Path xmlns='https://github.com/avaloniaui'
+                  Data='M 0 0 X 1 1' />
+            """);
+
+        Assert.ThrowsAny<Exception>(() => AvaloniaRuntimeXamlLoader.Load(
+            xamlDocument,
+            new RuntimeXamlLoaderConfiguration
+            {
+                DiagnosticHandler = diagnostic =>
+                {
+                    diagnostics.Add(diagnostic);
+                    return diagnostic.Severity;
+                }
+            }));
+
+        Assert.Contains(diagnostics, d =>
+            d is { Severity: RuntimeXamlDiagnosticSeverity.Error, Title: "Unable to parse \"M 0 0 X 1 1\" as a geometry" });
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

I wanted to have StreamGeometry parsed in compile time for a while.
It's the last part of our themes that's parsed in runtime for no particular reason.

But performance benefits of this are not so significant.
Current PathParser is fairly efficient, doesn't use reflection and little to no allocations. Even for a long geometry path's it is fast enough. 

I wrote a small benchmark that reads `PasswordBoxHideButtonData` deferred resource from the FluentTheme, re-parsing it each time. And difference was in a range of an error: <details>
| Method                      | Mean     | Error   | StdDev  | Allocated |
|---------------------------- |---------:|--------:|--------:|----------:|
| GetDeferredGeometryResource | 151.9 ns | 0.50 ns | 0.13 ns |         - |  

| Method                      | Mean     | Error   | StdDev  | Allocated |
|---------------------------- |---------:|--------:|--------:|----------:|
| GetDeferredGeometryResource | 151.2 ns | 2.01 ns | 0.31 ns |         - |       

InvocationCount=200000, IterationCount=5, WarmupCount=3
</details>

Even though, benchmark won't include platform rendering interfaces (like SKPath being used), it doesn't matter with XAML geometry parsing. 

IL difference, while not significant, is more substantial than perf benefit: +10KB for FluentTheme.