### PR TITLE
MacOS: Make sure macOS child window layer is not lower than parent window

### DIFF
--- a/native/Avalonia.Native/src/OSX/PopupImpl.mm
+++ b/native/Avalonia.Native/src/OSX/PopupImpl.mm
@@ -25,9 +25,14 @@ private:
     PopupImpl(IAvnWindowEvents* events) : TopLevelImpl(events), WindowBaseImpl(events)
     {
         WindowEvents = events;
-        [Window setLevel:NSPopUpMenuWindowLevel];
+        UpdateWindowLevel();
     }
 protected:
+    virtual NSWindowLevel GetBaseWindowLevel() override
+    {
+        return NSPopUpMenuWindowLevel;
+    }
+
     virtual NSWindowStyleMask CalculateStyleMask() override
     {
         return NSWindowStyleMaskBorderless;

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
@@ -80,8 +80,12 @@ public:
     virtual bool CanZoom() { return false; }
                            
     virtual HRESULT SetParent(IAvnWindowBase* parent) override;
-                           
+
+    void UpdateWindowLevel();
+
 protected:
+    virtual NSWindowLevel GetBaseWindowLevel();
+
     virtual NSWindowStyleMask CalculateStyleMask() = 0;
     virtual void UpdateAppearance() override;
     virtual void SetClientSize(NSSize size) override;
@@ -101,6 +105,7 @@ protected:
     AutoFitContentView *StandardContainer;
     AvnPoint lastPositionSet;
     bool _shown;
+    bool _isTopmost = false;
     std::list<ComObjectWeakPtr<WindowBaseImpl>> _children;
 
 public:

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -18,6 +18,7 @@
 #include "WindowImpl.h"
 #include "AvnTextInputMethod.h"
 #include "AvnView.h"
+#include <algorithm>
 
 @class AutoFitContentView;
 
@@ -206,9 +207,38 @@ HRESULT WindowBaseImpl::SetTopMost(bool value) {
     START_COM_CALL;
 
     @autoreleasepool {
-        [Window setLevel:value ? NSFloatingWindowLevel : NSNormalWindowLevel];
+        _isTopmost = value;
+
+        UpdateWindowLevel();
 
         return S_OK;
+    }
+}
+
+NSWindowLevel WindowBaseImpl::GetBaseWindowLevel() {
+    return _isTopmost ? NSFloatingWindowLevel : NSNormalWindowLevel;
+}
+
+void WindowBaseImpl::UpdateWindowLevel() {
+    if (Window == nullptr)
+        return;
+
+    auto level = GetBaseWindowLevel();
+
+    // An owned window must be able to come to the front of its owner.
+    // TODO: It shouldn't be necessary if we used `addChildWindow` API.
+    auto parent = Parent.tryGet();
+
+    if (parent != nullptr && parent->Window != nullptr)
+        level = std::max(level, [parent->Window level]);
+
+    [Window setLevel:level];
+
+    for (auto iterator = _children.begin(); iterator != _children.end(); iterator++) {
+        auto child = (*iterator).tryGet();
+
+        if (child != nullptr)
+            child->UpdateWindowLevel();
     }
 }
 
@@ -526,6 +556,8 @@ HRESULT WindowBaseImpl::SetParent(IAvnWindowBase *parent) {
 
             UpdateAppearance();
         }
+
+        UpdateWindowLevel();
 
         return S_OK;
     }

--- a/samples/IntegrationTestApp/TopmostWindowTest.axaml
+++ b/samples/IntegrationTestApp/TopmostWindowTest.axaml
@@ -9,8 +9,10 @@
         Height="480">
   <Grid>
     <TextBox Name="CurrentPosition"
-             Grid.Column="1"
-             Grid.Row="3"
+             VerticalAlignment="Top"
+             IsReadOnly="True" />
+    <TextBox Name="CurrentOrder"
+             VerticalAlignment="Bottom"
              IsReadOnly="True" />
     <Button HorizontalAlignment="Center" Name="MoveButton" VerticalAlignment="Center" Click="Button_OnClick">Move</Button>
   </Grid>

