### PR TITLE
Add built-in theme tests and fix several bugs found by them

### DIFF
--- a/Avalonia.Desktop.slnf
+++ b/Avalonia.Desktop.slnf
@@ -73,6 +73,7 @@
       "tests\\Avalonia.RenderTests.WpfCompare\\Avalonia.RenderTests.WpfCompare.csproj",
       "tests\\Avalonia.Skia.RenderTests\\Avalonia.Skia.RenderTests.csproj",
       "tests\\Avalonia.Skia.UnitTests\\Avalonia.Skia.UnitTests.csproj",
+      "tests\\Avalonia.Themes.UnitTests\\Avalonia.Themes.UnitTests.csproj",
       "tests\\Avalonia.UnitTests\\Avalonia.UnitTests.csproj",
       "tests\\Avalonia.Wayland.UnitTests\\Avalonia.Wayland.UnitTests.csproj",
       "tests\\TestFiles\\BuildTasks\\PInvoke\\PInvoke.csproj"

--- a/Avalonia.slnx
+++ b/Avalonia.slnx
@@ -157,6 +157,7 @@
     <Project Path="tests/Avalonia.RenderTests.WpfCompare/Avalonia.RenderTests.WpfCompare.csproj" />
     <Project Path="tests/Avalonia.Skia.RenderTests/Avalonia.Skia.RenderTests.csproj" />
     <Project Path="tests/Avalonia.Skia.UnitTests/Avalonia.Skia.UnitTests.csproj" />
+    <Project Path="tests/Avalonia.Themes.UnitTests/Avalonia.Themes.UnitTests.csproj" />
     <Project Path="tests/Avalonia.UnitTests/Avalonia.UnitTests.csproj" />
     <Project Path="tests/Avalonia.Wayland.UnitTests/Avalonia.Wayland.UnitTests.csproj" />
   </Folder>

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -282,6 +282,7 @@ partial class Build : NukeBuild
             RunCoreTest("Avalonia.Markup.UnitTests");
             RunCoreTest("Avalonia.Markup.Xaml.UnitTests");
             RunCoreTest("Avalonia.Skia.UnitTests");
+            RunCoreTest("Avalonia.Themes.UnitTests");
             RunCoreTest("Avalonia.Headless.NUnit.PerAssembly.UnitTests");
             RunCoreTest("Avalonia.Headless.NUnit.PerTest.UnitTests");
             RunCoreTest("Avalonia.Headless.XUnit.PerAssembly.UnitTests");

--- a/src/Avalonia.Base/Avalonia.Base.csproj
+++ b/src/Avalonia.Base/Avalonia.Base.csproj
@@ -47,6 +47,7 @@
     <InternalsVisibleTo Include="Avalonia.LeakTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Markup.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Markup.Xaml.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
+    <InternalsVisibleTo Include="Avalonia.Themes.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Skia.RenderTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Skia.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.UnitTests, PublicKey=$(AvaloniaPublicKey)" />

--- a/src/Avalonia.Controls/Avalonia.Controls.csproj
+++ b/src/Avalonia.Controls/Avalonia.Controls.csproj
@@ -17,6 +17,7 @@
     <InternalsVisibleTo Include="Avalonia.Base.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Controls.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Markup.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
+    <InternalsVisibleTo Include="Avalonia.Themes.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.DesignerSupport, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Diagnostics, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="AvaloniaUI.DiagnosticsSupport.Avalonia, PublicKey=$(AvaloniaPublicKey)" />

--- a/src/Avalonia.Themes.Fluent/Accents/FluentControlResources.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentControlResources.xaml
@@ -546,6 +546,7 @@
       <StaticResource x:Key="ToggleSwitchFillOff" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ToggleSwitchFillOffPointerOver" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ToggleSwitchFillOffPressed" ResourceKey="SystemControlHighlightBaseMediumLowBrush" />
+      <StaticResource x:Key="ToggleSwitchFillOffDisabled" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ToggleSwitchStrokeOff" ResourceKey="SystemControlForegroundBaseMediumBrush" />
       <StaticResource x:Key="ToggleSwitchStrokeOffPointerOver" ResourceKey="SystemControlHighlightBaseMediumHighBrush" />
       <StaticResource x:Key="ToggleSwitchStrokeOffPressed" ResourceKey="SystemControlForegroundBaseHighBrush" />
@@ -678,6 +679,7 @@
       <StaticResource x:Key="ScrollBarButtonBackground" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ScrollBarButtonBackgroundPointerOver" ResourceKey="SystemControlBackgroundListLowBrush" />
       <StaticResource x:Key="ScrollBarButtonBackgroundPressed" ResourceKey="SystemControlBackgroundBaseMediumBrush" />
+      <StaticResource x:Key="ScrollBarButtonBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ScrollBarButtonBorderBrush" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ScrollBarButtonBorderBrushPointerOver" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ScrollBarButtonBorderBrushPressed" ResourceKey="SystemControlTransparentBrush" />
@@ -1393,6 +1395,7 @@
       <StaticResource x:Key="ToggleSwitchFillOff" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ToggleSwitchFillOffPointerOver" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ToggleSwitchFillOffPressed" ResourceKey="SystemControlHighlightBaseMediumLowBrush" />
+      <StaticResource x:Key="ToggleSwitchFillOffDisabled" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ToggleSwitchStrokeOff" ResourceKey="SystemControlForegroundBaseMediumBrush" />
       <StaticResource x:Key="ToggleSwitchStrokeOffPointerOver" ResourceKey="SystemControlHighlightBaseMediumHighBrush" />
       <StaticResource x:Key="ToggleSwitchStrokeOffPressed" ResourceKey="SystemControlForegroundBaseHighBrush" />
@@ -1527,6 +1530,7 @@
       <StaticResource x:Key="ScrollBarButtonBackground" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ScrollBarButtonBackgroundPointerOver" ResourceKey="SystemControlBackgroundListLowBrush" />
       <StaticResource x:Key="ScrollBarButtonBackgroundPressed" ResourceKey="SystemControlBackgroundBaseMediumBrush" />
+      <StaticResource x:Key="ScrollBarButtonBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ScrollBarButtonBorderBrush" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ScrollBarButtonBorderBrushPointerOver" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="ScrollBarButtonBorderBrushPressed" ResourceKey="SystemControlTransparentBrush" />

--- a/src/Avalonia.Themes.Fluent/Accents/FluentControlResources.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentControlResources.xaml
@@ -460,6 +460,7 @@
       <SolidColorBrush x:Key="NotificationCardSuccessBackgroundBrush" Color="#128B44" />
       <SolidColorBrush x:Key="NotificationCardWarningBackgroundBrush" Color="#FFC316" />
       <SolidColorBrush x:Key="NotificationCardErrorBackgroundBrush" Color="#F03916" />
+      <BoxShadows x:Key="NotificationCardBoxShadow">0 6 8 0 #4F000000</BoxShadows>
 
       <!-- Resources for RadioButton.xaml -->
       <x:Double x:Key="RadioButtonBorderThemeThickness">1</x:Double>

--- a/src/Avalonia.Themes.Fluent/Accents/FluentControlResources.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentControlResources.xaml
@@ -1099,6 +1099,7 @@
       <StaticResource x:Key="TextControlBackgroundDisabled" ResourceKey="SystemControlBackgroundBaseLowBrush" />
       <StaticResource x:Key="TextControlBorderBrushFocused" ResourceKey="SystemControlHighlightAccentBrush" />
       <StaticResource x:Key="TextControlBorderBrushDisabled" ResourceKey="SystemControlDisabledBaseLowBrush" />
+      <x:Double x:Key="TextControlPlaceholderOpacity">0.5</x:Double>
       <StaticResource x:Key="TextControlPlaceholderForeground" ResourceKey="SystemControlPageTextBaseMediumBrush" />
       <StaticResource x:Key="TextControlPlaceholderForegroundPointerOver"
                       ResourceKey="SystemControlPageTextBaseMediumBrush" />
@@ -1310,6 +1311,7 @@
       <SolidColorBrush x:Key="NotificationCardSuccessBackgroundBrush" Color="#1F9E45" Opacity="0.75" />
       <SolidColorBrush x:Key="NotificationCardWarningBackgroundBrush" Color="#FDB328" Opacity="0.75" />
       <SolidColorBrush x:Key="NotificationCardErrorBackgroundBrush" Color="#BD202C" Opacity="0.75" />
+      <BoxShadows x:Key="NotificationCardBoxShadow">0 6 8 0 #4F000000</BoxShadows>
 
       <!-- Resources for RadioButton.xaml -->
       <x:Double x:Key="RadioButtonBorderThemeThickness">1</x:Double>

--- a/src/Avalonia.Themes.Fluent/Controls/CarouselPage.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CarouselPage.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <Design.PreviewWith>
     <Border Width="400" Height="300">
       <CarouselPage>

--- a/src/Avalonia.Themes.Fluent/Controls/ContentPage.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ContentPage.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <Design.PreviewWith>
     <ContentPage Header="Sample Page">
       <TextBlock Text="Content goes here"

--- a/src/Avalonia.Themes.Fluent/Controls/DrawerPage.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/DrawerPage.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <Design.PreviewWith>
     <DrawerPage Header="Sample Drawer Page"
                 DrawerLength="200"

--- a/src/Avalonia.Themes.Fluent/Controls/ManagedFileChooser.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ManagedFileChooser.xaml
@@ -4,6 +4,8 @@
         xmlns:internal="using:Avalonia.Dialogs.Internal"
         xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls"
         x:ClassModifier="internal">
+  <BoxShadows x:Key="ManagedFileChooserQuickLinksBoxShadow">inset -6 0 3 -3 #20000000</BoxShadows>
+
   <Design.PreviewWith>
     <Border Padding="20" Width="800" Height="500">
       <dialogs:ManagedFileChooser/>
@@ -283,7 +285,7 @@
       <Setter Property="Padding" Value="{DynamicResource ManagedFileChooserQuickLinksPadding}"/>
       <Setter Property="Template">
         <ControlTemplate>
-          <Border Name="border" BoxShadow="inset -6 0 3 -3 #20000000" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+          <Border Name="border" BoxShadow="{DynamicResource ManagedFileChooserQuickLinksBoxShadow}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
             <ScrollViewer Name="PART_ScrollViewer" HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}" VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
               <ItemsPresenter Name="PART_ItemsPresenter"
                               ItemsPanel="{TemplateBinding ItemsPanel}"

