### PR TITLE
Wayland: fix scroll axis units

### DIFF
--- a/src/Avalonia.Wayland/Server/Transient/WaylandInputDispatcher.cs
+++ b/src/Avalonia.Wayland/Server/Transient/WaylandInputDispatcher.cs
@@ -290,9 +290,13 @@ partial class WaylandInputDispatcher : IDisposable
         //    every scroll source (wheel + touchpad/continuous), regardless of version.
         //
         // For Avalonia (1.0 == one detent), value120/120 is the right unit when present.
-        // For continuous sources (touchpad), there is no value120 and we fall back to the
-        // raw axis value. We accumulate the two streams independently and combine at frame
+        // For continuous sources (touchpad), there is no value120 and we scale the raw axis
+        // value by AxisUnitsPerDetent. We accumulate the two streams independently and combine at frame
         // flush time, preferring v120 per axis when present). This is robust to either event order.
+
+        // Logical px per detent for continuous sources, as assumed by GTK3, Qt, SDL and Chromium
+        private const double AxisUnitsPerDetent = 10;
+
         private bool _frameHasAxis;
         private ulong _frameAxisTimestamp;
         private double _frameAxisRawX;
@@ -439,9 +443,9 @@ partial class WaylandInputDispatcher : IDisposable
                 handler._frameActions.Add(() =>
                 {
                     // Combine v120 (notches) with raw axis (continuous). Per axis, prefer v120
-                    // if any v120 event fired this frame; otherwise fall back to the raw axis.
-                    var deltaX = handler._frameV120SeenX ? handler._frameV120X : handler._frameAxisRawX;
-                    var deltaY = handler._frameV120SeenY ? handler._frameV120Y : handler._frameAxisRawY;
+                    // if any v120 event fired this frame; otherwise scale the raw axis.
+                    var deltaX = handler._frameV120SeenX ? handler._frameV120X : handler._frameAxisRawX / AxisUnitsPerDetent;
+                    var deltaY = handler._frameV120SeenY ? handler._frameV120Y : handler._frameAxisRawY / AxisUnitsPerDetent;
                     if (deltaX != 0 || deltaY != 0)
                     {
                         // Wayland: positive = scroll down/right. Avalonia: positive Y = scroll up.


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Correctly scales continuous (touchpad, trackpoint) scroll deltas on Wayland backend.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`WaylandInputDispatcher` treats raw pixel deltas as full mouse wheel notches, causing the scroll to be uncontrollably fast.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Touchpad scrolling on Wayland has a normal speed, similar to X11.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Only wheel sources send `axis_value120`, so every continuous source falls through to the raw axis value. `WaylandInputDispatcher` now divides the raw axis value by 10 pixels per detent, matching other Wayland clients:

- GTK3 — [`gdkdevice-wayland.c:1924`](https://gitlab.gnome.org/GNOME/gtk/-/blob/fb1f0f187cea06c488b079dac3e474b5ed15043c/gdk/wayland/gdkdevice-wayland.c#L1924) `wl_fixed_to_double (value) / 10.0`
- GTK4 — [`gtkeventcontrollerscroll.c:68`](https://gitlab.gnome.org/GNOME/gtk/-/blob/51a0bf3627204325ccf0f8f24f587728a18c43df/gtk/gtkeventcontrollerscroll.c#L68) `#define SURFACE_UNIT_DISCRETE_MAPPING 10`
- Qt — [`qwaylandinputdevice.cpp:1114`](https://github.com/qt/qtwayland/blob/25d29255fcf49015b44752221bbc8f1d8b265941/src/client/qwaylandinputdevice.cpp#L1114) `delta * -12` against a 120-per-detent scale
- SDL3 — [`SDL_waylandevents.c:78`](https://github.com/libsdl-org/SDL/blob/fe2bca9748afa754ebbca4c543c5b28bbce30cf4/src/video/wayland/SDL_waylandevents.c#L78) `#define WAYLAND_WHEEL_AXIS_UNIT 10`
- Chromium — [`wayland_pointer.cc:192`](https://github.com/chromium/chromium/blob/8b3a92a0160d86d906cb937bced05516ee86d25c/ui/ozone/platform/wayland/host/wayland_pointer.cc#L192) `constexpr double kAxisValueScale = 10.0`

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
_none_

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @MrJul -->
_none_

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #22034

