### PR TITLE
Fix headless session startup and disposal races

### DIFF
--- a/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
@@ -235,16 +235,16 @@ public sealed class HeadlessUnitTestSession : IDisposable, IAsyncDisposable
     public void Dispose()
     {
         _cancellationTokenSource.Cancel();
-        _queue.CompleteAdding();
         _dispatchTask.Wait();
+        _queue.CompleteAdding();
         _cancellationTokenSource.Dispose();
     }
 
     public async ValueTask DisposeAsync()
     {
         await _cancellationTokenSource.CancelAsync().ConfigureAwait(false);
-        _queue.CompleteAdding();
         await _dispatchTask.ConfigureAwait(false);
+        _queue.CompleteAdding();
         _cancellationTokenSource.Dispose();
     }
 
@@ -282,7 +282,7 @@ public sealed class HeadlessUnitTestSession : IDisposable, IAsyncDisposable
         var queue = new BlockingCollection<(Action, ExecutionContext?)>();
 
         Task? task = null;
-        task = Task.Run(() =>
+        task = new Task(() =>
         {
             try
             {
@@ -327,8 +327,9 @@ public sealed class HeadlessUnitTestSession : IDisposable, IAsyncDisposable
                 {
                 }
             }
-        });
+        }, TaskCreationOptions.DenyChildAttach);
 
+        task.Start(TaskScheduler.Default);
         return tcs.Task.GetAwaiter().GetResult();
     }
 

--- a/tests/Avalonia.Headless.UnitTests/HeadlessUnitTestSessionTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/HeadlessUnitTestSessionTests.cs
@@ -8,6 +8,20 @@ namespace Avalonia.Headless.UnitTests;
 
 public class HeadlessUnitTestSessionTests
 {
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task Session_Should_Support_Immediate_Disposal(bool asynchronously)
+    {
+        for (var i = 0; i < 10000; ++i)
+        {
+            var session = HeadlessUnitTestSession.StartNew(typeof(TestApplication));
+            if (asynchronously)
+                await session.DisposeAsync();
+            else
+                session.Dispose();
+        }
+    }
+
     [Test]
     public async Task Dispatch_Should_Report_Cleanup_Exceptions_And_Continue()
     {


### PR DESCRIPTION
## What does the pull request do?
Fix two races when immediately disposing a headless test session. The worker can capture its own task before StartNew assigns it, causing a NullReferenceException during disposal. Completing the work queue before the worker exits can also cause BlockingCollection.Take to throw.

Create the worker task before starting it, and wait for it to exit before completing the queue in both disposal methods. No public API changes.

## Validation
The first commit adds repeated immediate-disposal tests for synchronous and asynchronous shutdown. Both failed against the baseline; the second commit fixes them. Full NUnit per-test and per-assembly headless suites each passed 85 tests with one skipped; both xUnit suites each passed 80 tests with one skipped. A separate read-only review found no actionable defects.

This change was prepared with AI assistance.

