### PR TITLE
Fix StreamGeometry Clone and Open when a Transform is set

### DIFF
--- a/src/Avalonia.Base/Media/StreamGeometry.cs
+++ b/src/Avalonia.Base/Media/StreamGeometry.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Media
         /// <inheritdoc/>
         public override Geometry Clone()
         {
-            return new StreamGeometry(((IStreamGeometryImpl)PlatformImpl!).Clone());
+            return new StreamGeometry(StreamImpl.Clone()) { Transform = Transform };
         }
 
         /// <summary>
@@ -58,19 +58,24 @@ namespace Avalonia.Media
         /// </returns>
         public StreamGeometryContext Open()
         {
-            return new StreamGeometryContext(((IStreamGeometryImpl)PlatformImpl!).Open());
+            return new StreamGeometryContext(StreamImpl.Open(), OnContextDisposed);
         }
 
         /// <inheritdoc/>
-        private protected override IGeometryImpl? CreateDefiningGeometry()
-        {
-            if (_impl == null)
-            {
-                var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
-                _impl = factory.CreateStreamGeometry();
-            }
+        private protected override IGeometryImpl? CreateDefiningGeometry() => StreamImpl;
 
-            return _impl;
+        // The stream itself. PlatformImpl can't be used for this: it is wrapped when Transform is set.
+        private IStreamGeometryImpl StreamImpl =>
+            _impl ??= AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>().CreateStreamGeometry();
+
+        private void OnContextDisposed()
+        {
+            // A transformed geometry caches a transformed copy of the stream, which would otherwise keep
+            // showing the old content.
+            if (Transform is { } transform && transform.Value != Matrix.Identity)
+            {
+                InvalidateGeometry();
+            }
         }
     }
 }

--- a/src/Avalonia.Base/Media/StreamGeometryContext.cs
+++ b/src/Avalonia.Base/Media/StreamGeometryContext.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Platform;
 
 namespace Avalonia.Media
@@ -13,6 +14,7 @@ namespace Avalonia.Media
     public class StreamGeometryContext : IGeometryContext
     {
         private readonly IStreamGeometryContextImpl _impl;
+        private readonly Action? _onDisposed;
 
         private Point _currentPoint;
 
@@ -23,6 +25,12 @@ namespace Avalonia.Media
         public StreamGeometryContext(IStreamGeometryContextImpl impl)
         {
             _impl = impl;
+        }
+
+        internal StreamGeometryContext(IStreamGeometryContextImpl impl, Action onDisposed)
+            : this(impl)
+        {
+            _onDisposed = onDisposed;
         }
 
         /// <summary>
@@ -97,6 +105,7 @@ namespace Avalonia.Media
         public void Dispose()
         {
             _impl.Dispose();
+            _onDisposed?.Invoke();
         }
     }
 }

--- a/tests/Avalonia.RenderTests/Media/StreamGeometryTests.cs
+++ b/tests/Avalonia.RenderTests/Media/StreamGeometryTests.cs
@@ -48,5 +48,41 @@ namespace Avalonia.Skia.RenderTests
                     }
             await RenderToFile(grid);
         }
+
+        [Fact]
+        public void Clone_Should_Keep_Transform()
+        {
+            var geometry = StreamGeometry.Parse("M10,190 l190,-190");
+            geometry.Transform = new TranslateTransform(50, 50);
+
+            var clone = geometry.Clone();
+
+            Assert.Equal(geometry.Transform.Value, clone.Transform!.Value);
+            Assert.Equal(geometry.Bounds, clone.Bounds);
+        }
+
+        [Fact]
+        public void Open_Should_Update_Transformed_Geometry()
+        {
+            var geometry = StreamGeometry.Parse("M10,190 l190,-190");
+            geometry.Transform = new TranslateTransform(50, 50);
+            var untransformed = StreamGeometry.Parse("M10,190 l190,-190");
+
+            // Reading the bounds first makes the geometry cache its transformed copy.
+            var before = geometry.Bounds;
+
+            foreach (var target in new[] { geometry, untransformed })
+            {
+                using (var context = target.Open())
+                {
+                    context.BeginFigure(new Point(300, 300), true);
+                    context.LineTo(new Point(400, 400));
+                    context.EndFigure(false);
+                }
+            }
+
+            Assert.NotEqual(before, geometry.Bounds);
+            Assert.Equal(untransformed.Bounds.Translate(new Vector(50, 50)), geometry.Bounds);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Fixes `StreamGeometry.Clone()` and `Open()` throwing `InvalidCastException` when `Transform` is set.

This picks up #21509, which made the same core change but was closed without being merged because its CLA was never signed. The cause was worked out by @freddiesmartbox in the issue.

## What is the current behavior?

Once `Transform` is set, `PlatformImpl` is a transformed wrapper, and `Clone()` and `Open()` cast it to `IStreamGeometryImpl`.

It also crashes ordinary rendering. `Shape` clones its geometry to apply `Stretch`, so a stretched `Path` whose `StreamGeometry` has a `Transform` throws as soon as it is drawn.

## What is the updated/expected behavior with this PR?

`Clone()` and `Open()` use the stream itself rather than `PlatformImpl`. `Clone()` keeps the `Transform`, as `PolylineGeometry` and `GeometryGroup` do.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #21494

