### PR TITLE
Chore: Add android and ios solution filters

### DIFF
--- a/Avalonia.Android.slnf
+++ b/Avalonia.Android.slnf
@@ -1,0 +1,31 @@
+﻿{
+  "solution": {
+    "path": "Avalonia.slnx",
+    "projects": [
+      "packages\\Avalonia\\Avalonia.csproj",
+      "samples\\ControlCatalog.Android\\ControlCatalog.Android.csproj",
+      "samples\\ControlCatalog\\ControlCatalog.csproj",
+      "samples\\MiniMvvm\\MiniMvvm.csproj",
+      "samples\\SafeAreaDemo.Android\\SafeAreaDemo.Android.csproj",
+      "samples\\SafeAreaDemo\\SafeAreaDemo.csproj",
+      "src\\Android\\Avalonia.Android\\Avalonia.Android.csproj",
+      "src\\Avalonia.Base\\Avalonia.Base.csproj",
+      "src\\Avalonia.Build.Tasks\\Avalonia.Build.Tasks.csproj",
+      "src\\Avalonia.Controls.ColorPicker\\Avalonia.Controls.ColorPicker.csproj",
+      "src\\Avalonia.Controls\\Avalonia.Controls.csproj",
+      "src\\Avalonia.Dialogs\\Avalonia.Dialogs.csproj",
+      "src\\Avalonia.Fonts.Inter\\Avalonia.Fonts.Inter.csproj",
+      "src\\Avalonia.Remote.Protocol\\Avalonia.Remote.Protocol.csproj",
+      "src\\Avalonia.Themes.Fluent\\Avalonia.Themes.Fluent.csproj",
+      "src\\Avalonia.Themes.Simple\\Avalonia.Themes.Simple.csproj",
+      "src\\HarfBuzz\\Avalonia.HarfBuzz\\Avalonia.HarfBuzz.csproj",
+      "src\\Markup\\Avalonia.Markup.Xaml\\Avalonia.Markup.Xaml.csproj",
+      "src\\Markup\\Avalonia.Markup\\Avalonia.Markup.csproj",
+      "src\\Skia\\Avalonia.Skia\\Avalonia.Skia.csproj",
+      "src\\tools\\Avalonia.Analyzers.CodeFixes.CSharp\\Avalonia.Analyzers.CodeFixes.CSharp.csproj",
+      "src\\tools\\Avalonia.Analyzers.CSharp\\Avalonia.Analyzers.CSharp.csproj",
+      "src\\tools\\Avalonia.Analyzers.VisualBasic\\Avalonia.Analyzers.VisualBasic.csproj",
+      "src\\tools\\Avalonia.Generators\\Avalonia.Generators.csproj"
+    ]
+  }
+}

--- a/Avalonia.iOS.slnf
+++ b/Avalonia.iOS.slnf
@@ -1,0 +1,31 @@
+﻿{
+  "solution": {
+    "path": "Avalonia.slnx",
+    "projects": [
+      "packages\\Avalonia\\Avalonia.csproj",
+      "samples\\ControlCatalog.iOS\\ControlCatalog.iOS.csproj",
+      "samples\\ControlCatalog\\ControlCatalog.csproj",
+      "samples\\MiniMvvm\\MiniMvvm.csproj",
+      "samples\\SafeAreaDemo.iOS\\SafeAreaDemo.iOS.csproj",
+      "samples\\SafeAreaDemo\\SafeAreaDemo.csproj",
+      "src\\Avalonia.Base\\Avalonia.Base.csproj",
+      "src\\Avalonia.Build.Tasks\\Avalonia.Build.Tasks.csproj",
+      "src\\Avalonia.Controls.ColorPicker\\Avalonia.Controls.ColorPicker.csproj",
+      "src\\Avalonia.Controls\\Avalonia.Controls.csproj",
+      "src\\Avalonia.Dialogs\\Avalonia.Dialogs.csproj",
+      "src\\Avalonia.Fonts.Inter\\Avalonia.Fonts.Inter.csproj",
+      "src\\Avalonia.Remote.Protocol\\Avalonia.Remote.Protocol.csproj",
+      "src\\Avalonia.Themes.Fluent\\Avalonia.Themes.Fluent.csproj",
+      "src\\Avalonia.Themes.Simple\\Avalonia.Themes.Simple.csproj",
+      "src\\HarfBuzz\\Avalonia.HarfBuzz\\Avalonia.HarfBuzz.csproj",
+      "src\\iOS\\Avalonia.iOS\\Avalonia.iOS.csproj",
+      "src\\Markup\\Avalonia.Markup.Xaml\\Avalonia.Markup.Xaml.csproj",
+      "src\\Markup\\Avalonia.Markup\\Avalonia.Markup.csproj",
+      "src\\Skia\\Avalonia.Skia\\Avalonia.Skia.csproj",
+      "src\\tools\\Avalonia.Analyzers.CodeFixes.CSharp\\Avalonia.Analyzers.CodeFixes.CSharp.csproj",
+      "src\\tools\\Avalonia.Analyzers.CSharp\\Avalonia.Analyzers.CSharp.csproj",
+      "src\\tools\\Avalonia.Analyzers.VisualBasic\\Avalonia.Analyzers.VisualBasic.csproj",
+      "src\\tools\\Avalonia.Generators\\Avalonia.Generators.csproj"
+    ]
+  }
+}

--- a/docs/build.md
+++ b/docs/build.md
@@ -33,10 +33,12 @@ dotnet run
 Visual Studio, Visual Studio Code and Rider and supported.  
 You need a version that support at least .NET 10 (e.g. Visual Studio 2026 or Rider 2025.3).
 
-If you want to open Avalonia in your preferred IDE, you have two options:
+If you want to open Avalonia in your preferred IDE, you have several options:
 
 - `Avalonia.slnx`: This contains the whole of Avalonia in including desktop, mobile and web. You must have a number of dotnet workloads installed in order to build everything in this solution
 - `Avalonia.Desktop.slnf`: This solution filter opens only the parts of Avalonia required to run on desktop. This requires no extra workloads to be installed.
+- `Avalonia.iOS.slnf`: This solution filter opens only the parts of Avalonia required to run on iOS. This requires the `ios` workload to be installed (`dotnet workload install ios`).
+- `Avalonia.Android.slnf`: This solution filter opens only the parts of Avalonia required to run on Android. This requires the `android` workload to be installed (`dotnet workload install android`).
 
 Build and run the `ControlCatalog.Desktop` project to see the sample application.
 


### PR DESCRIPTION
## What does the pull request do?
small QOL improvements for targeted iOS/Android development workflows by adding iOS/Android solution filters

## What is the updated/expected behavior with this PR?
`dotnet build Avalonia.Android.slnf` and `dotnet build Avalonia.iOS.slnf` should pass given that android/iOS dotnet workloads have been installed

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
No breaking changes

## Obsoletions / Deprecations
No obsoletions/deprecations

## Addressed issues

Closes #22077 (caveat: self-opened issue and PR :))
