### PR TITLE
Allow a compiled binding path through a Nullable<T>

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
@@ -193,6 +193,11 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                     case BindingExpressionGrammar.PropertyNameNode propName:
                         {
                             IXamlType targetType = targetTypeResolver();
+
+                            // Nullable<T> defines only Value and HasValue: look anything else up on T, as C# does.
+                            if (targetType.IsNullable() && !HasMember(targetType, propName.PropertyName))
+                                targetType = targetType.GenericArguments[0];
+
                             var avaloniaPropertyFieldNameMaybe = propName.PropertyName + "Property";
                             var avaloniaPropertyFieldMaybe = targetType.GetAllFields().FirstOrDefault(f =>
                                 f.IsStatic && f.IsPublic && f.Name == avaloniaPropertyFieldNameMaybe);
@@ -397,6 +402,11 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 return TypeReferenceResolver.ResolveType(context, $"{ns}:{name}", false,
                     lineInfo, true).GetClrType();
             }
+
+            static bool HasMember(IXamlType type, string name) =>
+                type.GetAllFields().Any(f => f.IsStatic && f.IsPublic && f.Name == name + "Property")
+                || GetAllDefinedProperties(type).Any(p => p.Name == name)
+                || GetAllDefinedMethods(type).Any(m => m.Name == name);
 
             static IEnumerable<IXamlProperty> GetAllDefinedProperties(IXamlType type)
             {

--- a/tests/Avalonia.Base.UnitTests/Data/Core/NullConditionalBindingTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/NullConditionalBindingTests.cs
@@ -412,9 +412,91 @@ public class NullConditionalBindingTests
         Assert.Empty(log.Messages);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Should_Not_Report_Error_With_Null_Conditional_Operator_For_Nullable_Struct(bool compileBindings)
+    {
+        using var app = Start();
+        using var log = TestLogger.Create();
+        var xaml = $$$"""
+            <Window xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                    xmlns:local='using:Avalonia.Base.UnitTests.Data.Core'
+                    x:DataType='local:NullConditionalBindingTests+First'
+                    x:CompileBindings='{{{compileBindings}}}'>
+                <local:ErrorCollectingTextBox Text='{Binding NullableSecond?.Final}'/>
+            </Window>
+            """;
+        var data = new First { NullableSecond = null };
+        var window = CreateTarget(xaml, data);
+        var textBox = Assert.IsType<ErrorCollectingTextBox>(window.Content);
+
+        Assert.Null(textBox.Text);
+        Assert.Null(textBox.Error);
+        Assert.Equal(BindingValueType.Value, textBox.ErrorState);
+        Assert.Empty(log.Messages);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Should_Read_Property_With_Null_Conditional_Operator_For_Nullable_Struct(bool compileBindings)
+    {
+        using var app = Start();
+        using var log = TestLogger.Create();
+        var xaml = $$$"""
+            <Window xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                    xmlns:local='using:Avalonia.Base.UnitTests.Data.Core'
+                    x:DataType='local:NullConditionalBindingTests+First'
+                    x:CompileBindings='{{{compileBindings}}}'>
+                <local:ErrorCollectingTextBox Text='{Binding NullableSecond?.Final}'/>
+            </Window>
+            """;
+        var data = new First { NullableSecond = new NullableSecondValue { Final = "foo" } };
+        var window = CreateTarget(xaml, data);
+        var textBox = Assert.IsType<ErrorCollectingTextBox>(window.Content);
+
+        Assert.Equal("foo", textBox.Text);
+        Assert.Null(textBox.Error);
+        Assert.Equal(BindingValueType.Value, textBox.ErrorState);
+        Assert.Empty(log.Messages);
+    }
+
+    [Fact]
+    public void Should_Access_Value_Of_Nullable_Struct()
+    {
+        // Only compiled bindings: boxing erases Nullable<T>, so reflection bindings never see
+        // Value or HasValue.
+        using var app = Start();
+        using var log = TestLogger.Create();
+        var xaml = """
+            <Window xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                    xmlns:local='using:Avalonia.Base.UnitTests.Data.Core'
+                    x:DataType='local:NullConditionalBindingTests+First'
+                    x:CompileBindings='True'>
+                <local:ErrorCollectingTextBox Text='{Binding NullableSecond.Value.Final}'/>
+            </Window>
+            """;
+        var data = new First { NullableSecond = new NullableSecondValue { Final = "foo" } };
+        var window = CreateTarget(xaml, data);
+        var textBox = Assert.IsType<ErrorCollectingTextBox>(window.Content);
+
+        Assert.Equal("foo", textBox.Text);
+        Assert.Null(textBox.Error);
+        Assert.Empty(log.Messages);
+    }
+
     private static IDisposable Start()
     {
         return UnitTestApplication.Start(TestServices.StyledWindow);
+    }
+
+    public struct NullableSecondValue
+    {
+        public string? Final { get; set; }
     }
 
     public class First : StyledElement
@@ -423,6 +505,8 @@ public class NullConditionalBindingTests
             AvaloniaProperty.Register<First, Second?>(nameof(StyledSecond));
 
         public Second? Second { get; set; }
+
+        public NullableSecondValue? NullableSecond { get; set; }
 
         public Second? StyledSecond
         {


### PR DESCRIPTION
## What does the pull request do?

Makes a compiled binding path work through a `Nullable<T>`, e.g. `{Binding MyStruct?.MyProperty}` where `MyStruct` is nullable.

## What is the current behavior?

The build fails with `AVLN2000: Unable to resolve property or method of name 'MyProperty' on type 'System.Nullable1'`. Reflection bindings already work, because boxing a nullable gives either null or a boxed `T`, so only compiled bindings are affected.

## What is the updated/expected behavior with this PR?

The member resolves and the binding behaves like the reflection one. `Value` and `HasValue` continue to resolve on `Nullable<T>` itself, so the usual `{Binding MyStruct.Value.MyProperty}` workaround keeps working.

## How was the solution implemented (if it's not obvious)?

A member is looked up on the declared type of the previous path element. When that type is a `Nullable<T>` and it doesn't define the member, the lookup falls back to `T`, as C# does.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues

Fixes #18720