--- a/src/Avalonia.Themes.Fluent/Controls/NavigationPage.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/NavigationPage.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <Design.PreviewWith>
     <Border Width="400" Height="600">
       <NavigationPage />

--- a/src/Avalonia.Themes.Fluent/Controls/NavigationPage.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/NavigationPage.xaml
@@ -14,6 +14,11 @@
   <SolidColorBrush x:Key="NavigationBarBackground" Color="{DynamicResource SystemChromeMediumColor}" />
   <SolidColorBrush x:Key="NavigationBarForeground" Color="{DynamicResource SystemBaseMediumColor}" />
 
+  <LinearGradientBrush x:Key="NavigationBarShadowBackground" StartPoint="0%,0%" EndPoint="0%,100%">
+    <GradientStop Color="#0C000000" Offset="0" />
+    <GradientStop Color="#00000000" Offset="1" />
+  </LinearGradientBrush>
+
   <ControlTheme x:Key="{x:Type NavigationPage}" TargetType="NavigationPage">
     <!-- Transparent keeps the hit-test surface active for the back-swipe gesture edge area. -->
     <Setter Property="Background" Value="Transparent" />
@@ -183,14 +188,8 @@
                   VerticalAlignment="Top"
                   IsVisible="False"
                   Height="4"
-                  IsHitTestVisible="False">
-            <Border.Background>
-              <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
-                <GradientStop Color="#0C000000" Offset="0" />
-                <GradientStop Color="#00000000" Offset="1" />
-              </LinearGradientBrush>
-            </Border.Background>
-          </Border>
+                  IsHitTestVisible="False"
+                  Background="{DynamicResource NavigationBarShadowBackground}" />
 
           <!-- Modal overlay: ZIndex=99 holds the static layer during transitions; ZIndex=100 is the animating modal. -->
           <ContentPresenter Name="PART_ModalBackPresenter"

--- a/src/Avalonia.Themes.Fluent/Controls/NotificationCard.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/NotificationCard.xaml
@@ -17,7 +17,7 @@
     <Setter Property="Template">
       <ControlTemplate>
         <LayoutTransformControl Name="PART_LayoutTransformControl" UseRenderTransform="True">
-          <Border CornerRadius="{TemplateBinding CornerRadius}" BoxShadow="0 6 8 0 #4F000000" Margin="5 5 5 10">
+          <Border CornerRadius="{TemplateBinding CornerRadius}" BoxShadow="{DynamicResource NotificationCardBoxShadow}" Margin="5 5 5 10">
             <Border Background="{TemplateBinding Background}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"

--- a/src/Avalonia.Themes.Fluent/Controls/PipsPager.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/PipsPager.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <Design.PreviewWith>
     <PipsPager NumberOfPages="5" SelectedPageIndex="2" />
   </Design.PreviewWith>

--- a/src/Avalonia.Themes.Fluent/Controls/TabbedPage.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/TabbedPage.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <Design.PreviewWith>
     <Border Width="400" Height="400">
       <TabbedPage>

--- a/src/Avalonia.Themes.Fluent/Controls/TextSelectionHandle.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/TextSelectionHandle.xaml
@@ -1,5 +1,6 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <Design.PreviewWith>
     <Grid>
       <Border>

--- a/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
@@ -4,6 +4,7 @@
 
   <x:Double x:Key="CaptionButtonWidth">45</x:Double>
   <x:Double x:Key="CaptionButtonHeight">30</x:Double>
+  <BoxShadows x:Key="WindowDrawnDecorationsWindowBorderBoxShadow">0 2 10 2 #80000000</BoxShadows>
 
   <ControlTheme x:Key="FluentDrawnCaptionButton" TargetType="Button">
     <Setter Property="Background" Value="{DynamicResource CaptionButtonBackground}" />
@@ -170,7 +171,7 @@
       <Setter Property="Margin" Value="{TemplateBinding ShadowThickness}"/>
     </Style>
     <Style Selector="^:has-shadow /template/ Border#PART_WindowBorder">
-      <Setter Property="BoxShadow" Value="0 2 10 2 #80000000"/>
+      <Setter Property="BoxShadow" Value="{DynamicResource WindowDrawnDecorationsWindowBorderBoxShadow}"/>
     </Style>
     <Style Selector="^:has-shadow /template/ Panel#PART_OverlayWrapper">
       <Setter Property="Margin" Value="{TemplateBinding ShadowThickness}"/>

--- a/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml
@@ -5,6 +5,8 @@
   <x:Double x:Key="CaptionButtonWidth">45</x:Double>
   <x:Double x:Key="CaptionButtonHeight">30</x:Double>
   <BoxShadows x:Key="WindowDrawnDecorationsWindowBorderBoxShadow">0 2 10 2 #80000000</BoxShadows>
+  <SolidColorBrush x:Key="CaptionButtonCloseBackground" Color="#ffe81123" />
+  <SolidColorBrush x:Key="CaptionButtonCloseBorderBrush" Color="#fff1707a" />
 
   <ControlTheme x:Key="FluentDrawnCaptionButton" TargetType="Button">
     <Setter Property="Background" Value="{DynamicResource CaptionButtonBackground}" />
@@ -110,8 +112,8 @@
                   </Viewbox>
                 </Button>
                 <Button x:Name="PART_CloseButton"
-                        Background="#ffe81123"
-                        BorderBrush="#fff1707a"
+                        Background="{DynamicResource CaptionButtonCloseBackground}"
+                        BorderBrush="{DynamicResource CaptionButtonCloseBorderBrush}"
                         Theme="{StaticResource FluentDrawnCaptionButton}"
                         WindowDecorationProperties.ElementRole="CloseButton">
                   <Viewbox Width="11" Margin="2">
@@ -148,8 +150,8 @@
                   </Viewbox>
                 </Button>
                 <Button x:Name="PART_PopoverCloseButton"
-                        Background="#ffe81123"
-                        BorderBrush="#fff1707a"
+                        Background="{DynamicResource CaptionButtonCloseBackground}"
+                        BorderBrush="{DynamicResource CaptionButtonCloseBorderBrush}"
                         Theme="{StaticResource FluentDrawnCaptionButton}"
                         WindowDecorationProperties.ElementRole="CloseButton">
                   <Viewbox Width="11" Margin="2">

--- a/src/Avalonia.Themes.Fluent/Strings/InvariantResources.xaml
+++ b/src/Avalonia.Themes.Fluent/Strings/InvariantResources.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:ClassModifier="internal">
   <!-- Calendar -->
-  <x:String x:Key="StringCalendarWeekNumberHeader"> </x:String> <!-- Just one whitespace to preserve the resource -->
+  <x:String x:Key="StringCalendarWeekNumberHeader">&#160;</x:String> <!-- Just one non-breaking space to preserve the resource -->
   <!-- DatePicker -->
   <x:String x:Key="StringDatePickerDayText">day</x:String>
   <x:String x:Key="StringDatePickerMonthText">month</x:String>

--- a/src/Avalonia.Themes.Simple/Accents/Base.xaml
+++ b/src/Avalonia.Themes.Simple/Accents/Base.xaml
@@ -117,6 +117,9 @@
     Opacity="0.75"
     Color="#444444" />
   <SolidColorBrush
+    x:Key="NotificationCardForegroundBrush"
+    Color="White" />
+  <SolidColorBrush
     x:Key="NotificationCardInformationBackgroundBrush"
     Opacity="0.75"
     Color="#007ACC" />

--- a/src/Avalonia.Themes.Simple/Controls/CarouselPage.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/CarouselPage.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <Design.PreviewWith>
     <Border Width="400" Height="300">
       <CarouselPage>

--- a/src/Avalonia.Themes.Simple/Controls/ContentPage.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ContentPage.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <Design.PreviewWith>
     <ContentPage Header="Sample Page">
       <TextBlock Text="Content goes here"

--- a/src/Avalonia.Themes.Simple/Controls/DrawerPage.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/DrawerPage.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <Design.PreviewWith>
     <DrawerPage Header="Sample Drawer Page"
                 DrawerLength="200"

--- a/src/Avalonia.Themes.Simple/Controls/NavigationPage.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/NavigationPage.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <Design.PreviewWith>
     <Border Width="400" Height="600">
       <NavigationPage />

--- a/src/Avalonia.Themes.Simple/Controls/NavigationPage.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/NavigationPage.xaml
@@ -14,6 +14,11 @@
   <SolidColorBrush x:Key="NavigationBarBackground" Color="{DynamicResource ThemeControlMidColor}" />
   <SolidColorBrush x:Key="NavigationBarForeground" Color="{DynamicResource ThemeForegroundColor}" />
 
+  <LinearGradientBrush x:Key="NavigationBarShadowBackground" StartPoint="0%,0%" EndPoint="0%,100%">
+    <GradientStop Color="#0C000000" Offset="0" />
+    <GradientStop Color="#00000000" Offset="1" />
+  </LinearGradientBrush>
+
   <ControlTheme x:Key="{x:Type NavigationPage}" TargetType="NavigationPage">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="PageTransition">
@@ -164,14 +169,8 @@
                   VerticalAlignment="Top"
                   IsVisible="False"
                   Height="4"
-                  IsHitTestVisible="False">
-            <Border.Background>
-              <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
-                <GradientStop Color="#0C000000" Offset="0" />
-                <GradientStop Color="#00000000" Offset="1" />
-              </LinearGradientBrush>
-            </Border.Background>
-          </Border>
+                  IsHitTestVisible="False"
+                  Background="{DynamicResource NavigationBarShadowBackground}" />
 
           <ContentPresenter Name="PART_ModalBackPresenter"
                             ZIndex="99"

--- a/src/Avalonia.Themes.Simple/Controls/NotificationCard.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/NotificationCard.xaml
@@ -7,7 +7,7 @@
     <Setter Property="UseLayoutRounding" Value="True" />
     <Setter Property="Width" Value="350" />
     <Setter Property="FontSize" Value="{DynamicResource FontSizeLarge}" />