--- a/samples/IntegrationTestApp/TopmostWindowTest.axaml.cs
+++ b/samples/IntegrationTestApp/TopmostWindowTest.axaml.cs
@@ -1,16 +1,39 @@
+using System;
+using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 
 namespace IntegrationTestApp;
 
 public partial class TopmostWindowTest : Window
 {
+    private readonly DispatcherTimer? _timer;
+
     public TopmostWindowTest(string name)
     {
         Name = name;
         InitializeComponent();
         PositionChanged += (s, e) => CurrentPosition.Text = $"{Position}";
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            _timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(250) };
+            _timer.Tick += TimerOnTick;
+            _timer.Start();
+        }
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        base.OnClosed(e);
+        _timer?.Stop();
+    }
+
+    private void TimerOnTick(object? sender, EventArgs e)
+    {
+        CurrentOrder.Text = MacOSIntegration.GetOrderedIndex(this).ToString();
     }
 
     private void Button_OnClick(object? sender, RoutedEventArgs e)

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
@@ -203,6 +203,30 @@ namespace Avalonia.IntegrationTests.Appium
         }
 
         [PlatformFact(TestPlatforms.MacOS)]
+        public void WindowOrder_Owned_Window_Stays_InFront_Of_Topmost_Owner()
+        {
+            Session.FindElementByAccessibilityId("ShowTopmostWindow").Click();
+
+            try
+            {
+                Thread.Sleep(1000);
+
+                var ownerWindowIndex = GetWindowOrder("OwnerWindow");
+                var ownedWindowIndex = GetWindowOrder("OwnedWindow");
+
+                // orderedIndex counts from the front, so the owned window needs the lower index.
+                Assert.True(ownedWindowIndex < ownerWindowIndex,
+                    $"Expected the owned window in front of its topmost owner, but the owner was at " +
+                    $"{ownerWindowIndex} and the owned window at {ownedWindowIndex}.");
+            }
+            finally
+            {
+                CloseWindow("OwnedWindow");
+                CloseWindow("OwnerWindow");
+            }
+        }
+
+        [PlatformFact(TestPlatforms.MacOS)]
         public void WindowOrder_Owned_Is_Correct_After_Closing_Window()
         {
             using (OpenWindow(new PixelSize(300, 500), ShowWindowMode.Owned, WindowStartupLocation.CenterOwner))
@@ -439,6 +463,12 @@ namespace Avalonia.IntegrationTests.Appium
             var window = GetWindow(identifier);
             var order = window.FindElementByXPath("//*[@identifier='CurrentOrder']");
             return int.Parse(order.Text);
+        }
+
+        private void CloseWindow(string identifier)
+        {
+            GetWindow(identifier).FindElementByAccessibilityId("_XCUI:CloseWindow").Click();
+            Thread.Sleep(1000);
         }
 
         public enum ShowWindowMode

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
@@ -25,9 +25,9 @@ namespace Avalonia.IntegrationTests.Appium
             {
                 mainWindow.Click();
 
-                var secondaryWindowIndex = GetWindowOrder("SecondaryWindow");
-
                 Thread.Sleep(300); // sync with timer
+
+                var secondaryWindowIndex = GetWindowOrder("SecondaryWindow");
 
                 Assert.Equal(1, secondaryWindowIndex);
             }


### PR DESCRIPTION
## What does the pull request do?

Originally reported for XPF, but also a problem in Avalonia.
This PR improves handling of the AppKit window layers.

This bug wouldn't happen if we used `addChildWindow` APIs, but it comes with its own set of issues, and bigger behavioral differences from Avalonia needs to work.

## What is the current behavior?

If TopLevel window opens a child window, this child window will be layered behind the owner.

## What is the updated/expected behavior with this PR?

If TopLevel window opens a child window, this child window will be automatically put on the owner's layer.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

https://support.avaloniaui.net/agent/tickets/1833