### PR TITLE
Wayland : Add AppId in WaylandPlatformOptions and WaylandProperties

### DIFF
--- a/src/Avalonia.Controls/Platform/IWaylandOptionsToplevelImplFeature.cs
+++ b/src/Avalonia.Controls/Platform/IWaylandOptionsToplevelImplFeature.cs
@@ -1,0 +1,9 @@
+using Avalonia.Metadata;
+
+namespace Avalonia.Controls.Platform;
+
+[PrivateApi]
+public interface IWaylandOptionsToplevelImplFeature
+{
+    void SetAppId(string? appId);
+}

--- a/src/Avalonia.Controls/Platform/WaylandProperties.cs
+++ b/src/Avalonia.Controls/Platform/WaylandProperties.cs
@@ -1,0 +1,28 @@
+using Avalonia.Controls.Platform;
+using Avalonia.Platform;
+using Avalonia.Reactive;
+
+namespace Avalonia.Controls;
+
+/// <summary>
+/// Set of Wayland specific properties and events that allow deeper customization of the application per platform.
+/// </summary>
+public class WaylandProperties
+{
+    public static readonly AttachedProperty<string?> AppIdProperty =
+        AvaloniaProperty.RegisterAttached<WaylandProperties, Window, string?>("AppId");
+
+    public static void SetAppId(Window obj, string? value) => obj.SetValue(AppIdProperty, value);
+    public static string? GetAppId(Window obj) => obj.GetValue(AppIdProperty);
+
+    static WaylandProperties()
+    {
+        AppIdProperty.Changed.Subscribe(OnAppIdChanged);
+    }
+
+    private static IWaylandOptionsToplevelImplFeature? TryGetFeature(AvaloniaPropertyChangedEventArgs e)
+        => (e.Sender as TopLevel)?.PlatformImpl?.TryGetFeature<IWaylandOptionsToplevelImplFeature>();
+
+    private static void OnAppIdChanged(AvaloniaPropertyChangedEventArgs<string?> e) =>
+        TryGetFeature(e)?.SetAppId(e.NewValue.GetValueOrDefault(null));
+}

--- a/src/Avalonia.Wayland/Server/Persistent/IWXdgTopLevel.cs
+++ b/src/Avalonia.Wayland/Server/Persistent/IWXdgTopLevel.cs
@@ -50,6 +50,14 @@ internal interface IWXdgTopLevel : IWXdgShellSurface
     void SetTitle(string? title);
 
     /// <summary>
+    /// Sets the toplevel's application ID (xdg_toplevel.set_app_id). The compositor
+    /// may use this to group windows, match desktop files, display window icons, etc.
+    /// A <c>null</c> or empty value clears the app ID. The worker caches the value so it
+    /// survives compositor reconnects.
+    /// </summary>
+    void SetAppId(string? appId);
+
+    /// <summary>
     /// Tear down the worker's <c>zxdg_toplevel_decoration_v1</c> object
     /// (if any). Switches the compositor back to "client-side
     /// decorations on next commit" per the v1 spec. Also latches the

--- a/src/Avalonia.Wayland/Server/Persistent/WSurface.cs
+++ b/src/Avalonia.Wayland/Server/Persistent/WSurface.cs
@@ -634,6 +634,7 @@ class WXdgTopLevel : WXdgShellSurface, IWXdgTopLevel
     private Size? _minSize;
     private Size? _maxSize;
     private string? _title;
+    private string? _appId;
 
     private ZxdgToplevelDecorationV1? _decoration;
     // Disable SSD support completely and don't allow re-enabling it because we can't
@@ -664,6 +665,10 @@ class WXdgTopLevel : WXdgShellSurface, IWXdgTopLevel
         // Re-apply cached title on reconnect.
         if (_title != null)
             _xdgTopLevel.SetTitle(_title);
+
+        // Re-apply cached app id on reconnect.
+        if (_appId != null)
+            _xdgTopLevel.SetAppId(_appId);
 
         // Re-apply cached min/max if they were ever set on a previous
         // (now-dead) connection. The OnConnected commit below will
@@ -709,6 +714,12 @@ class WXdgTopLevel : WXdgShellSurface, IWXdgTopLevel
     {
         _title = title;
         _xdgTopLevel?.SetTitle(title ?? string.Empty);
+    }
+
+    public void SetAppId(string? appId)
+    {
+        _appId = appId;
+        _xdgTopLevel?.SetAppId(appId ?? string.Empty);
     }
 
     public void SetMinMaxSize(Size? minSize, Size? maxSize)