-    <Setter Property="Foreground" Value="White" />
+    <Setter Property="Foreground" Value="{DynamicResource NotificationCardForegroundBrush}" />
     <Setter Property="RenderTransformOrigin" Value="50%,75%" />
     <Setter Property="Template">
       <ControlTemplate>

--- a/src/Avalonia.Themes.Simple/Controls/PipsPager.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/PipsPager.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <Design.PreviewWith>
     <PipsPager NumberOfPages="5" SelectedPageIndex="2" />
   </Design.PreviewWith>

--- a/src/Avalonia.Themes.Simple/Controls/TabbedPage.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/TabbedPage.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <Design.PreviewWith>
     <Border Width="400" Height="400">
       <TabbedPage>

--- a/src/Avalonia.Themes.Simple/Controls/TextSelectionHandle.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/TextSelectionHandle.xaml
@@ -1,5 +1,6 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
   <x:Double x:Key="TextSelectHandleSize">24</x:Double>
   <DrawingImage x:Key="TextSelectionHandleDrawing">
     <DrawingImage.Drawing>

--- a/src/Avalonia.Themes.Simple/Controls/WindowDrawnDecorations.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/WindowDrawnDecorations.xaml
@@ -5,6 +5,8 @@
   <x:Double x:Key="CaptionButtonWidth">45</x:Double>
   <x:Double x:Key="CaptionButtonHeight">30</x:Double>
   <BoxShadows x:Key="WindowDrawnDecorationsWindowBorderBoxShadow">0 2 10 2 #80000000</BoxShadows>
+  <SolidColorBrush x:Key="CaptionButtonCloseBackground" Color="#ffe81123" />
+  <SolidColorBrush x:Key="CaptionButtonCloseBorderBrush" Color="#fff1707a" />
 
   <ControlTheme x:Key="SimpleDrawnCaptionButton" TargetType="Button">
     <Setter Property="Background" Value="{DynamicResource CaptionButtonBackground}" />
@@ -111,8 +113,8 @@
                   </Viewbox>
                 </Button>
                 <Button x:Name="PART_CloseButton"
-                        Background="#ffe81123"
-                        BorderBrush="#fff1707a"
+                        Background="{DynamicResource CaptionButtonCloseBackground}"
+                        BorderBrush="{DynamicResource CaptionButtonCloseBorderBrush}"
                         Theme="{StaticResource SimpleDrawnCaptionButton}"
                         WindowDecorationProperties.ElementRole="CloseButton"
                         AutomationProperties.Name="Close">
@@ -135,7 +137,7 @@
               <TextBlock x:Name="PART_PopoverTitleText"
                          Text="{TemplateBinding Title}"
                          VerticalAlignment="Center"
-                         Foreground="White"
+                         Foreground="{DynamicResource HighlightForegroundBrush}"
                          Margin="12,0,0,0"
                          FontSize="12" />
               <StackPanel HorizontalAlignment="Right"
@@ -152,8 +154,8 @@
                   </Viewbox>
                 </Button>
                 <Button x:Name="PART_PopoverCloseButton"
-                        Background="#ffe81123"
-                        BorderBrush="#fff1707a"
+                        Background="{DynamicResource CaptionButtonCloseBackground}"
+                        BorderBrush="{DynamicResource CaptionButtonCloseBorderBrush}"
                         Theme="{StaticResource SimpleDrawnCaptionButton}"
                         WindowDecorationProperties.ElementRole="CloseButton"
                         AutomationProperties.Name="Close">

--- a/src/Avalonia.Themes.Simple/Controls/WindowDrawnDecorations.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/WindowDrawnDecorations.xaml
@@ -4,6 +4,7 @@
 
   <x:Double x:Key="CaptionButtonWidth">45</x:Double>
   <x:Double x:Key="CaptionButtonHeight">30</x:Double>
+  <BoxShadows x:Key="WindowDrawnDecorationsWindowBorderBoxShadow">0 2 10 2 #80000000</BoxShadows>
 
   <ControlTheme x:Key="SimpleDrawnCaptionButton" TargetType="Button">
     <Setter Property="Background" Value="{DynamicResource CaptionButtonBackground}" />
@@ -175,7 +176,7 @@
       <Setter Property="Margin" Value="{TemplateBinding ShadowThickness}"/>
     </Style>
     <Style Selector="^:has-shadow /template/ Border#PART_WindowBorder">
-      <Setter Property="BoxShadow" Value="0 2 10 2 #80000000"/>
+      <Setter Property="BoxShadow" Value="{DynamicResource WindowDrawnDecorationsWindowBorderBoxShadow}"/>
     </Style>
     <Style Selector="^:has-shadow /template/ Panel#PART_OverlayWrapper">
       <Setter Property="Margin" Value="{TemplateBinding ShadowThickness}"/>

--- a/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
@@ -71,6 +71,7 @@
     <InternalsVisibleTo Include="Avalonia.Designer.HostApp, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.DesignerSupport, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Base.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
+    <InternalsVisibleTo Include="Avalonia.Themes.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Markup.Xaml.Loader, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Markup.Xaml.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
   </ItemGroup>

--- a/src/Markup/Avalonia.Markup.Xaml/Data/DynamicResourceExpression.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Data/DynamicResourceExpression.cs
@@ -32,6 +32,8 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
             _themeVariant = themeVariant;
         }
 
+        internal object ResourceKey => _resourceKey;
+
         public override string Description => $"DynamicResource {_resourceKey}";
 
         protected override void StartCore()

--- a/tests/Avalonia.Themes.UnitTests/Avalonia.Themes.UnitTests.csproj
+++ b/tests/Avalonia.Themes.UnitTests/Avalonia.Themes.UnitTests.csproj
@@ -15,5 +15,6 @@
   <Import Project="..\..\build\XUnit.props" />
   <Import Project="..\..\build\Base.props" />
   <Import Project="..\..\build\NullableEnable.props" />
+  <Import Project="..\..\build\SharedVersion.props" />
   <Import Project="..\..\build\UnitTests.NetCore.targets" />
 </Project>

--- a/tests/Avalonia.Themes.UnitTests/Avalonia.Themes.UnitTests.csproj
+++ b/tests/Avalonia.Themes.UnitTests/Avalonia.Themes.UnitTests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(AvsCurrentTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Avalonia.UnitTests\Avalonia.UnitTests.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.Themes.Fluent\Avalonia.Themes.Fluent.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.Themes.Simple\Avalonia.Themes.Simple.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\..\build\XUnit.props" />
+  <Import Project="..\..\build\Base.props" />
+  <Import Project="..\..\build\NullableEnable.props" />
+  <Import Project="..\..\build\UnitTests.NetCore.targets" />
+</Project>

--- a/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Avalonia.Controls;
 using Avalonia.Controls.Chrome;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Dialogs;
 using Avalonia.Markup.Xaml.MarkupExtensions;
@@ -69,6 +70,65 @@ public abstract class ControlThemeTests(Type typeEntryPoint) : ThemeTestBase(typ
             .ToHashSet();
 
         Assert.All(templatedControls, c => Assert.Contains(c, defaultControlThemes));
+    }
+
+    [Fact]
+    public void Should_Define_All_Requested_Template_Parts()
+    {
+        var theme = CreateAttachedTheme();
+        var defaultControlThemes = theme.EnumerateResources()
+            .Where(r => r is { Value: ControlTheme, Key: Type })
+            .Where(r => r.ThemeVariant == ThemeVariant.Default)
+            .Select(r => (ControlTheme)r.Value!);
+
+        var controlTypesToSkip = new Dictionary<Type, HashSet<string>>
+        {
+            // AutoCompleteBox has optional PART_SelectionAdapter, that was never defined in templates for "historical reasons".
+            [typeof(AutoCompleteBox)] = ["PART_SelectionAdapter"],
+            // ScrollBar, SplitView and Slider define templates per specific pseudoclasses, making it harder to test.
+            [typeof(ScrollBar)] = [],
+            [typeof(SplitView)] = [],
+            [typeof(Slider)] = []
+        };
+
+        Assert.All(defaultControlThemes, controlTheme =>
+        {
+            Assert.NotNull(controlTheme.TargetType);
+
+            // TemplatePart can be IsRequired=false, if it's not essential for the control to function.
+            // But for built-in default themes we expect all of them to be present.
+            // Exception is optional template parts from the base class, that were inherited and ignored by the control.
+            var requestedParts = controlTheme.TargetType
+                .GetCustomAttributes<TemplatePartAttribute>(inherit: false)
+                .Concat(controlTheme.TargetType
+                    .GetCustomAttributes<TemplatePartAttribute>(inherit: true).Where(p => p.IsRequired))
+                .Distinct()
+                .ToArray();
+
+            if (controlTypesToSkip.TryGetValue(controlTheme.TargetType, out var skipParts))
+            {
+                if (skipParts.Count == 0)
+                {
+                    return;
+                }
+
+                requestedParts = requestedParts.Where(p => !skipParts.Contains(p.Name)).ToArray();
+            }
+            
+            if (requestedParts.Length == 0)
+            {
+                return;
+            }
+
+            var template = controlTheme.ResolveTemplate();
+            Assert.NotNull(template);
+
+            Assert.All(requestedParts, part =>
+            {
+                var foundPart = template.NameScope.Find(part.Name);
+                Assert.IsType(part.Type, foundPart, exactMatch: false);
+            });
+        });
     }
 
     [Fact]

--- a/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
@@ -7,6 +7,8 @@ using Avalonia.Controls;
 using Avalonia.Controls.Chrome;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Diagnostics;
 using Avalonia.Dialogs;
 using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Media;
@@ -120,7 +122,7 @@ public abstract class ControlThemeTests(Type typeEntryPoint) : ThemeTestBase(typ
                 return;
             }
 
-            var template = controlTheme.ResolveTemplate();
+            var template = controlTheme.ResolveTemplateResult();
             Assert.NotNull(template);
 
             Assert.All(requestedParts, part =>
@@ -146,18 +148,37 @@ public abstract class ControlThemeTests(Type typeEntryPoint) : ThemeTestBase(typ
             .Where(r => r.ThemeVariant == ThemeVariant.Default)
             .Select(r => (ControlTheme)r.Value!);
 
-        // Enumerate all nested styles and retrieve full list of Setters
-        var allSetters = controlThemes
-            .SelectMany(t => t.EnumerateStyles())
-            .SelectMany(t => t.Setters);
-        var allDynamicResourceKeys = allSetters.OfType<Setter>()
-            .Select(s => s.Value)
-            .OfType<DynamicResourceExtension>()
-            .Select(r => r.ResourceKey);
-
-        Assert.All(allDynamicResourceKeys, c =>
+        Assert.All(controlThemes, controlTheme =>
         {
-            Assert.Contains(c, allResourcesPerVariant[ThemeVariant.Default]);
+            Assert.All(controlTheme.EnumerateStyles(), style =>
+            {
+                var allDynamicResourceKeys = style.Setters.OfType<Setter>()
+                    .Select(s => s.Value)
+                    .OfType<DynamicResourceExtension>()
+                    .Select(r => r.ResourceKey);
+
+                Assert.All(allDynamicResourceKeys, c =>
+                {
+                    Assert.Contains(c, allResourcesPerVariant[ThemeVariant.Default]);
+                });
+            });
+
+            Assert.All(controlTheme.EnumerateTemplateChildren(), templatePart =>
+            {
+                var allTemplateDynamicResourceKeys = templatePart.GetValueStoreDiagnostic()
+                    .AppliedFrames
+                    .SelectMany(f => f.Values)
+                    .Select(v => v.Property)
+                    .Distinct()
+                    .Select(prop => BindingOperations.GetBindingExpressionBase(templatePart, prop))
+                    .OfType<DynamicResourceExpression>()
+                    .Select(expr => expr.ResourceKey);
+
+                Assert.All(allTemplateDynamicResourceKeys, c =>
+                {
+                    Assert.Contains(c, allResourcesPerVariant[ThemeVariant.Default]);
+                });
+            });
         });
     }
 
@@ -171,21 +192,47 @@ public abstract class ControlThemeTests(Type typeEntryPoint) : ThemeTestBase(typ
             .Where(r => r.ThemeVariant == ThemeVariant.Default)
             .Select(r => (ControlTheme)r.Value!);
 
-        // Enumerate all nested styles and retrieve full list of Setters
-        var allSetters = controlThemes
-            .SelectMany(t => t.EnumerateStyles())
-            .SelectMany(t => t.Setters);
-        var allHardcodedColors = allSetters.OfType<Setter>()
-            .Where(s => s.Value switch
+        Assert.All(controlThemes, controlTheme =>
+        {
+            Assert.All(controlTheme.EnumerateStyles(), style =>
             {
-                Color c => !IsTransparentOrEmpty(c),
-                ISolidColorBrush b => !IsTransparentOrEmpty(b.Color),
-                IBrush => true,
-                _ => false
-            })
-            .DistinctBy(s => s.Value);
+                var allHardcodedSetterColors = style.Setters.OfType<Setter>()
+                    .Where(s => s.Value switch
+                    {
+                        Color c => !IsTransparentOrEmpty(c),
+                        ISolidColorBrush b => !IsTransparentOrEmpty(b.Color),
+                        IBrush => true,
+                        _ => false
+                    })
+                    .DistinctBy(s => s.Value);
 
-        Assert.Empty(allHardcodedColors);
+                Assert.Empty(allHardcodedSetterColors);
+            });
+
+            Assert.All(controlTheme.EnumerateTemplateChildren(), templatePart =>
+            {
+                var allHardcodedTemplateColors = templatePart.GetValueStoreDiagnostic()
+                    .AppliedFrames
+                    // Skip local values, as these are set from the code-behind, not XAML templates.
+                    .Where(f => f.Type != IValueFrameDiagnostic.FrameType.Local)
+                    .SelectMany(f => f.Values)
+                    .Where(d => BindingOperations.GetBindingExpressionBase(templatePart, d.Property) is null)
+                    .Where(d => d.Value switch
+                    {
+                        Color c => !IsTransparentOrEmpty(c),
+                        ISolidColorBrush b => !IsTransparentOrEmpty(b.Color),
+                        IBrush => true,
+                        _ => false
+                    })
+                    .DistinctBy(s => s.Value);
+
+                if (allHardcodedTemplateColors.Count() > 0)
+                {
+                    
+                }
+                Assert.Empty(allHardcodedTemplateColors);
+            });
+        });
 
         static bool IsTransparentOrEmpty(Color color) => color == Colors.Transparent || color == default;
     }

--- a/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Avalonia.Controls;
+using Avalonia.Controls.Chrome;
+using Avalonia.Controls.Primitives;
+using Avalonia.Dialogs;
+using Avalonia.Markup.Xaml.MarkupExtensions;
+using Avalonia.Styling;
+using Avalonia.Themes.Fluent;
+using Avalonia.Themes.Simple;
+using Avalonia.Themes.UnitTests.Utilities;
+using Xunit;
+
+namespace Avalonia.Themes.UnitTests;
+
+public class FluentControlThemeTests() : ControlThemeTests(typeof(FluentTheme));
+public class SimpleControlThemeTests() : ControlThemeTests(typeof(SimpleTheme));
+
+public abstract class ControlThemeTests(Type typeEntryPoint) : ThemeTestBase(typeEntryPoint)
+{
+    [Fact]
+    public void Should_Not_Contain_Any_Global_Styles()
+    {
+        // For performance reasons, we want all styles to be enclosed in ControlThemes,
+        // without selectors that apply globally.
+
+        var theme = CreateAttachedTheme();
+        var allStyles = theme.EnumerateStyles();
+        Assert.DoesNotContain(allStyles, s => s.Parent is null);
+    }
+
+    [Fact]
+    public void Should_Define_ControlTheme_For_BuiltIn_Templated_Controls()
+    {
+        Assembly[] assembliesToScan = [typeof(Control).Assembly, typeof(ManagedFileChooser).Assembly];
+        HashSet<Type> ignoredControls =
+        [
+            typeof(Control), typeof(TemplatedControl), typeof(ContentControl), typeof(NativeMenuBar),
+            typeof(HeaderedItemsControl), typeof(HeaderedSelectingItemsControl), typeof(SelectingItemsControl),
+            typeof(Thumb)
+        ];
+
+        var templatedControls = assembliesToScan.SelectMany(s => s.GetTypes())
+            // Resolve all public non-abstract TemplatedControls
+            // Technically, any StyledElement can have a control theme,
+            // but templated control are ones that won't work without one.
+            .Where(t => t is { DeclaringType: null, IsAbstract: false, IsPublic: true }
+                        && typeof(TemplatedControl).IsAssignableFrom(t) && t.GetConstructor([]) is not null)
+            // Respect StyleKeyOverride, and we don't care about initializing the object itself (skip ctor)
+            .Select(t => (RuntimeHelpers.GetUninitializedObject(t) as StyledElement)?.StyleKey ?? t)
+            .Distinct()
+            // Filter common types that we don't style 
+            .Where(t => !typeof(UserControl).IsAssignableFrom(t)
+                        && (!typeof(Window).IsAssignableFrom(t) || t == typeof(Window))
+                        && !ignoredControls.Contains(t))
+            // WindowDrawnDecorations is the only StyleElement that is not Control but has ControlTheme
+            .Prepend(typeof(WindowDrawnDecorations));
+
+        var theme = CreateAttachedTheme();
+        var defaultControlThemes = theme.EnumerateResources()
+            .Where(r => r is { Value: ControlTheme, Key: Type })
+            // Default ControlThemes must not be defined per specific ThemeVariant.
+            .Where(r => r.ThemeVariant == ThemeVariant.Default)
+            .Select(r => (Type)r.Key)
+            .ToHashSet();
+
+        Assert.All(templatedControls, c => Assert.Contains(c, defaultControlThemes));
+    }
+
+    [Fact]
+    public void Should_Create_Setters_With_Valid_Dynamic_Resources()
+    {
+        // Validate that <Setter Value="{DynamicResource}"> points to an actually defined resource.
+        // Unfortunately, we can't reliably include DynamicResource from templates
+
+        var theme = CreateAttachedTheme();
+        var allResourcesPerVariant = theme.EnumerateResources().GroupBy(r => r.ThemeVariant)
+            .ToDictionary(g => g.Key, g => g.Select(r => r.Key).ToList());
+
+        var controlThemes = theme.EnumerateResources()
+            .Where(r => r is { Value: ControlTheme })
+            .Where(r => r.ThemeVariant == ThemeVariant.Default)
+            .Select(r => (ControlTheme)r.Value!);
+
+        // Enumerate all nested styles and retrieve full list of Setters
+        var allSetters = controlThemes
+            .SelectMany(t => t.EnumerateStyles())
+            .SelectMany(t => t.Setters);
+        var allDynamicResourceKeys = allSetters.OfType<Setter>()
+            .Select(s => s.Value)
+            .OfType<DynamicResourceExtension>()
+            .Select(r => r.ResourceKey);
+
+        Assert.All(allDynamicResourceKeys, c =>
+        {
+            Assert.Contains(c, allResourcesPerVariant[ThemeVariant.Default]);
+        });
+    }
+}

--- a/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
@@ -196,44 +196,35 @@ public abstract class ControlThemeTests(Type typeEntryPoint) : ThemeTestBase(typ
         {
             Assert.All(controlTheme.EnumerateStyles(), style =>
             {
-                var allHardcodedSetterColors = style.Setters.OfType<Setter>()
-                    .Where(s => s.Value switch
-                    {
-                        Color c => !IsTransparentOrEmpty(c),
-                        ISolidColorBrush b => !IsTransparentOrEmpty(b.Color),
-                        IBrush => true,
-                        _ => false
-                    })
-                    .DistinctBy(s => s.Value);
-
-                Assert.Empty(allHardcodedSetterColors);
+                AssertValues(style.Setters.OfType<Setter>().ToArray(), setter => setter.Value);
             });
 
             Assert.All(controlTheme.EnumerateTemplateChildren(), templatePart =>
             {
-                var allHardcodedTemplateColors = templatePart.GetValueStoreDiagnostic()
+                var hardcodedValueEntries = templatePart.GetValueStoreDiagnostic()
                     .AppliedFrames
                     // Skip local values, as these are set from the code-behind, not XAML templates.
                     .Where(f => f.Type != IValueFrameDiagnostic.FrameType.Local)
                     .SelectMany(f => f.Values)
                     .Where(d => BindingOperations.GetBindingExpressionBase(templatePart, d.Property) is null)
-                    .Where(d => d.Value switch
-                    {
-                        Color c => !IsTransparentOrEmpty(c),
-                        ISolidColorBrush b => !IsTransparentOrEmpty(b.Color),
-                        IBrush => true,
-                        _ => false
-                    })
-                    .DistinctBy(s => s.Value);
+                    .ToArray();
 
-                if (allHardcodedTemplateColors.Count() > 0)
-                {
-                    
-                }
-                Assert.Empty(allHardcodedTemplateColors);
+                AssertValues(hardcodedValueEntries, expr => expr.Value);
             });
         });
 
+        void AssertValues<T>(IReadOnlyCollection<T> hardcodeValueEntries, Func<T, object?> getValue)
+        {
+            Assert.DoesNotContain(hardcodeValueEntries, d => getValue(d) switch
+            {
+                Color c => !IsTransparentOrEmpty(c),
+                ISolidColorBrush b => !IsTransparentOrEmpty(b.Color),
+                IBrush => true,
+                BoxShadows => true,
+                _ => false
+            });
+        }
+        
         static bool IsTransparentOrEmpty(Color color) => color == Colors.Transparent || color == default;
     }
 }