--- a/src/Avalonia.Wayland/Server/WaylandWorker.cs
+++ b/src/Avalonia.Wayland/Server/WaylandWorker.cs
@@ -31,6 +31,7 @@ partial class WaylandWorker
     public WaylandPlatformGraphics PlatformGraphics { get; } = new();
     private Thread? _thread;
     public IRawEventGrouperDispatchQueue InputDispatchQueue { get; }
+    public WaylandPlatformOptions Options { get; private set; } = new();
 
 
     public Compositor Compositor { get; }
@@ -293,6 +294,7 @@ partial class WaylandWorker
     void StartCore(WaylandPlatformOptions options, WaylandConnection? probedConnection, WlDisplay? foreignDisplay,
         TaskCompletionSource<ExceptionDispatchInfo?>? initTcs)
     {
+        Options = options;
         new Thread(() =>
         {
             if(probedConnection!=null)

--- a/src/Avalonia.Wayland/Server/WaylandWorkerClient.cs
+++ b/src/Avalonia.Wayland/Server/WaylandWorkerClient.cs
@@ -32,6 +32,8 @@ class WaylandWorkerClient
 
     public Compositor Compositor { get; }
 
+    public WaylandPlatformOptions Options => _worker.Options;
+
     /// <summary>Shared platform-wide input-dispatch queue (any-thread safe).</summary>
     public IRawEventGrouperDispatchQueue InputDispatchQueue { get; }
 

--- a/src/Avalonia.Wayland/WaylandPlatformOptions.cs
+++ b/src/Avalonia.Wayland/WaylandPlatformOptions.cs
@@ -14,6 +14,12 @@ namespace Avalonia;
 public class WaylandPlatformOptions
 {
     /// <summary>
+    /// The default AppId for Wayland windows (xdg_toplevel.set_app_id).
+    /// If null, defaults to the entry assembly name.
+    /// </summary>
+    public string? AppId { get; set; }
+
+    /// <summary>
     /// The name of the Wayland display to connect to (e.g. <c>wayland-0</c>). When <c>null</c>,
     /// the <c>WAYLAND_DISPLAY</c> environment variable is used. Ignored when <see cref="DisplayFd"/> is set.
     /// </summary>
@@ -90,4 +96,16 @@ public class WaylandPlatformOptions
     /// Only used when <see cref="UseGLibMainLoop"/> is enabled.
     /// </summary>
     public Action<Exception>? ExternalGLibMainLoopExceptionLogger { get; set; }
+
+    public WaylandPlatformOptions()
+    {
+        try
+        {
+            AppId = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name;
+        }
+        catch
+        {
+            //
+        }
+    }
 }

--- a/src/Avalonia.Wayland/WindowImpl.Sink.cs
+++ b/src/Avalonia.Wayland/WindowImpl.Sink.cs
@@ -48,6 +48,11 @@ partial class WindowImpl
             if (Parent._title != null)
                 _surfaceProxy.SetTitle(Parent._title);
 
+            // Re-send cached app id to the new surface
+            var effectiveAppId = Parent._appId ?? Parent.Client.Options.AppId;
+            if (effectiveAppId != null)
+                _surfaceProxy.SetAppId(effectiveAppId);
+
             // Re-apply cached min/max size constraints after a fresh worker
             // surface is created. null on both sides means SetMinMaxSize was
             // never called (or both bounds are unconstrained) — nothing to push.

--- a/src/Avalonia.Wayland/WindowImpl.cs
+++ b/src/Avalonia.Wayland/WindowImpl.cs
@@ -17,7 +17,7 @@ using NWayland.Protocols.XdgShell;
 
 namespace Avalonia.Wayland;
 
-internal partial class WindowImpl : WindowBaseImpl, IWindowImpl
+internal partial class WindowImpl : WindowBaseImpl, IWindowImpl, IWaylandOptionsToplevelImplFeature
 {
     private WaylandSurfaceCreateResult<WXdgTopLevelProxy>? _handle;
     private WXdgTopLevelProxy? _surfaceProxy;
@@ -36,6 +36,7 @@ internal partial class WindowImpl : WindowBaseImpl, IWindowImpl
     // This is a limitation of V1 of the protocol that's supported in the wild
     private bool _csdSticky;
     private string? _title;
+    private string? _appId;
     private FallbackStorageProvider? _storageProvider;
 
     public WindowImpl(WaylandWorkerClient client) : base(client)
@@ -105,6 +106,8 @@ internal partial class WindowImpl : WindowBaseImpl, IWindowImpl
             return _textInputMethod ??= new WaylandTextInputMethod(this);
         if (featureType == typeof(IStorageProvider))
             return _storageProvider ??= new FallbackStorageProvider(BuildStorageFactories());
+        if (featureType == typeof(IWaylandOptionsToplevelImplFeature))
+            return this;
         return base.TryGetFeature(featureType);
     }
 
@@ -230,6 +233,12 @@ internal partial class WindowImpl : WindowBaseImpl, IWindowImpl
     {
         _title = title;
         _surfaceProxy?.SetTitle(title);
+    }
+
+    public void SetAppId(string? appId)
+    {
+        _appId = appId;
+        _surfaceProxy?.SetAppId(appId ?? Client.Options.AppId);
     }
 
     public void SetParent(IWindowImpl? parent)

--- a/tests/Avalonia.Controls.UnitTests/Platform/WaylandPropertiesTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Platform/WaylandPropertiesTests.cs
@@ -1,0 +1,52 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Platform;
+using Avalonia.Platform;
+using Avalonia.UnitTests;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests.Platform;
+
+public class WaylandPropertiesTests : ScopedTestBase
+{
+    [Fact]
+    public void WaylandProperties_AppId_AttachedProperty_Works()
+    {
+        using (UnitTestApplication.Start(TestServices.MockWindowingPlatform))
+        {
+            var window = new Window();
+            Assert.Null(WaylandProperties.GetAppId(window));
+
+            WaylandProperties.SetAppId(window, "org.test.app");
+            Assert.Equal("org.test.app", WaylandProperties.GetAppId(window));
+
+            WaylandProperties.SetAppId(window, null);
+            Assert.Null(WaylandProperties.GetAppId(window));
+        }
+    }
+
+    [Fact]
+    public void WaylandProperties_AppId_NotifiesFeature()
+    {
+        var featureMock = new Mock<IWaylandOptionsToplevelImplFeature>();
+        var windowImplMock = new Mock<IWindowImpl>();
+        windowImplMock.Setup(r => r.RenderScaling).Returns(1.0);
+        windowImplMock.Setup(r => r.Compositor).Returns(RendererMocks.CreateDummyCompositor());
+        windowImplMock.Setup(x => x.TryGetFeature(typeof(IWaylandOptionsToplevelImplFeature)))
+            .Returns(featureMock.Object);
+
+        var services = TestServices.StyledWindow.With(
+            windowingPlatform: new MockWindowingPlatform(() => windowImplMock.Object));
+
+        using (UnitTestApplication.Start(services))
+        {
+            var window = new Window();
+
+            WaylandProperties.SetAppId(window, "my.custom.appid");
+            featureMock.Verify(x => x.SetAppId("my.custom.appid"), Times.Once);
+
+            WaylandProperties.SetAppId(window, null);
+            featureMock.Verify(x => x.SetAppId(null), Times.Once);
+        }
+    }
+}

--- a/tests/Avalonia.Wayland.UnitTests/WaylandAppIdTests.cs
+++ b/tests/Avalonia.Wayland.UnitTests/WaylandAppIdTests.cs
@@ -1,0 +1,18 @@
+using Avalonia;
+using Xunit;
+
+namespace Avalonia.Wayland.UnitTests;
+
+public class WaylandAppIdTests
+{
+    [Fact]
+    public void WaylandPlatformOptions_CanSetAppId()
+    {
+        var options = new WaylandPlatformOptions
+        {
+            AppId = "org.avaloniaui.test"
+        };
+
+        Assert.Equal("org.avaloniaui.test", options.AppId);
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
In Wayland, an app in a "Alt+Tab" should have the name and the icon of the .desktop 
Added a property  AppId in WaylandPlatformOptions and WaylandProperties to overload the app id if the executable name don't match the app name of the .desktop file. By default it will take the name of the executable if it is not set.

## What is the current behavior?
For now, the icon is the default system one and the name is unknow.


## What is the updated/expected behavior with this PR?
A new property AppId in WaylandPlatformOptions or set WaylandProperties.AppId in a Window


## How was the solution implemented (if it's not obvious)?
I copied the SetTitle in Wayland and add the possibility to set the property AppId in WaylandPlatformOptions or in Windows.WaylandProperties


## Checklist

- [x ] Added unit tests (if possible)?
- [ x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None
## Obsoletions / Deprecations
None