--- a/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
@@ -20,7 +20,9 @@ using Xunit;
 
 namespace Avalonia.Themes.UnitTests;
 
+[Trait("Category", "FluentTheme")]
 public class FluentControlThemeTests() : ControlThemeTests(typeof(FluentTheme));
+[Trait("Category", "SimpleTheme")]
 public class SimpleControlThemeTests() : ControlThemeTests(typeof(SimpleTheme));
 
 public abstract class ControlThemeTests(Type typeEntryPoint) : ThemeTestBase(typeEntryPoint)

--- a/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
@@ -150,22 +150,19 @@ public abstract class ControlThemeTests(Type typeEntryPoint) : ThemeTestBase(typ
             .Where(r => r.ThemeVariant == ThemeVariant.Default)
             .Select(r => (ControlTheme)r.Value!);
 
-        Assert.All(controlThemes, controlTheme =>
+        Assert.All(controlThemes.SelectMany(t => t.EnumerateStyles()), style =>
         {
-            Assert.All(controlTheme.EnumerateStyles(), style =>
-            {
-                var allDynamicResourceKeys = style.Setters.OfType<Setter>()
-                    .Select(s => s.Value)
-                    .OfType<DynamicResourceExtension>()
-                    .Select(r => r.ResourceKey);
+            var allDynamicResourceKeys = style.Setters.OfType<Setter>()
+                .Select(s => s.Value)
+                .OfType<DynamicResourceExtension>()
+                .Select(r => r.ResourceKey);
 
-                Assert.All(allDynamicResourceKeys, c =>
-                {
-                    Assert.Contains(c, allResourcesPerVariant[ThemeVariant.Default]);
-                });
+            Assert.All(allDynamicResourceKeys, c =>
+            {
+                Assert.Contains(c, allResourcesPerVariant[ThemeVariant.Default]);
             });
 
-            Assert.All(controlTheme.EnumerateTemplateChildren(), templatePart =>
+            Assert.All(style.EnumerateTemplateChildren(), templatePart =>
             {
                 var allTemplateDynamicResourceKeys = templatePart.GetValueStoreDiagnostic()
                     .AppliedFrames
@@ -194,14 +191,11 @@ public abstract class ControlThemeTests(Type typeEntryPoint) : ThemeTestBase(typ
             .Where(r => r.ThemeVariant == ThemeVariant.Default)
             .Select(r => (ControlTheme)r.Value!);
 
-        Assert.All(controlThemes, controlTheme =>
+        Assert.All(controlThemes.SelectMany(t => t.EnumerateStyles()), style =>
         {
-            Assert.All(controlTheme.EnumerateStyles(), style =>
-            {
-                AssertValues(style.Setters.OfType<Setter>().ToArray(), setter => setter.Value);
-            });
+            AssertValues(style.Setters.OfType<Setter>().ToArray(), setter => setter.Value);
 
-            Assert.All(controlTheme.EnumerateTemplateChildren(), templatePart =>
+            Assert.All(style.EnumerateTemplateChildren(), templatePart =>
             {
                 var hardcodedValueEntries = templatePart.GetValueStoreDiagnostic()
                     .AppliedFrames

--- a/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/ControlThemeTests.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls.Chrome;
 using Avalonia.Controls.Primitives;
 using Avalonia.Dialogs;
 using Avalonia.Markup.Xaml.MarkupExtensions;
+using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Themes.Fluent;
 using Avalonia.Themes.Simple;
@@ -71,7 +72,7 @@ public abstract class ControlThemeTests(Type typeEntryPoint) : ThemeTestBase(typ
     }
 
     [Fact]
-    public void Should_Create_Setters_With_Valid_Dynamic_Resources()
+    public void Should_Define_Setters_With_Valid_Dynamic_Resources()
     {
         // Validate that <Setter Value="{DynamicResource}"> points to an actually defined resource.
         // Unfortunately, we can't reliably include DynamicResource from templates
@@ -98,5 +99,34 @@ public abstract class ControlThemeTests(Type typeEntryPoint) : ThemeTestBase(typ
         {
             Assert.Contains(c, allResourcesPerVariant[ThemeVariant.Default]);
         });
+    }
+
+    [Fact]
+    public void Should_Not_Define_Setters_With_Hardcoded_Brushes_Or_Colors()
+    {
+        var theme = CreateAttachedTheme();
+
+        var controlThemes = theme.EnumerateResources()
+            .Where(r => r is { Value: ControlTheme })
+            .Where(r => r.ThemeVariant == ThemeVariant.Default)
+            .Select(r => (ControlTheme)r.Value!);
+
+        // Enumerate all nested styles and retrieve full list of Setters
+        var allSetters = controlThemes
+            .SelectMany(t => t.EnumerateStyles())
+            .SelectMany(t => t.Setters);
+        var allHardcodedColors = allSetters.OfType<Setter>()
+            .Where(s => s.Value switch
+            {
+                Color c => !IsTransparentOrEmpty(c),
+                ISolidColorBrush b => !IsTransparentOrEmpty(b.Color),
+                IBrush => true,
+                _ => false
+            })
+            .DistinctBy(s => s.Value);
+
+        Assert.Empty(allHardcodedColors);
+
+        static bool IsTransparentOrEmpty(Color color) => color == Colors.Transparent || color == default;
     }
 }

--- a/tests/Avalonia.Themes.UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/Avalonia.Themes.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Avalonia.Themes.UnitTests/PublicApiTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/PublicApiTests.cs
@@ -15,6 +15,10 @@ public abstract class PublicApiTests(Type typeEntryPoint) : ThemeTestBase(typeEn
     [Fact]
     public void Should_Not_Include_Any_Reachable_Xaml_Files()
     {
+        // This test looks up any control themes or other XAML files,
+        // that were not marked as "internal" class modifier.
+        // In our built-in themes it's expected that XAML files are internal, except theme entry point itself.
+
         var xamlMethods = FindXamlPopulateMethods().Concat(FindXamlBuildMethods()).ToArray();
         Assert.NotEmpty(xamlMethods);
         Assert.DoesNotContain(xamlMethods, m => m.IsPublic);

--- a/tests/Avalonia.Themes.UnitTests/PublicApiTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/PublicApiTests.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Linq;
+using Avalonia.Themes.Fluent;
+using Avalonia.Themes.Simple;
+using Avalonia.Themes.UnitTests.Utilities;
+using Xunit;
+
+namespace Avalonia.Themes.UnitTests;
+
+public class FluentPublicApiTests() : PublicApiTests(typeof(FluentTheme));
+public class SimplePublicApiTests() : PublicApiTests(typeof(SimpleTheme));
+
+public abstract class PublicApiTests(Type typeEntryPoint) : ThemeTestBase(typeEntryPoint)
+{
+    [Fact]
+    public void Should_Not_Include_Any_Reachable_Xaml_Files()
+    {
+        var xamlMethods = FindXamlPopulateMethods().Concat(FindXamlBuildMethods()).ToArray();
+        Assert.NotEmpty(xamlMethods);
+        Assert.DoesNotContain(xamlMethods, m => m.IsPublic);
+    }
+}

--- a/tests/Avalonia.Themes.UnitTests/PublicApiTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/PublicApiTests.cs
@@ -7,7 +7,9 @@ using Xunit;
 
 namespace Avalonia.Themes.UnitTests;
 
+[Trait("Category", "FluentTheme")]
 public class FluentPublicApiTests() : PublicApiTests(typeof(FluentTheme));
+[Trait("Category", "SimpleTheme")]
 public class SimplePublicApiTests() : PublicApiTests(typeof(SimpleTheme));
 
 public abstract class PublicApiTests(Type typeEntryPoint) : ThemeTestBase(typeEntryPoint)

--- a/tests/Avalonia.Themes.UnitTests/ResourceDictionaryTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/ResourceDictionaryTests.cs
@@ -7,7 +7,9 @@ using Xunit;
 
 namespace Avalonia.Themes.UnitTests;
 
+[Trait("Category", "FluentTheme")]
 public class FluentResourceDictionaryTests() : ResourceDictionaryTests(typeof(FluentTheme));
+[Trait("Category", "SimpleTheme")]
 public class SimpleResourceDictionaryTests() : ResourceDictionaryTests(typeof(SimpleTheme));
 
 public abstract class ResourceDictionaryTests(Type typeEntryPoint) : ThemeTestBase(typeEntryPoint)

--- a/tests/Avalonia.Themes.UnitTests/ResourceDictionaryTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/ResourceDictionaryTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using Avalonia.Themes.Fluent;
+using Avalonia.Themes.Simple;
+using Avalonia.Themes.UnitTests.Utilities;
+using Xunit;
+
+namespace Avalonia.Themes.UnitTests;
+
+public class FluentResourceDictionaryTests() : ResourceDictionaryTests(typeof(FluentTheme));
+public class SimpleResourceDictionaryTests() : ResourceDictionaryTests(typeof(SimpleTheme));
+
+public abstract class ResourceDictionaryTests(Type typeEntryPoint) : ThemeTestBase(typeEntryPoint)
+{
+    [Fact]
+    public void Should_Define_Identical_Keys_In_ThemeDictionaries()
+    {
+        // Any resource defined in one ThemeDictionary, must be defined in the rest
+
+        var theme = CreateAttachedTheme();
+        // We expect that our built-in themes define ThemeDictionaries on the root style object.
+        var flatThemeDictionaryResources = theme.Resources
+            .ThemeDictionaries.ToDictionary(
+                dict => dict.Key,
+                dict => dict.Value.EnumerateResources());
+
+        Assert.All(flatThemeDictionaryResources.Keys, variant =>
+        {
+            var variantResourceKeys = flatThemeDictionaryResources[variant].Select(r => r.Key);
+            var otherResourceKeys = flatThemeDictionaryResources
+                .Where(p => p.Key != variant)
+                .SelectMany(p => p.Value).Select(r => r.Key)
+                .ToHashSet();
+
+            Assert.All(variantResourceKeys, k => Assert.Contains(k, otherResourceKeys));
+        });
+    }
+}

--- a/tests/Avalonia.Themes.UnitTests/ThemeClassTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/ThemeClassTests.cs
@@ -7,7 +7,9 @@ using Xunit;
 
 namespace Avalonia.Themes.UnitTests;
 
+[Trait("Category", "FluentTheme")]
 public class FluentThemeClassTests() : ThemeClassTests(typeof(FluentTheme));
+[Trait("Category", "SimpleTheme")]
 public class SimpleThemeClassTests() : ThemeClassTests(typeof(SimpleTheme));
 
 public abstract class ThemeClassTests(Type typeEntryPoint) : ThemeTestBase(typeEntryPoint)

--- a/tests/Avalonia.Themes.UnitTests/ThemeClassTests.cs
+++ b/tests/Avalonia.Themes.UnitTests/ThemeClassTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Reflection;
+using Avalonia.Themes.Fluent;
+using Avalonia.Themes.Simple;
+using Avalonia.Themes.UnitTests.Utilities;
+using Xunit;
+
+namespace Avalonia.Themes.UnitTests;
+
+public class FluentThemeClassTests() : ThemeClassTests(typeof(FluentTheme));
+public class SimpleThemeClassTests() : ThemeClassTests(typeof(SimpleTheme));
+
+public abstract class ThemeClassTests(Type typeEntryPoint) : ThemeTestBase(typeEntryPoint)
+{
+    [Fact]
+    public void Should_Have_ServiceProvider_Ctor()
+    {
+        var ctor = EntryPointClass.GetConstructor(
+            BindingFlags.Public | BindingFlags.Instance, [typeof(IServiceProvider)]);
+        Assert.NotNull(ctor);
+    }
+
+    [Fact]
+    public void Should_Be_Reachable_With_Ctor()
+    {
+        var theme = CallCtor();
+        Assert.NotNull(theme);
+        Assert.IsType(EntryPointClass, theme);
+    }
+
+    [Fact]
+    public void Should_Be_Reachable_With_Avares_Loader()
+    {
+        var theme = CallTryLoad($"{EntryPointClass.Name}.xaml");
+        Assert.NotNull(theme);
+        Assert.IsType(EntryPointClass, theme);
+    }
+}

--- a/tests/Avalonia.Themes.UnitTests/Utilities/ControlThemeExtensions.cs
+++ b/tests/Avalonia.Themes.UnitTests/Utilities/ControlThemeExtensions.cs
@@ -37,15 +37,21 @@ internal static class ControlThemeExtensions
             throw new ArgumentException("ControlTheme must have TargetType set", nameof(theme));
         }
 
-        if (theme.ResolveTemplate() is not IControlTemplate controlTemplate)
+        return theme.ResolveTemplate() switch
         {
-            return [];
-        }
+            IControlTemplate controlTemplate => EnumerateControlTemplateChildren(theme.TargetType, controlTemplate),
+            IWindowDrawnDecorationsTemplate decorationsTemplate => EnumerateDecorationsChildren(decorationsTemplate),
+            _ => []
+        };
+    }
 
+    private static IEnumerable<AvaloniaObject> EnumerateControlTemplateChildren(
+        Type targetType, IControlTemplate controlTemplate)
+    {
         TemplatedControl templatedParent;
         try
         {
-            templatedParent = (TemplatedControl)Activator.CreateInstance(theme.TargetType)!;
+            templatedParent = (TemplatedControl)Activator.CreateInstance(targetType)!;
             templatedParent.Template = controlTemplate;
             templatedParent.ApplyTemplate();
         }
@@ -60,8 +66,25 @@ internal static class ControlThemeExtensions
 
         // Use visual tree instead of logical tree for the most complete result.
         // Because logical tree might not necessary 1to1 map to XAML.
-        // And we filter by the same TemplateParent anyway. 
+        // And we filter by the same TemplateParent anyway.
         return templateRoot.GetVisualDescendants().Where(v => v.TemplatedParent == templatedParent).Prepend(templateRoot);
+    }
+
+    private static IEnumerable<AvaloniaObject> EnumerateDecorationsChildren(IWindowDrawnDecorationsTemplate template)
+    {
+        var decorations = new WindowDrawnDecorations { Template = template };
+        decorations.ApplyTemplate();
+
+        if (decorations.Content is not { } content)
+        {
+            return [];
+        }
+
+        // Window decorations have unique template configuration, that we need to resolve for each part:
+        return new[] { content.Underlay, content.Overlay, content.FullscreenPopover }
+            .OfType<Control>()
+            .SelectMany(root => root.GetVisualDescendants().Prepend(root))
+            .Where(v => v.TemplatedParent == decorations);
     }
 
     public static object? ResolveTemplate(this ControlTheme theme)

--- a/tests/Avalonia.Themes.UnitTests/Utilities/ControlThemeExtensions.cs
+++ b/tests/Avalonia.Themes.UnitTests/Utilities/ControlThemeExtensions.cs
@@ -30,16 +30,14 @@ internal static class ControlThemeExtensions
         return null;
     }
 
-    public static IEnumerable<AvaloniaObject> EnumerateTemplateChildren(this ControlTheme theme)
+    public static IEnumerable<AvaloniaObject> EnumerateTemplateChildren(this StyleBase styleBase)
     {
-        if (theme.TargetType is null)
-        {
-            throw new ArgumentException("ControlTheme must have TargetType set", nameof(theme));
-        }
+        var targetType = ResolveTargetType(styleBase) ??
+                         throw new ArgumentException("Style must have TargetType set", nameof(styleBase));
 
-        return theme.ResolveTemplate() switch
+        return styleBase.ResolveTemplate() switch
         {
-            IControlTemplate controlTemplate => EnumerateControlTemplateChildren(theme.TargetType, controlTemplate),
+            IControlTemplate controlTemplate => EnumerateControlTemplateChildren(targetType, controlTemplate),
             IWindowDrawnDecorationsTemplate decorationsTemplate => EnumerateDecorationsChildren(decorationsTemplate),
             _ => []
         };
@@ -87,16 +85,14 @@ internal static class ControlThemeExtensions
             .Where(v => v.TemplatedParent == decorations);
     }
 
-    public static object? ResolveTemplate(this ControlTheme theme)
+    public static object? ResolveTemplate(this StyleBase styleBase)
     {
-        if (theme.TargetType is null)
-        {
-            throw new ArgumentException("ControlTheme must have TargetType set", nameof(theme));
-        }
+        var targetType = ResolveTargetType(styleBase) ??
+                         throw new ArgumentException("Style must have TargetType set", nameof(styleBase));
 
         object? template = null;
 
-        if (theme.Setters.OfType<Setter>()
+        if (styleBase.Setters.OfType<Setter>()
                 .FirstOrDefault(s => s.Property == TemplatedControl.TemplateProperty
                                      || s.Property == WindowDrawnDecorations.TemplateProperty)?
                 .Value is { } setterValue)
@@ -108,12 +104,40 @@ internal static class ControlThemeExtensions
         }
 
         // ContentControl derived controls inherit its template.
-        if (template is null && typeof(ContentControl).IsAssignableFrom(theme.TargetType))
+        if (template is null && typeof(ContentControl).IsAssignableFrom(targetType))
         {
             template = TemplatedControl.TemplateProperty.GetDefaultValue(typeof(ContentControl))
                        ?? throw new InvalidOperationException("ContentControl must always have default template");
         }
 
         return template;
+    }
+
+    private static Type? ResolveTargetType(StyleBase styleBase)
+    {
+        if (styleBase is ControlTheme controlTheme)
+        {
+            return controlTheme.TargetType;
+        }
+
+        if (styleBase is Style style)
+        {
+            if (style.Selector?.TargetType is { } selectorTargetType)
+            {
+                return selectorTargetType;
+            }
+
+            if (style.Parent is StyleBase styleParent)
+            {
+                return ResolveTargetType(styleParent);
+            }
+        }
+
+        if (styleBase is ContainerQuery { Parent: StyleBase containerQueryParent })
+        {
+            return ResolveTargetType(containerQueryParent);
+        }
+
+        return null;
     }
 }

--- a/tests/Avalonia.Themes.UnitTests/Utilities/ControlThemeExtensions.cs
+++ b/tests/Avalonia.Themes.UnitTests/Utilities/ControlThemeExtensions.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Avalonia.Controls;
+using Avalonia.Controls.Chrome;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+
+namespace Avalonia.Themes.UnitTests.Utilities;
+
+internal static class ControlThemeExtensions
+{
+    public static ITemplateResult? ResolveTemplate(this ControlTheme theme)
+    {
+        if (theme.TargetType is null)
+        {
+            throw new ArgumentException("ControlTheme must have TargetType set", nameof(theme));
+        }
+
+        object? template = null;
+
+        if (theme.Setters.OfType<Setter>()
+                .FirstOrDefault(s => s.Property == TemplatedControl.TemplateProperty
+                                     || s.Property == WindowDrawnDecorations.TemplateProperty)?
+                .Value is { } setterValue)
+        {
+            if (setterValue is IControlTemplate or IWindowDrawnDecorationsTemplate)
+            {
+                template = setterValue;
+            }
+        }
+
+        // ContentControl derived controls inherit its template.
+        if (template is null && typeof(ContentControl).IsAssignableFrom(theme.TargetType))
+        {
+            template = TemplatedControl.TemplateProperty.GetDefaultValue(typeof(ContentControl))
+                       ?? throw new InvalidOperationException("ContentControl must always have default template");
+        }
+
+        if (template is null)
+        {
+            return null;
+        }
+
+        return template switch
+        {
+            IControlTemplate controlTemplate => controlTemplate.Build(
+                (TemplatedControl)RuntimeHelpers.GetUninitializedObject(theme.TargetType)),
+            IWindowDrawnDecorationsTemplate windowDrawnDecorationsTemplate => windowDrawnDecorationsTemplate.Build()
+        };
+    }
+
+    public static IEnumerable<AvaloniaObject> EnumerateTemplateChildren(this Control templateRoot)
+    {
+        var templatedParent = templateRoot.TemplatedParent;
+        if (templatedParent is null)
+        {
+            // No templated parent - no template at all.
+            return [];
+        }
+
+        // Use visual tree instead of logical tree for the most complete result.
+        // Because logical tree might not necessary 1to1 map to XAML.
+        // And we filter by the same TemplateParent anyway. 
+        return templateRoot.GetVisualDescendants().Where(v => v.TemplatedParent == templatedParent).Prepend(templateRoot);
+    }
+}

--- a/tests/Avalonia.Themes.UnitTests/Utilities/ControlThemeExtensions.cs
+++ b/tests/Avalonia.Themes.UnitTests/Utilities/ControlThemeExtensions.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Avalonia.Controls;
 using Avalonia.Controls.Chrome;
 using Avalonia.Controls.Primitives;
@@ -14,7 +12,59 @@ namespace Avalonia.Themes.UnitTests.Utilities;
 
 internal static class ControlThemeExtensions
 {
-    public static ITemplateResult? ResolveTemplate(this ControlTheme theme)
+    public static ITemplateResult? ResolveTemplateResult(this ControlTheme theme)
+    {
+        var template = theme.ResolveTemplate();
+
+        if (template is IControlTemplate controlTemplate)
+        {
+            var control = new TemplatedControl();
+            return controlTemplate.Build(control);
+        }
+
+        if (template is IWindowDrawnDecorationsTemplate windowDrawnDecorationsTemplate)
+        {
+            return windowDrawnDecorationsTemplate.Build();
+        }
+
+        return null;
+    }
+
+    public static IEnumerable<AvaloniaObject> EnumerateTemplateChildren(this ControlTheme theme)
+    {
+        if (theme.TargetType is null)
+        {
+            throw new ArgumentException("ControlTheme must have TargetType set", nameof(theme));
+        }
+
+        if (theme.ResolveTemplate() is not IControlTemplate controlTemplate)
+        {
+            return [];
+        }
+
+        TemplatedControl templatedParent;
+        try
+        {
+            templatedParent = (TemplatedControl)Activator.CreateInstance(theme.TargetType)!;
+            templatedParent.Template = controlTemplate;
+            templatedParent.ApplyTemplate();
+        }
+        catch
+        {
+            templatedParent = new TemplatedControl();
+            templatedParent.Template = controlTemplate;
+            templatedParent.ApplyTemplate();
+        }
+
+        var templateRoot = (Control)templatedParent.GetVisualChildren().First();
+
+        // Use visual tree instead of logical tree for the most complete result.
+        // Because logical tree might not necessary 1to1 map to XAML.
+        // And we filter by the same TemplateParent anyway. 
+        return templateRoot.GetVisualDescendants().Where(v => v.TemplatedParent == templatedParent).Prepend(templateRoot);
+    }
+
+    public static object? ResolveTemplate(this ControlTheme theme)
     {
         if (theme.TargetType is null)
         {
@@ -41,31 +91,6 @@ internal static class ControlThemeExtensions
                        ?? throw new InvalidOperationException("ContentControl must always have default template");
         }
 
-        if (template is null)
-        {
-            return null;
-        }
-
-        return template switch
-        {
-            IControlTemplate controlTemplate => controlTemplate.Build(
-                (TemplatedControl)RuntimeHelpers.GetUninitializedObject(theme.TargetType)),
-            IWindowDrawnDecorationsTemplate windowDrawnDecorationsTemplate => windowDrawnDecorationsTemplate.Build()
-        };
-    }
-
-    public static IEnumerable<AvaloniaObject> EnumerateTemplateChildren(this Control templateRoot)
-    {
-        var templatedParent = templateRoot.TemplatedParent;
-        if (templatedParent is null)
-        {
-            // No templated parent - no template at all.
-            return [];
-        }
-
-        // Use visual tree instead of logical tree for the most complete result.
-        // Because logical tree might not necessary 1to1 map to XAML.
-        // And we filter by the same TemplateParent anyway. 
-        return templateRoot.GetVisualDescendants().Where(v => v.TemplatedParent == templatedParent).Prepend(templateRoot);
+        return template;
     }
 }

--- a/tests/Avalonia.Themes.UnitTests/Utilities/KnownResourceProviders.cs
+++ b/tests/Avalonia.Themes.UnitTests/Utilities/KnownResourceProviders.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+
+namespace Avalonia.Themes.UnitTests.Utilities;
+
+/// <summary>
+/// Fluent theme uses ResourceProviders for computed resources, which don't have any public API to read Keys collections.
+/// TODO: revisit Avalonia API, and consider adding IReadOnlyResourceDictionary or KeyedResourceProvider of sorts. 
+/// </summary>
+internal class KnownResourceProviders
+{
+    private static readonly string[] s_accentKeys =
+    [
+        "SystemAccentColor",
+        "SystemAccentColorDark1",
+        "SystemAccentColorDark2",
+        "SystemAccentColorDark3",
+        "SystemAccentColorLight1",
+        "SystemAccentColorLight2",
+        "SystemAccentColorLight3"
+    ];
+
+    private static readonly string[] s_colorKeys =
+    [
+        "SystemAltHighColor",
+        "SystemAltLowColor",
+        "SystemAltMediumColor",
+        "SystemAltMediumHighColor",
+        "SystemAltMediumLowColor",
+        "SystemBaseHighColor",
+        "SystemBaseLowColor",
+        "SystemBaseMediumColor",
+        "SystemBaseMediumHighColor",
+        "SystemBaseMediumLowColor",
+        "SystemChromeAltLowColor",
+        "SystemChromeBlackHighColor",
+        "SystemChromeBlackLowColor",
+        "SystemChromeBlackMediumColor",
+        "SystemChromeBlackMediumLowColor",
+        "SystemChromeDisabledHighColor",
+        "SystemChromeDisabledLowColor",
+        "SystemChromeGrayColor",
+        "SystemChromeHighColor",
+        "SystemChromeLowColor",
+        "SystemChromeMediumColor",
+        "SystemChromeMediumLowColor",
+        "SystemChromeWhiteColor",
+        "SystemErrorTextColor",
+        "SystemListLowColor",
+        "SystemListMediumColor",
+        "SystemRegionColor"
+    ];
+
+    public static IEnumerable<string>? TryGetKnownResourceKeys(IResourceProvider provider)
+    {
+        if (provider.GetType().Name == "SystemAccentColors")
+        {
+            return s_accentKeys;
+        }
+
+        if (provider.GetType().Name == "ColorPaletteResources")
+        {
+            return s_accentKeys.Concat(s_colorKeys);
+        }
+
+        return null;
+    }
+}

--- a/tests/Avalonia.Themes.UnitTests/Utilities/ResourceExtensions.cs
+++ b/tests/Avalonia.Themes.UnitTests/Utilities/ResourceExtensions.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Styling;
+using Xunit;
+
+namespace Avalonia.Themes.UnitTests.Utilities;
+
+public static class ResourceExtensions
+{
+    public static IEnumerable<ResourceEntry> EnumerateResources(
+        this Application application)
+    {
+        foreach (var r in application.Resources.EnumerateResources(anchor: application))
+        {
+            yield return r;
+        }
+
+        foreach (var style in application.Styles)
+        {
+            foreach (var r in style.EnumerateResources())
+            {
+                yield return r;
+            }
+        }
+    }
+
+    public static IEnumerable<ResourceEntry> EnumerateResources(
+        this StyledElement styledElement)
+    {
+        foreach (var r in styledElement.Resources.EnumerateResources(anchor: styledElement))
+        {
+            yield return r;
+        }
+
+        foreach (var style in styledElement.Styles)
+        {
+            foreach (var r in style.EnumerateResources())
+            {
+                yield return r;
+            }
+        }
+    }
+
+    public static IEnumerable<ResourceEntry> EnumerateResources(
+        this IStyle style)
+    {
+        if (style is Styles styles)
+        {
+            foreach (var r in styles.Resources.EnumerateResources(anchor: styles))
+            {
+                yield return r;
+            }
+        }
+        else if (style is StyleBase styleBase)
+        {
+            foreach (var r in styleBase.Resources.EnumerateResources(anchor: styleBase))
+            {
+                yield return r;
+            }
+        }
+
+        foreach (var childStyle in style.Children)
+        {
+            foreach (var r in childStyle.EnumerateResources())
+            {
+                yield return r;
+            }
+        }
+    }
+
+    public static IEnumerable<ResourceEntry> EnumerateResources(
+        this IResourceDictionary resourceDictionary)
+        => resourceDictionary.EnumerateResources(anchor: resourceDictionary);
+
+    public static IEnumerable<ResourceEntry> EnumerateResources(
+        this IResourceProvider resourceProvider, IEnumerable<object> keys)
+        => resourceProvider.EnumerateResources(keys, anchor: resourceProvider, themeVariant: null);
+
+    private static IEnumerable<ResourceEntry> EnumerateResources(
+        this IResourceDictionary resourceDictionary, object? anchor, ThemeVariant? themeVariant = null)
+    {
+        foreach (var r in resourceDictionary.EnumerateResources(resourceDictionary.Keys, anchor, themeVariant))
+        {
+            yield return r;
+        }
+
+        foreach (var (variant, variantProvider) in resourceDictionary.ThemeDictionaries)
+        {
+            foreach (var r in variantProvider.EnumerateResources(anchor, variant))
+            {
+                yield return r;
+            }
+        }
+
+        foreach (var mergedProvider in resourceDictionary.MergedDictionaries)
+        {
+            foreach (var r in mergedProvider.EnumerateResources(anchor, themeVariant))
+            {
+                yield return r;
+            }
+        }
+    }
+
+    private static IEnumerable<ResourceEntry> EnumerateResources(
+        this IResourceProvider resourceProvider, object? anchor, ThemeVariant? themeVariant)
+    {
+        if (resourceProvider is IResourceDictionary resourceDictionary)
+        {
+            return resourceDictionary.EnumerateResources(anchor, themeVariant);
+        }
+
+        if (KnownResourceProviders.TryGetKnownResourceKeys(resourceProvider) is { } knownKeys)
+        {
+            return resourceProvider.EnumerateResources(knownKeys, anchor, themeVariant);
+        }
+
+        return [];
+    }
+
+    private static IEnumerable<ResourceEntry> EnumerateResources(
+        this IResourceProvider resourceProvider, IEnumerable<object> keys, object? anchor, ThemeVariant? themeVariant)
+    {
+        return keys.Select(k =>
+        {
+            Assert.True(resourceProvider.TryGetResource(k, themeVariant, out var val), $"Key \"{k}\" defined, but value was not found");
+  
+            return new ResourceEntry(
+                Anchor: anchor ?? resourceProvider,
+                Provider: resourceProvider,
+                Key: k,
+                Value: val,
+                IsDeferred: (resourceProvider as ResourceDictionary)?.ContainsDeferredKey(k) ?? false,
+                ThemeVariant: themeVariant ?? ThemeVariant.Default);
+        });
+    }
+
+    public record ResourceEntry(
+        object Anchor,
+        IResourceProvider Provider,
+        object Key,
+        object? Value,
+        bool IsDeferred,
+        ThemeVariant ThemeVariant)
+    {
+        public bool IsReadOnly => Provider is not IResourceDictionary; 
+    }
+}

--- a/tests/Avalonia.Themes.UnitTests/Utilities/ResourceExtensions.cs
+++ b/tests/Avalonia.Themes.UnitTests/Utilities/ResourceExtensions.cs
@@ -43,6 +43,8 @@ public static class ResourceExtensions
     }
 
     public static IEnumerable<ResourceEntry> EnumerateResources(
+        this Styles style) => ((IStyle)style).EnumerateResources();
+    public static IEnumerable<ResourceEntry> EnumerateResources(
         this IStyle style)
     {
         if (style is Styles styles)
@@ -76,6 +78,10 @@ public static class ResourceExtensions
     public static IEnumerable<ResourceEntry> EnumerateResources(
         this IResourceProvider resourceProvider, IEnumerable<object> keys)
         => resourceProvider.EnumerateResources(keys, anchor: resourceProvider, themeVariant: null);
+
+    public static IEnumerable<ResourceEntry> EnumerateResources(
+        this IResourceProvider resourceProvider)
+        => resourceProvider.EnumerateResources(anchor: resourceProvider, themeVariant: null);
 
     private static IEnumerable<ResourceEntry> EnumerateResources(
         this IResourceDictionary resourceDictionary, object? anchor, ThemeVariant? themeVariant = null)

--- a/tests/Avalonia.Themes.UnitTests/Utilities/StyleExtensions.cs
+++ b/tests/Avalonia.Themes.UnitTests/Utilities/StyleExtensions.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Styling;
+
+namespace Avalonia.Themes.UnitTests.Utilities;
+
+public static class StyleExtensions
+{
+    public static IEnumerable<StyleBase> EnumerateStyles(this IStyle style)
+    {
+        if (style is StyleBase styleBase)
+        {
+            yield return styleBase;
+        }
+
+        // IStyle.Children enumerates both Style's nested styles and Styles (collection) children.
+        foreach (var nestedStyle in style.Children.SelectMany(s => s.EnumerateStyles()))
+        {
+            yield return nestedStyle;
+        }
+    }
+}

--- a/tests/Avalonia.Themes.UnitTests/Utilities/ThemeTestBase.cs
+++ b/tests/Avalonia.Themes.UnitTests/Utilities/ThemeTestBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Avalonia.Markup.Xaml.XamlIl.Runtime;
 using Avalonia.Platform;
 using Avalonia.Styling;
 using Avalonia.UnitTests;
@@ -37,6 +38,15 @@ public abstract class ThemeTestBase(Type typeEntryPoint) : IDisposable
         var tryLoadMethod = loaderType.GetMethod("TryLoad", BindingFlags.Public | BindingFlags.Static, [typeof(IServiceProvider), typeof(string)]);
         Assert.NotNull(tryLoadMethod);
         return tryLoadMethod;
+    }
+
+    protected Styles CreateAttachedTheme(IStyleHost? host = null)
+    {
+        host ??= Application.Current ?? throw new InvalidOperationException("Application.Current should not be null.");
+        var sp = XamlIlRuntimeHelpers.CreateRootServiceProviderV2();
+        var theme = CallCtor(sp);
+        host.Styles.Add(theme);
+        return theme;
     }
 
     protected Styles CallCtor(IServiceProvider? sp = null)

--- a/tests/Avalonia.Themes.UnitTests/Utilities/ThemeTestBase.cs
+++ b/tests/Avalonia.Themes.UnitTests/Utilities/ThemeTestBase.cs
@@ -4,12 +4,15 @@ using System.Linq;
 using System.Reflection;
 using Avalonia.Platform;
 using Avalonia.Styling;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Themes.UnitTests.Utilities;
 
-public abstract class ThemeTestBase(Type typeEntryPoint)
+public abstract class ThemeTestBase(Type typeEntryPoint) : IDisposable
 {
+    private readonly HeadlessUnitTestApplication.Scope _headlessScope = HeadlessUnitTestApplication.Start();
+
     static ThemeTestBase()
     {
         StandardAssetLoader.RegisterResUriParsers();
@@ -48,4 +51,6 @@ public abstract class ThemeTestBase(Type typeEntryPoint)
         Assert.True(Uri.TryCreate(fullPath, UriKind.Absolute, out _), "Invalid TryLoad URL");
         return FindXamlLoader().Invoke(null, [sp, fullPath]);
     }
+
+    public void Dispose() => _headlessScope.Dispose();
 }

--- a/tests/Avalonia.Themes.UnitTests/Utilities/ThemeTestBase.cs
+++ b/tests/Avalonia.Themes.UnitTests/Utilities/ThemeTestBase.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Avalonia.Platform;
+using Avalonia.Styling;
+using Xunit;
+
+namespace Avalonia.Themes.UnitTests.Utilities;
+
+public abstract class ThemeTestBase(Type typeEntryPoint)
+{
+    static ThemeTestBase()
+    {
+        StandardAssetLoader.RegisterResUriParsers();
+    }
+
+    protected Assembly TestAssembly { get; } = typeEntryPoint.Assembly;
+    protected Type EntryPointClass { get; } = typeEntryPoint;
+
+    protected IEnumerable<MethodInfo> FindXamlPopulateMethods() =>
+        TestAssembly.GetType("CompiledAvaloniaXaml.!AvaloniaResources", throwOnError: true)!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(m => m.Name.StartsWith("Populate:"));
+
+    protected IEnumerable<MethodInfo> FindXamlBuildMethods() =>
+        TestAssembly.GetType("CompiledAvaloniaXaml.!AvaloniaResources", throwOnError: true)!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(m => m.Name.StartsWith("Build:"));
+
+    protected MethodInfo FindXamlLoader()
+    {
+        var loaderType = TestAssembly.GetType("CompiledAvaloniaXaml.!XamlLoader", throwOnError: true)!;
+        var tryLoadMethod = loaderType.GetMethod("TryLoad", BindingFlags.Public | BindingFlags.Static, [typeof(IServiceProvider), typeof(string)]);
+        Assert.NotNull(tryLoadMethod);
+        return tryLoadMethod;
+    }
+
+    protected Styles CallCtor(IServiceProvider? sp = null)
+    {
+        var theme = Activator.CreateInstance(EntryPointClass, sp);
+        return Assert.IsAssignableFrom<Styles>(theme);
+    }
+
+    protected object? CallTryLoad(string relativePath, IServiceProvider? sp = null)
+    {
+        var fullPath = $"avares://{TestAssembly.GetName().Name}/{relativePath}";
+        Assert.True(Uri.TryCreate(fullPath, UriKind.Absolute, out _), "Invalid TryLoad URL");
+        return FindXamlLoader().Invoke(null, [sp, fullPath]);
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Adds a new `Avalonia.Themes.UnitTests` project that validates the built-in Fluent and Simple themes, and fixes the theme issues these tests found.

## What is the current behavior?

Before this PR, built-in themes were not covered by any tests. Several types of issues existed unnoticed:
- DynamicResource targetting undefined resources
- Brushes/colors being hardcoded in the setter or template parts
- Several XAML files were compiled as public (doubling IL output, as we merge XAML files)
- `StringCalendarWeekNumberHeader` apparently was still ignored as a resource

## What is the updated/expected behavior with this PR?

New tests:
- Theme class has a `ctor(IServiceProvider)` and can be reached via `avares:` (which we technically always supported).
- All XAML files should be internal (except entry point).
- Every theme dictionary defines the same resources.
- No global styles are defined, only ControlTheme with nested styles.
- Every built-in templated control has a ControlTheme (with some known exceptions).
- Every `[TemplatePart]` is defined in the template.
- Every `{DynamicResource}` references a defined key.
- No brush, color or box shadow is hardcoded in a setter or a template

## How was the solution implemented (if it's not obvious)?

All tests are defined in abstract classes with specific implementations per each theme:

```csharp
[Trait("Category", "FluentTheme")]
public class FluentControlThemeTests() : ControlThemeTests(typeof(FluentTheme));
[Trait("Category", "SimpleTheme")]
public class SimpleControlThemeTests() : ControlThemeTests(typeof(SimpleTheme));

public abstract class ControlThemeTests(Type typeEntryPoint) : ThemeTestBase(typeEntryPoint)
{
}
```

With an idea to later add Fluent2 to the same test project.

## Breaking changes

None


Disclamer: This PR was written by hand, without an AI. Code might be better or worse depending on who reads.
But it still was reviewed by Opus.